### PR TITLE
Fix close position signature

### DIFF
--- a/tradeexecutor/cli/testtrade.py
+++ b/tradeexecutor/cli/testtrade.py
@@ -143,6 +143,11 @@ def make_test_trade(
         position_id = trade.position_id
         position = state.portfolio.get_position_by_id(position_id)
 
+        if not trade.is_success():
+            logger.error("Test buy failed: %s", trade)
+            logger.error("Trade dump:\n%s", trade.get_full_debug_dump_str())
+            raise AssertionError("Test buy failed")
+
     logger.info("Position %s open. Now closing the position.", position)
 
     # Recreate the position manager for the new timestamp,

--- a/tradeexecutor/cli/testtrade.py
+++ b/tradeexecutor/cli/testtrade.py
@@ -155,12 +155,12 @@ def make_test_trade(
         pricing_model,
     )
 
-    trade = position_manager.close_position(
+    trades = position_manager.close_position(
         position,
         notes=notes,
     )
-    assert len(trade) == 1
-    sell_trade = trade[0]
+    assert len(trades) == 1
+    sell_trade = trades[0]
 
     execution_model.execute_trades(
             ts,

--- a/tradeexecutor/cli/testtrade.py
+++ b/tradeexecutor/cli/testtrade.py
@@ -170,10 +170,15 @@ def make_test_trade(
     execution_model.execute_trades(
             ts,
             state,
-            trade,
+            [sell_trade],
             routing_model,
             routing_state,
         )
+
+    if not sell_trade.is_success():
+        logger.error("Test sell failed: %s", sell_trade)
+        logger.error("Trade dump:\n%s", sell_trade.get_full_debug_dump_str())
+        raise AssertionError("Test sell failed")
 
     gas_at_end = hot_wallet.get_native_currency_balance(web3)
     reserve_currency_at_end = state.portfolio.get_default_reserve_position().get_value()

--- a/tradeexecutor/strategy/pandas_trader/position_manager.py
+++ b/tradeexecutor/strategy/pandas_trader/position_manager.py
@@ -593,7 +593,7 @@ class PositionManager:
                        trade_type: TradeType=TradeType.rebalance,
                        notes: Optional[str] = None,
                        slippage_tolerance: Optional[float] = None,
-                       ) -> Optional[TradeExecution] | List[TradeExecution]:
+                       ) -> List[TradeExecution]:
         """Close a single position.
 
         The position may already have piled up selling trades.
@@ -630,7 +630,7 @@ class PositionManager:
             # We have already generated closing trades for this position
             # earlier
             logger.warning("Tried to close position that is likely already closed, as there are no tokens to sell: %s", position)
-            return None
+            return []
 
         pair = position.pair
         quantity = quantity_left


### PR DESCRIPTION
- `close_position()` should always return a list of trades, not None
- Make sure `perform_test_trade` aborts the execution if the first buy fails