### PR TITLE
Trading fee tracking

### DIFF
--- a/tests/ganache/test_uniswap_v2_routing.py
+++ b/tests/ganache/test_uniswap_v2_routing.py
@@ -260,7 +260,9 @@ def routing_model(busd_asset):
     return UniswapV2SimpleRoutingModel(
         factory_router_map,
         allowed_intermediary_pairs,
-        reserve_token_address=busd_asset.address)
+        reserve_token_address=busd_asset.address,
+        trading_fee=0.0025, # https://docs.pancakeswap.finance/products/pancakeswap-exchange/pancakeswap-pools
+    )
 
 
 @pytest.fixture()

--- a/tests/test_approval_in_terminal.py
+++ b/tests/test_approval_in_terminal.py
@@ -250,6 +250,7 @@ def routing_model(uniswap_v2, asset_usdc, asset_weth, weth_usdc_pair) -> Uniswap
         factory_router_map,
         allowed_intermediary_pairs,
         reserve_token_address=asset_usdc.address,
+        trading_fee=0.0,
     )
 
 

--- a/tests/test_backtest_execution.py
+++ b/tests/test_backtest_execution.py
@@ -278,7 +278,7 @@ def test_buy_with_fee(
     # Check we calculated LP fees correctly
     assert trade.is_buy()
     assert trade.get_status() == TradeStatus.success
-    assert trade.lp_fee == 0.0050
+    assert trade.fee_tier == 0.0050
     assert trade.executed_price == pytest.approx(357.15260665419106)
     assert trade.lp_fees_estimated == 5.0
     assert trade.lp_fees_paid == 5.0
@@ -321,7 +321,7 @@ def test_buy_sell_backtest_with_fee(
     sell_price = trade.executed_price
 
     assert position.is_closed()
-    assert trade.lp_fee == 0.005
+    assert trade.fee_tier == 0.005
     assert trade.lp_fees_estimated == pytest.approx(4.960199004975125)
     assert trade.lp_fees_paid == pytest.approx(4.960199004975125)
 

--- a/tests/test_backtest_execution.py
+++ b/tests/test_backtest_execution.py
@@ -168,11 +168,11 @@ def test_get_historical_price(
 
     # Get the price for buying WBNB for 1000 USD at 2021-1-1
     buy_price = trader.get_buy_price(wbnb_busd, Decimal(1_000))
-    assert buy_price == pytest.approx(354.3096008300781)
+    assert buy_price.price == pytest.approx(354.3096008300781)
 
     # Get the price for sellinb 1 WBNB
     sell_price = trader.get_sell_price(wbnb_busd, Decimal(1))
-    assert sell_price == pytest.approx(354.3096008300781)
+    assert sell_price.price == pytest.approx(354.3096008300781)
 
 
 def test_create_and_execute_backtest_trade(

--- a/tests/test_ethereum_tester_trade.py
+++ b/tests/test_ethereum_tester_trade.py
@@ -304,7 +304,7 @@ def routing_model(uniswap_v2, asset_usdc, asset_weth, weth_usdc_pair) -> Uniswap
         factory_router_map,
         allowed_intermediary_pairs,
         reserve_token_address=asset_usdc.address,
-        trading_fee=0.0,
+        trading_fee=0.030,
     )
 
 
@@ -582,12 +582,12 @@ def test_simulated_uniswap_qstrader_strategy_round_trip(
 
     # We have lost some money in trading fees
     assert state.portfolio.get_total_equity() == pytest.approx(9983.773698830146, rel=APPROX_REL)
-    assert state.portfolio.get_current_cash() == pytest.approx(936.5293500249995, rel=APPROX_REL)
+    assert state.portfolio.get_current_cash() == pytest.approx(913.1489764500003, rel=APPROX_REL)
 
     # Check our two open positions
     assert len(state.portfolio.open_positions) == 2
     position_1 = state.portfolio.get_open_position_for_pair(weth_usdc_pair)
-    assert position_1.get_quantity() == Decimal('2.747249930253346052')
+    assert position_1.get_quantity() == Decimal('2.754699344146152536')
     assert position_1.get_value() == pytest.approx(4684.555636069401, rel=APPROX_REL)
     position_2 = state.portfolio.get_open_position_for_pair(aave_usdc_pair)
     assert position_2.get_value() == pytest.approx(4362.366674108017, rel=APPROX_REL)

--- a/tests/test_ethereum_tester_trade.py
+++ b/tests/test_ethereum_tester_trade.py
@@ -304,6 +304,7 @@ def routing_model(uniswap_v2, asset_usdc, asset_weth, weth_usdc_pair) -> Uniswap
         factory_router_map,
         allowed_intermediary_pairs,
         reserve_token_address=asset_usdc.address,
+        trading_fee=0.0,
     )
 
 

--- a/tests/test_position_manager.py
+++ b/tests/test_position_manager.py
@@ -156,7 +156,7 @@ def test_get_current_position(position_manager_with_open_position: PositionManag
 def test_estimate_fee_not_available(synthetic_universe, position_manager):
     """"Estimate the trading fee."""
     eth_usdc = synthetic_universe.get_single_pair()
-    fee = position_manager.estimate_trading_fee(eth_usdc)
+    fee = position_manager.get_pair_fee(eth_usdc)
     assert fee is None
 
 
@@ -171,7 +171,7 @@ def test_estimate_fee_from_router(state, synthetic_universe, position_manager):
     eth_usdc = synthetic_universe.get_single_pair()
     ts = datetime.datetime(2021, 6, 2)
     position_manager = PositionManager(ts, synthetic_universe.universe, state, pricing_model)
-    fee = position_manager.estimate_trading_fee(eth_usdc)
+    fee = position_manager.get_pair_fee(eth_usdc)
     assert fee == 0.0025
 
 
@@ -179,5 +179,5 @@ def test_estimate_fee_from_pair(synthetic_universe, position_manager):
     """"Estimate the trading fee."""
     eth_usdc = synthetic_universe.get_single_pair()
     eth_usdc.fee = 0.020
-    fee = position_manager.estimate_trading_fee(eth_usdc)
+    fee = position_manager.get_pair_fee(eth_usdc)
     assert fee == 0.020

--- a/tests/test_position_manager.py
+++ b/tests/test_position_manager.py
@@ -106,7 +106,7 @@ def position_manager_with_open_position(
 ):
     """Force in one executed position."""
 
-    ts = datetime.datetime(2021, 6,12)
+    ts = datetime.datetime(2021, 6, 12)
 
     eth_usdc = synthetic_universe.get_single_pair()
     state = position_manager.state
@@ -151,3 +151,33 @@ def test_get_current_position(position_manager_with_open_position: PositionManag
     # point for the convenience.
     price = current_position.get_opening_price()
     assert price == 1648.28488966024
+
+
+def test_estimate_fee_not_available(synthetic_universe, position_manager):
+    """"Estimate the trading fee."""
+    eth_usdc = synthetic_universe.get_single_pair()
+    fee = position_manager.estimate_trading_fee(eth_usdc)
+    assert fee is None
+
+
+def test_estimate_fee_from_router(state, synthetic_universe, position_manager):
+    """"Estimate the trading fee based on router data."""
+
+    routing_model = generate_simple_routing_model(synthetic_universe, trading_fee=0.0025)
+    pricing_model = BacktestSimplePricingModel(
+        synthetic_universe.universe.candles,
+        routing_model
+    )
+    eth_usdc = synthetic_universe.get_single_pair()
+    ts = datetime.datetime(2021, 6, 2)
+    position_manager = PositionManager(ts, synthetic_universe.universe, state, pricing_model)
+    fee = position_manager.estimate_trading_fee(eth_usdc)
+    assert fee == 0.0025
+
+
+def test_estimate_fee_from_pair(synthetic_universe, position_manager):
+    """"Estimate the trading fee."""
+    eth_usdc = synthetic_universe.get_single_pair()
+    eth_usdc.fee = 0.020
+    fee = position_manager.estimate_trading_fee(eth_usdc)
+    assert fee == 0.020

--- a/tests/test_uniswap_live_pricing.py
+++ b/tests/test_uniswap_live_pricing.py
@@ -194,6 +194,7 @@ def routing_model(uniswap_v2, asset_usdc, asset_weth, weth_usdc_pair) -> Uniswap
         factory_router_map,
         allowed_intermediary_pairs,
         reserve_token_address=asset_usdc.address,
+        trading_fee=0.0,
     )
 
 
@@ -211,8 +212,8 @@ def test_uniswap_two_leg_buy_price_no_price_impact(
     pair = translate_trading_pair(weth_usdc)
 
     # Get price for "infinite" small trade amount
-    price = pricing_method.get_buy_price(datetime.datetime.utcnow(), pair, None)
-    assert price == pytest.approx(1705.12, rel=APPROX_REL)
+    price_structure = pricing_method.get_buy_price(datetime.datetime.utcnow(), pair, None)
+    assert price_structure.price == pytest.approx(1705.12, rel=APPROX_REL)
 
 
 def test_uniswap_two_leg_buy_price_with_price_impact(
@@ -230,11 +231,11 @@ def test_uniswap_two_leg_buy_price_with_price_impact(
 
     # Get price for 100 USDC
     # TODO: Looks incorrect
-    price = pricing_method.get_buy_price(datetime.datetime.utcnow(), pair, Decimal(50_000))
-    assert price == pytest.approx(1755.1153460381142, rel=APPROX_REL)
+    price_structure = pricing_method.get_buy_price(datetime.datetime.utcnow(), pair, Decimal(50_000))
+    assert price_structure.price == pytest.approx(1755.1153460381142, rel=APPROX_REL)
 
     mid_price = pricing_method.get_mid_price(datetime.datetime.utcnow(), pair)
-    assert price > mid_price
+    assert price_structure.price > mid_price
 
 
 def test_uniswap_two_leg_sell_price_no_price_impact(
@@ -250,11 +251,11 @@ def test_uniswap_two_leg_sell_price_no_price_impact(
     pair = translate_trading_pair(weth_usdc)
 
     # Get price for "infinite" small trade amount
-    price = pricing_method.get_sell_price(datetime.datetime.utcnow(), pair, None)
-    assert price == pytest.approx(1705.12, rel=APPROX_REL)
+    price_structure = pricing_method.get_sell_price(datetime.datetime.utcnow(), pair, None)
+    assert price_structure.price == pytest.approx(1705.12, rel=APPROX_REL)
 
     mid_price = pricing_method.get_mid_price(datetime.datetime.utcnow(), pair)
-    assert price < mid_price
+    assert price_structure.price < mid_price
 
 
 def test_uniswap_two_leg_sell_price_with_price_impact(
@@ -271,8 +272,8 @@ def test_uniswap_two_leg_sell_price_with_price_impact(
     pair = translate_trading_pair(weth_usdc)
 
     # Sell 50 ETH
-    price = pricing_method.get_sell_price(datetime.datetime.utcnow(), pair, Decimal(50))
-    assert price == pytest.approx(1614.42110776, rel=APPROX_REL)
+    price_structure = pricing_method.get_sell_price(datetime.datetime.utcnow(), pair, Decimal(50))
+    assert price_structure.price == pytest.approx(1614.42110776, rel=APPROX_REL)
 
 
 def test_uniswap_three_leg_buy_price_with_price_impact(
@@ -320,8 +321,8 @@ def test_uniswap_three_leg_buy_price_with_price_impact(
     assert weth_usdc.address == weth_pair_for
 
     # Get price for 20_000 USDC
-    price = pricing_method.get_buy_price(datetime.datetime.utcnow(), pair, Decimal(20_000))
-    assert price == pytest.approx(350.06125296652243, rel=APPROX_REL)
+    price_structure = pricing_method.get_buy_price(datetime.datetime.utcnow(), pair, Decimal(20_000))
+    assert price_structure.price == pytest.approx(350.06125296652243, rel=APPROX_REL)
 
 
 def test_uniswap_three_leg_sell_price_with_price_impact(
@@ -344,7 +345,7 @@ def test_uniswap_three_leg_sell_price_with_price_impact(
     pair = translate_trading_pair(aave_weth)
 
     # Get price for 500 AAVE
-    price = pricing_method.get_buy_price(datetime.datetime.utcnow(), pair, Decimal(500))
-    assert price == pytest.approx(342.2495177609056, rel=APPROX_REL)
+    price_structure = pricing_method.get_buy_price(datetime.datetime.utcnow(), pair, Decimal(500))
+    assert price_structure.price == pytest.approx(342.2495177609056, rel=APPROX_REL)
 
 

--- a/tradeexecutor/backtest/backtest_execution.py
+++ b/tradeexecutor/backtest/backtest_execution.py
@@ -155,7 +155,7 @@ class BacktestExecutionModel(ExecutionModel):
                 executed_price,
                 executed_quantity,
                 executed_reserve,
-                lp_fees=0,
+                lp_fees=trade.lp_fees_estimated,
                 native_token_price=1)
 
     def get_routing_state_details(self) -> dict:

--- a/tradeexecutor/backtest/backtest_pricing.py
+++ b/tradeexecutor/backtest/backtest_pricing.py
@@ -129,6 +129,7 @@ class BacktestSimplePricingModel(PricingModel):
             lp_fee=lp_fee,
             pair_fee=pair_fee,
             market_feed_delay=delay.to_pytimedelta(),
+            side=False,
         )
 
     def get_buy_price(self,
@@ -168,6 +169,7 @@ class BacktestSimplePricingModel(PricingModel):
             lp_fee=lp_fee,
             pair_fee=pair_fee,
             market_feed_delay=delay.to_pytimedelta(),
+            side=True,
         )
 
     def get_mid_price(self,

--- a/tradeexecutor/backtest/backtest_pricing.py
+++ b/tradeexecutor/backtest/backtest_pricing.py
@@ -154,6 +154,7 @@ class BacktestSimplePricingModel(PricingModel):
             price = mid_price * (1 + pair_fee)
         else:
             lp_fee = None
+            price = mid_price
 
         return TradePricing(
             price=float(price),

--- a/tradeexecutor/backtest/backtest_pricing.py
+++ b/tradeexecutor/backtest/backtest_pricing.py
@@ -142,6 +142,17 @@ class BacktestSimplePricingModel(PricingModel):
         decimals = pair.base.decimals
         return Decimal(quantity).quantize((Decimal(10) ** Decimal(-decimals)), rounding=ROUND_DOWN)
 
+    def estimate_trading_fee(self,
+                      ts: datetime.datetime,
+                      pair: TradingPairIdentifier,
+                    ) -> Optional[float]:
+        """Figure out the fee from a pair or a routing."""
+        if pair.fee:
+            return pair.fee
+
+        return self.routing_model.get_default_trading_fee()
+
+
 
 def backtest_pricing_factory(
         execution_model: ExecutionModel,

--- a/tradeexecutor/backtest/backtest_pricing.py
+++ b/tradeexecutor/backtest/backtest_pricing.py
@@ -1,5 +1,6 @@
 import logging
 import datetime
+import math
 import warnings
 from decimal import Decimal, ROUND_DOWN
 from typing import Optional
@@ -145,16 +146,21 @@ class BacktestSimplePricingModel(PricingModel):
             kind=self.candle_timepoint_kind,
         )
 
+        assert mid_price not in (0, math.nan), f"Got bad mid price: {mid_price}"
+
         pair_fee = self.get_pair_fee(ts, pair)
 
-        if pair_fee:
+        if pair_fee is not None:
             lp_fee = float(reserve) * pair_fee
 
             # Move price above mid price
             price = mid_price * (1 + pair_fee)
         else:
+            # Fee information not available
             lp_fee = None
             price = mid_price
+
+        assert price not in (0, math.nan) and price > 0, f"Got bad price: {price}"
 
         return TradePricing(
             price=float(price),

--- a/tradeexecutor/backtest/backtest_routing.py
+++ b/tradeexecutor/backtest/backtest_routing.py
@@ -104,6 +104,7 @@ class BacktestRoutingModel(RoutingModel):
                  factory_router_map: Dict[str, Tuple[str, Optional[str]]],
                  allowed_intermediary_pairs: Dict[str, str],
                  reserve_token_address: str,
+                 trading_fee: Optional[float] = None,
                  ):
         """
         :param factory_router_map:
@@ -126,6 +127,10 @@ class BacktestRoutingModel(RoutingModel):
             Token address of our reserve currency.
             Relevent for buy/sell routing.
             Lowercase.
+
+        :param trading_fee:
+            The trading fee applied to all trades by default,
+            unless a pair overrides.
         """
 
         assert type(factory_router_map) == dict
@@ -139,6 +144,10 @@ class BacktestRoutingModel(RoutingModel):
         self.factory_router_map = {k.lower(): v for k, v in factory_router_map.items()}
         self.allowed_intermediary_pairs = {k.lower(): v.lower() for k, v in allowed_intermediary_pairs.items()}
         self.reserve_token_address = reserve_token_address
+        self.trading_fee = trading_fee
+
+    def get_default_trading_fee(self) -> Optional[float]:
+        return self.trading_fee
 
     def get_reserve_asset(self, pair_universe: PandasPairUniverse) -> AssetIdentifier:
         """Translate our reserve token address tok an asset description."""

--- a/tradeexecutor/backtest/backtest_valuation.py
+++ b/tradeexecutor/backtest/backtest_valuation.py
@@ -27,8 +27,8 @@ class BacktestValuationModel(ValuationModel):
 
         assert position.is_long(), "Short not supported"
         quantity = position.get_quantity()
-        price = self.pricing_model.get_sell_price(ts, pair, quantity)
-        return ts, float(price)
+        price_structure = self.pricing_model.get_sell_price(ts, pair, quantity)
+        return ts, float(price_structure.price)
 
 
 def backtest_valuation_factory(pricing_model):

--- a/tradeexecutor/ethereum/routing_data.py
+++ b/tradeexecutor/ethereum/routing_data.py
@@ -368,7 +368,7 @@ def create_uniswap_v2_compatible_routing(routing_type: TradeRouting, reserve_cur
         params["allowed_intermediary_pairs"],
         params["reserve_token_address"],
         params["chain_id"],
-        params["trading_fee"]
+        params["trading_fee"] / 10_000,
     )
 
     return routing_model

--- a/tradeexecutor/ethereum/uniswap_v2_execution_v0.py
+++ b/tradeexecutor/ethereum/uniswap_v2_execution_v0.py
@@ -143,6 +143,7 @@ class UniswapV2ExecutionModelVersion0(ExecutionModel):
             },
             allowed_intermediary_pairs={},
             reserve_token_address=reserve_asset.address,
+            trading_fee=0.0,
         )
 
         state.start_trades(datetime.datetime.utcnow(), trades)

--- a/tradeexecutor/ethereum/uniswap_v2_live_pricing.py
+++ b/tradeexecutor/ethereum/uniswap_v2_live_pricing.py
@@ -152,6 +152,7 @@ class UniswapV2LivePricing(PricingModel):
             mid_price=mid_price,
             lp_fee=lp_fee,
             pair_fee=fee,
+            side=False,
         )
 
     def get_buy_price(self,
@@ -218,6 +219,7 @@ class UniswapV2LivePricing(PricingModel):
             lp_fee=lp_fee,
             pair_fee=fee,
             market_feed_delay=datetime.timedelta(seconds=0),
+            side=True,
         )
 
     def get_mid_price(self,
@@ -233,7 +235,7 @@ class UniswapV2LivePricing(PricingModel):
         # Here we are using a hack)
         bp = self.get_buy_price(ts, pair, self.very_small_amount)
         sp = self.get_sell_price(ts, pair, self.very_small_amount)
-        return (bp + sp) / 2
+        return (bp.price + sp.price) / 2
 
     def quantize_base_quantity(self, pair: TradingPairIdentifier, quantity: Decimal, rounding=ROUND_DOWN) -> Decimal:
         """Convert any base token quantity to the native token units by its ERC-20 decimals."""

--- a/tradeexecutor/ethereum/uniswap_v2_live_pricing.py
+++ b/tradeexecutor/ethereum/uniswap_v2_live_pricing.py
@@ -19,7 +19,7 @@ from tradeexecutor.strategy.execution_model import ExecutionModel
 from eth_defi.uniswap_v2.fees import estimate_buy_price_decimals, estimate_sell_price_decimals, \
     estimate_buy_received_amount_raw, estimate_sell_received_amount_raw
 from tradeexecutor.state.types import USDollarAmount
-from tradeexecutor.strategy.pricing_model import PricingModel
+from tradeexecutor.strategy.pricing_model import PricingModel, TradePricing
 from tradeexecutor.strategy.trading_strategy_universe import TradingStrategyUniverse, translate_trading_pair
 from tradingstrategy.pair import PandasPairUniverse
 
@@ -94,7 +94,7 @@ class UniswapV2LivePricing(PricingModel):
                        ts: datetime.datetime,
                        pair: TradingPairIdentifier,
                        quantity: Optional[Decimal],
-                       ) -> USDollarAmount:
+                       ) -> TradePricing:
         """Get live price on Uniswap."""
 
         if quantity is None:
@@ -131,7 +131,7 @@ class UniswapV2LivePricing(PricingModel):
                        ts: datetime.datetime,
                        pair: TradingPairIdentifier,
                        reserve: Optional[Decimal],
-                       ) -> USDollarAmount:
+                       ) -> TradePricing:
         """Get live price on Uniswap.
 
         :param reserve:
@@ -185,6 +185,13 @@ class UniswapV2LivePricing(PricingModel):
         assert isinstance(pair, TradingPairIdentifier)
         decimals = pair.base.decimals
         return Decimal(quantity).quantize((Decimal(10) ** Decimal(-decimals)), rounding=ROUND_DOWN)
+
+    def get_pair_fee(self,
+                     ts: datetime.datetime,
+                     pair: TradingPairIdentifier,
+                     ) -> Optional[float]:
+        """Uniswap v2 compatibles have fixed fee across the exchange."""
+        return self.routing_model.get_default_trading_fee()
 
 
 def uniswap_v2_live_pricing_factory(

--- a/tradeexecutor/ethereum/uniswap_v2_live_pricing.py
+++ b/tradeexecutor/ethereum/uniswap_v2_live_pricing.py
@@ -6,10 +6,12 @@ and JSON-RPC API.
 import logging
 import datetime
 from decimal import Decimal, ROUND_DOWN
-from typing import Optional
+from typing import Optional, Dict
 
 from web3 import Web3
 
+from eth_defi.uniswap_v2.deployment import UniswapV2Deployment
+from eth_defi.uniswap_v2.pair import fetch_pair_details
 from tradeexecutor.ethereum.uniswap_v2_execution import UniswapV2ExecutionModel
 from tradeexecutor.ethereum.uniswap_v2_execution_v0 import UniswapV2ExecutionModelVersion0
 from tradeexecutor.ethereum.uniswap_v2_routing import UniswapV2SimpleRoutingModel, route_tokens, get_uniswap_for_pair
@@ -70,9 +72,17 @@ class UniswapV2LivePricing(PricingModel):
         if(hasattr(routing_model, 'trading_fee')):
             self.trading_fee = routing_model.trading_fee
         else:
-            self.trading_fee = 30 
+            self.trading_fee = 30
+
+        self.uniswap_cache: Dict[TradingPairIdentifier, UniswapV2Deployment] = {}
 
         assert isinstance(self.very_small_amount, Decimal)
+
+    def get_uniswap(self, target_pair: TradingPairIdentifier) -> UniswapV2Deployment:
+        """Helper function to speed up Uniswap v2 deployment resolution."""
+        if target_pair not in self.uniswap_cache:
+            self.uniswap_cache[target_pair] = get_uniswap_for_pair(self.web3, self.routing_model.factory_router_map, target_pair)
+        return self.uniswap_cache[target_pair]
 
     def get_pair_for_id(self, internal_id: int) -> Optional[TradingPairIdentifier]:
         """Look up a trading pair.
@@ -106,7 +116,7 @@ class UniswapV2LivePricing(PricingModel):
 
         base_addr, quote_addr, intermediate_addr = route_tokens(target_pair, intermediate_pair)
 
-        uniswap = get_uniswap_for_pair(self.web3, self.routing_model.factory_router_map, target_pair)
+        uniswap = self.get_uniswap(target_pair)
 
         # In three token trades, be careful to use the correct reserve token
         quantity_raw = target_pair.base.convert_to_raw_amount(quantity)
@@ -125,7 +135,24 @@ class UniswapV2LivePricing(PricingModel):
         else:
             received = target_pair.quote.convert_to_decimal(received_raw)
 
-        return float(received / quantity)
+        fee = self.get_pair_fee(ts, pair)
+        assert fee is not None, f"Uniswap v2 fee data missing: {uniswap}"
+
+        price = float(received / quantity)
+
+        # TODO: Verify calculation
+        mid_price = price * (1 + fee)
+
+        assert price <= mid_price, f"Bad pricing: {price}, {mid_price}"
+
+        lp_fee = (mid_price - price) * float(quantity)
+
+        return TradePricing(
+            price=price,
+            mid_price=mid_price,
+            lp_fee=lp_fee,
+            pair_fee=fee,
+        )
 
     def get_buy_price(self,
                        ts: datetime.datetime,
@@ -134,10 +161,13 @@ class UniswapV2LivePricing(PricingModel):
                        ) -> TradePricing:
         """Get live price on Uniswap.
 
+        TODO: Fees are incorrectly calculated in the case of multipair routing
+
         :param reserve:
             The buy size in quote token e.g. in dollars
 
-        :return: Price for one reserve unit e.g. a dollar
+        :return:
+            Price for one reserve unit e.g. a dollar
         """
 
         if reserve is None:
@@ -159,6 +189,7 @@ class UniswapV2LivePricing(PricingModel):
             reserve_raw = target_pair.quote.convert_to_raw_amount(reserve)
             self.check_supported_quote_token(pair)
 
+        # Calculate base token received
         token_raw_received = estimate_buy_received_amount_raw(
             uniswap,
             base_addr,
@@ -166,16 +197,40 @@ class UniswapV2LivePricing(PricingModel):
             reserve_raw,
             intermediate_token_address=intermediate_addr
         )
+
         token_received = target_pair.base.convert_to_decimal(token_raw_received)
-        return float(reserve / token_received)
+
+        fee = self.get_pair_fee(ts, pair)
+        assert fee is not None, f"Uniswap v2 fee data missing: {uniswap}"
+
+        price = float(reserve / token_received)
+
+        lp_fee = float(reserve) * fee
+
+        # TODO: Verify calculation
+        mid_price = price * (1 - fee)
+
+        assert price >= mid_price, f"Bad pricing: {price}, {mid_price}"
+
+        return TradePricing(
+            price=float(price),
+            mid_price=float(mid_price),
+            lp_fee=lp_fee,
+            pair_fee=fee,
+            market_feed_delay=datetime.timedelta(seconds=0),
+        )
 
     def get_mid_price(self,
                       ts: datetime.datetime,
                       pair: TradingPairIdentifier) -> USDollarAmount:
-        """Get the mid price by the candle."""
+        """Get the mid price from Uniswap pool.
+
+        Gets tricky, because we calculate dollar mid-price, not
+        quote token midprice.
+        """
 
         # TODO: Use native Uniswap router functions to get the mid price
-        # Here we are using a hack
+        # Here we are using a hack)
         bp = self.get_buy_price(ts, pair, self.very_small_amount)
         sp = self.get_sell_price(ts, pair, self.very_small_amount)
         return (bp + sp) / 2

--- a/tradeexecutor/ethereum/uniswap_v2_routing.py
+++ b/tradeexecutor/ethereum/uniswap_v2_routing.py
@@ -6,6 +6,8 @@ from decimal import Decimal
 from typing import Dict, Set, List, Optional, Tuple
 
 from eth_typing import HexAddress, ChecksumAddress
+
+from tradeexecutor.state.types import BPS
 from tradingstrategy.chain import ChainId
 from web3 import Web3
 from web3.contract import Contract
@@ -258,7 +260,7 @@ class UniswapV2SimpleRoutingModel(RoutingModel):
                  allowed_intermediary_pairs: Dict[str, str],
                  reserve_token_address: str,
                  chain_id: Optional[ChainId] = None,
-                 trading_fee: Optional[int] = None
+                 trading_fee: Optional[BPS] = None
                  ):
         """
         :param factory_router_map:
@@ -278,7 +280,7 @@ class UniswapV2SimpleRoutingModel(RoutingModel):
             are allowed to be used as a hop.
 
         :param trading_fee:
-            Trading fee express as int in bps. E.g. 30 => 0.3%
+            Trading fee express as float bps.
 
         :param chain_id:
             Store the chain id for which these routes were generated for.
@@ -301,6 +303,11 @@ class UniswapV2SimpleRoutingModel(RoutingModel):
         self.allowed_intermediary_pairs = {k.lower(): v.lower() for k, v in allowed_intermediary_pairs.items()}
         self.reserve_token_address = reserve_token_address
         self.chain_id = chain_id
+
+        assert trading_fee is not None, "Trading fee missing"
+        assert trading_fee >= 0, f"Got fee: {trading_fee}"
+        assert trading_fee <= 1, f"Got fee: {trading_fee}"
+
         self.trading_fee = trading_fee
 
     def get_default_trading_fee(self) -> Optional[float]:

--- a/tradeexecutor/ethereum/uniswap_v2_routing.py
+++ b/tradeexecutor/ethereum/uniswap_v2_routing.py
@@ -282,6 +282,8 @@ class UniswapV2SimpleRoutingModel(RoutingModel):
         :param trading_fee:
             Trading fee express as float bps.
 
+            This is the LP fee applied to all swaps.
+
         :param chain_id:
             Store the chain id for which these routes were generated for.
 

--- a/tradeexecutor/ethereum/uniswap_v2_routing.py
+++ b/tradeexecutor/ethereum/uniswap_v2_routing.py
@@ -301,6 +301,10 @@ class UniswapV2SimpleRoutingModel(RoutingModel):
         self.allowed_intermediary_pairs = {k.lower(): v.lower() for k, v in allowed_intermediary_pairs.items()}
         self.reserve_token_address = reserve_token_address
         self.chain_id = chain_id
+        self.trading_fee = trading_fee
+
+    def get_default_trading_fee(self) -> Optional[float]:
+        return self.trading_fee
 
     def get_reserve_asset(self, pair_universe: PandasPairUniverse) -> AssetIdentifier:
         """Translate our reserve token address tok an asset description."""

--- a/tradeexecutor/ethereum/uniswap_v2_valuation.py
+++ b/tradeexecutor/ethereum/uniswap_v2_valuation.py
@@ -42,9 +42,9 @@ class UniswapV2PoolRevaluator(ValuationModel):
         if quantity == 0:
             return ts, 0.0
 
-        price = self.pricing_model.get_sell_price(ts, pair, quantity)
+        price_structure = self.pricing_model.get_sell_price(ts, pair, quantity)
 
-        return ts, price
+        return ts, price_structure.price
 
 
 def uniswap_v2_sell_valuation_factory(pricing_model):

--- a/tradeexecutor/state/identifier.py
+++ b/tradeexecutor/state/identifier.py
@@ -106,8 +106,14 @@ class TradingPairIdentifier:
     #: Info page URL for this trading pair e.g. with the price charts
     info_url: Optional[str] = None
 
+    #: Trading fee for this pair.
+    #:
+    #: Uniswap v3 style fee where all trades share the same LP fees.
+    #:
+    fee: Optional[float] = None
+
     def __repr__(self):
-        return f"<Pair {self.base.token_symbol}-{self.quote.token_symbol} at {self.pool_address} on exchange {self.exchange_address}>"
+        return f"<Pair {self.base.token_symbol}-{self.quote.token_symbol} at {self.pool_address} ({self.fee * 100:.2} % fee) on exchange {self.exchange_address}>"
 
     def __hash__(self):
         assert self.internal_id, "Internal id needed to be hashable"

--- a/tradeexecutor/state/identifier.py
+++ b/tradeexecutor/state/identifier.py
@@ -113,7 +113,8 @@ class TradingPairIdentifier:
     fee: Optional[float] = None
 
     def __repr__(self):
-        return f"<Pair {self.base.token_symbol}-{self.quote.token_symbol} at {self.pool_address} ({self.fee * 100:.2} % fee) on exchange {self.exchange_address}>"
+        fee = self.fee or 0
+        return f"<Pair {self.base.token_symbol}-{self.quote.token_symbol} at {self.pool_address} ({fee * 100:.4f}% fee) on exchange {self.exchange_address}>"
 
     def __hash__(self):
         assert self.internal_id, "Internal id needed to be hashable"

--- a/tradeexecutor/state/portfolio.py
+++ b/tradeexecutor/state/portfolio.py
@@ -381,7 +381,6 @@ class Portfolio:
         :param revalue_frozen:
             Revalue frozen positions as well
         """
-
         try:
             for p in self.open_positions.values():
                 ts, price = valuation_method(ts, p)

--- a/tradeexecutor/state/portfolio.py
+++ b/tradeexecutor/state/portfolio.py
@@ -13,7 +13,7 @@ from tradeexecutor.state.position import TradingPosition
 from tradeexecutor.state.reserve import ReservePosition
 from tradeexecutor.state.trade import TradeType
 from tradeexecutor.state.trade import TradeExecution
-from tradeexecutor.state.types import USDollarAmount
+from tradeexecutor.state.types import USDollarAmount, BPS
 
 
 class NotEnoughMoney(Exception):
@@ -211,6 +211,7 @@ class Portfolio:
                      reserve_currency: AssetIdentifier,
                      reserve_currency_price: USDollarAmount,
                      notes: Optional[str] = None,
+                     lp_fee: Optional[BPS] = None,
                      ) -> Tuple[TradingPosition, TradeExecution, bool]:
         """Create a trade.
 

--- a/tradeexecutor/state/portfolio.py
+++ b/tradeexecutor/state/portfolio.py
@@ -13,7 +13,7 @@ from tradeexecutor.state.position import TradingPosition
 from tradeexecutor.state.reserve import ReservePosition
 from tradeexecutor.state.trade import TradeType
 from tradeexecutor.state.trade import TradeExecution
-from tradeexecutor.state.types import USDollarAmount, BPS
+from tradeexecutor.state.types import USDollarAmount, BPS, USDollarPrice
 
 
 class NotEnoughMoney(Exception):
@@ -138,9 +138,9 @@ class Portfolio:
     def open_new_position(self,
                           ts: datetime.datetime,
                           pair: TradingPairIdentifier,
-                          assumed_price: USDollarAmount,
+                          assumed_price: USDollarPrice,
                           reserve_currency: AssetIdentifier,
-                          reserve_currency_price: USDollarAmount) -> TradingPosition:
+                          reserve_currency_price: USDollarPrice) -> TradingPosition:
         """Opens a new trading position.
 
         - Marks the position opened.
@@ -211,7 +211,8 @@ class Portfolio:
                      reserve_currency: AssetIdentifier,
                      reserve_currency_price: USDollarAmount,
                      notes: Optional[str] = None,
-                     lp_fee: Optional[BPS] = None,
+                     pair_fee: Optional[BPS] = None,
+                     lp_fees_estimated: Optional[USDollarAmount] = None,
                      ) -> Tuple[TradingPosition, TradeExecution, bool]:
         """Create a trade.
 
@@ -225,7 +226,12 @@ class Portfolio:
 
         position = self.get_position_by_trading_pair(pair)
         if position is None:
-            position = self.open_new_position(ts, pair, assumed_price, reserve_currency, reserve_currency_price)
+            position = self.open_new_position(
+                ts,
+                pair,
+                assumed_price,
+                reserve_currency,
+                reserve_currency_price)
             created = True
         else:
             created = False
@@ -238,9 +244,12 @@ class Portfolio:
             assumed_price,
             trade_type,
             reserve_currency,
-            reserve_currency_price)
+            reserve_currency_price,
+            pair_fee=pair_fee,
+            lp_fees_estimated=lp_fees_estimated,
+        )
 
-        # Udpate notes
+        # Update notes
         trade.notes = notes
         position.notes = notes
 

--- a/tradeexecutor/state/position.py
+++ b/tradeexecutor/state/position.py
@@ -97,10 +97,11 @@ class TradingPosition:
         assert self.position_id > 0
         assert self.last_pricing_at is not None
         assert self.reserve_currency is not None
+
         # Note that price *can* be zero,
         # on some obscure cases when we load the state from the disk
-        assert self.last_token_price >= 0
-        assert self.last_reserve_price >= 0
+        assert self.last_token_price >= 0, f"Token price was: {self.last_token_price}"
+        assert self.last_reserve_price >= 0, f"Reserve price was: {self.last_reserve_price}"
 
         # Do some extra checks to avoid Pandas types in serialisation
         assert isinstance(self.opened_at, datetime.datetime)
@@ -284,7 +285,8 @@ class TradingPosition:
                    trade_type: TradeType,
                    reserve_currency: AssetIdentifier,
                    reserve_currency_price: USDollarAmount,
-                   lp_fee: Optional[BPS] = None
+                   pair_fee: Optional[BPS] = None,
+                   lp_fees_estimated: Optional[USDollarAmount] = None,
                    ) -> TradeExecution:
         """Open a new trade on position.
 
@@ -315,7 +317,8 @@ class TradingPosition:
             planned_price=assumed_price,
             planned_reserve=planned_reserve,
             reserve_currency=self.reserve_currency,
-            lp_fee=lp_fee,
+            fee_tier=pair_fee,
+            lp_fees_estimated=lp_fees_estimated,
         )
         self.trades[trade.trade_id] = trade
         return trade

--- a/tradeexecutor/state/position.py
+++ b/tradeexecutor/state/position.py
@@ -13,7 +13,7 @@ from dataclasses_json import dataclass_json
 from tradeexecutor.state.identifier import TradingPairIdentifier, AssetIdentifier
 from tradeexecutor.state.trade import TradeType
 from tradeexecutor.state.trade import TradeExecution
-from tradeexecutor.state.types import USDollarAmount
+from tradeexecutor.state.types import USDollarAmount, BPS
 
 
 @dataclass_json
@@ -283,7 +283,9 @@ class TradingPosition:
                    assumed_price: USDollarAmount,
                    trade_type: TradeType,
                    reserve_currency: AssetIdentifier,
-                   reserve_currency_price: USDollarAmount) -> TradeExecution:
+                   reserve_currency_price: USDollarAmount,
+                   lp_fee: Optional[BPS] = None
+                   ) -> TradeExecution:
         """Open a new trade on position.
 
         Trade can be opened by knowing how much you want to buy (quantity) or how much cash you have to buy (reserve).
@@ -313,6 +315,7 @@ class TradingPosition:
             planned_price=assumed_price,
             planned_reserve=planned_reserve,
             reserve_currency=self.reserve_currency,
+            lp_fee=lp_fee,
         )
         self.trades[trade.trade_id] = trade
         return trade

--- a/tradeexecutor/state/state.py
+++ b/tradeexecutor/state/state.py
@@ -92,7 +92,8 @@ class State:
                      reserve_currency: AssetIdentifier,
                      reserve_currency_price: USDollarAmount,
                      notes: Optional[str] = None,
-                     lp_fee: Optional[BPS] = None,
+                     pair_fee: Optional[BPS] = None,
+                     lp_fees_estimated: Optional[USDollarAmount] = None,
                      ) -> Tuple[TradingPosition, TradeExecution, bool]:
         """Creates a request for a new trade.
 
@@ -122,7 +123,10 @@ class State:
             assumed_price,
             trade_type,
             reserve_currency,
-            reserve_currency_price)
+            reserve_currency_price,
+            pair_fee=pair_fee,
+            lp_fees_estimated=lp_fees_estimated,
+        )
         return position, trade, created
 
     def start_execution(self, ts: datetime.datetime, trade: TradeExecution, txid: str, nonce: int):

--- a/tradeexecutor/state/state.py
+++ b/tradeexecutor/state/state.py
@@ -18,7 +18,7 @@ from .position import TradingPosition
 from .reserve import ReservePosition
 from .statistics import Statistics
 from .trade import TradeExecution, TradeStatus, TradeType
-from .types import USDollarAmount
+from .types import USDollarAmount, BPS, USDollarPrice
 from .visualisation import Visualisation
 
 
@@ -92,6 +92,7 @@ class State:
                      reserve_currency: AssetIdentifier,
                      reserve_currency_price: USDollarAmount,
                      notes: Optional[str] = None,
+                     lp_fee: Optional[BPS] = None,
                      ) -> Tuple[TradingPosition, TradeExecution, bool]:
         """Creates a request for a new trade.
 
@@ -150,7 +151,14 @@ class State:
         assert trade.get_status() == TradeStatus.started
         trade.broadcasted_at = broadcasted_at
 
-    def mark_trade_success(self, executed_at: datetime.datetime, trade: TradeExecution, executed_price: USDollarAmount, executed_amount: Decimal, executed_reserve: Decimal, lp_fees: USDollarAmount, native_token_price: USDollarAmount):
+    def mark_trade_success(self,
+                           executed_at: datetime.datetime,
+                           trade: TradeExecution,
+                           executed_price: USDollarPrice,
+                           executed_amount: Decimal,
+                           executed_reserve: Decimal,
+                           lp_fees: USDollarAmount,
+                           native_token_price: USDollarPrice):
         """"""
 
         position = self.portfolio.find_position_for_trade(trade)

--- a/tradeexecutor/state/trade.py
+++ b/tradeexecutor/state/trade.py
@@ -138,12 +138,14 @@ class TradeExecution:
     #: How much reserves we spend for this traded, the actual realised amount.
     executed_reserve: Optional[Decimal] = None
 
-    #: LP fee recorded before the execution starts.
+    #: LP fee % recorded before the execution starts.
     #:
     #: Not available in the case this is ignored
     #: in backtesting or not supported by routers/trading pairs.
     #:
     #: Used to calculate :py:attr:`lp_fees_estimated`.
+    #:
+    #: Sourced from Uniswap v2 router or Uniswap v3 pool information.
     #:
     fee_tier: Optional[BPS] = None
 

--- a/tradeexecutor/state/trade.py
+++ b/tradeexecutor/state/trade.py
@@ -50,7 +50,9 @@ class TradeExecution:
     Each trade has a reserve currency that we use to trade the token (usually USDC).
 
     Each trade can be
+
     - Buy: swap quote token -> base token
+
     - Sell: swap base token -> quote token
 
     When doing a buy `planned_reserve` (fiat) is the input. This yields to `executed_quantity` of tokens
@@ -60,9 +62,13 @@ class TradeExecution:
     of fiat that might be different from `planned_reserve.
 
     Trade execution has four states
+
     - Planning: The execution object is prepared
+
     - Capital allocation and transaction creation: We move reserve from out portfolio to the trade in internal accounting
+
     - Transaction broadcast: trade cannot be cancelled in this point
+
     - Resolving the trade: We check the Ethereum transaction receipt to see how well we succeeded in the trade
 
     There trade state is resolved based on the market variables (usually timestamps).
@@ -139,7 +145,7 @@ class TradeExecution:
     #:
     #: Used to calculate :py:attr:`lp_fees_estimated`.
     #:
-    lp_fee: Optional[BPS] = None
+    fee_tier: Optional[BPS] = None
 
     #: LP fees paid, currency convereted to the USD.
     #:
@@ -160,7 +166,7 @@ class TradeExecution:
     #:
     #: We set this exchange rate before the trade is started.
     #: Both `lp_fees_estimated` and `lp_fees_paid` need to use the same exchange rate,
-    #: even though it would not be timestamp accurage.
+    #: even though it would not be timestamp accurte.
     lp_fee_exchange_rate: Optional[USDollarPrice] = None
 
     #: USD price per blockchain native currency unit, at the time of execution
@@ -209,6 +215,12 @@ class TradeExecution:
         assert self.planned_reserve >= 0
         assert type(self.planned_price) == float, f"Price was given as {self.planned_price.__class__}: {self.planned_price}"
         assert self.opened_at.tzinfo is None, f"We got a datetime {self.opened_at} with tzinfo {self.opened_at.tzinfo}"
+
+        if self.lp_fees_estimated is not None:
+            assert type(self.lp_fees_estimated) == float
+
+        if self.fee_tier is not None:
+            assert type(self.fee_tier) == float
 
     def get_human_description(self) -> str:
         """User friendly description for this trade"""

--- a/tradeexecutor/state/trade.py
+++ b/tradeexecutor/state/trade.py
@@ -431,18 +431,3 @@ class TradeExecution:
     def get_planned_max_gas_price(self) -> int:
         """Get the maximum gas fee set to all transactions in this trade."""
         return max([t.get_planned_gas_price() for t in self.blockchain_transactions])
-
-    def estimate_trading_fee(self,
-                          lp_fee_exchange_rate: float,
-                          ) -> USDollarAmount:
-        """Fill in the LP fee estimation structure.
-
-        The trade must be prefilled with buy/sell side
-        quantity/value information. We calcualte
-        and convert the fees based
-
-        :param trading_pair_fee:
-        """
-
-
-

--- a/tradeexecutor/state/types.py
+++ b/tradeexecutor/state/types.py
@@ -7,33 +7,25 @@
     so work here is much unfinished.
 
 """
