### PR TITLE
Stop loss more

### DIFF
--- a/tests/backtest/test_backtest_inline_synthetic_data.py
+++ b/tests/backtest/test_backtest_inline_synthetic_data.py
@@ -315,7 +315,11 @@ def test_basic_summary_statistics(
     assert summary.max_pos_cons == 1
     assert summary.max_pullback == pytest.approx(-0.01703492069936046, rel=APPROX_REL)
 
+    assert summary.winning_stop_losses == 0
+    assert summary.winning_stop_losses_percent is None
 
+    assert summary.losing_stop_losses == 0
+    assert summary.losing_stop_losses_percent is None
 
 def test_advanced_summary_statistics(
     summary: TradeSummary

--- a/tradeexecutor/analysis/trade_analyser.py
+++ b/tradeexecutor/analysis/trade_analyser.py
@@ -135,8 +135,8 @@ class TradeSummary:
     #: provided quantstats helper methods
     daily_returns: Optional[pd.Series] = None
     
-    winning_stop_losses: Optional[int] = None
-    losing_stop_losses: Optional[int] = None
+    winning_stop_losses: Optional[int] = 0
+    losing_stop_losses: Optional[int] = 0
     
     winning_stop_losses_percent: Optional[float] = field(init=False)
     losing_stop_losses_percent: Optional[float] = field(init=False)


### PR DESCRIPTION
## Details

Adds 4 new summary statistics. These stats are relevant to strategies with trailing stop losses where stop losses can occur on winning position, and also strategies where take profits can occur on losing position (if they exist)

1. `winning_stop_losses`
2. `losing_stop_losses`
3. `winning_stop_losses_percent`
4. `losing_stop_losses_percent`

## Tasks

- Fixes #263 