### PR TITLE
remove rebuilding approach

### DIFF
--- a/tests/test_backtest_inline_synthetic_data.py
+++ b/tests/test_backtest_inline_synthetic_data.py
@@ -400,8 +400,8 @@ def test_timeline(
     assert row['PnL USD'] == '$21.09'
     assert row['PnL %'] == '2.11%'
     assert row['PnL % raw'] == pytest.approx(0.021094526830844895, 1e-6)
-    assert row['Open mid price USD'] == '$1,000.000000'
-    assert row['Close mid price USD'] == '$1,021.094527'
+    assert row['Open mid price USD'] == '$1,617.279626'
+    assert row['Close mid price USD'] == '$1,651.395374'
     assert row['Trade count'] == 2
     assert row['LP fees'] == '$6.07'
 
@@ -418,8 +418,8 @@ def test_timeline(
     assert row2['PnL USD'] == '$-142.47'
     assert row2['PnL %'] == '-14.22%'
     assert row2['PnL % raw'] == pytest.approx(-0.14216816784355246, 1e-6)
-    assert row2['Open mid price USD'] == '$1,002.109453'
-    assert row2['Close mid price USD'] == '$859.641388'
+    assert row2['Open mid price USD'] == '$1,710.914224'
+    assert row2['Close mid price USD'] == '$1,467.676683'
     assert row2['Trade count'] == 2
     assert row2['LP fees'] == '$5.59'
     
@@ -435,8 +435,8 @@ def test_timeline(
     assert last_row['PnL USD'] == '$-50.32'
     assert last_row['PnL %'] == '-5.03%'
     assert last_row['PnL % raw'] == pytest.approx(-0.05030528788437061, 1e-6)
-    assert last_row['Open mid price USD'] == '$1,000.315069'
-    assert last_row['Close mid price USD'] == '$949.993932'
+    assert last_row['Open mid price USD'] == '$2,004.138663'
+    assert last_row['Close mid price USD'] == '$1,903.319891'
     assert last_row['Trade count'] == 2
     assert last_row['LP fees'] == '$5.86'
     

--- a/tests/test_backtest_inline_synthetic_data.py
+++ b/tests/test_backtest_inline_synthetic_data.py
@@ -11,7 +11,7 @@ import pytest
 import pandas as pd
 from pandas_ta.overlap import ema
 
-from tradeexecutor.analysis.trade_analyser import build_trade_analysis, expand_timeline, TimelineRowStylingMode, TradeAnalysis, TradeSummary
+from tradeexecutor.analysis.trade_analyser import build_trade_analysis, expand_timeline, expand_timeline_raw, TimelineRowStylingMode, TradeAnalysis, TradeSummary
 from tradeexecutor.backtest.backtest_runner import run_backtest_inline
 from tradeexecutor.cli.log import setup_pytest_logging
 from tradeexecutor.state.identifier import AssetIdentifier, TradingPairIdentifier
@@ -439,6 +439,57 @@ def test_timeline(
     assert last_row['Close mid price USD'] == '$949.993932'
     assert last_row['Trade count'] == 2
     assert last_row['LP fees'] == '$5.86'
+    
+
+def test_timeline_raw(
+    analysis: TradeAnalysis,
+    backtest_result: tuple[State, TradingStrategyUniverse, dict],
+    summary: TradeSummary # need to run to get bad_data_issues flag
+):
+    state, universe, debug_dump = backtest_result
+
+    timeline = analysis.create_timeline()
+
+    expanded_timeline_raw = expand_timeline_raw(
+        timeline,
+    )
+
+    # Do checks for the first position
+    row = expanded_timeline_raw.iloc[0]
+    assert row['Id'] == 1
+    assert row['Remarks'] == ''
+    assert row['Opened at'] == '2021-07-02'
+    assert row['Duration'] == '8 days      '
+    assert row['position_max_size'] == pytest.approx(1021.094527, rel=1e-4)
+    assert row['pnl_usd'] == pytest.approx(21.094527, rel=1e-4)
+    assert row['pnl_pct_raw'] == pytest.approx(0.021095, rel=1e-4)
+    assert row['open_price_usd'] == pytest.approx(1617.279626, rel=1e-4)
+    assert row['close_price_usd'] == pytest.approx(1651.395374, rel=1e-4)
+    assert row['trade_count'] == 2
+
+    row2 = expanded_timeline_raw.iloc[1]
+    assert row2['Id'] == 2
+    assert row2['Remarks'] == ''
+    assert row2['Opened at'] == '2021-07-11'
+    assert row2['Duration'] == '26 days      '
+    assert row2['position_max_size'] == pytest.approx(1002.109453, rel=1e-4)
+    assert row2['pnl_usd'] == pytest.approx(-142.468065, rel=1e-4)
+    assert row2['pnl_pct_raw'] == pytest.approx(-0.142168, rel=1e-4)
+    assert row2['open_price_usd'] == pytest.approx(1710.914224, rel=1e-4)
+    assert row2['close_price_usd'] == pytest.approx(1467.676683, rel=1e-4)
+    assert row2['trade_count'] == 2
+    
+    last_row = expanded_timeline_raw.iloc[-1]
+    assert last_row['Id'] == 11
+    assert last_row['Remarks'] == ''
+    assert last_row['Opened at'] == '2021-12-23'
+    assert last_row['Duration'] == '7 days      '
+    assert last_row['position_max_size'] == pytest.approx(1000.315069, rel=1e-4)
+    assert last_row['pnl_usd'] == pytest.approx(-50.321138, rel=1e-4)
+    assert last_row['pnl_pct_raw'] == pytest.approx(-0.050305, rel=1e-4)
+    assert last_row['open_price_usd'] == pytest.approx(2004.138663, rel=1e-4)
+    assert last_row['close_price_usd'] == pytest.approx(1903.319891, rel=1e-4)
+    assert last_row['trade_count'] == 2
 
 
 def test_benchmark_synthetic_trading_portfolio(

--- a/tests/test_backtest_inline_synthetic_data.py
+++ b/tests/test_backtest_inline_synthetic_data.py
@@ -389,12 +389,56 @@ def test_timeline(
     # Do checks for the first position
     # 0    1          2021-07-01   8 days                      WETH        USDC         $2,027.23    $27.23    2.72%   0.027230  $1,617.294181   $1,661.333561            2
     row = expanded_timeline.iloc[0]
-    assert row["Opened at"] == "2021-07-02"
-    assert row["Trade count"] == 2
+    assert row['Id'] == 1
+    assert row['Remarks'] == ''
+    assert row['Opened at'] == '2021-07-02'
+    assert row['Duration'] == '8 days      '
+    assert row['Exchange'] == ''
+    assert row['Base asset'] == 'WETH'
+    assert row['Quote asset'] == 'USDC'
+    assert row['Position max value'] == '$1,021.09'
+    assert row['PnL USD'] == '$21.09'
+    assert row['PnL %'] == '2.11%'
+    assert row['PnL % raw'] == pytest.approx(0.021094526830844895, 1e-6)
+    assert row['Open mid price USD'] == '$1,000.000000'
+    assert row['Close mid price USD'] == '$1,021.094527'
+    assert row['Trade count'] == 2
+    assert row['LP fees'] == '$6.07'
 
     # 1    3          2021-07-10  26 days                      WETH        USDC         $1,002.72  $-137.39  -13.70%  -0.137013  $1,710.929622   $1,476.509241            2
     row2 = expanded_timeline.iloc[1]
-    assert row2["Opened at"] == "2021-07-11"
+    assert row2['Id'] == 2
+    assert row2['Remarks'] == ''
+    assert row2['Opened at'] == '2021-07-11'
+    assert row2['Duration'] == '26 days      '
+    assert row2['Exchange'] == ''
+    assert row2['Base asset'] == 'WETH'
+    assert row2['Quote asset'] == 'USDC'
+    assert row2['Position max value'] == '$1,002.11'
+    assert row2['PnL USD'] == '$-142.47'
+    assert row2['PnL %'] == '-14.22%'
+    assert row2['PnL % raw'] == pytest.approx(-0.14216816784355246, 1e-6)
+    assert row2['Open mid price USD'] == '$1,002.109453'
+    assert row2['Close mid price USD'] == '$859.641388'
+    assert row2['Trade count'] == 2
+    assert row2['LP fees'] == '$5.59'
+    
+    last_row = expanded_timeline.iloc[-1]
+    assert last_row['Id'] == 11
+    assert last_row['Remarks'] == ''
+    assert last_row['Opened at'] == '2021-12-23'
+    assert last_row['Duration'] == '7 days      '
+    assert last_row['Exchange'] == ''
+    assert last_row['Base asset'] == 'WETH'
+    assert last_row['Quote asset'] == 'USDC'
+    assert last_row['Position max value'] == '$1,000.32'
+    assert last_row['PnL USD'] == '$-50.32'
+    assert last_row['PnL %'] == '-5.03%'
+    assert last_row['PnL % raw'] == pytest.approx(-0.05030528788437061, 1e-6)
+    assert last_row['Open mid price USD'] == '$1,000.315069'
+    assert last_row['Close mid price USD'] == '$949.993932'
+    assert last_row['Trade count'] == 2
+    assert last_row['LP fees'] == '$5.86'
 
 
 def test_benchmark_synthetic_trading_portfolio(

--- a/tests/test_backtest_inline_synthetic_data.py
+++ b/tests/test_backtest_inline_synthetic_data.py
@@ -298,7 +298,7 @@ def test_basic_summary_statistics(
     assert summary.lp_fees_average_pc == pytest.approx(0.003004503819031923, rel=APPROX_REL)
     assert summary.lp_fees_paid == pytest.approx(65.79952827646791, rel=APPROX_REL)
 
-    assert summary.average_duration_of_losing_trades == pd.Timedelta('8 days 13:42:51.428571428')
+    assert summary.average_duration_of_losing_trades == pd.Timedelta('8 days 13:42:51.428571')
     assert summary.average_duration_of_winning_trades == pd.Timedelta('19 days 00:00:00')
 
     assert summary.median_trade == pytest.approx(-0.02569303244842014, rel=APPROX_REL)
@@ -359,7 +359,8 @@ def test_advanced_summary_statistics(
 
 def test_timeline(
     analysis: TradeAnalysis,
-    backtest_result: tuple[State, TradingStrategyUniverse, dict]
+    backtest_result: tuple[State, TradingStrategyUniverse, dict],
+    summary: TradeSummary # need to run to get bad_data_issues flag
 ):
     state, universe, debug_dump = backtest_result
 

--- a/tradeexecutor/analysis/trade_analyser.py
+++ b/tradeexecutor/analysis/trade_analyser.py
@@ -755,8 +755,8 @@ def expand_timeline(
             "PnL USD": format_value(position.get_realised_profit_usd()) if position.is_closed() else np.nan,
             "PnL %": format_percent_2_decimals(realised_profit_percent) if position.is_closed() else np.nan,
             "PnL % raw": realised_profit_percent if position.is_closed() else 0,
-            "Open mid price USD": format_price(position.get_value_at_open()),
-            "Close mid price USD": format_price(position.get_value_at_close()) if position.is_closed() else np.nan,
+            "Open mid price USD": format_price(position.get_opening_price()),
+            "Close mid price USD": format_price(position.get_closing_price()) if position.is_closed() else np.nan,
             "Trade count": position.get_trade_count(),
             "LP fees": f"${position.get_total_lp_fees_paid():,.2f}"
         }
@@ -786,15 +786,17 @@ def expand_timeline(
 def expand_timeline_raw(
         timeline: pd.DataFrame,
         timestamp_format="%Y-%m-%d"
-    ) -> pd.DataFrame:  # sourcery skip: remove-unreachable-code
+    ) -> pd.DataFrame:
         """A simplified version of expand_timeline that does not care about
-        pair info, exchanges, or opening capital, and also provides raw figures"""
+        pair info, exchanges, or opening capital, and also provides raw figures.
+        
+        Unused in codebase, but can be useful for advanced users to use directly"""
 
         # https://stackoverflow.com/a/52363890/315168
         def expander(row):
             position: TradingPosition = row["position"]
             # timestamp = row.name  # ???
-            pair_id = position.pair_id
+            pair_id = position.pair.internal_id
 
             if position.is_stop_loss():
                 remarks = "SL"
@@ -816,8 +818,8 @@ def expand_timeline_raw(
                 "position_max_size": position.get_max_size(),
                 "pnl_usd": pnl_usd,
                 "pnl_pct_raw": realised_profit_percent if position.is_closed() else 0,
-                "open_price_usd": position.open_price,
-                "close_price_usd": position.close_price if position.is_closed() else np.nan,
+                "open_price_usd": position.get_opening_price(),
+                "close_price_usd": position.get_closing_price() if position.is_closed() else np.nan,
                 "trade_count": position.get_trade_count(),
             }
 

--- a/tradeexecutor/state/portfolio.py
+++ b/tradeexecutor/state/portfolio.py
@@ -5,6 +5,7 @@ from dataclasses import dataclass, field
 from decimal import Decimal
 from itertools import chain
 from typing import Dict, Iterable, Optional, Tuple, List, Callable
+from pandas import Timestamp
 
 from dataclasses_json import dataclass_json
 
@@ -129,6 +130,49 @@ class Portfolio:
     def get_all_positions(self) -> Iterable[TradingPosition]:
         """Get open, closed and frozen, positions."""
         return chain(self.open_positions.values(), self.closed_positions.values(), self.frozen_positions.values())
+    
+    def get_all_positions_filtered(self) -> Iterable[TradingPosition]:
+        """Get open, closed and frozen, positions filtered."""
+        all_positions = self.get_all_positions()
+        filtered_positions = []
+        
+        for position in all_positions:
+            
+            filtered_position = position
+            filtered_position.trades = {}
+            
+            for key, trade in position.trades.items():
+                if trade.is_repaired() or trade.is_repair_trade():
+                    # These trades have quantity set to zero
+                    continue
+
+                # filter out failed trade
+                if trade.executed_at is None:
+                    continue
+                
+                # Internally negative quantities are for sells
+                # TODO bad_data_issues only used for remark
+                bad_data_issues = False
+                quantity = trade.executed_quantity
+
+                if trade.planned_mid_price not in (0, None):
+                    price = trade.planned_mid_price
+                else:
+                    # TODO: Legacy trades.
+                    # mid_price is filled to all latest trades
+                    price = trade.executed_price
+                    bad_data_issues = True
+                    
+                trade.bad_data_issues = bad_data_issues
+                    
+                assert quantity != 0, f"Got bad quantity for {trade}"
+                assert (price is not None) and price > 0, f"Got invalid trade {trade.get_full_debug_dump_str()} - price is {price}"
+                
+                filtered_position.trades[key] = trade
+            
+            filtered_positions.append(filtered_position)
+        
+        return filtered_positions
 
     def get_open_positions(self) -> Iterable[TradingPosition]:
         """Get currently open positions."""
@@ -660,4 +704,5 @@ class Portfolio:
             reserve_token_price=None,
             last_pricing_at=None,
         )
-
+        
+        

--- a/tradeexecutor/state/portfolio.py
+++ b/tradeexecutor/state/portfolio.py
@@ -1,6 +1,7 @@
 """Portfolio state management."""
 
 import datetime
+import copy
 from dataclasses import dataclass, field
 from decimal import Decimal
 from itertools import chain
@@ -138,7 +139,8 @@ class Portfolio:
         
         for position in all_positions:
             
-            filtered_position = position
+            # to avoid copying with same reference
+            filtered_position = copy.deepcopy(position)
             filtered_position.trades = {}
             
             for key, trade in position.trades.items():

--- a/tradeexecutor/state/position.py
+++ b/tradeexecutor/state/position.py
@@ -308,6 +308,12 @@ class TradingPosition:
         first_trade = self.get_first_trade()
         return first_trade.executed_price
 
+    def get_closing_price(self) -> USDollarAmount:
+        """Get the price when the position was closed."""
+        assert self.has_executed_trades()
+        last_trade = self.get_last_trade()
+        return last_trade.executed_price
+
     def get_equity_for_position(self) -> Decimal:
         """How many asset units this position tolds."""
         return sum_decimal([t.get_equity_for_position() for t in self.trades.values() if t.is_success()])

--- a/tradeexecutor/state/position.py
+++ b/tradeexecutor/state/position.py
@@ -738,6 +738,28 @@ class TradingPosition:
             return self.closed_at - self.opened_at  
         else:
             return None
+    
+    def get_total_lp_fees_paid(self) -> int:
+        """Get the total amount of swap fees paid in the position. Includes all trades."""
+        
+        lp_fees_paid = 0
+
+        for trade in self.trades.values():
+            if type(trade.lp_fees_paid) == list:
+                lp_fees_paid += sum(filter(None,trade.lp_fees_paid))
+            else:
+                lp_fees_paid += trade.lp_fees_paid or 0
+
+        return lp_fees_paid
+    
+    def get_buy_value(self) -> USDollarAmount:
+        """Get the total value of the position when it was bought."""
+        
+        return sum(t.get_executed_value() - t.commission for t in self.trades.values() if t.is_buy())
+    
+    def sell_value(self) -> USDollarAmount:
+        """Get the total value of the position when it was sold."""
+        return sum(t.get_executed_value() - t.commission for t in self.trades.values() if t.is_sell())
 
 
 class PositionType(enum.Enum):

--- a/tradeexecutor/state/trade.py
+++ b/tradeexecutor/state/trade.py
@@ -325,6 +325,11 @@ class TradeExecution:
     #:
     #: TradePricing instance can refer to more than one swap
     price_structure: Optional[TradePricing] = None
+    
+    #: Set for legacy trades with legacy data.
+    #:
+    #: Mark that calculations on this trade might be incorrect
+    bad_data_issues: bool = False
 
     def __repr__(self):
         if self.is_buy():

--- a/tradeexecutor/state/trade.py
+++ b/tradeexecutor/state/trade.py
@@ -329,6 +329,8 @@ class TradeExecution:
     #: Set for legacy trades with legacy data.
     #:
     #: Mark that calculations on this trade might be incorrect
+    #:
+    #: Currently only used for remark
     bad_data_issues: bool = False
 
     def __repr__(self):


### PR DESCRIPTION
- Removes rebuilding approach from `TradeAnalysis`. See #259 for full details. 
- Basically, `asset_histories` and duplicate classes such as `SpotTrade` and `TradePosition` are removed
- This reduces chances for error in these duplicates, and makes the code easier to maintain
- Unblocks #227 and #263