### PR TITLE
Restructuring live trade execution prechecks before the main loop

### DIFF
--- a/tradeexecutor/cli/commands/start.py
+++ b/tradeexecutor/cli/commands/start.py
@@ -1,4 +1,7 @@
-"""start command"""
+"""start command
+
+TODO: Restructure and move backtesting related functionality to a separate command
+"""
 
 import datetime
 import logging
@@ -360,6 +363,7 @@ def start(
                     mode=ExecutionMode.real_trading,
                     timed_task_context_manager=timed_task,
                 )
+
     except Exception as e:
         # Logging is set up is in this point, so we can log this exception that
         # caused the start up to fail
@@ -367,38 +371,42 @@ def start(
         logger.exception(e)
         raise
 
+    loop = ExecutionLoop(
+        name=name,
+        command_queue=command_queue,
+        execution_model=execution_model,
+        execution_context=execution_context,
+        sync_model=sync_model,
+        approval_model=approval_model,
+        pricing_model_factory=pricing_model_factory,
+        valuation_model_factory=valuation_model_factory,
+        store=store,
+        client=client,
+        strategy_factory=strategy_factory,
+        reset=reset_state,
+        max_cycles=max_cycles,
+        debug_dump_file=debug_dump_file,
+        backtest_start=backtest_start,
+        backtest_end=backtest_end,
+        backtest_stop_loss_time_frame_override=backtest_stop_loss_time_frame_override,
+        backtest_candle_time_frame_override=backtest_candle_time_frame_override,
+        stop_loss_check_frequency=stop_loss_check_frequency,
+        cycle_duration=cycle_duration,
+        tick_offset=tick_offset,
+        max_data_delay=max_data_delay,
+        trade_immediately=trade_immediately,
+        stats_refresh_frequency=stats_refresh_frequency,
+        position_trigger_check_frequency=position_trigger_check_frequency,
+        run_state=run_state,
+        strategy_cycle_trigger=strategy_cycle_trigger,
+        routing_model=routing_model,
+    )
+
+    # Crash gracefully at the start up if our main loop cannot set itself up
+    state = loop.setup()
+
     try:
-        loop = ExecutionLoop(
-            name=name,
-            command_queue=command_queue,
-            execution_model=execution_model,
-            execution_context=execution_context,
-            sync_model=sync_model,
-            approval_model=approval_model,
-            pricing_model_factory=pricing_model_factory,
-            valuation_model_factory=valuation_model_factory,
-            store=store,
-            client=client,
-            strategy_factory=strategy_factory,
-            reset=reset_state,
-            max_cycles=max_cycles,
-            debug_dump_file=debug_dump_file,
-            backtest_start=backtest_start,
-            backtest_end=backtest_end,
-            backtest_stop_loss_time_frame_override=backtest_stop_loss_time_frame_override,
-            backtest_candle_time_frame_override=backtest_candle_time_frame_override,
-            stop_loss_check_frequency=stop_loss_check_frequency,
-            cycle_duration=cycle_duration,
-            tick_offset=tick_offset,
-            max_data_delay=max_data_delay,
-            trade_immediately=trade_immediately,
-            stats_refresh_frequency=stats_refresh_frequency,
-            position_trigger_check_frequency=position_trigger_check_frequency,
-            run_state=run_state,
-            strategy_cycle_trigger=strategy_cycle_trigger,
-            routing_model=routing_model,
-        )
-        loop.run()
+        loop.run(state)
 
         # Display summary stats for terminal backtest runs
         if backtest_start:

--- a/tradeexecutor/cli/commands/start.py
+++ b/tradeexecutor/cli/commands/start.py
@@ -406,7 +406,7 @@ def start(
     state = loop.setup()
 
     try:
-        loop.run(state)
+        loop.run_with_state(state)
 
         # Display summary stats for terminal backtest runs
         if backtest_start:

--- a/tradeexecutor/cli/loop.py
+++ b/tradeexecutor/cli/loop.py
@@ -993,7 +993,8 @@ class ExecutionLoop:
         state = self.init_state()
 
         if not self.is_backtest():
-            assert self.sync_model.is_ready_for_live_trading(), f"{self.sync_model} not initialised for live trading"
+            if not self.sync_model.is_ready_for_live_trading(state):
+                raise RuntimeError(f"{self.sync_model} not initialised for live trading - run trade-executor init command first")
 
         self.init_execution_model()
 
@@ -1025,7 +1026,7 @@ class ExecutionLoop:
 
         return state
 
-    def run(self, state: State):
+    def run_with_state(self, state: State) -> dict:
         """Start the execution.
 
         :return:
@@ -1035,10 +1036,21 @@ class ExecutionLoop:
             Any exception thrown from this function should be considered as live execution error,
             not a start up error.
         """
-
+        # TODO: Refactore
         if self.is_backtest():
             # Walk through backtesting range
             return self.run_backtest(state)
         else:
             return self.run_live(state)
+
+    def run(self):
+        """Start the execution.
+
+        .. note::
+
+            Legacy entry point
+        """
+        # TODO: Refactore
+        state = self.setup()
+        return self.run_with_state(state)
 

--- a/tradeexecutor/ethereum/enzyme/vault.py
+++ b/tradeexecutor/ethereum/enzyme/vault.py
@@ -101,6 +101,10 @@ class EnzymeVaultSyncModel(SyncModel):
     def get_hot_wallet(self) -> Optional[HotWallet]:
         return self.hot_wallet
 
+    def is_ready_for_live_trading(self, state: State) -> bool:
+        """Have we run init command on the vault."""
+        return state.sync.deployment.block_number is not None
+
     def _notify(
             self,
             current_block: int,

--- a/tradeexecutor/strategy/execution_model.py
+++ b/tradeexecutor/strategy/execution_model.py
@@ -168,3 +168,10 @@ class AssetManagementMode(enum.Enum):
     #: - Does not connect to any network or blockchain
     #:
     backtest = "backtest"
+
+    def is_live_trading(self) -> bool:
+        """Is this a live trading setup.
+
+        Are we executing against a blockchain (including test chains).
+        """
+        return self in (AssetManagementMode.hot_wallet, AssetManagementMode.enzyme,)

--- a/tradeexecutor/strategy/sync_model.py
+++ b/tradeexecutor/strategy/sync_model.py
@@ -44,6 +44,11 @@ class SyncModel(ABC):
         we are not getting wrong nonce error when broadcasting the transaction.
         """
 
+    def is_ready_for_live_trading(self, state: State) -> bool:
+        """Check that the state and sync model is ready for live trading."""
+        # By default not any checks are needed
+        return True
+
     @abstractmethod
     def sync_initial(self, state: State, **kwargs):
         """Initialize the vault connection.


### PR DESCRIPTION
- Run the live trading loop setup before setting the trade executor to web server mode
- Fail at startup if enzyme vault has not been initialised