-import datetime
-
-# Wait until NumPy supports Python 3.10 on macOS
-# from typing import TypeAlias
 
 #: Represents a US dollar amount used in valuation and prices.
 #: This type alias cannot be used for accounting. For accountable amounts always use Decimal.
 #: This type is only used for symboling that the function return value will be approximately
 #: amount in the US dollar, mostly for being human readable purposes.
-from decimal import Decimal
+from typing import TypeAlias
 
 
-class USDollarAmount(float):
-    pass
+#: Dollar amount that does not need to be accurately amounted
+USDollarAmount: TypeAlias = float
 
+#: Dollar price that does not need to be accurately amounted
+USDollarPrice: TypeAlias = float
 
-class NaiveDatetime(datetime.datetime):
-    """Always encode datetime with timezones.
+#: Basis points expressed as float
+#:
+#: 10000 bps = 100 % = 1 float
+BPS: TypeAlias = float
 
-    By default datetime.datetime(ts) deserialises to a local timezone.
-    We want to force UTC every to make sure state is transferrable between different computers.
-    """
-    def __init__(self, *args, **kwargs):
-        """"""
-        if len(args) == 1:
-            pass
+JSONHexAddress: TypeAlias = str
 
-
-JSONHexAddress = str
-JSONHexBytes = str
+JSONHexBytes: TypeAlias = str

