### PR TITLE
Pass confirmation_block_count around

### DIFF
--- a/tradeexecutor/ethereum/execution.py
+++ b/tradeexecutor/ethereum/execution.py
@@ -469,6 +469,7 @@ def broadcast_and_resolve(
         state: State,
         trades: List[TradeExecution],
         confirmation_timeout: datetime.timedelta = datetime.timedelta(minutes=1),
+        confirmation_block_count: int=1,
         stop_on_execution_failure=False,
 ):
     """Do the live trade execution.
@@ -478,6 +479,9 @@ def broadcast_and_resolve(
     - Wait transactions to be mined
 
     - Based on the transaction result, update the state of the trade if it was success or not
+
+    :param confirmation_block_count:
+        How many blocks to wait until marking transaction as confirmed
 
     :confirmation_timeout:
         Max time to wait for a confirmation.
@@ -500,6 +504,7 @@ def broadcast_and_resolve(
             web3,
             trades,
             max_timeout=confirmation_timeout,
+            confirmation_block_count=confirmation_block_count,
         )
 
         resolve_trades(

--- a/tradeexecutor/ethereum/execution.py
+++ b/tradeexecutor/ethereum/execution.py
@@ -469,7 +469,7 @@ def broadcast_and_resolve(
         state: State,
         trades: List[TradeExecution],
         confirmation_timeout: datetime.timedelta = datetime.timedelta(minutes=1),
-        confirmation_block_count: int=1,
+        confirmation_block_count: int=0,
         stop_on_execution_failure=False,
 ):
     """Do the live trade execution.

--- a/tradeexecutor/ethereum/uniswap_v2_execution.py
+++ b/tradeexecutor/ethereum/uniswap_v2_execution.py
@@ -110,7 +110,9 @@ class UniswapV2ExecutionModel(ExecutionModel):
 
         state.start_trades(datetime.datetime.utcnow(), trades, max_slippage=self.max_slippage)
 
-        assert self.confirmation_block_count > 0, f"confirmation_block_count set to {self.confirmation_block_count} "
+        # 61 is Ethereum Tester
+        if self.web3.eth.chain_id != 61:
+            assert self.confirmation_block_count > 0, f"confirmation_block_count set to {self.confirmation_block_count} "
 
         routing_model.setup_trades(
             routing_state,
@@ -148,8 +150,10 @@ class UniswapV2ExecutionModel(ExecutionModel):
         assert self.confirmation_timeout > datetime.timedelta(0), \
             "Make sure you have a good tx confirmation timeout setting before attempting a repair"
 
-        assert self.confirmation_block_count > 0, \
-            "Make sure you have a good confirmation_block_count setting before attempting a repair"
+        # Check if we are on a live chain, not Ethereum Tester
+        if self.web3.eth.chain_id != 61:
+            assert self.confirmation_block_count > 0, \
+                "Make sure you have a good confirmation_block_count setting before attempting a repair"
 
         for p in state.portfolio.open_positions.values():
             t: TradeExecution

--- a/tradeexecutor/ethereum/uniswap_v2_execution.py
+++ b/tradeexecutor/ethereum/uniswap_v2_execution.py
@@ -110,6 +110,8 @@ class UniswapV2ExecutionModel(ExecutionModel):
 
         state.start_trades(datetime.datetime.utcnow(), trades, max_slippage=self.max_slippage)
 
+        assert self.confirmation_block_count > 0, f"confirmation_block_count set to {self.confirmation_block_count} "
+
         routing_model.setup_trades(
             routing_state,
             trades,
@@ -120,6 +122,7 @@ class UniswapV2ExecutionModel(ExecutionModel):
             state,
             trades,
             confirmation_timeout=self.confirmation_timeout,
+            confirmation_block_count=self.confirmation_block_count,
         )
 
         # Clean up failed trades
@@ -145,6 +148,9 @@ class UniswapV2ExecutionModel(ExecutionModel):
         assert self.confirmation_timeout > datetime.timedelta(0), \
             "Make sure you have a good tx confirmation timeout setting before attempting a repair"
 
+        assert self.confirmation_block_count > 0, \
+            "Make sure you have a good confirmation_block_count setting before attempting a repair"
+
         for p in state.portfolio.open_positions.values():
             t: TradeExecution
             for t in p.trades.values():
@@ -157,6 +163,7 @@ class UniswapV2ExecutionModel(ExecutionModel):
                         self.web3,
                         [t],
                         max_timeout=self.confirmation_timeout,
+                        confirmation_block_count=self.confirmation_block_count,
                     )
 
                     assert len(receipt_data) > 0, f"Got bad receipts: {receipt_data}"

--- a/tradeexecutor/ethereum/web3config.py
+++ b/tradeexecutor/ethereum/web3config.py
@@ -124,7 +124,7 @@ class Web3Config:
         try:
             return self.connections[self.default_chain_id]
         except KeyError:
-            raise RuntimeError(f"We haev {self.default_chain_id.name} configured as the default blockchain, but we do not have a connection for it in the connection pool. Did you pass right RPC configuration?")
+            raise RuntimeError(f"We have {self.default_chain_id.name} configured as the default blockchain, but we do not have a connection for it in the connection pool. Did you pass right RPC configuration?")
 
     def check_default_chain_id(self):
         """Check that we are connected to the correct chain.

--- a/tradeexecutor/testing/simulated_execution_loop.py
+++ b/tradeexecutor/testing/simulated_execution_loop.py
@@ -76,6 +76,7 @@ def set_up_simulated_execution_loop_uniswap_v2(
         web3,
         hot_wallet,
         max_slippage=1.00,
+        confirmation_block_count=0,  # Must be zero for the test chain
     )
 
     # Pricing model factory for single Uni v2 exchange


### PR DESCRIPTION
- Make sure we have a good `confirmation_block_count` setting when doing live trade execution
