### PR TITLE
Best/worst day + volatility

### DIFF
--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -489,7 +489,7 @@ def test_statistics(usdc, weth_usdc, aave_usdc, start_ts):
     assert summary.won == 1
     assert summary.lost == 0
     assert summary.zero_loss == 1
-    assert summary.total_trades == 2
+    assert summary.total_positions == 2
     assert summary.win_percent == 0.5
     assert summary.return_percent == pytest.approx(0.04363200000000006)
     assert summary.annualised_return_percent == pytest.approx(152886.528)
@@ -860,7 +860,7 @@ def test_state_summary_without_initial_cash(usdc, weth_usdc, start_ts: datetime.
     assert summary.initial_cash is None
     assert summary.return_percent is None
     assert summary.annualised_return_percent is None
-    assert summary.total_trades == 1
+    assert summary.total_positions == 1
     assert summary.end_value == pytest.approx(1006.418)
     assert summary.average_net_profit == pytest.approx(9.800999)
 

--- a/tradeexecutor/analysis/trade_analyser.py
+++ b/tradeexecutor/analysis/trade_analyser.py
@@ -1202,7 +1202,12 @@ def build_trade_analysis(portfolio: Portfolio) -> TradeAnalysis:
             # used in calculate_summary_statistics()
             avg_daily_profit_usd = position.get_avg_daily_profit_usd()
             stop_loss = position.stop_loss
-            capital_tied_at_open_pct=position.get_capital_tied_at_open_pct()
+            
+            if position.portfolio_value_at_open:
+                capital_tied_at_open_pct=position.get_capital_tied_at_open_pct()
+            else:
+                capital_tied_at_open_pct=None
+            
             if stop_loss:
                 loss_risk_at_open_pct = position.get_loss_risk_at_open_pct()
             else:

--- a/tradeexecutor/analysis/trade_analyser.py
+++ b/tradeexecutor/analysis/trade_analyser.py
@@ -1201,9 +1201,13 @@ def build_trade_analysis(portfolio: Portfolio) -> TradeAnalysis:
 
             # used in calculate_summary_statistics()
             loss_risk_at_open_pct = position.get_loss_risk_at_open_pct()
-            capital_tied_at_open_pct = position.get_capital_tied_at_open_pct()
             avg_daily_profit_usd = position.get_avg_daily_profit_usd()
             stop_loss = position.stop_loss
+
+            if stop_loss:
+                loss_risk_at_open_pct = position.get_loss_risk_at_open_pct()
+            else:
+                loss_risk_at_open_pct = None
 
             history.add_trade(
                 spot_trade, 

--- a/tradeexecutor/analysis/trade_analyser.py
+++ b/tradeexecutor/analysis/trade_analyser.py
@@ -1203,7 +1203,7 @@ def build_trade_analysis(portfolio: Portfolio) -> TradeAnalysis:
             loss_risk_at_open_pct = position.get_loss_risk_at_open_pct()
             avg_daily_profit_usd = position.get_avg_daily_profit_usd()
             stop_loss = position.stop_loss
-
+            capital_tied_at_open_pct=position.get_capital_tied_at_open_pct()
             if stop_loss:
                 loss_risk_at_open_pct = position.get_loss_risk_at_open_pct()
             else:

--- a/tradeexecutor/analysis/trade_analyser.py
+++ b/tradeexecutor/analysis/trade_analyser.py
@@ -746,7 +746,14 @@ class TradeAnalysis:
         all_trades = winning_trades + losing_trades + [0 for i in range(zero_loss)]
         average_trade = func_with_check(avg, all_trades)
         median_trade = func_with_check(median, all_trades)
-        volatility = stdev(all_trades)
+
+        # variance requires at least two data points
+        if len(all_trades) >=2:
+            volatility = stdev(all_trades)
+        elif len(all_trades) == 1:
+            volatility = 0
+        else:
+            volatility = None
 
         average_winning_trade_profit_pc = get_avg_profit_pct_check(winning_trades)
         average_losing_trade_loss_pc = get_avg_profit_pct_check(losing_trades)

--- a/tradeexecutor/analysis/trade_analyser.py
+++ b/tradeexecutor/analysis/trade_analyser.py
@@ -1200,7 +1200,6 @@ def build_trade_analysis(portfolio: Portfolio) -> TradeAnalysis:
             portfolio_value_at_open = position.portfolio_value_at_open
 
             # used in calculate_summary_statistics()
-            loss_risk_at_open_pct = position.get_loss_risk_at_open_pct()
             avg_daily_profit_usd = position.get_avg_daily_profit_usd()
             stop_loss = position.stop_loss
             capital_tied_at_open_pct=position.get_capital_tied_at_open_pct()

--- a/tradeexecutor/state/position.py
+++ b/tradeexecutor/state/position.py
@@ -617,6 +617,32 @@ class TradingPosition:
             # Old invalid data
             return 0
 
+    def get_avg_daily_profit_usd(self) -> USDollarAmount | None:
+        """Gets the average daily profit in dollars for the position.
+        For accuracy, gets the average profit per second then multiply by 1440
+        (1440 seconds in a day)"""
+        
+        # only applies to closed positions with profit values
+
+        total_profit_usd = self.get_total_profit_usd()
+
+        if (total_profit_usd is None) or (self.opened_at is None) or (self.closed_at is None):
+            return None
+
+        seconds = (self.closed_at - self.opened_at).total_seconds()
+
+        # to avoid division by 0
+        if seconds > 0:
+            avg_daily_profit_usd = total_profit_usd / seconds * 1440
+        elif seconds == 0:
+            # opened and closed in the same instant
+            avg_daily_profit_usd = total_profit_usd * 1440
+        else:
+            raise ValueError("closed_at smaller than opened_at")
+
+        return avg_daily_profit_usd
+        
+
 
 class PositionType(enum.Enum):
     token_hold = "token_hold"


### PR DESCRIPTION
# Goal

- [x] To add `best day` and `worst day` usd statistics.
- [x] Add volatility.

# Notes

- Refactored `Trade_Position` to have more properties, so that we can use TradePosition instead of getting full position from portfolio
- Was unable to find a way to find exact figures, so instead used `best average daily profit` and `worst average daily profit`
- `total_trades` in `TradeSummary` class was mistakenly named. Changed to `total_positions`