### PR TITLE
standardise fees

### DIFF
--- a/tests/test_execute_trade_uniswap_v3.py
+++ b/tests/test_execute_trade_uniswap_v3.py
@@ -33,14 +33,12 @@ from tradeexecutor.testing.ethereumtrader_uniswap_v3 import UniswapV3TestTrader
 from tradeexecutor.testing.dummy_trader import DummyTestTrader
 
 
-@pytest.fixture()
-def weth_usdc_fee() -> int:
-    return 3000
 
+WETH_USDC_FEE = 0.003
+AAVE_USDC_FEE = 0.003
 
-@pytest.fixture()
-def aave_usdc_fee() -> int:
-    return 3000
+WETH_USDC_FEE_RAW = 3000
+AAVE_USDC_FEE_RAW = 3000
 
 
 @pytest.fixture
@@ -132,9 +130,9 @@ def asset_aave(aave_token, chain_id) -> AssetIdentifier:
 
 
 @pytest.fixture
-def aave_usdc_uniswap_trading_pair(web3, deployer, uniswap_v3, aave_token, usdc_token, aave_usdc_fee) -> HexAddress:
+def aave_usdc_uniswap_trading_pair(web3, deployer, uniswap_v3, aave_token, usdc_token) -> HexAddress:
     """AAVE-USDC pool with 200k liquidity. Fee of 0.1%"""