--- a/tradeexecutor/strategy/pandas_trader/position_manager.py
+++ b/tradeexecutor/strategy/pandas_trader/position_manager.py
@@ -417,9 +417,9 @@ class PositionManager:
         dex_pair = self.universe.universe.pairs.get_pair_by_id(pair_id)
         return translate_trading_pair(dex_pair)
 
-    def estimate_trading_fee(self,
-                             pair: Optional[TradingPairIdentifier] = None,
-                             ) -> Optional[float]:
+    def get_pair_fee(self,
+                     pair: Optional[TradingPairIdentifier] = None,
+                     ) -> Optional[float]:
         """Estimate the trading/LP fees for a trading pair.
 
         This information can come either from the exchange itself (Uni v2 compatibles),

--- a/tradeexecutor/strategy/pandas_trader/position_manager.py
+++ b/tradeexecutor/strategy/pandas_trader/position_manager.py
@@ -416,3 +416,32 @@ class PositionManager:
         """
         dex_pair = self.universe.universe.pairs.get_pair_by_id(pair_id)
         return translate_trading_pair(dex_pair)
+
+    def estimate_trading_fee(self,
+                             pair: Optional[TradingPairIdentifier] = None,
+                             ) -> Optional[float]:
+        """Estimate the trading/LP fees for a trading pair.
+
+        This information can come either from the exchange itself (Uni v2 compatibles),
+        or from the trading pair (Uni v3).
+
+        The return value is used to fill the
+        fee values for any newly opened trades.
+
+        :param pair:
+            Trading pair for which we want to have the fee.
+
+            Can be left empty if the underlying exchange is always
+            offering the same fee.
+
+        :return:
+            The estimated trading fee, expressed as %.
+
+            Returns None if the fee information is not available.
+            This can be different from zero fees.
+        """
+        return self.pricing_model.estimate_trading_fee(self.timestamp, pair)
+
+
+
+

