### PR TITLE
Better gas price spike reporting

### DIFF
--- a/tests/test_transaction_builder.py
+++ b/tests/test_transaction_builder.py
@@ -182,6 +182,30 @@ def test_build_erc20_approve(
     assert receipt.status == 1  # Success
 
 
+def test_planned_gas_price(
+        web3,
+        hot_wallet,
+        uniswap_v2,
+        usdc_token,
+    ):
+    """We can read planned gas price back from the transaction."""
+
+    fees = estimate_gas_fees(web3)
+
+    tx_builder = TransactionBuilder(
+        web3,
+        hot_wallet,
+        fees,
+    )
+
+    tx = tx_builder.create_transaction(
+        usdc_token,
+        "approve",
+        (uniswap_v2.router.address, 2**256-1),
+        APPROVE_GAS_LIMIT,
+    )
+
+    assert tx.get_planned_gas_price() == 100
 
 
 

--- a/tests/test_transaction_builder.py
+++ b/tests/test_transaction_builder.py
@@ -205,7 +205,8 @@ def test_planned_gas_price(
         APPROVE_GAS_LIMIT,
     )
 
-    assert tx.get_planned_gas_price() == 100
+    # 1844540158
+    assert tx.get_planned_gas_price() >= 1_000_000
 
 
 

--- a/tradeexecutor/ethereum/tx.py
+++ b/tradeexecutor/ethereum/tx.py
@@ -70,8 +70,6 @@ class TransactionBuilder:
         signed_tx = self.hot_wallet.sign_transaction_with_new_nonce(tx)
         signed_bytes = signed_tx.rawTransaction.hex()
 
-        import ipdb ; ipdb.set_trace()
-
         return BlockchainTransaction(
             chain_id=self.chain_id,
             from_address=self.hot_wallet.address,

--- a/tradeexecutor/ethereum/tx.py
+++ b/tradeexecutor/ethereum/tx.py
@@ -70,6 +70,8 @@ class TransactionBuilder:
         signed_tx = self.hot_wallet.sign_transaction_with_new_nonce(tx)
         signed_bytes = signed_tx.rawTransaction.hex()
 
+        import ipdb ; ipdb.set_trace()
+
         return BlockchainTransaction(
             chain_id=self.chain_id,
             from_address=self.hot_wallet.address,
@@ -79,6 +81,7 @@ class TransactionBuilder:
             signed_bytes=signed_bytes,
             tx_hash=signed_tx.hash.hex(),
             nonce=signed_tx.nonce,
+            details=tx,
         )
 
     def create_transaction(

--- a/tradeexecutor/state/blockhain_transaction.py
+++ b/tradeexecutor/state/blockhain_transaction.py
@@ -64,6 +64,11 @@ class BlockchainTransaction:
 
     #: Raw Ethereum transaction dict.
     #: Output from web3 buildTransaction()
+    #:
+    #: Example:
+    #:
+    #: `{'value': 0, 'maxFeePerGas': 1844540158, 'maxPriorityFeePerGas': 1000000000, 'chainId': 61, 'from': '0x6B49598B34B9c7FbF7C57306d0b0578676D55ffA', 'gas': 100000, 'to': '0xF2E246BB76DF876Cef8b38ae84130F4F55De395b', 'data': '0x095ea7b30000000000000000000000006d411e0a54382ed43f02410ce1c7a7c122afa6e1ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff', 'nonce': 0}`
+    #:
     details: Optional[Dict] = None
 
     #: Raw bytes of the signed transaction
@@ -160,3 +165,14 @@ class BlockchainTransaction:
         self.realised_gas_units_consumed = realised_gas_units_consumed
         self.status = status
         self.revert_reason = revert_reason
+
+    def get_planned_gas_price(self) -> int:
+        """How much wei per gas unit we planned to spend on this transactions.
+
+        Gets `maxFeePerGas` for EVM transction.
+
+        :return:
+            0 if unknown
+        """
+        assert self.details, "Details not set, cannot know the gas price"
+        return self.details.get("maxFeePerGas", 0)

--- a/tradeexecutor/state/trade.py
+++ b/tradeexecutor/state/trade.py
@@ -376,5 +376,9 @@ class TradeExecution:
         assert not self.blockchain_transactions
         self.blockchain_transactions = txs
 
+    def get_planned_max_gas_price(self) -> int:
+        """Get the maximum gas fee set to all transactions in this trade."""
+        return max([t.get_planned_gas_price() for t in self.blockchain_transactions])
+
 
 


### PR DESCRIPTION
- Log out planned gas the fees before transaction is broadcasted
- If the transaction broadcast fails, then write more details what is the transaction node rejected