### PR TITLE
Add trade fee analysis

### DIFF
--- a/tests/strategy_tests/test_defi_bluechip.py
+++ b/tests/strategy_tests/test_defi_bluechip.py
@@ -12,6 +12,7 @@ from IPython.core.display_functions import display
 
 from tradeexecutor.analysis.alpha_model_analyser import create_alpha_model_timeline_all_assets, render_alpha_model_plotly_table, analyse_alpha_model_weights, \
     create_pair_weight_analysis_summary_table
+from tradeexecutor.analysis.fee_analyser import analyse_trading_fees, create_pair_trading_fee_summary_table
 from tradeexecutor.backtest.backtest_runner import run_backtest, setup_backtest
 from tradeexecutor.cli.log import setup_pytest_logging
 from tradeexecutor.statistics.summary import calculate_summary_statistics
@@ -115,3 +116,8 @@ def test_defi_bluechip(
     assert pair_weight_summary.iloc[0].name == "AAVE-WETH"
     assert pair_weight_summary.iloc[0]["normalised_weight"]["amax"] == 1.0
     #display(pair_weight_summary)
+
+    fee_analysis = analyse_trading_fees(state)
+    pair_fee_summary = create_pair_trading_fee_summary_table(fee_analysis)
+    #display(pair_fee_summary)
+

--- a/tradeexecutor/analysis/fee_analyser.py
+++ b/tradeexecutor/analysis/fee_analyser.py
@@ -1,0 +1,89 @@
+"""Analyser trading fees."""
+import numpy as np
+import pandas as pd
+
+from tradeexecutor.state.state import State
+from tradeexecutor.state.trade import TradeExecution
+
+
+def analyse_trading_fees(
+        state: State,
+) -> pd.DataFrame:
+    """Create a table containing trading fees for every trade.
+
+    :return:
+        DataFrame with the following columns.
+
+        - strategy_cycle_at
+
+        - pair_ticker
+
+        - trade_type ("buy" or "sell")
+
+        - pair_id
+
+        - value_usd
+
+        - fee_tier
+
+        - fees_paid_usd
+
+        - fees_paid_pct
+
+        - fees_estimated_usd
+
+        - fees_estimated_pct
+
+    """
+
+    rows = []
+
+    trade: TradeExecution
+    for trade in state.portfolio.get_all_trades():
+        pair = trade.pair
+        type = "buy" if trade.is_buy() else "sell"
+        estimated_fees = trade.lp_fees_estimated or 0
+        row = {
+            "strategy_cycle_at": trade.strategy_cycle_at,
+            "pair_id": pair.internal_id,
+            "pair_ticker": pair.get_ticker(),
+            "trade_type": type,
+            "value_usd": trade.get_value(),
+            "fee_tier": trade.fee_tier,
+            "fees_paid_usd": trade.get_fees_paid(),
+            "fees_paid_pct": trade.get_fees_paid() / trade.get_value(),
+            "fees_estimated_usd": estimated_fees,
+            "fees_estimated_pct": estimated_fees / trade.get_value(),
+        }
+
+        rows.append(row)
+
+    return pd.DataFrame(rows)
+
+
+def create_pair_trading_fee_summary_table(analysis: pd.DataFrame) -> pd.DataFrame:
+    """Creates a summary table that break down trading fees per pair and trade type.
+
+    :param analysis:
+        DataFrame of all trades analysed.
+
+        Output from :py:func:`analyse_trading_fees`.
+
+    """
+
+    # https://pandas.pydata.org/docs/reference/api/pandas.pivot_table.html
+    agg_funcs = {
+        "fee_tier": [np.max, np.min],
+        "value_usd": [np.sum, np.max, np.min, np.mean],
+        "fees_paid_usd": [np.sum, np.max, np.min, np.mean],
+        "fees_paid_pct": [np.max, np.min, np.mean],
+        "fees_estimated_usd": [np.max, np.min, np.mean],
+        "fees_estimated_pct": [np.max, np.min, np.mean],
+
+    }
+
+    return pd.pivot_table(
+        analysis,
+        index=['pair_ticker', 'trade_type'],
+        values=['fee_tier', 'value_usd', 'fees_paid_usd', 'fees_paid_pct', 'fees_estimated_usd', 'fees_estimated_pct'],
+        aggfunc=agg_funcs)

--- a/tradeexecutor/state/trade.py
+++ b/tradeexecutor/state/trade.py
@@ -382,14 +382,6 @@ class TradeExecution:
         """
         return self._fee_tier
 
-    @property
-    def lp_fees_estimated(self) -> float:
-        """LP fees estimated in the USD.
-        This is set before the execution and is mostly useful
-        for backtesting.
-        """
-        return self._lp_fees_estimated
-    
     @fee_tier.setter
     def fee_tier(self, value):
         """Setter for fee_tier.
@@ -409,7 +401,15 @@ class TradeExecution:
             self._fee_tier = self.pair.fee
         else:
             self._fee_tier = value
-    
+
+    @property
+    def lp_fees_estimated(self) -> float:
+        """LP fees estimated in the USD.
+        This is set before the execution and is mostly useful
+        for backtesting.
+        """
+        return self._lp_fees_estimated
+
     @lp_fees_estimated.setter
     def lp_fees_estimated(self, value):
         """Setter for lp_fees_estimated"""


### PR DESCRIPTION
- In `tradeexecutor.analysis.fee_analyser` add `analyse_trading_fees`, `create_pair_trading_fee_summary_table`
- List of all trades with their fees
- Trading fee pivot table per trading pair