--- a/tradeexecutor/strategy/pandas_trader/position_manager.py
+++ b/tradeexecutor/strategy/pandas_trader/position_manager.py
@@ -440,7 +440,7 @@ class PositionManager:
             Returns None if the fee information is not available.
             This can be different from zero fees.
         """
-        return self.pricing_model.estimate_trading_fee(self.timestamp, pair)
+        return self.pricing_model.get_pair_fee(self.timestamp, pair)
 
 
 

--- a/tradeexecutor/strategy/pandas_trader/position_manager.py
+++ b/tradeexecutor/strategy/pandas_trader/position_manager.py
@@ -290,7 +290,8 @@ class PositionManager:
         assert weight <= 1, f"Target weight cannot be over one: {weight}"
         assert weight >= 0, f"Target weight cannot be negative: {weight}"
 
-        price = self.pricing_model.get_buy_price(self.timestamp, pair, dollar_amount_delta)
+        price_structure = self.pricing_model.get_buy_price(self.timestamp, pair, dollar_amount_delta)
+        price = price_structure.price
 
         reserve_asset, reserve_price = self.state.portfolio.get_default_reserve_currency()
 

--- a/tradeexecutor/strategy/pricing_model.py
+++ b/tradeexecutor/strategy/pricing_model.py
@@ -50,6 +50,13 @@ class TradePricing:
     #:
     market_feed_delay: Optional[datetime.timedelta] = None
 
+    #: Is this buy or sell trade.
+    #:
+    #: True for buy.
+    #: False for sell.
+    #: None for Unknown.
+    side: Optional[bool] = None
+
     def __repr__(self):
         fee = self.pair_fee or 0
         return f"<TradePricing:{self.price} mid:{self.mid_price} fee:{fee:.4f}%>"
@@ -67,6 +74,13 @@ class TradePricing:
             assert type(self.pair_fee) == float, f"Got fee: {type(self.pair_fee)}"
         if self.market_feed_delay is not None:
             assert isinstance(self.market_feed_delay, datetime.timedelta)
+
+        # Do satefy checks for the price calculation
+        if self.side is not None:
+            if self.side:
+                assert self.price >= self.mid_price, f"Got bad buy pricing: {self.price} > {self.mid_price}"
+            if not self.side:
+                assert self.price <= self.mid_price, f"Got bad sell pricing: {self.price} < {self.mid_price}"
 
 
 class PricingModel(abc.ABC):

--- a/tradeexecutor/strategy/pricing_model.py
+++ b/tradeexecutor/strategy/pricing_model.py
@@ -2,14 +2,67 @@
 
 import abc
 import datetime
+from dataclasses import dataclass
 from decimal import Decimal, ROUND_DOWN
 from typing import Callable, Optional
 
 from tradeexecutor.state.identifier import TradingPairIdentifier
-from tradeexecutor.state.types import USDollarAmount
+from tradeexecutor.state.types import USDollarAmount, BPS, USDollarPrice
 from tradeexecutor.strategy.execution_model import ExecutionModel
 from tradeexecutor.strategy.routing import RoutingModel
 from tradeexecutor.strategy.universe_model import StrategyExecutionUniverse
+
+
+@dataclass(slots=True, frozen=True)
+class TradePricing:
+    """Describe price results for a price query.
+
+    - Each price result is tied to quantiy/amount
+
+    - Each price result gets a split that describes liquidity provider fees
+
+    A helper class to deal with problems of accounting and estimation of prices on Uniswap like exchange.
+    """
+
+    #: The price we expect this transaction to clear.
+    #:
+    #: This price has LP fees already deducted away from it.
+    #: It may or may not include price impact if liquidity data was available
+    #: for the pricing model.
+    price: USDollarPrice
+
+    #: The "fair" market price during the transaction.
+    #:
+    #: This is the mid price - no LP fees, price impact,
+    #: etc. included.
+    mid_price: USDollarPrice
+
+    #: How much liquidity provider fees we are going to pay on this trade.
+    #:
+    #: Set to None if data is not available.
+    lp_fee: Optional[USDollarAmount] = None
+
+    #: What was the LP fee % used as the base of the calculations.
+    #:
+    pair_fee: Optional[BPS] = None
+
+    #: How old price data we used for this estimate
+    #:
+    market_feed_delay: Optional[datetime.timedelta] = None
+
+    def __post_init__(self):
+        """Validate parameters.
+
+        Make sure we don't slip in e.g. NumPy types.
+        """
+        assert type(self.price) == float
+        assert type(self.mid_price) == float
+        if self.lp_fee is not None:
+            assert type(self.lp_fee) == float
+        if self.pair_fee is not None:
+            assert type(self.pair_fee) == float
+        if self.market_feed_delay is not None:
+            assert isinstance(self.market_feed_delay, datetime.timedelta)
 
 
 class PricingModel(abc.ABC):
@@ -37,7 +90,7 @@ class PricingModel(abc.ABC):
     def get_sell_price(self,
                        ts: datetime.datetime,
                        pair: TradingPairIdentifier,
-                       quantity: Optional[Decimal]) -> USDollarAmount:
+                       quantity: Optional[Decimal]) -> TradePricing:
         """Get the sell price for an asset.
 
         :param ts:
