### PR TITLE
Friendlier State JSON serialisation

### DIFF
--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -849,6 +849,11 @@ def test_serialize_state(usdc, weth_usdc, start_ts: datetime.datetime):
     assert isinstance(summary.average_duration_of_winning_trades, datetime.timedelta)
     assert isinstance(summary.average_duration_of_losing_trades, datetime.timedelta)
 
+    # test restore from dump using different method
+    dump = state.to_json_safe()
+    state3 = State.from_json(dump)
+    state3.perform_integrity_check()
+
 
 def test_state_summary_without_initial_cash(usdc, weth_usdc, start_ts: datetime.datetime):
     """Backward compat test for reverse without init cash info."""


### PR DESCRIPTION
- Whitelist [numpy.float32 and numpy.float64](https://stackoverflow.com/questions/76430373/converting-pandas-float32-and-float64-to-pythons-native-float-and-loss-of-accu?noredirect=1#comment134769813_76430373) - it's too painful developer experience wise to manually cast these to `float()` all the time
- Add `State.to_json_safe()` to make it easier to test the state serialisation within notebooks