### PR TITLE
Switch backtesting to use open price by default

### DIFF
--- a/tests/test_backtest_execution.py
+++ b/tests/test_backtest_execution.py
@@ -168,11 +168,11 @@ def test_get_historical_price(
 
     # Get the price for buying WBNB for 1000 USD at 2021-1-1
     buy_price = trader.get_buy_price(wbnb_busd, Decimal(1_000))
-    assert buy_price == pytest.approx(361.9442138671875)
+    assert buy_price == pytest.approx(354.3096008300781)
 
     # Get the price for sellinb 1 WBNB
     sell_price = trader.get_sell_price(wbnb_busd, Decimal(1))
-    assert sell_price == pytest.approx(361.9442138671875)
+    assert sell_price == pytest.approx(354.3096008300781)
 
 
 def test_create_and_execute_backtest_trade(
@@ -199,14 +199,14 @@ def test_create_and_execute_backtest_trade(
 
     assert trade.is_buy()
     assert trade.get_status() == TradeStatus.success
-    assert trade.executed_price == pytest.approx(363.03331380861334)
+    assert trade.executed_price == pytest.approx(355.375728014120)
 
     # We bought around 3 BNB
-    assert position.get_quantity() == pytest.approx(Decimal('2.754568140066582411061992325'))
+    assert position.get_quantity() == pytest.approx(Decimal('2.813923183747276159258725343'))
 
     # Check our wallet was credited
     assert wallet.get_balance(busd.address) == 9_000
-    assert wallet.get_balance(wbnb.address) == pytest.approx(Decimal('2.754568140066582411061992325'))
+    assert wallet.get_balance(wbnb.address) == Decimal('2.813923183747276159258725343')
 
 
 def test_buy_sell_backtest(

--- a/tests/test_backtest_execution_three_way.py
+++ b/tests/test_backtest_execution_three_way.py
@@ -245,14 +245,14 @@ def test_create_and_execute_backtest_three_way_trade(
 
     assert trade.is_buy()
     assert trade.get_status() == TradeStatus.success
-    assert trade.executed_price == pytest.approx(17.904151299211975)
+    assert trade.executed_price == pytest.approx(18.066385000585278)
 
     # We bought around 3 BNB
-    assert position.get_quantity() == pytest.approx(Decimal('55.85296858187371816087568680'))
+    assert position.get_quantity() == pytest.approx(Decimal('55.35141645479181046093885541'))
 
     # Check our wallet was credited
     assert wallet.get_balance(busd.address) == 9_000
-    assert wallet.get_balance(cake.address) == pytest.approx(Decimal('55.85296858187371816087568680'))
+    assert wallet.get_balance(cake.address) == pytest.approx(Decimal('55.35141645479181046093885541'))
 
 
 def test_buy_sell_three_way_backtest(

--- a/tests/test_backtest_inline_synthetic_data.py
+++ b/tests/test_backtest_inline_synthetic_data.py
@@ -175,7 +175,7 @@ def test_ema_on_universe(universe: TradingStrategyUniverse):
     """Calculate exponential moving average on single pair candle universe."""
     start_timestamp = pd.Timestamp("2021-6-1")
     batch_size = 20
-    candles = universe.universe.candles.get_single_pair_data(start_timestamp, sample_count=batch_size)
+    candles = universe.universe.candles.get_single_pair_data(start_timestamp, sample_count=batch_size, allow_current=True)
     assert len(candles) == 1
 
     # Not enough data to calculate EMA - we haave only 1 sample
@@ -183,7 +183,7 @@ def test_ema_on_universe(universe: TradingStrategyUniverse):
     assert ema_20_series is None
 
     end_timestamp = pd.Timestamp("2021-12-31")
-    candles = universe.universe.candles.get_single_pair_data(end_timestamp, sample_count=batch_size)
+    candles = universe.universe.candles.get_single_pair_data(end_timestamp, sample_count=batch_size, allow_current=True)
     assert len(candles) == batch_size
 
     ema_20_series = ema(candles["close"], length=20)
@@ -287,14 +287,14 @@ def test_analyse_synthetic_trading_portfolio(
     # Do checks for the first position
     # 0    1          2021-07-01   8 days                      WETH        USDC         $2,027.23    $27.23    2.72%   0.027230  $1,617.294181   $1,661.333561            2
     row = expanded_timeline.iloc[0]
-    assert row["Opened at"] == "2021-07-01"
+    assert row["Opened at"] == "2021-07-02"
     assert row["Trade count"] == 2
     assert row["Open price USD"] == "$1,617.294181"
     assert row["Position max size"] == "$1,027.23"
 
     # 1    3          2021-07-10  26 days                      WETH        USDC         $1,002.72  $-137.39  -13.70%  -0.137013  $1,710.929622   $1,476.509241            2
     row2 = expanded_timeline.iloc[1]
-    assert row2["Opened at"] == "2021-07-10"
+    assert row2["Opened at"] == "2021-07-11"
     assert row2["Close price USD"] == "$1,476.509241"
     assert row2["Position max size"] == "$1,002.72"
 

--- a/tests/test_backtest_position_trigger.py
+++ b/tests/test_backtest_position_trigger.py
@@ -346,14 +346,14 @@ def test_synthetic_data_backtest_stop_loss(
     for p in state.portfolio.get_all_positions():
         assert p.stop_loss, f"Position did not have stop loss: {p}"
 
-    assert len(list(state.portfolio.get_all_positions())) == 44
-    assert len(list(state.portfolio.get_all_trades())) == 88
+    assert len(list(state.portfolio.get_all_positions())) == 41
+    assert len(list(state.portfolio.get_all_trades())) == 81
 
     # We should have some stop loss trades and some trades closed for profit
     stop_loss_trades = [t for t in state.portfolio.get_all_trades() if t.is_stop_loss()]
     rebalance_trades = [t for t in state.portfolio.get_all_trades() if t.is_rebalance()]
-    assert len(rebalance_trades) == 46
-    assert len(stop_loss_trades) == 42
+    assert len(rebalance_trades) == 43
+    assert len(stop_loss_trades) == 38
 
     # Check are stop loss positions unprofitable
     stop_loss_positions = [p for p in state.portfolio.get_all_positions() if p.is_stop_loss()]
@@ -442,13 +442,13 @@ def test_synthetic_data_backtest_take_profit(
         assert p.take_profit, f"Position did not have take profit: {p}"
 
     assert len(list(state.portfolio.get_all_positions())) == 46
-    assert len(list(state.portfolio.get_all_trades())) == 92
+    assert len(list(state.portfolio.get_all_trades())) == 91
 
     # We should have some stop loss trades and some trades closed for profit
     take_profit_trades = [t for t in state.portfolio.get_all_trades() if t.is_take_profit()]
     rebalance_trades = [t for t in state.portfolio.get_all_trades() if t.is_rebalance()]
     assert len(rebalance_trades) == 46
-    assert len(take_profit_trades) == 46
+    assert len(take_profit_trades) == 45
 
     # Check are stop loss positions unprofitable
     take_profit_positions = [p for p in state.portfolio.get_all_positions() if p.is_take_profit()]

--- a/tests/test_position_manager.py
+++ b/tests/test_position_manager.py
@@ -136,18 +136,18 @@ def test_get_current_position(position_manager_with_open_position: PositionManag
     # because Ethereum token balances are accurate up to 18 decimals
     # and this kind of accuracy cannot be expressed in floating point numbers.
     quantity = current_position.get_quantity()
-    assert quantity == Decimal('0.03045760003971992547285959728')
+    assert quantity == Decimal('0.03033456189136483055782720622')
 
     # The current price is the price of the trading pair
     # that was recorded on the last price feed sync.
     # This is a 64-bit floating point, as the current price
     # is always approximation based on market conditions.
     price = current_position.get_current_price()
-    assert price == 1641.6263899583264
+    assert price == 1648.28488966024
 
     # The opening price is the price of the first trade
     # that was made for this position. This is the actual
     # executed price of the trade, expressed as floating
     # point for the convenience.
     price = current_position.get_opening_price()
-    assert price == 1641.6263899583264
+    assert price == 1648.28488966024

--- a/tests/test_summary_statistics.py
+++ b/tests/test_summary_statistics.py
@@ -167,7 +167,7 @@ def test_get_statistics_as_dataframe(state: State):
     assert s.loc[pd.Timestamp('2021-06-01 00:00:00')] == 9997.0
 
     # Last value by index
-    assert s.iloc[-1] == 9960.344506946696
+    assert s.iloc[-1] == 10172.463477344705
 
     assert len(s) == 214
 
@@ -182,7 +182,7 @@ def test_calculate_profitability_90_days(state: State):
     profitability_90_days, time_window = calculate_naive_profitability(s, look_back=pd.Timedelta(days=90))
 
     # Calculate last 90 days
-    assert profitability_90_days == pytest.approx(-0.003181862051407544)
+    assert profitability_90_days == pytest.approx(0.007274625902692977)
     assert time_window == pd.Timedelta(days=90)
 
 
@@ -197,7 +197,7 @@ def test_calculate_profitability_overflow_time_window(state: State):
     profitability_10_years, time_window = calculate_naive_profitability(s, look_back=pd.Timedelta(days=10*365))
 
     assert time_window == pd.Timedelta('213 days 00:00:00')
-    assert profitability_10_years == pytest.approx(-0.0036666493001204234)
+    assert profitability_10_years == pytest.approx(0.01755161321843604)
 
 
 def test_calculate_profitability_empty():
@@ -230,13 +230,13 @@ def test_calculate_all_summary_statistics(state: State):
     assert summary.enough_data
     assert summary.first_trade_at == datetime.datetime(2021, 6, 1, 0, 0)
     assert summary.last_trade_at == datetime.datetime(2021, 12, 31, 0, 0)
-    assert summary.profitability_90_days == pytest.approx(-0.003181862051407544)
-    assert summary.current_value == pytest.approx(9960.344506946696)
+    assert summary.profitability_90_days == pytest.approx(0.007274625902692977)
+    assert summary.current_value == pytest.approx(10172.463477344705)
 
     datapoints = summary.performance_chart_90_days
     assert len(datapoints) == 91
 
     assert datapoints[0] == (datetime.datetime(2021, 10, 2, 0, 0), 0.0)
-    assert datapoints[-1] == (datetime.datetime(2021, 12, 31, 0, 0), -0.003181862051407544)
+    assert datapoints[-1] == (datetime.datetime(2021, 12, 31, 0, 0), 0.007274625902692977 )
 
 

--- a/tradeexecutor/backtest/backtest_pricing.py
+++ b/tradeexecutor/backtest/backtest_pricing.py
@@ -25,7 +25,8 @@ logger = logging.getLogger(__name__)
 class BacktestSimplePricingModel(PricingModel):
     """Look up the historical prices.
 
-    - Candle close price is used
+    - Open price of the price candle at the timestamp,
+      or closest earlier timestamp is used
 
     - This is a simple model and does not use liquidity data
       for the price impact estimation
@@ -38,7 +39,7 @@ class BacktestSimplePricingModel(PricingModel):
                  candle_universe: GroupedCandleUniverse,
                  routing_model: RoutingModel,
                  data_delay_tolerance=pd.Timedelta("2d"),
-                 candle_timepoint_kind="close",
+                 candle_timepoint_kind="open",
                  very_small_amount=Decimal("0.10")):
         """
 

--- a/tradeexecutor/ethereum/web3config.py
+++ b/tradeexecutor/ethereum/web3config.py
@@ -81,7 +81,12 @@ class Web3Config:
 
         assert isinstance(gas_price_method, GasPriceMethod)
 
-        logger.info("Connected to chain id: %d, using gas price method %s", chain_id, gas_price_method.name)
+        chain_id_obj = ChainId(chain_id)
+
+        logger.trade("Connected to chain: %s, node provider: %s, gas pricing method: %s",
+                     chain_id_obj.name,
+                     get_url_domain(url),
+                     gas_price_method.name)
 
         # London is the default method
         if gas_price_method == GasPriceMethod.legacy:


### PR DESCRIPTION
- Current assumed execution price was the candle close price of the timestamp
- Assume we are so good that we can execute at open price 