@@ -50,6 +103,9 @@ class PricingModel(abc.ABC):
 
         :param quantity:
             If the sel quantity is known, get the price with price impact.
+
+        :return:
+            Price structure for the trade.
         """
 
     @abc.abstractmethod
@@ -57,7 +113,7 @@ class PricingModel(abc.ABC):
                       ts: datetime.datetime,
                       pair: TradingPairIdentifier,
                       reserve: Optional[Decimal]
-                      ) -> USDollarAmount:
+                      ) -> TradePricing:
         """Get the sell price for an asset.
 
         :param ts:
@@ -71,12 +127,15 @@ class PricingModel(abc.ABC):
         :param reserve:
             If the buy token quantity quantity is known,
             get the buy price with price impact.
+
+        :return:
+            Price structure for the trade.
         """
 
     @abc.abstractmethod
     def get_mid_price(self,
                       ts: datetime.datetime,
-                      pair: TradingPairIdentifier) -> USDollarAmount:
+                      pair: TradingPairIdentifier) -> USDollarPrice:
         """Get the mid-price for an asset.
 
         Mid price is an non-trddeable price between the best ask
@@ -88,10 +147,10 @@ class PricingModel(abc.ABC):
         """Convert any base token quantity to the native token units by its ERC-20 decimals."""
 
     @abc.abstractmethod
