### PR TITLE
Correctly draw heatmaps with None and Nan items on axes

### DIFF
--- a/tradeexecutor/analysis/grid_search.py
+++ b/tradeexecutor/analysis/grid_search.py
@@ -204,7 +204,7 @@ def visualise_heatmap_2d(
 
     # setting all column values to string will hint
     # Plotly to make all boxes same size regardless of value
-    if continuous_scale:
+    if not continuous_scale:
         df[parameter_1] = df[parameter_1].astype(str)
         df[parameter_2] = df[parameter_2].astype(str)
 

--- a/tradeexecutor/analysis/grid_search.py
+++ b/tradeexecutor/analysis/grid_search.py
@@ -200,7 +200,7 @@ def visualise_heatmap_2d(
 
     # Detect any non-number values on axes
     if continuous_scale is None:
-        continuous_scale = df[parameter_1].isna() or df[parameter_2].isna()
+        continuous_scale = not(df[parameter_1].isna() or df[parameter_2].isna())
 
     # setting all column values to string will hint
     # Plotly to make all boxes same size regardless of value

--- a/tradeexecutor/analysis/grid_search.py
+++ b/tradeexecutor/analysis/grid_search.py
@@ -200,7 +200,7 @@ def visualise_heatmap_2d(
 
     # Detect any non-number values on axes
     if continuous_scale is None:
-        continuous_scale = not(df[parameter_1].isna() or df[parameter_2].isna())
+        continuous_scale = not(df[parameter_1].isna().any() or df[parameter_2].isna().any())
 
     # setting all column values to string will hint
     # Plotly to make all boxes same size regardless of value


### PR DESCRIPTION
Makes it possible to visualise grid search results where `None` is one of the searched values.