### PR TITLE
Unclean state handling

### DIFF
--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -831,13 +831,11 @@ def test_state_summary_without_initial_cash(usdc, weth_usdc, start_ts: datetime.
     assert summary.average_net_profit == pytest.approx(9.800999)
 
 
-
 def test_validate_state():
     """Catch common errors in setting bad state data."""
 
     ok = {"foo": datetime.datetime(1970, 1, 1)}
     validate_nested_state_dict(ok)
-
 
     ok = {"foo": Decimal(1)}
     validate_nested_state_dict(ok)
@@ -862,4 +860,3 @@ def test_validate_state():
     with pytest.raises(BadStateData):
         bad = {"foo": {"bar": pd.Timestamp("1970-1-1")}}
         validate_nested_state_dict(bad)
-

--- a/tests/test_unclean_state.py
+++ b/tests/test_unclean_state.py
@@ -71,6 +71,8 @@ def test_broadcasted_trade(start_ts, weth_usdc, weth, usdc):
     reserve = ReservePosition(usdc, Decimal(500), start_ts, 1.0, start_ts)
     portfolio.reserves[reserve.get_identifier()] = reserve
 
+    # Create a trade that was broadcasted,
+    # but not confirmed
     trade = TradeExecution(
         trade_id = 1,
         position_id =1,

--- a/tests/test_unclean_state.py
+++ b/tests/test_unclean_state.py
@@ -1,0 +1,112 @@
+"""Unclean state checks.
+
+Check for the conditions that could be "unclean" state that needs manual intervetion
+to get the accouting back to the track.
+
+We will do tests by constructing a problematic state by hand.
+"""
+import datetime
+from decimal import Decimal
+
+import pytest
+from hexbytes import HexBytes
+from tradingstrategy.chain import ChainId
+
+from tradeexecutor.state.blockhain_transaction import BlockchainTransaction
+from tradeexecutor.state.identifier import AssetIdentifier, TradingPairIdentifier
+from tradeexecutor.state.portfolio import Portfolio
+from tradeexecutor.state.reserve import ReservePosition
+from tradeexecutor.state.trade import TradeType, TradeExecution
+
+
+@pytest.fixture
+def mock_exchange_address() -> str:
+    """Mock an exchange"""
+    return "0x1"
+
+
+@pytest.fixture
+def usdc() -> AssetIdentifier:
+    """Mock some assets"""
+    return AssetIdentifier(ChainId.ethereum.value, "0x0", "USDC", 6)
+
+
+@pytest.fixture
+def weth() -> AssetIdentifier:
+    """Mock some assets"""
+    return AssetIdentifier(ChainId.ethereum.value, "0x1", "WETH", 18)
+
+
+@pytest.fixture
+def aave() -> AssetIdentifier:
+    """Mock some assets"""
+    return AssetIdentifier(ChainId.ethereum.value, "0x3", "AAVE", 18)
+
+
+@pytest.fixture
+def weth_usdc(mock_exchange_address, usdc, weth) -> TradingPairIdentifier:
+    """Mock some assets"""
+    return TradingPairIdentifier(weth, usdc, "0x4", mock_exchange_address, internal_id=1)
+
+
+@pytest.fixture
+def aave_usdc(mock_exchange_address, usdc, aave) -> TradingPairIdentifier:
+    """Mock some assets"""
+    return TradingPairIdentifier(aave, usdc, "0x5", mock_exchange_address, internal_id=2)
+
+
+@pytest.fixture
+def start_ts(usdc, weth) -> datetime.datetime:
+    """Timestamp of action started"""
+    return datetime.datetime(2022, 1, 1, tzinfo=None)
+
+
+def test_broadcasted_trade(start_ts, weth_usdc, weth, usdc):
+    """Clean check fails if we have broadcasted, but not confirmed trades."""
+
+    p = Portfolio()
+
+    reserve = ReservePosition(usdc, Decimal(500), start_ts, 1.0, start_ts)
+    p.reserves[reserve.get_identifier()] = reserve
+
+    trade = TradeExecution(
+        trade_id = 1,
+        position_id =1,
+        trade_type = TradeType.rebalance,
+        pair=weth_usdc,
+        opened_at = start_ts,
+        planned_quantity = Decimal(0.1),
+        planned_price=1670.0,
+        planned_reserve=Decimal(167),
+        reserve_currency = usdc,
+        started_at = start_ts,
+        reserve_currency_allocated = 167,
+        broadcasted_at =start_ts,
+        lp_fees_paid =2.5,
+        native_token_price=1.9,
+    )
+
+    tx = BlockchainTransaction(
+        tx_hash=HexBytes("0x01"),
+        nonce=1,
+        realised_gas_units_consumed=150_000,
+        realised_gas_price=15,
+    )
+    trade.blockchain_transactions = [tx]
+
+    assert not trade.is_success()
+    assert not trade.is_success()
+    assert trade.is_success()
+
+    position = TradingPosition(
+        position_id=1,
+        pair=weth_usdc,
+        opened_at=start_ts,
+        last_token_price=1660,
+        last_reserve_price=1,
+        last_pricing_at=start_ts,
+        reserve_currency=usdc,
+        trades={1: trade},
+    )
+
+    p.open_positions = {1: position}

--- a/tests/test_uniswap_live_stop_loss.py
+++ b/tests/test_uniswap_live_stop_loss.py
@@ -539,11 +539,28 @@ def test_broadcast_failed_and_repair_state(
         live=True,
     )
 
+    # Reset confirmation timeout to the normal value
+    execution_model.confirmation_timeout = datetime.timedelta(seconds=30)
+
     # We are stuck with broadcasted but not confirmed trades
     with pytest.raises(UncleanState):
         state.check_if_clean()
 
     t = state.portfolio.open_positions[1].trades[1]
     assert t.is_unfinished()
+
+    # Attempt repair
+    trades = loop.runner.repair_state(state)
+
+    # We repaired one trade
+    assert len(trades)== 1
+
+    # State is clean now
+    t = state.portfolio.open_positions[1].trades[1]
+    assert t.is_success()
+
+    state.check_if_clean()
+
+
 
 

--- a/tests/test_uniswap_live_stop_loss.py
+++ b/tests/test_uniswap_live_stop_loss.py
@@ -491,7 +491,6 @@ def test_live_stop_loss_missing(
     assert len(trades) == 0, "Stop loss unexpectedly triggered"
 
 
-
 def test_broadcast_failed_and_repair_state(
         logger,
         web3: Web3,
@@ -558,5 +557,6 @@ def test_broadcast_failed_and_repair_state(
     # State is clean now
     t = state.portfolio.open_positions[1].trades[1]
     assert t.is_success()
+    assert t.is_repaired()
 
     state.check_if_clean()

--- a/tests/test_uniswap_live_stop_loss.py
+++ b/tests/test_uniswap_live_stop_loss.py
@@ -560,7 +560,3 @@ def test_broadcast_failed_and_repair_state(
     assert t.is_success()
 
     state.check_if_clean()
-
-
-
-

--- a/tests/test_webhook_api.py
+++ b/tests/test_webhook_api.py
@@ -49,7 +49,7 @@ def test_home(logger, server_url):
     assert resp.status_code == 200
     # Chuck the Trade Executor server, version 0.1.0, our URL is http://127.0.0.1:5000
     assert resp.headers["content-type"] == "text/plain; charset=UTF-8"
-    assert "Chuck the Trade Executor server" in resp.text
+    assert "Chuck the Trade Executor" in resp.text
 
 
 def test_ping(logger,server_url):

--- a/tradeexecutor/backtest/backtest_execution.py
+++ b/tradeexecutor/backtest/backtest_execution.py
@@ -161,3 +161,5 @@ class BacktestExecutionModel(ExecutionModel):
     def get_routing_state_details(self) -> dict:
         return {"wallet": self.wallet}
 
+    def repair_unconfirmed_trades(self, state: State) -> List[TradeExecution]:
+        raise NotImplementedError()

--- a/tradeexecutor/cli/commands/repair.py
+++ b/tradeexecutor/cli/commands/repair.py
@@ -1,0 +1,140 @@
+"""repair command.
+
+This command does not have automatic test coverage,
+as it is pretty hard to drive to the test point.
+"""
+
+import datetime
+from pathlib import Path
+from typing import Optional
+
+import typer
+
+from tradingstrategy.client import Client
+from .app import app
+from ..init import prepare_executor_id, prepare_cache, create_web3_config, create_state_store, \
+    create_trade_execution_model
+from ..log import setup_logging
+from ..testtrade import make_test_trade
+from ...state.state import UncleanState
+from ...strategy.approval import UncheckedApprovalModel
+from ...strategy.bootstrap import make_factory_from_strategy_mod
+from ...strategy.description import StrategyExecutionDescription
+from ...strategy.execution_context import ExecutionContext, ExecutionMode
+from ...strategy.execution_model import TradeExecutionType
+from ...strategy.run_state import RunState
+from ...strategy.strategy_module import read_strategy_module
+from ...strategy.trading_strategy_universe import TradingStrategyUniverseModel
+from ...strategy.universe_model import UniverseOptions
+from ...utils.timer import timed_task
+
+
+@app.command()
+def repair(
+    id: str = typer.Option(None, envvar="EXECUTOR_ID", help="Executor id used when programmatically referring to this instance. If not given, take the base of --strategy-file."),
+    log_level: str = typer.Option(None, envvar="LOG_LEVEL", help="The Python default logging level. The defaults are 'info' is live execution, 'warning' if backtesting. Set 'disabled' in testing."),
+
+    strategy_file: Path = typer.Option(..., envvar="STRATEGY_FILE"),
+    private_key: str = typer.Option(None, envvar="PRIVATE_KEY"),
+    trading_strategy_api_key: str = typer.Option(None, envvar="TRADING_STRATEGY_API_KEY", help="Trading Strategy API key"),
+    state_file: Optional[Path] = typer.Option(None, envvar="STATE_FILE", help="JSON file where we serialise the execution state. If not given defaults to state/{executor-id}.json"),
+    cache_path: Optional[Path] = typer.Option("cache/", envvar="CACHE_PATH", help="Where to store downloaded datasets"),
+
+    # Web3 connection options
+    json_rpc_binance: str = typer.Option(None, envvar="JSON_RPC_BINANCE", help="BNB Chain JSON-RPC node URL we connect to"),
+    json_rpc_polygon: str = typer.Option(None, envvar="JSON_RPC_POLYGON", help="Polygon JSON-RPC node URL we connect to"),
+    json_rpc_ethereum: str = typer.Option(None, envvar="JSON_RPC_ETHEREUM", help="Ethereum JSON-RPC node URL we connect to"),
+    json_rpc_avalanche: str = typer.Option(None, envvar="JSON_RPC_AVALANCHE", help="Avalanche C-chain JSON-RPC node URL we connect to"),
+):
+    """Repair broken state.
+
+    Attempt to repair a broken strategy execution state. This may include
+
+    - Confirming trades that failed to broadcast
+
+    """
+    global logger
+
+    id = prepare_executor_id(id, strategy_file)
+
+    logger = setup_logging(log_level=log_level)
+
+    mod = read_strategy_module(strategy_file)
+
+    cache_path = prepare_cache(id, cache_path)
+
+    client = Client.create_live_client(trading_strategy_api_key, cache_path=cache_path)
+
+    execution_context = ExecutionContext(
+        mode=ExecutionMode.preflight_check,
+        timed_task_context_manager=timed_task
+    )
+
+    web3config = create_web3_config(
+        json_rpc_binance=json_rpc_binance,
+        json_rpc_polygon=json_rpc_polygon,
+        json_rpc_avalanche=json_rpc_avalanche,
+        json_rpc_ethereum=json_rpc_ethereum,
+        gas_price_method=None,
+    )
+
+    assert web3config, "No RPC endpoints given. A working JSON-RPC connection is needed for check-wallet"
+
+    # Check that we are connected to the chain strategy assumes
+    web3config.set_default_chain(mod.chain_id)
+    web3config.check_default_chain_id()
+
+    execution_model, sync_method, valuation_model_factory, pricing_model_factory = create_trade_execution_model(
+        execution_type=TradeExecutionType.uniswap_v2_hot_wallet,
+        private_key=private_key,
+        web3config=web3config,
+        confirmation_timeout=60,
+        confirmation_block_count=6,
+        max_slippage=2.50,
+        min_balance_threshold=0,
+    )
+
+    if not state_file:
+        state_file = f"state/{id}.json"
+
+    store = create_state_store(Path(state_file))
+
+    if store.is_pristine():
+        state = store.create()
+    else:
+        state = store.load()
+
+    # Set up the strategy engine
+    factory = make_factory_from_strategy_mod(mod)
+    run_description: StrategyExecutionDescription = factory(
+        execution_model=execution_model,
+        execution_context=execution_context,
+        timed_task_context_manager=execution_context.timed_task_context_manager,
+        sync_method=sync_method,
+        valuation_model_factory=valuation_model_factory,
+        pricing_model_factory=pricing_model_factory,
+        approval_model=UncheckedApprovalModel(),
+        client=client,
+        run_state=RunState(),
+    )
+
+    # We construct the trading universe to know what's our reserve asset
+    universe_model: TradingStrategyUniverseModel = run_description.universe_model
+    ts = datetime.datetime.utcnow()
+    universe = universe_model.construct_universe(
+        ts,
+        ExecutionMode.preflight_check,
+        UniverseOptions())
+
+    runner = run_description.runner
+
+    try:
+        state.check_if_clean()
+        raise RuntimeError("State was clean - nothing to repair")
+    except UncleanState:
+        pass
+
+    runner.repair_state(state)
+
+    store.sync(state)
+

--- a/tradeexecutor/cli/commands/repair.py
+++ b/tradeexecutor/cli/commands/repair.py
@@ -15,7 +15,6 @@ from .app import app
 from ..init import prepare_executor_id, prepare_cache, create_web3_config, create_state_store, \
     create_trade_execution_model
 from ..log import setup_logging
-from ..testtrade import make_test_trade
 from ...state.state import UncleanState
 from ...strategy.approval import UncheckedApprovalModel
 from ...strategy.bootstrap import make_factory_from_strategy_mod
@@ -134,7 +133,8 @@ def repair(
     except UncleanState:
         pass
 
-    runner.repair_state(state)
+    repaired = runner.repair_state(state)
 
     store.sync(state)
 
+    print(f"Repaired {len(repaired)} trades")

--- a/tradeexecutor/cli/commands/start.py
+++ b/tradeexecutor/cli/commands/start.py
@@ -222,6 +222,7 @@ def start(
 
     run_state = RunState()
     run_state.version = VersionInfo.read_docker_version()
+    run_state.executor_id = id
 
     # Create our webhook server
     if http_enabled:

--- a/tradeexecutor/cli/loop.py
+++ b/tradeexecutor/cli/loop.py
@@ -555,6 +555,9 @@ class ExecutionLoop:
         ts = datetime.datetime.utcnow()
         logger.info("Strategy is executed in live mode, now is %s", ts)
 
+        # Do not allow starting a strategy that has unclean state
+        state.check_if_clean()
+
         if self.is_live_trading_unit_test():
             # Test app initialisation.
             # Do not start any background threads.

--- a/tradeexecutor/ethereum/execution.py
+++ b/tradeexecutor/ethereum/execution.py
@@ -266,7 +266,8 @@ def broadcast(
         ts: datetime.datetime,
         instructions: List[TradeExecution],
         confirmation_block_count: int=0,
-        ganache_sleep=0.5) -> Dict[HexBytes, Tuple[TradeExecution, BlockchainTransaction]]:
+        ganache_sleep=0.5,
+) -> Dict[HexBytes, Tuple[TradeExecution, BlockchainTransaction]]:
     """Broadcast multiple transations and manage the trade executor state for them.
 
     :return: Map of transaction hashes to watch
@@ -344,6 +345,12 @@ def resolve_trades(
     Read on-chain Uniswap swap data from the transaction receipt and record how it went.
 
     Mutates the trade objects in-place.
+
+    :param tx_map:
+        tx hash -> (trade, transaction) mapping
+
+    :param receipts:
+        tx hash -> receipt object mapping
 
     :param stop_on_execution_failure:
         Raise an exception if any of the trades failed

--- a/tradeexecutor/ethereum/execution.py
+++ b/tradeexecutor/ethereum/execution.py
@@ -473,7 +473,10 @@ def broadcast_and_resolve(
     - Based on the transaction result, update the state of the trade if it was success or not
 
     :confirmation_timeout:
-        Max time to wait for a confirmation
+        Max time to wait for a confirmation.
+
+        We can use zero or negative values to simulate unconfirmed trades.
+        See `test_broadcast_failed_and_repair_state`.
 
     :param stop_on_execution_failure:
         If any of the transactions fail, then raise an exception.
@@ -483,15 +486,19 @@ def broadcast_and_resolve(
     assert isinstance(confirmation_timeout, datetime.timedelta)
 
     broadcasted = broadcast(web3, datetime.datetime.utcnow(), trades)
-    receipts = wait_trades_to_complete(
-        web3,
-        trades,
-        max_timeout=confirmation_timeout,
-    )
-    resolve_trades(
-        web3,
-        datetime.datetime.now(),
-        state,
-        broadcasted,
-        receipts,
-        stop_on_execution_failure=stop_on_execution_failure)
+
+    if confirmation_timeout > datetime.timedelta(0):
+
+        receipts = wait_trades_to_complete(
+            web3,
+            trades,
+            max_timeout=confirmation_timeout,
+        )
+
+        resolve_trades(
+            web3,
+            datetime.datetime.now(),
+            state,
+            broadcasted,
+            receipts,
+            stop_on_execution_failure=stop_on_execution_failure)

--- a/tradeexecutor/ethereum/uniswap_v2_execution.py
+++ b/tradeexecutor/ethereum/uniswap_v2_execution.py
@@ -175,6 +175,12 @@ class UniswapV2ExecutionModel(ExecutionModel):
                         receipt_data,
                         stop_on_execution_failure=True)
 
+                    t.repaired_at = datetime.datetime.utcnow()
+                    if not t.notes:
+                        # Add human readable note,
+                        # but don't override any other notes
+                        t.notes = "Failed broadcast repaired"
+
                     repaired.append(t)
 
         return repaired

--- a/tradeexecutor/ethereum/uniswap_v2_execution_v0.py
+++ b/tradeexecutor/ethereum/uniswap_v2_execution_v0.py
@@ -222,3 +222,6 @@ class UniswapV2ExecutionModelVersion0(ExecutionModel):
             "web3": self.web3,
             "hot_wallet": self.hot_wallet,
         }
+
+    def repair_unconfirmed_trades(self, state: State) -> List[TradeExecution]:
+        raise NotImplementedError()

--- a/tradeexecutor/state/state.py
+++ b/tradeexecutor/state/state.py
@@ -22,6 +22,11 @@ from .types import USDollarAmount
 from .visualisation import Visualisation
 
 
+
+class UncleanState(Exception):
+    """State containst trades that need manual intervention."""
+
+
 @dataclass_json
 @dataclass
 class State:
@@ -238,3 +243,32 @@ class State:
 
             t.started_at = ts
             t.planned_max_slippage = max_slippage
+
+    def check_if_clean(self):
+        """Check that the state data is intact.
+
+        Check for the issues that could be caused e.g. trade-executor unclean shutdown
+        or a blockchain node crash.
+
+        One of a typical issue would be
+
+        - A trade that failed to execute
+
+        - A trade that was broadcasted, but we did not get a confirmation back in time,
+          causing the trade executor to crash
+
+        Call this when you restart a trade execution to ensure
+        the old state is intact. For any unfinished trades,
+        run a repair command or manually repair the database.
+
+        :raise UncleanState:
+            In the case we detect unclean stuff
+        """
+
+        for position_id, p in self.portfolio.open_positions.values():
+            t: TradeExecution
+            for t in p.trades:
+                if t.is_unfinished():
+                    raise UncleanState(f"Position {p}, trade {t} is unfinished")
+
+

--- a/tradeexecutor/state/state.py
+++ b/tradeexecutor/state/state.py
@@ -265,9 +265,9 @@ class State:
             In the case we detect unclean stuff
         """
 
-        for position_id, p in self.portfolio.open_positions.values():
+        for p in self.portfolio.open_positions.values():
             t: TradeExecution
-            for t in p.trades:
+            for t in p.trades.values():
                 if t.is_unfinished():
                     raise UncleanState(f"Position {p}, trade {t} is unfinished")
 

--- a/tradeexecutor/state/trade.py
+++ b/tradeexecutor/state/trade.py
@@ -154,6 +154,12 @@ class TradeExecution:
     #: Special case; not worth to display unless the field is filled in.
     notes: Optional[str] = None
 
+    #: Trade was manually repaird
+    #:
+    #: E.g. failed broadcast issue was fixed.
+    #: Marked when the repair command is called.
+    repaired_at: Optional[datetime.datetime] = None
+
     def __repr__(self):
         if self.is_buy():
             return f"<Buy #{self.trade_id} {self.planned_quantity} {self.pair.base.token_symbol} at {self.planned_price}, {self.get_status().name}>"

--- a/tradeexecutor/state/trade.py
+++ b/tradeexecutor/state/trade.py
@@ -223,12 +223,16 @@ class TradeExecution:
         """This trade is made to close take profit on a position."""
         return self.trade_type == TradeType.take_profit
 
-    def is_accounted_for_equity(self):
+    def is_accounted_for_equity(self) -> bool:
         """Does this trade contribute towards the trading position equity.
 
         Failed trades are reverted. Only their fees account.
         """
         return self.get_status() in (TradeStatus.started, TradeStatus.broadcasted, TradeStatus.success)
+
+    def is_unfinished(self) -> bool:
+        """We could not confirm this trade back from the blockchain after broadcasting."""
+        return self.get_status() in (TradeStatus.broadcasted,)
 
     def get_status(self) -> TradeStatus:
         if self.failed_at:

--- a/tradeexecutor/state/trade.py
+++ b/tradeexecutor/state/trade.py
@@ -240,6 +240,14 @@ class TradeExecution:
         """We could not confirm this trade back from the blockchain after broadcasting."""
         return self.get_status() in (TradeStatus.broadcasted,)
 
+    def is_repaired(self) -> bool:
+        """The automatic execution failed and this was later repaired.
+
+        A manual repair command was issued and it manaeged to correctly repair this trade
+        and underlying transactions.
+        """
+        return self.repaired_at is not None
+
     def get_status(self) -> TradeStatus:
         if self.failed_at:
             return TradeStatus.failed

--- a/tradeexecutor/strategy/execution_model.py
+++ b/tradeexecutor/strategy/execution_model.py
@@ -103,6 +103,18 @@ class ExecutionModel(abc.ABC):
         """
 
 
+    @abc.abstractmethod
+    def repair_unconfirmed_trades(self, state: State) -> List[TradeExecution]:
+        """Repair unconfirmed trades.
+
+        Repair trades that failed to properly broadcast or confirm due to
+        blockchain node issues.
+
+        :return:
+            List of fixed trades
+        """
+
+
 class TradeExecutionType(enum.Enum):
     """Default execution options.
 

--- a/tradeexecutor/strategy/execution_model.py
+++ b/tradeexecutor/strategy/execution_model.py
@@ -102,7 +102,6 @@ class ExecutionModel(abc.ABC):
             Useful during unit tests to spot issues in trade routing.
         """
 
-
     @abc.abstractmethod
     def repair_unconfirmed_trades(self, state: State) -> List[TradeExecution]:
         """Repair unconfirmed trades.

--- a/tradeexecutor/strategy/repair.py
+++ b/tradeexecutor/strategy/repair.py
@@ -1,0 +1,6 @@
+"""Generic state repair.
+
+Repair issues with state.
+"""
+
+

--- a/tradeexecutor/strategy/run_state.py
+++ b/tradeexecutor/strategy/run_state.py
@@ -82,6 +82,9 @@ class RunState:
     - /summary
     """
 
+    #: Reflect executor id back to the web interface, etc.
+    executor_id: Optional[str] = None
+
     #: When the execution state was updated last time
     last_refreshed_at: datetime.datetime = field(default_factory=datetime.datetime.utcnow)
 

--- a/tradeexecutor/strategy/runner.py
+++ b/tradeexecutor/strategy/runner.py
@@ -441,3 +441,20 @@ class StrategyRunner(abc.ABC):
 
             return approved_trades
 
+
+    def repair_state(self, state: State) -> List[TradeExecution]:
+        """Repair unclean state issues.
+
+        Currently supports
+
+        - Fixing unfinished trades
+
+        :return:
+            List of fixed trades
+        """
+
+        logger.info("Reparing the state")
+
+        repaired = []
+        repaired += self.execution_model.repair_unconfirmed_trades(state)
+        return repaired

--- a/tradeexecutor/webhook/api.py
+++ b/tradeexecutor/webhook/api.py
@@ -27,9 +27,9 @@ def web_home(request: Request):
     The homepage displays plain text version banner.
     """
     url = request.application_url
-    version_ = version('trade-executor')
+    run_state: RunState = request.registry["run_state"]
     # https://angrybirds.fandom.com/wiki/The_Flock
-    return Response(f'Chuck the Trade Executor server, version {version_}, our URL is {url}\nFor more information see https://tradingstrategy.ai\nRemember to play Angry Birds.', content_type="text/plain")
+    return Response(f'Chuck the Trade Executor, running strategy {run_state.executor_id}, version {run_state.version.tag}, our URL is {url}\nFor more information see https://tradingstrategy.ai\nRemember to play Angry Birds.', content_type="text/plain")
 
 
 @view_config(route_name='web_ping', renderer='json', permission='view')


### PR DESCRIPTION
- Detect dangling transasctions that were broadcasted but failed to confirm
- Offer `repair` command to fix any dangling transactions
- Refuse to start up with unclean state 