-    def estimate_trading_fee(self,
-                      ts: datetime.datetime,
-                      pair: TradingPairIdentifier,
-                    ) -> Optional[float]:
+    def get_pair_fee(self,
+                     ts: datetime.datetime,
+                     pair: TradingPairIdentifier,
+                     ) -> Optional[float]:
         """Estimate the trading/LP fees for a trading pair.
 
         This information can come either from the exchange itself (Uni v2 compatibles),

--- a/tradeexecutor/strategy/pricing_model.py
+++ b/tradeexecutor/strategy/pricing_model.py
@@ -50,6 +50,9 @@ class TradePricing:
     #:
     market_feed_delay: Optional[datetime.timedelta] = None
 
+    def __repr__(self):
+        return f"<TradePricing:{self.price} mid:{self.mid_price} fee:{self.pair_fee:.4f}>"
+
     def __post_init__(self):
         """Validate parameters.
 

--- a/tradeexecutor/strategy/pricing_model.py
+++ b/tradeexecutor/strategy/pricing_model.py
@@ -51,7 +51,8 @@ class TradePricing:
     market_feed_delay: Optional[datetime.timedelta] = None
 
     def __repr__(self):
-        return f"<TradePricing:{self.price} mid:{self.mid_price} fee:{self.pair_fee:.4f}>"
+        fee = self.pair_fee or 0
+        return f"<TradePricing:{self.price} mid:{self.mid_price} fee:{fee:.4f}%>"
 
     def __post_init__(self):
         """Validate parameters.

--- a/tradeexecutor/strategy/pricing_model.py
+++ b/tradeexecutor/strategy/pricing_model.py
@@ -64,7 +64,7 @@ class TradePricing:
         if self.lp_fee is not None:
             assert type(self.lp_fee) == float
         if self.pair_fee is not None:
-            assert type(self.pair_fee) == float
+            assert type(self.pair_fee) == float, f"Got fee: {type(self.pair_fee)}"
         if self.market_feed_delay is not None:
             assert isinstance(self.market_feed_delay, datetime.timedelta)
 

--- a/tradeexecutor/strategy/pricing_model.py
+++ b/tradeexecutor/strategy/pricing_model.py
@@ -87,6 +87,31 @@ class PricingModel(abc.ABC):
     def quantize_base_quantity(self, pair: TradingPairIdentifier, quantity: Decimal, rounding=ROUND_DOWN) -> Decimal:
         """Convert any base token quantity to the native token units by its ERC-20 decimals."""
 
+    @abc.abstractmethod
+    def estimate_trading_fee(self,
+                      ts: datetime.datetime,
+                      pair: TradingPairIdentifier,
+                    ) -> Optional[float]:
+        """Estimate the trading/LP fees for a trading pair.
+
+        This information can come either from the exchange itself (Uni v2 compatibles),
+        or from the trading pair (Uni v3).
+
+        The return value is used to fill the
+        fee values for any newly opened trades.
+
+        :param pair:
+            Trading pair for which we want to have the fee.
+
+            Can be left empty if the underlying exchange is always
+            offering the same fee.
+
+        :return:
+            The estimated trading fee, expressed as %.
+
+            Returns None if the fee information is not available.
+            This can be different from zero fees.
+        """
 
 #: This factory creates a new pricing model for each trade cycle.
 #: Pricing model depends on the trading universe that may change for each strategy tick,

--- a/tradeexecutor/strategy/pricing_model.py
+++ b/tradeexecutor/strategy/pricing_model.py
@@ -75,7 +75,7 @@ class TradePricing:
         if self.market_feed_delay is not None:
             assert isinstance(self.market_feed_delay, datetime.timedelta)
 
-        # Do satefy checks for the price calculation
+        # Do safety checks for the price calculation
         if self.side is not None:
             if self.side:
                 assert self.price >= self.mid_price, f"Got bad buy pricing: {self.price} > {self.mid_price}"
@@ -158,6 +158,15 @@ class PricingModel(abc.ABC):
 
         Mid price is an non-trddeable price between the best ask
         and the best pid.
+
+        :param ts:
+            Timestamp. Ignored for live pricing models.
+
+        :param pair:
+            Which trading pair price we query.
+
+        :return:
+            The mid price for the pair at a timestamp.
         """
 
     @abc.abstractmethod
