### PR TITLE
Stats adjust

### DIFF
--- a/tradeexecutor/analysis/trade_analyser.py
+++ b/tradeexecutor/analysis/trade_analyser.py
@@ -592,6 +592,7 @@ class TradeAnalysis:
         average_losing_trade_loss_pc = get_avg_profit_pct(losing_trades)
 
         max_realised_loss = min(realised_losses)
+        avg_realised_risk = avg(realised_losses)
 
         avg_capital_tied_at_open_pc = avg(capital_tied_at_open_pc)
         

--- a/tradeexecutor/analysis/trade_analyser.py
+++ b/tradeexecutor/analysis/trade_analyser.py
@@ -516,7 +516,7 @@ class TradeAnalysis:
                 else:
                     return np.mean(duration_list)
             else:
-                return None
+                return datetime.timedelta(0)
 
         def max_check(lst):
             return max(lst) if lst else None

--- a/tradeexecutor/analysis/trade_analyser.py
+++ b/tradeexecutor/analysis/trade_analyser.py
@@ -93,8 +93,7 @@ class SpotTrade:
         return abs(self.price * float(self.quantity))
 
 
-# Changed to kw_only = True so users aware of changes in parameters
-@dataclass(kw_only=True)
+@dataclass
 class TradePosition:
     """How a particular asset traded.
 
@@ -106,7 +105,7 @@ class TradePosition:
 
     * Exit (sell optionally)
     """
-
+    
     #: Position id of the trade
     #: Used to be self.trades[0].trade_id
     position_id: int


### PR DESCRIPTION
Fixes #157. This PR allows calculation of same/similar summary statistics as before, but removes the need for deriving and specifying various parameters to the `calculate_summary_statistics` method. The only remaining optional parameter is the `time_bucket` 