### PR TITLE
triple benchmark default chart height

### DIFF
--- a/tradeexecutor/visual/benchmark.py
+++ b/tradeexecutor/visual/benchmark.py
@@ -90,7 +90,7 @@ def visualise_benchmark(
     all_cash: Optional[float]=None,
     buy_and_hold_asset_name: Optional[str]=None,
     buy_and_hold_price_series: Optional[pd.Series]=None,
-    height=800,
+    height=1600,
     start_at: Optional[Union[pd.Timestamp, datetime.datetime]]=None,
     end_at: Optional[Union[pd.Timestamp, datetime.datetime]]=None,
 

--- a/tradeexecutor/visual/benchmark.py
+++ b/tradeexecutor/visual/benchmark.py
@@ -122,7 +122,6 @@ def visualise_benchmark(
         When the backtest ended
     """
 
-
     fig = go.Figure()
 
     assert portfolio_statistics

--- a/tradeexecutor/visual/benchmark.py
+++ b/tradeexecutor/visual/benchmark.py
@@ -122,6 +122,7 @@ def visualise_benchmark(
         When the backtest ended
     """
 
+
     fig = go.Figure()
 
     assert portfolio_statistics

--- a/tradeexecutor/visual/benchmark.py
+++ b/tradeexecutor/visual/benchmark.py
@@ -90,7 +90,7 @@ def visualise_benchmark(
     all_cash: Optional[float]=None,
     buy_and_hold_asset_name: Optional[str]=None,
     buy_and_hold_price_series: Optional[pd.Series]=None,
-    height=1600,
+    height=2400,
     start_at: Optional[Union[pd.Timestamp, datetime.datetime]]=None,
     end_at: Optional[Union[pd.Timestamp, datetime.datetime]]=None,
 


### PR DESCRIPTION
Triple the default chart height for benchmark.visualise_benchmark from 800 to 2400.