@@ -176,6 +185,11 @@ class PricingModel(abc.ABC):
 
         The return value is used to fill the
         fee values for any newly opened trades.
+
+        :param ts:
+            Timestamp of the trade. Note that currently
+            fees do not vary over time, but might
+            do so in the future.
 
         :param pair:
             Trading pair for which we want to have the fee.

--- a/tradeexecutor/strategy/qstrader/order_sizer.py
+++ b/tradeexecutor/strategy/qstrader/order_sizer.py
@@ -165,7 +165,8 @@ class CashBufferedOrderSizer(OrderSizer):
             if weight > 0:
 
                 trading_pair = self.pricing_model.get_pair_for_id(asset)
-                asset_price = self.pricing_model.get_buy_price(dt, trading_pair, Decimal(after_cost_dollar_weight))
+                price_structure = self.pricing_model.get_buy_price(dt, trading_pair, Decimal(after_cost_dollar_weight))
+                asset_price = price_structure.price
 
                 if asset_price is not None:
 

--- a/tradeexecutor/strategy/qstrader/portfolio_construction_model.py
+++ b/tradeexecutor/strategy/qstrader/portfolio_construction_model.py
@@ -282,7 +282,8 @@ class PortfolioConstructionModel:
         for asset_id, asset_data in current_portfolio.items():
             pair = self.pricing_model.get_pair_for_id(asset_id)
             if pair:
-                target_prices[asset_id] = self.pricing_model.get_buy_price(dt, pair, None)
+                price_structure = self.pricing_model.get_buy_price(dt, pair, None)
+                target_prices[asset_id] = price_structure.price
 
         # Expose internal states to unit tests
         debug_details["positions_at_start_of_construction"] = current_portfolio.copy()  # current_portfolio is mutated later

--- a/tradeexecutor/strategy/routing.py
+++ b/tradeexecutor/strategy/routing.py
@@ -7,7 +7,7 @@ Here we define the abstract overview of routing.
 """
 import abc
 from decimal import Decimal
-from typing import List
+from typing import List, Optional
 
 from tradeexecutor.state.identifier import TradingPairIdentifier
 from tradeexecutor.state.trade import TradeExecution
@@ -52,6 +52,24 @@ class RoutingModel(abc.ABC):
     Nothing done here - check the subclasses.
     """
 