-    min_tick, max_tick = get_default_tick_range(aave_usdc_fee)
+    min_tick, max_tick = get_default_tick_range(AAVE_USDC_FEE_RAW)
     
     pool_contract = deploy_pool(
         web3,
@@ -142,7 +140,7 @@ def aave_usdc_uniswap_trading_pair(web3, deployer, uniswap_v3, aave_token, usdc_
         deployment=uniswap_v3,
         token0=aave_token,
         token1=usdc_token,
-        fee=aave_usdc_fee
+        fee=AAVE_USDC_FEE_RAW
     )
     
     add_liquidity(
@@ -159,9 +157,9 @@ def aave_usdc_uniswap_trading_pair(web3, deployer, uniswap_v3, aave_token, usdc_
 
 
 @pytest.fixture
-def weth_usdc_uniswap_trading_pair(web3, deployer, uniswap_v3, weth_token, usdc_token, weth_usdc_fee) -> HexAddress:
+def weth_usdc_uniswap_trading_pair(web3, deployer, uniswap_v3, weth_token, usdc_token) -> HexAddress:
     """ETH-USDC pool with 1.7M liquidity."""
-    min_tick, max_tick = get_default_tick_range(weth_usdc_fee)
+    min_tick, max_tick = get_default_tick_range(WETH_USDC_FEE_RAW)
     
     pool_contract = deploy_pool(
         web3,
@@ -169,7 +167,7 @@ def weth_usdc_uniswap_trading_pair(web3, deployer, uniswap_v3, weth_token, usdc_
         deployment=uniswap_v3,
         token0=weth_token,
         token1=usdc_token,
-        fee=weth_usdc_fee
+        fee=WETH_USDC_FEE_RAW
     )
     
     add_liquidity(
@@ -186,24 +184,24 @@ def weth_usdc_uniswap_trading_pair(web3, deployer, uniswap_v3, weth_token, usdc_
 
 
 @pytest.fixture
-def weth_usdc_pair(uniswap_v3, weth_usdc_uniswap_trading_pair, asset_usdc, asset_weth, weth_usdc_fee) -> TradingPairIdentifier:
+def weth_usdc_pair(uniswap_v3, weth_usdc_uniswap_trading_pair, asset_usdc, asset_weth) -> TradingPairIdentifier:
     return TradingPairIdentifier(
         asset_weth, 
         asset_usdc, 
         weth_usdc_uniswap_trading_pair, 
         uniswap_v3.factory.address,
-        fee = weth_usdc_fee
+        fee = WETH_USDC_FEE
     )
 
 
 @pytest.fixture
-def aave_usdc_pair(uniswap_v3, aave_usdc_uniswap_trading_pair, asset_usdc, asset_aave, aave_usdc_fee) -> TradingPairIdentifier:
+def aave_usdc_pair(uniswap_v3, aave_usdc_uniswap_trading_pair, asset_usdc, asset_aave) -> TradingPairIdentifier:
     return TradingPairIdentifier(
         asset_aave, 
         asset_usdc, 
         aave_usdc_uniswap_trading_pair, 
         uniswap_v3.factory.address,
-        fee = aave_usdc_fee
+        fee = AAVE_USDC_FEE
     )
 
 
@@ -277,7 +275,6 @@ def test_execute_trade_instructions_buy_weth(
     weth_usdc_pair: TradingPairIdentifier,
     start_ts: datetime.datetime,
     price_helper: UniswapV3PriceHelper,
-    weth_usdc_fee,
     ethereum_trader: UniswapV3TestTrader 
 ):
     """Sync reserves from one deposit."""
@@ -295,7 +292,7 @@ def test_execute_trade_instructions_buy_weth(
 
     # swap from quote to base (usdc to weth)
     path = [usdc_token.address, weth_token.address]
-    fees = [weth_usdc_fee]
+    fees = [WETH_USDC_FEE_RAW]
     
     # Estimate price
     raw_assumed_quantity = price_helper.get_amount_out(buy_amount * 10 ** 6, path, fees)

--- a/tradeexecutor/ethereum/uniswap_v3_execution.py
+++ b/tradeexecutor/ethereum/uniswap_v3_execution.py
@@ -100,14 +100,14 @@ def get_current_price(web3: Web3, uniswap: UniswapV3Deployment, pair: TradingPai
     quantity_raw = pair.base.convert_to_raw_amount(quantity)
     
     path = [pair.base.checksum_address,  pair.quote.checksum_address] 
-    fees = [pair.fee]
-    assert fees, "no fees in pair"        
+    raw_fees = [int(pair.fee * 1_000_000)]
+    assert raw_fees, "no fees in pair"        
         
     price_helper = UniswapV3PriceHelper(uniswap)
     out_raw = price_helper.get_amount_out(
         amount_in=quantity_raw,
         path=path,
-        fees=fees
+        fees=raw_fees
     )
     
     return float(pair.quote.convert_to_decimal(out_raw))

--- a/tradeexecutor/ethereum/uniswap_v3_live_pricing.py
+++ b/tradeexecutor/ethereum/uniswap_v3_live_pricing.py
@@ -144,13 +144,11 @@ class UniswapV3LivePricing(EthereumPricingModel):
 
         lp_fee = (mid_price - price) * float(quantity)
         
-        fees_multiplier = [fee/1_000_000 for fee in fees]
-        
         return TradePricing(
             price=price,
             mid_price=mid_price,
             lp_fee=[lp_fee],
-            pair_fee=fees_multiplier,
+            pair_fee=fees,
             side=False,
             path=path
         )
@@ -227,13 +225,11 @@ class UniswapV3LivePricing(EthereumPricingModel):
 
         assert price >= mid_price, f"Bad pricing: {price}, {mid_price}"
         
-        fees_multiplier = [fee/1_000_000 for fee in fees]
-
         return TradePricing(
             price=float(price),
             mid_price=float(mid_price),
             lp_fee=[lp_fee],
-            pair_fee=fees_multiplier,
+            pair_fee=fees,
             market_feed_delay=datetime.timedelta(seconds=0),
             side=True,
             path=path

--- a/tradeexecutor/ethereum/uniswap_v3_routing.py
+++ b/tradeexecutor/ethereum/uniswap_v3_routing.py
@@ -65,9 +65,7 @@ class UniswapV3RoutingState(EthereumRoutingState):
         if check_balances:
             self.check_has_enough_tokens(quote_token, reserve_amount)
 
-        fee = target_pair.fee
-        
-        assert fee > 1, "fee must be provided as raw fee for uniswap v3"
+        raw_fee = int(target_pair.fee * 1_000_000)
         
         bound_swap_func = swap_with_slippage_protection(
             uniswap,
@@ -76,7 +74,7 @@ class UniswapV3RoutingState(EthereumRoutingState):
             quote_token=quote_token,
             amount_in=reserve_amount,
             max_slippage=max_slippage * 100,  # In BPS
-            pool_fees=[fee]
+            pool_fees=[raw_fee]
         )
         
         return self.get_signed_tx(bound_swap_func, self.swap_gas_limit)
@@ -107,16 +105,15 @@ class UniswapV3RoutingState(EthereumRoutingState):
         if check_balances:
             self.check_has_enough_tokens(quote_token, reserve_amount)
 
-        assert intermediary_pair.fee > 1 and target_pair.fee > 1, "fees must be provided as raw fee for uniswap v3"
-        
-        pool_fees = [intermediary_pair.fee, target_pair.fee]
+        # eth_defi uses raw_fees
+        raw_pool_fees = [int(intermediary_pair.fee * 1_000_000), int(target_pair.fee * 1_000_000)]
         
         bound_swap_func = swap_with_slippage_protection(
             uniswap,
             recipient_address=hot_wallet.address,
             base_token=base_token,
             quote_token=quote_token,
-            pool_fees=pool_fees,
+            pool_fees=raw_pool_fees,
             amount_in=reserve_amount,
             max_slippage=max_slippage * 100,  # In BPS,
             intermediate_token=intermediary_token,

--- a/tradeexecutor/state/identifier.py
+++ b/tradeexecutor/state/identifier.py
@@ -147,6 +147,7 @@ class TradingPairIdentifier:
 
     def __post_init__(self):
         assert self.base.chain_id == self.quote.chain_id, "Cross-chain trading pairs are not possible"
+        assert (type(self.fee) in {float, type(None)}) or (self.fee == 0)
 
     def __repr__(self):
         fee = self.fee or 0

--- a/tradeexecutor/state/state.py
+++ b/tradeexecutor/state/state.py
@@ -136,7 +136,7 @@ class State:
                      reserve_currency: AssetIdentifier,
                      reserve_currency_price: USDollarPrice,
                      notes: Optional[str] = None,
-                     pair_fee: Optional[BPS] = None,
+                     pair_fee: Optional[float] = None,
                      lp_fees_estimated: Optional[USDollarAmount] = None,
                      planned_mid_price: Optional[USDollarPrice] = None,
                      price_structure: Optional[TradePricing] = None
@@ -160,6 +160,9 @@ class State:
 
         assert isinstance(strategy_cycle_at, datetime.datetime)
         assert not isinstance(strategy_cycle_at, pd.Timestamp)
+        
+        if pair_fee:
+            assert type(pair_fee) == float
         
         if price_structure is not None:
             assert isinstance(price_structure, TradePricing)

--- a/tradeexecutor/strategy/trade_pricing.py
+++ b/tradeexecutor/strategy/trade_pricing.py
@@ -88,7 +88,7 @@ class TradePricing:
         
         assert [type(_lp_fee) in {float, type(None)} for _lp_fee in self.lp_fee], f"lp_fee must be provided as type list with float or NoneType elements. Got Got lp_fee: {self.lp_fee} {type(self.lp_fee)}"
         
-        assert [type(_pair_fee) in {float, int, type(None)} for _pair_fee in self.pair_fee], f"pair_fee must be provided as a list with float, int, or NoneType elements. Got fee: {self.pair_fee} {type(self.pair_fee)} "
+        assert [type(_pair_fee) in {float, type(None)} for _pair_fee in self.pair_fee], f"pair_fee must be provided as a list with float, int, or NoneType elements. Got fee: {self.pair_fee} {type(self.pair_fee)} "
         
         if self.market_feed_delay is not None:
             assert isinstance(self.market_feed_delay, datetime.timedelta)

--- a/tradeexecutor/strategy/trading_strategy_universe.py
+++ b/tradeexecutor/strategy/trading_strategy_universe.py
@@ -924,16 +924,25 @@ def translate_trading_pair(pair: DEXPair) -> TradingPairIdentifier:
         fee = None
     else:
         # Convert DEXPair.fee BPS to %
+        # So, after this, fee can either be multiplier or None
         if pair.fee is not None:
             # If BPS fee is set it must be more than 1 BPS.
             # Allow explicit fee = 0 in testing.
-            if pair.fee != 0:
-                assert pair.fee > 1, f"DEXPair fee must be in BPS, got {pair.fee}"
-            fee = pair.fee / 10_000
+            # if pair.fee != 0:
+            #     assert pair.fee > 1, f"DEXPair fee must be in BPS, got {pair.fee}"
+            
+            # hack because currently single pair universe gets from jsonl endpoint 
+            # which returns multiplier
+            # so we could either get multiplier or bps
+            if pair.fee > 1:
+                fee = pair.fee / 10_000
+                
+                # highest fee tier is currently 0.3%, which is 0.003 (hack)
+                assert fee <= 0.003, "fee must be provided as bps, not raw fee"
             
             # If fee is bigger than, then it must be bps or raw_fee, which are ints
-            if fee > 1:
-                fee = int(fee)
+            # if fee > 1:
+            #     fee = int(fee)
         else:
             fee = None
 

--- a/tradeexecutor/testing/dummy_trader.py
+++ b/tradeexecutor/testing/dummy_trader.py
@@ -34,12 +34,6 @@ class DummyTestTrader:
         """Open a new trade."""
         # 1. Plan
         
-        fee = (
-            pair.fee/1_000_000
-            if pair.fee 
-            else None
-        )
-        
         position, trade, created = self.state.create_trade(
             strategy_cycle_at=self.ts,
             pair=pair,
@@ -50,7 +44,7 @@ class DummyTestTrader:
             reserve_currency=pair.quote,
             reserve_currency_price=1.0,
             planned_mid_price=price,
-            pair_fee=fee
+            pair_fee=pair.fee
         )
 
         self.ts += datetime.timedelta(seconds=1)

--- a/tradeexecutor/testing/ethereumtrader_uniswap_v2.py
+++ b/tradeexecutor/testing/ethereumtrader_uniswap_v2.py
@@ -41,12 +41,6 @@ class UniswapV2TestTrader(EthereumTrader):
         assumed_quantity = Decimal(raw_assumed_quantity) / Decimal(10**pair.base.decimals)
         assumed_price = amount_in_usd / assumed_quantity
 
-        fee = (
-            pair.fee/1_000_000
-            if pair.fee 
-            else None
-        )
-        
         position, trade, created= self.state.create_trade(
             strategy_cycle_at=self.ts,
             pair=pair,
@@ -56,7 +50,7 @@ class UniswapV2TestTrader(EthereumTrader):
             trade_type=TradeType.rebalance,
             reserve_currency=pair.quote,
             reserve_currency_price=1.0,
-            pair_fee=fee
+            pair_fee=pair.fee
         )
 
         if execute:
@@ -77,12 +71,6 @@ class UniswapV2TestTrader(EthereumTrader):
         # assumed_price = quantity / assumed_quota_token
         assumed_price = assumed_quota_token / quantity
 
-        fee = (
-            pair.fee/1_000_000
-            if pair.fee 
-            else None
-        )
-        
         position, trade, created = self.state.create_trade(
             strategy_cycle_at=self.ts,
             pair=pair,
@@ -92,7 +80,7 @@ class UniswapV2TestTrader(EthereumTrader):
             trade_type=TradeType.rebalance,
             reserve_currency=pair.quote,
             reserve_currency_price=1.0,
-            pair_fee=fee
+            pair_fee=pair.fee
         )
         
 

--- a/tradeexecutor/testing/ethereumtrader_uniswap_v3.py
+++ b/tradeexecutor/testing/ethereumtrader_uniswap_v3.py
@@ -41,22 +41,18 @@ class UniswapV3TestTrader(EthereumTrader):
         
         amount_in = int(amount_in_usd * (10 ** pair.quote.decimals))
         
+        raw_fee = int(pair.fee * 1_000_000)
+        
         # TODO see estimate_buy_quantity in eth_defi/uniswap_v2/fees
         raw_assumed_quantity = self.price_helper.get_amount_out(
             amount_in,
             [quote_token.address, base_token.address],
-            [pair.fee]
+            [raw_fee]
         )
         
         assumed_quantity = Decimal(raw_assumed_quantity) / Decimal(10**pair.base.decimals)
         assumed_price = amount_in_usd / assumed_quantity
 
-        fee = (
-            pair.fee/1_000_000
-            if pair.fee 
-            else None
-        )
-        
         position, trade, created= self.state.create_trade(
             strategy_cycle_at=self.ts,
             pair=pair,
@@ -66,7 +62,7 @@ class UniswapV3TestTrader(EthereumTrader):
             trade_type=TradeType.rebalance,
             reserve_currency=pair.quote,
             reserve_currency_price=1.0,
-            pair_fee=fee
+            pair_fee=pair.fee
         )
 
         if execute:
@@ -83,11 +79,13 @@ class UniswapV3TestTrader(EthereumTrader):
 
         raw_quantity = int(quantity * 10**pair.base.decimals)
         
+        raw_fee = int(pair.fee * 1_000_000)
+        
         # TODO see estimate_sell_price() in eth_defi/uniswap_v2/fees.py
         raw_assumed_quote_token = self.price_helper.get_amount_out(
             raw_quantity,
             [base_token.address, quote_token.address],
-            [pair.fee]
+            [raw_fee]
         )
         
         assumed_quota_token = Decimal(raw_assumed_quote_token) / Decimal(10**pair.quote.decimals)
@@ -95,12 +93,6 @@ class UniswapV3TestTrader(EthereumTrader):
         # assumed_price = quantity / assumed_quota_token
         assumed_price = assumed_quota_token / quantity
 
-        fee = (
-            pair.fee/1_000_000
-            if pair.fee 
-            else None
-        )
-        
         position, trade, created = self.state.create_trade(
             strategy_cycle_at=self.ts,
             pair=pair,
@@ -110,7 +102,7 @@ class UniswapV3TestTrader(EthereumTrader):
             trade_type=TradeType.rebalance,
             reserve_currency=pair.quote,
             reserve_currency_price=1.0,
-            pair_fee=fee
+            pair_fee=pair.fee
         )
 
         if execute:


### PR DESCRIPTION
# Goal

- Standardise fees in the tradeexecutor repo to be float (multiplier), whereever possible.

# Notes

- `eth_defi` repo only uses `raw_fees` since it interacts with smart contracts. When tradeexecutor uses functions or classes from this repo, it converts them to raw fees. 
- `DEXPair` class is allowed to contain fees as BPS, since this is how it receives them from the backend
-  Had to implement a hack to allow DEXPair to also receive multiplier since when it receives data from jsonl endpoint (for single pair universes), it is in multiplier format instead of BPS