### PR TITLE
Fix visulisation type bugs

### DIFF
--- a/tests/test_visualisation.py
+++ b/tests/test_visualisation.py
@@ -8,6 +8,7 @@ import pytest
 from tradeexecutor.state.identifier import AssetIdentifier, TradingPairIdentifier
 from tradeexecutor.state.reserve import ReservePosition
 from tradeexecutor.state.state import State
+from tradeexecutor.state.validator import validate_state_serialisation
 from tradeexecutor.state.visualisation import PlotKind
 from tradeexecutor.testing.synthetic_price_data import generate_ohlcv_candles
 from tradeexecutor.testing.dummy_trader import DummyTestTrader
@@ -93,6 +94,8 @@ def test_visualise_trades_with_indicator(usdc, weth, weth_usdc):
     pos, trade = trader.sell_with_price_data(weth_usdc, sell_q_2, candle_universe)
     assert pos.get_quantity() == 0
     state.visualisation.plot_indicator(trader.ts, "Test indicator", PlotKind.technical_indicator_on_price, 1700, colour="azure")
+
+    validate_state_serialisation(state)
 
     assert len(list(state.portfolio.get_all_trades())) == 3
     assert len(state.portfolio.open_positions) == 0

--- a/tradeexecutor/state/visualisation.py
+++ b/tradeexecutor/state/visualisation.py
@@ -33,6 +33,11 @@ class PlotKind(enum.Enum):
 @dataclass_json
 @dataclass
 class Plot:
+    """Descibe singe plot on a strategy.
+
+    Plot is usually displayed as an overlay line over the price chart.
+    E.g. simple moving average over price candles.
+    """
 
     name: str
 
@@ -125,6 +130,14 @@ class Visualisation:
         """
 
         assert type(name) == str, f"Got name"
+
+        if not isinstance(value, float):
+            # Convert numpy.float32 and numpy.float64 to serializable float instances,
+            # e.g. prices
+            try:
+                value = float(value)
+            except TypeError as e:
+                raise RuntimeError(f"Could not convert value {value} {value.__class__} to float") from e
 
         plot = self.plots.get(name, Plot(name=name, kind=kind))
 

--- a/tradeexecutor/state/visualisation.py
+++ b/tradeexecutor/state/visualisation.py
@@ -54,6 +54,7 @@ class Plot:
                   value: float,
                   ):
         assert isinstance(timestamp, datetime.datetime)
+        assert isinstance(value, float), f"Got {value} ({value.__class__}"
         timestamp = convert_and_validate_timestamp_as_int(timestamp)
         self.points[timestamp] = value
 
@@ -122,6 +123,9 @@ class Visualisation:
         :param colour:
             Optional colour
         """
+
+        assert type(name) == str, f"Got name"
+
         plot = self.plots.get(name, Plot(name=name, kind=kind))
 
         plot.add_point(timestamp, value)


### PR DESCRIPTION
- We cannot allow `numpy.float64` to slip in the visualisation data, because this number is unserializable