+    def perform_preflight_checks_and_logging(self, state: RoutingState):
+        """"Checks the integrity of the routing.
+
+        - Called from check-wallet to see our routing and balances are good
+        """
+
+    def get_default_trading_fee(self) -> Optional[float]:
+        """Get the trading/LP fee applied to all trading pairs.
+
+        This is Uni v2 style fee.
+
+        :return:
+            Trading fee, BPS * 10000 as a float.
+
+            If information not available return None.
+        """
+        return None
+
     @abc.abstractmethod
     def create_routing_state(self,
                              universe: StrategyExecutionUniverse,
@@ -85,8 +103,4 @@ class RoutingModel(abc.ABC):
             If a trade cannot be executed, e.g. due to an unsupported pair or an exchange,
         """
 
-    def perform_preflight_checks_and_logging(self, state: RoutingState):
-        """"Checks the integrity of the routing.
 
-        - Called from check-wallet to see our routing and balances are good
-        """

--- a/tradeexecutor/strategy/trading_strategy_universe.py
+++ b/tradeexecutor/strategy/trading_strategy_universe.py
@@ -720,6 +720,7 @@ def translate_trading_pair(pair: DEXPair) -> TradingPairIdentifier:
         internal_id=pair.pair_id,
         info_url=pair.get_trading_pair_page_url(),
         exchange_address=pair.exchange_address,
+        fee=pair.fee,
     )
 
 

--- a/tradeexecutor/strategy/trading_strategy_universe.py
+++ b/tradeexecutor/strategy/trading_strategy_universe.py
@@ -12,6 +12,7 @@ import textwrap
 from abc import abstractmethod
 from dataclasses import dataclass
 import logging
+from math import isnan
 from typing import List, Optional, Callable, Tuple, Set, Dict, Iterable
 
 import pandas as pd
@@ -713,6 +714,12 @@ def translate_trading_pair(pair: DEXPair) -> TradingPairIdentifier:
         decimals=pair.quote_token_decimals,
     )
 
+    if isnan(pair.fee):
+        # Repair some data
+        fee = None
+    else:
+        fee = pair.fee
+
     return TradingPairIdentifier(
         base=base,
         quote=quote,
@@ -720,7 +727,7 @@ def translate_trading_pair(pair: DEXPair) -> TradingPairIdentifier:
         internal_id=pair.pair_id,
         info_url=pair.get_trading_pair_page_url(),
         exchange_address=pair.exchange_address,
-        fee=pair.fee,
+        fee=fee,
     )
 
 

--- a/tradeexecutor/strategy/trading_strategy_universe.py
+++ b/tradeexecutor/strategy/trading_strategy_universe.py
@@ -714,7 +714,7 @@ def translate_trading_pair(pair: DEXPair) -> TradingPairIdentifier:
         decimals=pair.quote_token_decimals,
     )
 
-    if isnan(pair.fee):
+    if pair.fee and isnan(pair.fee):
         # Repair some data
         fee = None
     else:

--- a/tradeexecutor/strategy/valuation.py
+++ b/tradeexecutor/strategy/valuation.py
@@ -52,9 +52,9 @@ class ValuationModel(Protocol):
         if quantity == 0:
             return ts, 0.0
 
-        price = self.pricing_model.get_sell_price(ts, pair, position)
+        price_structure = self.pricing_model.get_sell_price(ts, pair, position)
 
-        return ts, price
+        return ts, price_structure.price
 
 
 class ValuationModelFactory(Protocol):

--- a/tradeexecutor/testing/backtest_trader.py
+++ b/tradeexecutor/testing/backtest_trader.py
@@ -99,7 +99,7 @@ class BacktestTrader:
             reserve=reserve,
             price=price)
 
-        trade.lp_fee = lp_fee
+        trade.fee_tier = lp_fee
         trade.lp_fees_estimated = lp_fees_estimated
 
         # Run trade start, simulated broadcast, simulated execution using

--- a/tradeexecutor/testing/backtest_trader.py
+++ b/tradeexecutor/testing/backtest_trader.py
@@ -53,12 +53,15 @@ class BacktestTrader:
         """Get the historical price for our current backtest time."""
         return self.pricing_model.get_buy_price(self.ts, pair, reserve)
 
-
     def get_sell_price(self, pair: TradingPairIdentifier, quantity: Decimal) -> TradePricing:
         """Get the historical price for our current backtest time."""
         return self.pricing_model.get_sell_price(self.ts, pair, quantity)
 
-    def create(self, pair: TradingPairIdentifier, quantity: Optional[Decimal], reserve: Optional[Decimal], price: float) -> Tuple[TradingPosition, TradeExecution]:
+    def create(self,
+               pair: TradingPairIdentifier,
+               quantity: Optional[Decimal],
+               reserve: Optional[Decimal],
+               price: float) -> Tuple[TradingPosition, TradeExecution]:
         """Open a new trade."""
 
         assert len(self.universe.reserve_assets) == 1
@@ -72,8 +75,8 @@ class BacktestTrader:
             assumed_price=price,
             trade_type=TradeType.rebalance,
             reserve_currency=self.universe.reserve_assets[0],
-            reserve_currency_price=1.0,
-            lp_fee=pair.fee,
+            reserve_currency_price=1.0
+
         )
 
         return position, trade

--- a/tradeexecutor/testing/ethereumtrader.py
+++ b/tradeexecutor/testing/ethereumtrader.py
@@ -142,6 +142,7 @@ def execute_trades_simple(
         },
         allowed_intermediary_pairs={},
         reserve_token_address=reserve_asset.address,
+        trading_fee=0.030,
     )
 
     state.start_trades(datetime.datetime.utcnow(), trades)

--- a/tradeexecutor/testing/simulated_trader.py
+++ b/tradeexecutor/testing/simulated_trader.py
@@ -26,7 +26,8 @@ class SimulatedTestTrader:
             amount_in_usd: Decimal) -> TradeExecution:
         """Buy token (trading pair) for a certain value."""
 
-        price = self.pricing_model.get_buy_price(ts, pair, amount_in_usd)
+        price_structure = self.pricing_model.get_buy_price(ts, pair, amount_in_usd)
+        price = price_structure.price
 
         reserve_currency, exchange_rate = self.state.portfolio.get_default_reserve_currency()
 

--- a/tradeexecutor/testing/synthetic_exchange_data.py
+++ b/tradeexecutor/testing/synthetic_exchange_data.py
@@ -2,6 +2,7 @@
 from typing import Optional
 
 from tradeexecutor.backtest.backtest_routing import BacktestRoutingModel
+from tradeexecutor.state.types import BPS
 from tradeexecutor.strategy.trading_strategy_universe import TradingStrategyUniverse
 from tradeexecutor.testing.synthetic_ethereum_data import generate_random_ethereum_address
 from tradingstrategy.chain import ChainId
@@ -22,7 +23,7 @@ def generate_exchange(exchange_id: int, chain_id: ChainId, address="0x0000000000
     return exchange
 
 
-def generate_simple_routing_model(universe: TradingStrategyUniverse, trading_fee: Optional[float]=None) -> BacktestRoutingModel:
+def generate_simple_routing_model(universe: TradingStrategyUniverse, trading_fee: Optional[BPS] = None) -> BacktestRoutingModel:
     """Creates a routing model for data generated synthetically.
 
     - Assumes there is only one exchange in the trading universe

--- a/tradeexecutor/testing/synthetic_exchange_data.py
+++ b/tradeexecutor/testing/synthetic_exchange_data.py
@@ -1,4 +1,6 @@
 """Generate synthetic exchange."""
+from typing import Optional
+
 from tradeexecutor.backtest.backtest_routing import BacktestRoutingModel
 from tradeexecutor.strategy.trading_strategy_universe import TradingStrategyUniverse
 from tradeexecutor.testing.synthetic_ethereum_data import generate_random_ethereum_address
@@ -20,7 +22,7 @@ def generate_exchange(exchange_id: int, chain_id: ChainId, address="0x0000000000
     return exchange
 
 
-def generate_simple_routing_model(universe: TradingStrategyUniverse) -> BacktestRoutingModel:
+def generate_simple_routing_model(universe: TradingStrategyUniverse, trading_fee: Optional[float]=None) -> BacktestRoutingModel:
     """Creates a routing model for data generated synthetically.
 
     - Assumes there is only one exchange in the trading universe
@@ -54,4 +56,5 @@ def generate_simple_routing_model(universe: TradingStrategyUniverse) -> Backtest
         factory_router_map,
         allowed_intermediary_pairs,
         reserve_token_address=reserve_asset.address,
+        trading_fee=trading_fee,
     )


### PR DESCRIPTION
- Add LP fee tracking through the code base
- `TradeExecution.fee_tier`, `TradeExecution.lp_fees_estimated`, `TradeExecution.lp_fee_exchange_rate` added
- `PricingModel.get_buy_price()` and `get_sell_price()` now return `TradePricing` structure instead of naive float price
- Backtests correctly account for LP fees paid
- Uniswap v2 routers, pricing models and valuation models account for LP fees
- Tests that backtest simulated trades reflect LP fees paid
- Start to use `TypeAlias` properly as we have migrated to Python 3.10