### PR TITLE
Adding live trading chart

### DIFF
--- a/tradeexecutor/visual/single_pair.py
+++ b/tradeexecutor/visual/single_pair.py
@@ -1,12 +1,15 @@
 """Tools to visualise live trading/backtest outcome for strategies trading only one pair."""
 import datetime
 import logging
-from typing import Optional, Union
+import textwrap
+from typing import Optional, Union, List
 
 import plotly.graph_objects as go
 import pandas as pd
+from plotly.graph_objs.layout import Annotation, Shape
 
 from tradeexecutor.state.portfolio import Portfolio
+from tradeexecutor.state.position import TradingPosition
 from tradeexecutor.state.state import State
 from tradeexecutor.state.trade import TradeExecution
 from tradeexecutor.state.visualisation import Visualisation, Plot
@@ -233,6 +236,201 @@ def visualise_trades(
     return fig
 
 
+
+def get_position_hover_text(p: TradingPosition) -> str:
+    """Get position hover text for Plotly."""
+
+       # First draw a position as a re
+    first_trade = p.get_first_trade()
+    last_trade = p.get_last_trade()
+
+    duration = last_trade.executed_at - first_trade.executed_at
+
+    started_at = first_trade.started_at.strftime("%Y-%m-%d, %H:%M:%S UTC")
+    ended_at = last_trade.executed_at.strftime("%Y-%m-%d, %H:%M:%S UTC")
+
+    entry_diff = (first_trade.executed_price - first_trade.planned_price) / first_trade.planned_price
+    entry_dur = (first_trade.executed_at - first_trade.started_at)
+    exit_diff = (last_trade.executed_price - last_trade.planned_price) / last_trade.planned_price
+    exit_dur = (last_trade.executed_at - last_trade.started_at)
+
+    if p.is_stop_loss():
+        remarks = f"Stop loss triggered at: {p.stop_loss:.2f} USD"
+    else:
+        remarks = "-"
+
+    text = textwrap.dedent(f"""    Position #{p.position_id}
+    
+    Remarks: {remarks}
+    
+    Profit: {p.get_realised_profit_usd():.2f} USD
+    Profit: {p.get_total_profit_percent()*100:.4f} %
+    
+    Entry price: {first_trade.planned_price:.2f} USD (expected)
+    Entry price: {first_trade.executed_price:.2f} USD (executed)
+    Entry slippage: {entry_diff * 100:.4f} %
+    Entry duration: {entry_dur} 
+    
+    Exit price: {last_trade.planned_price:.2f} USD (expected)
+    Exit price: {last_trade.executed_price:.2f} USD (executed)
+    Exit slippage: {exit_diff * 100:.4f} %
+    Exit duration: {exit_dur}
+    
+    Avg buy price: {p.get_average_buy():.2f} USD
+    Avg sell price: {p.get_average_sell():.2f} USD
+   
+    Duration: {duration}
+    Started: {started_at} (first trade started)  
+    Ended: {ended_at} (last trade executed at)
+    """)
+
+    return text.replace("\n", "<br>")
+
+
+def visualise_positions_with_duration_and_slippage(
+        fig: go.Figure,
+        candles: pd.DataFrame,
+        positions: List[TradingPosition]):
+    """Visualise trades as coloured area over time.
+
+    Add arrow indicators to point start and end duration,
+    and slippage.
+    """
+
+    # TODO: Figure out how to add a Y coordinate
+    # for Scatter in Plotly paper space
+    max_price = max(candles["high"])
+
+    # https://stackoverflow.com/a/58128982/315168
+    annotations: List[Annotation] = []
+
+    trade_markers = {
+        "x": [],
+        "y": [],
+        "text": [],
+    }
+
+    for position in positions:
+
+        # First draw a position as a re
+        first_trade = position.get_first_trade()
+        last_trade = position.get_last_trade()
+
+        left_x = pd.Timestamp(first_trade.started_at)
+        right_x = pd.Timestamp(last_trade.executed_at)
+
+        if position.is_profitable():
+            colour = "LightGreen"
+        else:
+            colour = "LightPink"
+
+        # https://plotly.com/python/shapes/
+        fig.add_vrect(
+            x0=left_x,
+            x1=right_x,
+            xref="x",
+            fillcolor=colour,
+            opacity=0.5,
+            layer="below",
+            line_width=0,
+        )
+
+        position_text = get_position_hover_text(position)
+
+        # Add tooltips as the dot market at the top left corner
+        # of the position
+        fig.add_trace(
+            go.Scatter(
+                x=[left_x + (right_x - left_x) / 2],
+                y=[max_price],
+                hovertext=position_text,
+                hoverinfo="text",
+                showlegend=False,
+                mode='markers',
+                marker={"color": colour, "size": 12}
+            ))
+
+        # Visualise trades as lines
+        # TODO: Plotly arrow drawing broken for small arrows
+        t: TradeExecution
+        for t in position.trades.values():
+
+            colour = "black"
+
+            fig.add_shape(
+                type="line",
+                x0=t.started_at,
+                x1=t.executed_at,
+                xref="x",
+                y0=t.planned_price,
+                y1=t.executed_price,
+                yref="y",
+                line={
+                    "color": colour,
+                    "width": 4,
+                }
+            )
+
+            trade_markers["x"].append(t.executed_at)
+            trade_markers["y"].append(t.executed_price)
+
+            trade_markers["text"].append(str(t))
+
+            # Plotly does not render arrows if they are
+            # too small.
+            #
+            # ann = {
+            #     "showarrow": True,
+            #     "ax": t.started_at,
+            #     "axref": "x",
+            #     "x": t.executed_at,
+            #     "xref": "x",
+            #     "ay":t.planned_price,
+            #     "ayref": "y",
+            #     "y" :t.executed_price,
+            #     "yref": "y",
+            #     "arrowwidth": 2,
+            #     "arrowhead": 5,
+            #     "arrowcolor": colour,
+            # }
+            #
+            # annotations.append(ann)
+
+            # dict(
+            #     x= x_end,
+            #     y= y_end,
+            #     xref="x", yref="y",
+            #     text="",
+            #     showarrow=True,
+            #     axref = "x", ayref='y',
+            #     ax= x_start,
+            #     ay= y_start,
+            #     arrowhead = 3,
+            #     arrowwidth=1.5,
+            #     arrowcolor='rgb(255,51,0)',)
+            # )
+
+    # Add "arrowheads" to trade lines
+    fig.add_trace(
+        go.Scatter(
+            x=trade_markers["x"],
+            y=trade_markers["y"],
+            text=trade_markers["text"],
+            showlegend=False,
+            mode='markers',
+            marker={"color": "black", "size": 6, "symbol": "diamond", "line": {"width": 2, "color": "black"}},
+        )
+    )
+
+    # TODO: Currently does not work
+    # https://stackoverflow.com/questions/58095322/draw-multiple-arrows-using-plotly-python
+    if annotations:
+        print(annotations)
+        fig.update_layout(annotations=annotations)
+
+    return fig
+
+
 def visualise_single_pair(
         state: State,
         candle_universe: GroupedCandleUniverse | pd.DataFrame,
@@ -356,5 +554,133 @@ def visualise_single_pair(
     # Add trade markers if any trades have been made
     if len(trades_df) > 0:
         visualise_trades(fig, candles, trades_df)
+
+    return fig
+
+
+
+def visualise_single_pair_positions_with_duration_and_slippage(
+        state: State,
+        candles: pd.DataFrame,
+        start_at: Optional[Union[pd.Timestamp, datetime.datetime]] = None,
+        end_at: Optional[Union[pd.Timestamp, datetime.datetime]] = None,
+        height=800,
+        axes=True,
+        title=True,
+        theme="plotly_white",
+) -> go.Figure:
+    """Visualise performance of a live trading strategy.
+
+    Unlike :py:func:`visualise_single_pair`
+    attempt to visualise
+
+    - position duration, as a colored area
+
+    - more position tooltip text
+
+    - trade duration (started at - executed)
+
+    - slippage
+
+    :param state:
+        The recorded state of the strategy execution.
+        Either live or backtest.
+
+    :param candle_universe:
+        Price candles we used for the strategy
+
+    :param height:
+        Chart height in pixels
+
+    :param start_at:
+        When the backtest started or when we crop the content
+
+    :param end_at:
+        When the backtest ended or when we crop the content
+
+    :param axes:
+        Draw axes labels
+
+    :param title:
+        Draw title labels
+
+    :param theme:
+        Plotly colour scheme to use
+    """
+
+    logger.info("Visualising %s", state)
+
+    if isinstance(start_at, datetime.datetime):
+        start_at = pd.Timestamp(start_at)
+
+    if isinstance(end_at, datetime.datetime):
+        end_at = pd.Timestamp(end_at)
+
+    if start_at is not None:
+        assert isinstance(start_at, pd.Timestamp)
+
+    if end_at is not None:
+        assert isinstance(end_at, pd.Timestamp)
+
+    try:
+        first_trade = next(iter(state.portfolio.get_all_trades()))
+    except StopIteration:
+        first_trade = None
+
+    if first_trade:
+        pair_name = f"{first_trade.pair.base.token_symbol} - {first_trade.pair.quote.token_symbol}"
+    else:
+        pair_name = None
+
+    candle_start_ts = candles.iloc[0]["timestamp"]
+    if not start_at:
+        # No trades made, use the first candle timestamp
+        start_at = candle_start_ts
+
+    candle_end_ts = candles.iloc[-1]["timestamp"]
+
+    if not end_at:
+        end_at = candle_end_ts
+
+    logger.info(f"Visualising single pair strategy for range {start_at} - {end_at}")
+
+    # Candles define our diagram X axis
+    # Crop it to the trading range
+    candles = candles.loc[candles["timestamp"].between(start_at, end_at)]
+
+    logger.info(f"Candles are {candle_start_ts} = {candle_end_ts}")
+
+    positions = [p for p in state.portfolio.get_all_positions()]
+
+    if title:
+        title_text = state.name
+    else:
+        title_text = None
+
+    if axes:
+        axes_text = pair_name
+        volume_text = "Volume USD"
+    else:
+        axes_text = None
+        volume_text = None
+
+    fig = visualise_ohlcv(
+        candles,
+        height=height,
+        theme=theme,
+        chart_name=title_text,
+        y_axis_name=axes_text,
+        volume_axis_name=volume_text,
+    )
+
+    visualise_technical_indicators(
+        fig,
+        state.visualisation,
+        start_at,
+        end_at,
+    )
+
+    # Add trade markers if any trades have been made
+    visualise_positions_with_duration_and_slippage(fig, candles, positions)
 
     return fig


### PR DESCRIPTION
Add a new chart type to visualise live trades.

- We use a specific chart to display live positions
- This chart type shows slippage and duration, between the trade start and trade end,
  to visualise how much much losses were taken on slippage
- Positions are visualised as area: green is closed for profit, red is closed for loss
- Individual trades, entries and exists are visualised as arrows
- Arrows so the trade duration and slippage move from expected to executed price

<img width="1661" alt="image" src="https://user-images.githubusercontent.com/49922/206523492-0df5a5de-dbbd-422c-b949-a3196b4d5efe.png">
