### PR TITLE
Profit calculation with inflow

### DIFF
--- a/strategies/test_only/pandas_buy_every_second_day.py
+++ b/strategies/test_only/pandas_buy_every_second_day.py
@@ -60,6 +60,7 @@ def decide_trades(
     assert pair.pair_id > 0
 
     cash = state.portfolio.get_current_cash()
+    assert cash > 0, "You did not top up the backtest simulation"
 
     # 30 days EMA
     candles: pd.DataFrame = universe.candles.get_single_pair_data(sample_count=30)

--- a/tests/backtest/test_backtest_execution.py
+++ b/tests/backtest/test_backtest_execution.py
@@ -18,7 +18,7 @@ from tradingstrategy.timebucket import TimeBucket
 from tradeexecutor.backtest.backtest_execution import BacktestExecutionModel
 from tradeexecutor.backtest.backtest_pricing import BacktestSimplePricingModel
 from tradeexecutor.backtest.backtest_routing import BacktestRoutingModel
-from tradeexecutor.backtest.backtest_sync import BacktestSyncer
+from tradeexecutor.backtest.legacy_backtest_sync import BacktestSyncer
 from tradeexecutor.backtest.backtest_valuation import BacktestValuationModel
 from tradeexecutor.backtest.simulated_wallet import SimulatedWallet
 from tradeexecutor.cli.log import setup_pytest_logging

--- a/tests/backtest/test_backtest_execution.py
+++ b/tests/backtest/test_backtest_execution.py
@@ -134,7 +134,7 @@ def deposit_syncer(wallet) -> BacktestSyncer:
 def state(universe: TradingStrategyUniverse, deposit_syncer: BacktestSyncer) -> State:
     """Start with 10,000 USD cash in the portfolio."""
     state = State()
-    events = deposit_syncer(state.portfolio, datetime.datetime(1970, 1, 1), universe.reserve_assets)
+    events = deposit_syncer(state, datetime.datetime(1970, 1, 1), universe.reserve_assets)
     assert len(events) == 1
     token, usd_exchange_rate = state.portfolio.get_default_reserve()
     assert token.token_symbol == "BUSD"

--- a/tests/backtest/test_backtest_execution_three_way.py
+++ b/tests/backtest/test_backtest_execution_three_way.py
@@ -208,7 +208,7 @@ def state(universe: TradingStrategyUniverse, deposit_syncer: BacktestSyncer) -> 
     state = State()
     assert len(universe.reserve_assets) == 1
     assert universe.reserve_assets[0].token_symbol == "BUSD"
-    events = deposit_syncer(state.portfolio, datetime.datetime(1970, 1, 1), universe.reserve_assets)
+    events = deposit_syncer(state, datetime.datetime(1970, 1, 1), universe.reserve_assets)
     assert len(events) == 1
     token, usd_exchange_rate = state.portfolio.get_default_reserve()
     assert token.token_symbol == "BUSD"

--- a/tests/backtest/test_backtest_execution_three_way.py
+++ b/tests/backtest/test_backtest_execution_three_way.py
@@ -19,7 +19,7 @@ from tradingstrategy.timebucket import TimeBucket
 from tradeexecutor.backtest.backtest_execution import BacktestExecutionModel
 from tradeexecutor.backtest.backtest_pricing import BacktestSimplePricingModel
 from tradeexecutor.backtest.backtest_routing import BacktestRoutingModel
-from tradeexecutor.backtest.backtest_sync import BacktestSyncer
+from tradeexecutor.backtest.legacy_backtest_sync import BacktestSyncer
 from tradeexecutor.backtest.backtest_valuation import BacktestValuationModel
 from tradeexecutor.backtest.simulated_wallet import SimulatedWallet
 from tradeexecutor.cli.log import setup_pytest_logging

--- a/tests/backtest/test_backtest_investment_flow.py
+++ b/tests/backtest/test_backtest_investment_flow.py
@@ -1,0 +1,178 @@
+"""Test investment flow calculations
+
+"""
+import datetime
+import logging
+import os
+from pathlib import Path
+
+import pytest
+
+import pandas as pd
+
+from tradeexecutor.backtest.backtest_routing import BacktestRoutingModel
+from tradeexecutor.backtest.backtest_runner import run_backtest, setup_backtest_for_universe
+from tradeexecutor.cli.log import setup_pytest_logging
+from tradeexecutor.state.identifier import AssetIdentifier, TradingPairIdentifier
+from tradeexecutor.strategy.cycle import CycleDuration
+from tradeexecutor.strategy.trading_strategy_universe import TradingStrategyUniverse, create_pair_universe_from_code
+from tradeexecutor.testing.synthetic_ethereum_data import generate_random_ethereum_address
+from tradeexecutor.testing.synthetic_exchange_data import generate_exchange, generate_simple_routing_model
+from tradeexecutor.testing.synthetic_price_data import generate_ohlcv_candles
+from tradingstrategy.candle import GroupedCandleUniverse
+from tradingstrategy.chain import ChainId
+from tradingstrategy.exchange import Exchange, ExchangeUniverse
+from tradingstrategy.pair import PandasPairUniverse, DEXPair
+from tradingstrategy.timebucket import TimeBucket
+from tradingstrategy.universe import Universe
+
+
+@pytest.fixture(scope="module")
+def logger(request):
+    """Setup test logger."""
+    return setup_pytest_logging(request, mute_requests=False)
+
+
+@pytest.fixture
+def mock_chain_id() -> ChainId:
+    """Mock a chai id."""
+    return ChainId.ethereum
+
+
+@pytest.fixture
+def mock_exchange(mock_chain_id) -> Exchange:
+    """Mock an exchange."""
+    return generate_exchange(exchange_id=1, chain_id=mock_chain_id, address=generate_random_ethereum_address())
+
+
+@pytest.fixture
+def usdc() -> AssetIdentifier:
+    """Mock some assets"""
+    return AssetIdentifier(ChainId.ethereum.value, generate_random_ethereum_address(), "USDC", 6, 1)
+
+
+@pytest.fixture
+def weth() -> AssetIdentifier:
+    """Mock some assets"""
+    return AssetIdentifier(ChainId.ethereum.value, generate_random_ethereum_address(), "WETH", 18, 2)
+
+
+@pytest.fixture
+def weth_usdc(mock_exchange, usdc, weth) -> TradingPairIdentifier:
+    """Mock some assets"""
+    return TradingPairIdentifier(
+        weth,
+        usdc,
+        generate_random_ethereum_address(),
+        mock_exchange.address,
+        internal_id=555,
+        internal_exchange_id=mock_exchange.exchange_id)
+
+
+@pytest.fixture()
+def strategy_path() -> Path:
+    """Where do we load our strategy file."""
+    return Path(os.path.join(os.path.dirname(__file__), "../..", "strategies", "test_only", "pandas_buy_every_second_day.py"))
+
+
+@pytest.fixture()
+def synthetic_universe(mock_chain_id, mock_exchange, weth_usdc) -> TradingStrategyUniverse:
+    """Generate synthetic trading data universe for a single trading pair.
+
+    - Single mock exchange
+
+    - Single mock trading pair
+
+    - Random candles
+
+    - No liquidity data available
+    """
+
+    start_date = datetime.datetime(2021, 6, 1)
+    end_date = datetime.datetime(2022, 1, 1)
+
+    time_bucket = TimeBucket.d1
+
+    pair_universe = create_pair_universe_from_code(mock_chain_id, [weth_usdc])
+
+    # Generate candles for pair_id = 1
+    candles = generate_ohlcv_candles(time_bucket, start_date, end_date, pair_id=weth_usdc.internal_id)
+    candle_universe = GroupedCandleUniverse.create_from_single_pair_dataframe(candles)
+
+    universe = Universe(
+        time_bucket=time_bucket,
+        chains={mock_chain_id},
+        exchanges={mock_exchange},
+        pairs=pair_universe,
+        candles=candle_universe,
+        liquidity=None
+    )
+
+    return TradingStrategyUniverse(universe=universe, reserve_assets=[weth_usdc.quote])
+
+
+@pytest.fixture()
+def routing_model(synthetic_universe) -> BacktestRoutingModel:
+    return generate_simple_routing_model(synthetic_universe)
+
+
+def test_synthetic_candles(
+        logger: logging.Logger,
+        strategy_path: Path,
+        synthetic_universe: TradingStrategyUniverse,
+    ):
+    """Generate synthetic candle data."""
+
+    start, end = synthetic_universe.universe.candles.get_timestamp_range()
+    assert start == pd.Timestamp('2021-06-01 00:00:00')
+    assert end == pd.Timestamp('2021-12-31 00:00:00')
+
+    candles_for_pair = synthetic_universe.universe.candles.get_candles_by_pair(555)
+    start = candles_for_pair.iloc[0]["timestamp"]
+    end = candles_for_pair.iloc[-1]["timestamp"]
+    assert start == pd.Timestamp('2021-06-01 00:00:00')
+    assert end == pd.Timestamp('2021-12-31 00:00:00')
+
+
+def test_synthetic_data_backtest_run(
+        logger: logging.Logger,
+        strategy_path: Path,
+        synthetic_universe: TradingStrategyUniverse,
+        routing_model: BacktestRoutingModel,
+    ):
+    """Run the strategy backtest.
+
+    - Use synthetic data
+
+    - Run a strategy for 6 months
+    """
+
+    # Run the test
+    setup = setup_backtest_for_universe(
+        strategy_path,
+        start_at=datetime.datetime(2021, 6, 1),
+        end_at=datetime.datetime(2022, 1, 1),
+        cycle_duration=CycleDuration.cycle_1d,  # Override to use 24h cycles despite what strategy file says
+        candle_time_frame=TimeBucket.d1,  # Override to use 24h cycles despite what strategy file says
+        initial_deposit=10_000,
+        universe=synthetic_universe,
+        routing_model=routing_model,
+        allow_missing_fees=True,
+    )
+
+    state, universe, debug_dump = run_backtest(setup, allow_missing_fees=True)
+
+    assert len(debug_dump) == 214
+
+    portfolio = state.portfolio
+    assert len(list(portfolio.get_all_trades())) == 214
+    buys = [t for t in portfolio.get_all_trades() if t.is_buy()]
+    sells = [t for t in portfolio.get_all_trades() if t.is_sell()]
+
+    assert len(buys) == 107
+    assert len(sells) == 107
+
+    # The actual result might vary, but we should slowly leak
+    # portfolio valuation because losses on trading fees
+    assert portfolio.get_current_cash() > 9000
+    assert portfolio.get_current_cash() < 10_500

--- a/tests/backtest/test_backtest_profit_calculation.py
+++ b/tests/backtest/test_backtest_profit_calculation.py
@@ -24,7 +24,7 @@ from tradeexecutor.strategy.trading_strategy_universe import TradingStrategyUniv
 from tradeexecutor.testing.synthetic_ethereum_data import generate_random_ethereum_address
 from tradeexecutor.testing.synthetic_exchange_data import generate_exchange, generate_simple_routing_model
 from tradeexecutor.testing.synthetic_price_data import generate_ohlcv_candles
-from tradeexecutor.visual.equity_curve import calculate_investment_flow, calculate_realised_profitability
+from tradeexecutor.visual.equity_curve import calculate_investment_flow, calculate_realised_profitability, calculate_deposit_adjusted_returns
 from tradingstrategy.candle import GroupedCandleUniverse
 from tradingstrategy.chain import ChainId
 from tradingstrategy.exchange import Exchange
@@ -197,6 +197,7 @@ def test_calculate_funding_flow(backtest_result: State):
     """Calculate funding flow for test deposits/redemptions."""
     state = backtest_result
     flow = calculate_investment_flow(state)
+    assert isinstance(flow.index, pd.DatetimeIndex)
     assert max(flow) == 100, "Deposit simulation did not work out"
     assert min(flow) == -90, "Redemption simulation did not work out"
     deposits = flow[flow > 0]  # https://stackoverflow.com/a/28272238/315168
@@ -211,3 +212,12 @@ def test_calculate_realised_trading_profitability(backtest_result: State):
     profitability = calculate_realised_profitability(state)
     assert 0.04 < max(profitability) < 0.06
     assert -0.06 < min(profitability) < -0.04
+    assert isinstance(profitability.index, pd.DatetimeIndex)
+
+
+def test_calculate_deposit_adjusted_returns(backtest_result: State):
+    """Calculate the realised trading profitability."""
+    state = backtest_result
+    returns = calculate_deposit_adjusted_returns(state)
+    import ipdb ; ipdb.set_trace()
+

--- a/tests/backtest/test_backtest_profit_calculation.py
+++ b/tests/backtest/test_backtest_profit_calculation.py
@@ -11,6 +11,7 @@ import pandas as pd
 
 from tradeexecutor.backtest.backtest_routing import BacktestRoutingModel
 from tradeexecutor.backtest.backtest_runner import run_backtest, setup_backtest_for_universe
+from tradeexecutor.backtest.backtest_sync import BacktestSyncModel
 from tradeexecutor.cli.log import setup_pytest_logging
 from tradeexecutor.cli.loop import ExecutionTestHook
 from tradeexecutor.state.identifier import AssetIdentifier, TradingPairIdentifier
@@ -31,11 +32,19 @@ from tradingstrategy.universe import Universe
 
 class DepositSimulator(ExecutionTestHook):
 
-    def on_before_cycle(self, cycle: int, state: State):
-        """Called before entering the strategy tick."""
+    def on_before_cycle(
+            self,
+            cycle: int,
+            cycle_st: datetime.datetime,
+            state: State,
+            sync_model: BacktestSyncModel
+    ):
+        """Do FizzBuzz deposits/redemptions simulation."""
+        if cycle % 3 == 0:
+            sync_model.simulate_deposit(100)
 
-    def on_after_cycle(self, cycle: int, state: State):
-        """Called after the strategy tick."""
+        if cycle % 5 == 0:
+            sync_model.simulate_redemption(90)
 
 
 @pytest.fixture(scope="module")

--- a/tests/backtest/test_backtest_profit_calculation.py
+++ b/tests/backtest/test_backtest_profit_calculation.py
@@ -1,0 +1,180 @@
+"""Test different profit / equity calculation models.
+"""
+import datetime
+import logging
+import os
+from pathlib import Path
+
+import pytest
+
+import pandas as pd
+
+from tradeexecutor.backtest.backtest_routing import BacktestRoutingModel
+from tradeexecutor.backtest.backtest_runner import run_backtest, setup_backtest_for_universe
+from tradeexecutor.cli.log import setup_pytest_logging
+from tradeexecutor.cli.loop import ExecutionTestHook
+from tradeexecutor.state.identifier import AssetIdentifier, TradingPairIdentifier
+from tradeexecutor.state.state import State
+from tradeexecutor.strategy.cycle import CycleDuration
+from tradeexecutor.strategy.trading_strategy_universe import TradingStrategyUniverse, create_pair_universe_from_code
+from tradeexecutor.testing.synthetic_ethereum_data import generate_random_ethereum_address
+from tradeexecutor.testing.synthetic_exchange_data import generate_exchange, generate_simple_routing_model
+from tradeexecutor.testing.synthetic_price_data import generate_ohlcv_candles
+from tradingstrategy.candle import GroupedCandleUniverse
+from tradingstrategy.chain import ChainId
+from tradingstrategy.exchange import Exchange, ExchangeUniverse
+from tradingstrategy.pair import PandasPairUniverse, DEXPair
+from tradingstrategy.timebucket import TimeBucket
+from tradingstrategy.universe import Universe
+
+
+
+class DepositSimulator(ExecutionTestHook):
+
+    def on_before_cycle(self, cycle: int, state: State):
+        """Called before entering the strategy tick."""
+
+    def on_after_cycle(self, cycle: int, state: State):
+        """Called after the strategy tick."""
+
+
+@pytest.fixture(scope="module")
+def logger(request):
+    """Setup test logger."""
+    return setup_pytest_logging(request, mute_requests=False)
+
+
+@pytest.fixture(scope="module")
+def mock_chain_id() -> ChainId:
+    """Mock a chai id."""
+    return ChainId.ethereum
+
+
+@pytest.fixture(scope="module")
+def mock_exchange(mock_chain_id) -> Exchange:
+    """Mock an exchange."""
+    return generate_exchange(exchange_id=1, chain_id=mock_chain_id, address=generate_random_ethereum_address())
+
+
+@pytest.fixture(scope="module")
+def usdc() -> AssetIdentifier:
+    """Mock some assets"""
+    return AssetIdentifier(ChainId.ethereum.value, generate_random_ethereum_address(), "USDC", 6, 1)
+
+
+@pytest.fixture(scope="module")
+def weth() -> AssetIdentifier:
+    """Mock some assets"""
+    return AssetIdentifier(ChainId.ethereum.value, generate_random_ethereum_address(), "WETH", 18, 2)
+
+
+@pytest.fixture(scope="module")
+def weth_usdc(mock_exchange, usdc, weth) -> TradingPairIdentifier:
+    """Mock some assets"""
+    return TradingPairIdentifier(
+        weth,
+        usdc,
+        generate_random_ethereum_address(),
+        mock_exchange.address,
+        internal_id=555,
+        internal_exchange_id=mock_exchange.exchange_id)
+
+
+@pytest.fixture(scope="module")
+def strategy_path() -> Path:
+    """Where do we load our strategy file."""
+    return Path(os.path.join(os.path.dirname(__file__), "../..", "strategies", "test_only", "pandas_buy_every_second_day.py"))
+
+
+@pytest.fixture(scope="module")
+def synthetic_universe(mock_chain_id, mock_exchange, weth_usdc) -> TradingStrategyUniverse:
+    """Generate synthetic trading data universe for a single trading pair.
+
+    - Single mock exchange
+
+    - Single mock trading pair
+
+    - Random candles
+
+    - No liquidity data available
+    """
+
+    start_date = datetime.datetime(2021, 6, 1)
+    end_date = datetime.datetime(2022, 1, 1)
+
+    time_bucket = TimeBucket.d1
+
+    pair_universe = create_pair_universe_from_code(mock_chain_id, [weth_usdc])
+
+    # Generate candles for pair_id = 1
+    candles = generate_ohlcv_candles(time_bucket, start_date, end_date, pair_id=weth_usdc.internal_id)
+    candle_universe = GroupedCandleUniverse.create_from_single_pair_dataframe(candles)
+
+    universe = Universe(
+        time_bucket=time_bucket,
+        chains={mock_chain_id},
+        exchanges={mock_exchange},
+        pairs=pair_universe,
+        candles=candle_universe,
+        liquidity=None
+    )
+
+    return TradingStrategyUniverse(universe=universe, reserve_assets=[weth_usdc.quote])
+
+
+@pytest.fixture(scope="module")
+def routing_model(synthetic_universe) -> BacktestRoutingModel:
+    return generate_simple_routing_model(synthetic_universe)
+
+
+@pytest.fixture(scope="module")
+def backtest_result(
+        logger: logging.Logger,
+        strategy_path: Path,
+        synthetic_universe: TradingStrategyUniverse,
+        routing_model: BacktestRoutingModel,
+    ) -> State:
+    """Run the strategy backtest.
+
+    - Use synthetic data
+
+    - Run a strategy for 6 months
+    """
+
+    # Run the test
+    setup = setup_backtest_for_universe(
+        strategy_path,
+        start_at=datetime.datetime(2021, 6, 1),
+        end_at=datetime.datetime(2022, 1, 1),
+        cycle_duration=CycleDuration.cycle_1d,  # Override to use 24h cycles despite what strategy file says
+        candle_time_frame=TimeBucket.d1,  # Override to use 24h cycles despite what strategy file says
+        initial_deposit=10_000,
+        universe=synthetic_universe,
+        routing_model=routing_model,
+        allow_missing_fees=True,
+    )
+
+    state, universe, debug_dump = run_backtest(
+        setup,
+        allow_missing_fees=True,
+        execution_test_hook=DepositSimulator(),
+    )
+
+    assert len(debug_dump) == 214
+
+    portfolio = state.portfolio
+    assert len(list(portfolio.get_all_trades())) == 214
+    buys = [t for t in portfolio.get_all_trades() if t.is_buy()]
+    sells = [t for t in portfolio.get_all_trades() if t.is_sell()]
+
+    assert len(buys) == 107
+    assert len(sells) == 107
+
+    # The actual result might vary, but we should slowly leak
+    # portfolio valuation because losses on trading fees
+    assert portfolio.get_current_cash() > 9000
+    assert portfolio.get_current_cash() < 10_500
+
+
+def test_calculate_profit():
+    pass

--- a/tests/backtest/test_backtest_profit_calculation.py
+++ b/tests/backtest/test_backtest_profit_calculation.py
@@ -25,7 +25,8 @@ from tradeexecutor.strategy.trading_strategy_universe import TradingStrategyUniv
 from tradeexecutor.testing.synthetic_ethereum_data import generate_random_ethereum_address
 from tradeexecutor.testing.synthetic_exchange_data import generate_exchange, generate_simple_routing_model
 from tradeexecutor.testing.synthetic_price_data import generate_ohlcv_candles
-from tradeexecutor.visual.equity_curve import calculate_investment_flow, calculate_realised_profitability, calculate_deposit_adjusted_returns
+from tradeexecutor.visual.equity_curve import calculate_investment_flow, calculate_realised_profitability, calculate_deposit_adjusted_returns, \
+    calculate_compounding_realised_profitability
 from tradingstrategy.candle import GroupedCandleUniverse
 from tradingstrategy.chain import ChainId
 from tradingstrategy.exchange import Exchange
@@ -218,6 +219,10 @@ def test_calculate_realised_trading_profitability(backtest_result: State):
     assert 0.04 < max(profitability) < 0.06
     assert -0.06 < min(profitability) < -0.04
     assert isinstance(profitability.index, pd.DatetimeIndex)
+
+    compounded_profitability = calculate_compounding_realised_profitability(state)
+    assert -0.05 < compounded_profitability.iloc[0] < 0.01
+    assert compounded_profitability.iloc[-1] < 0.70  # Down 30%
 
 
 def test_calculate_deposit_adjusted_returns(backtest_result: State):

--- a/tests/backtest/test_backtest_profit_calculation.py
+++ b/tests/backtest/test_backtest_profit_calculation.py
@@ -216,17 +216,29 @@ def test_calculate_realised_trading_profitability(backtest_result: State):
     """Calculate the realised trading profitability."""
     state = backtest_result
     profitability = calculate_realised_profitability(state)
+    assert isinstance(profitability, pd.Series)
     assert 0.04 < max(profitability) < 0.06
     assert -0.06 < min(profitability) < -0.04
     assert isinstance(profitability.index, pd.DatetimeIndex)
 
     compounded_profitability = calculate_compounding_realised_profitability(state)
+    assert isinstance(compounded_profitability, pd.Series)
     assert -0.05 < compounded_profitability.iloc[0] < 0.01
     assert compounded_profitability.iloc[-1] < 0.70  # Down 30%
 
 
+def test_calculate_realised_trading_profitability_no_trades():
+    """Do not crash when calculating realised trading profitability if there are no trades."""
+    state = State()
+    profitability = calculate_realised_profitability(state)
+    assert len(profitability) == 0
+
+    compounded_profitability = calculate_compounding_realised_profitability(state)
+    assert len(compounded_profitability) == 0
+
+
 def test_calculate_deposit_adjusted_returns(backtest_result: State):
-    """Calculate the realised trading profitability."""
+    """Calculate the deposit adjusted returns."""
     state = backtest_result
 
     returns = calculate_deposit_adjusted_returns(state)
@@ -237,3 +249,9 @@ def test_calculate_deposit_adjusted_returns(backtest_result: State):
     assert -20 < max(returns) < 0
     assert -150 < min(returns) < -100
 
+
+def test_calculate_deposit_adjusted_returns_no_trades():
+    """Do not crash calculating the deposit adjusted returns if there are no trades."""
+    state = State()
+    returns = calculate_deposit_adjusted_returns(state)
+    assert len(returns) == 0

--- a/tests/backtest/test_backtest_profit_calculation.py
+++ b/tests/backtest/test_backtest_profit_calculation.py
@@ -26,7 +26,7 @@ from tradeexecutor.testing.synthetic_ethereum_data import generate_random_ethere
 from tradeexecutor.testing.synthetic_exchange_data import generate_exchange, generate_simple_routing_model
 from tradeexecutor.testing.synthetic_price_data import generate_ohlcv_candles
 from tradeexecutor.visual.equity_curve import calculate_investment_flow, calculate_realised_profitability, calculate_deposit_adjusted_returns, \
-    calculate_compounding_realised_profitability
+    calculate_compounding_realised_profitability, calculate_size_relative_realised_profitability
 from tradingstrategy.candle import GroupedCandleUniverse
 from tradingstrategy.chain import ChainId
 from tradingstrategy.exchange import Exchange
@@ -221,10 +221,13 @@ def test_calculate_realised_trading_profitability(backtest_result: State):
     assert -0.06 < min(profitability) < -0.04
     assert isinstance(profitability.index, pd.DatetimeIndex)
 
+    sized_profitability = calculate_size_relative_realised_profitability(state)
+    assert sized_profitability[0] == pytest.approx(profitability[0] / 10, rel=0.01)  # 10% position size is used
+
     compounded_profitability = calculate_compounding_realised_profitability(state)
     assert isinstance(compounded_profitability, pd.Series)
     assert -0.05 < compounded_profitability.iloc[0] < 0.01
-    assert compounded_profitability.iloc[-1] < 0.70  # Down 30%
+    assert compounded_profitability.iloc[-1] == pytest.approx(-0.04583804672389613)  # Strategy has destroyed 4.5% of capital
 
 
 def test_calculate_realised_trading_profitability_no_trades():

--- a/tests/ethereum/test_execute_trade_uniswap.py
+++ b/tests/ethereum/test_execute_trade_uniswap.py
@@ -190,20 +190,21 @@ def supported_reserves(asset_usdc) -> List[AssetIdentifier]:
 
 
 @pytest.fixture()
-def portfolio(web3, hot_wallet, start_ts, supported_reserves) -> Portfolio:
+def portfolio() -> Portfolio:
     """A portfolio loaded with the initial cash.
 
     We start with 10,000 USDC.
     """
     portfolio = Portfolio()
-    events = sync_reserves(web3, start_ts, hot_wallet.address, [], supported_reserves)
-    apply_sync_events(portfolio, events)
     return portfolio
 
 
 @pytest.fixture()
-def state(portfolio) -> State:
-    return State(portfolio=portfolio)
+def state(portfolio, web3, hot_wallet, start_ts, supported_reserves) -> State:
+    state = State(portfolio=portfolio)
+    events = sync_reserves(web3, start_ts, hot_wallet.address, [], supported_reserves)
+    apply_sync_events(state, events)
+    return state
 
 
 @pytest.fixture()

--- a/tests/ethereum/test_execute_trade_uniswap_v3.py
+++ b/tests/ethereum/test_execute_trade_uniswap_v3.py
@@ -238,21 +238,19 @@ def supported_reserves(asset_usdc) -> List[AssetIdentifier]:
     return [asset_usdc]
 
 
-@pytest.fixture()
-def portfolio(web3, hot_wallet, start_ts, supported_reserves) -> Portfolio:
-    """A portfolio loaded with the initial cash.
+@pytest.fixture
+def state(web3, hot_wallet, asset_usdc) -> State:
+    """State used in the tests."""
+    state = State()
 
-    We start with 10,000 USDC.
-    """
-    portfolio = Portfolio()
-    events = sync_reserves(web3, start_ts, hot_wallet.address, [], supported_reserves)
-    apply_sync_events(portfolio, events)
-    return portfolio
-
-
-@pytest.fixture()
-def state(portfolio) -> State:
-    return State(portfolio=portfolio)
+    events = sync_reserves(
+        web3, datetime.datetime.utcnow(), hot_wallet.address, [], [asset_usdc]
+    )
+    assert len(events) > 0
+    apply_sync_events(state, events)
+    reserve_currency, exchange_rate = state.portfolio.get_default_reserve()
+    assert reserve_currency == asset_usdc
+    return state
 
 
 @pytest.fixture()

--- a/tests/mainnet_fork/test_uniswap_v2_routing.py
+++ b/tests/mainnet_fork/test_uniswap_v2_routing.py
@@ -260,22 +260,18 @@ def execution_model(web3, hot_wallet) -> UniswapV2ExecutionModel:
     return UniswapV2ExecutionModel(tx_builder)
 
 
-@pytest.fixture()
-def portfolio(web3, hot_wallet, busd_asset) -> Portfolio:
-    """A portfolio synced to the hot wallet, starting with 10_000 BUSD."""
-    portfolio = Portfolio()
-    events = sync_reserves(web3, datetime.datetime.utcnow(), hot_wallet.address, [], [busd_asset])
-    assert len(events) > 0
-    apply_sync_events(portfolio, events)
-    reserve_currency, exchange_rate = portfolio.get_default_reserve()
-    assert reserve_currency == busd_asset
-    return portfolio
-
-
 @pytest.fixture
-def state(portfolio) -> State:
+def state(web3, hot_wallet, busd_asset) -> State:
     """State used in the tests."""
-    state = State(portfolio=portfolio)
+    state = State()
+
+    events = sync_reserves(
+        web3, datetime.datetime.utcnow(), hot_wallet.address, [], [busd_asset]
+    )
+    assert len(events) > 0
+    apply_sync_events(state, events)
+    reserve_currency, exchange_rate = state.portfolio.get_default_reserve()
+    assert reserve_currency == busd_asset
     return state
 
 

--- a/tests/mainnet_fork/test_uniswap_v3_routing.py
+++ b/tests/mainnet_fork/test_uniswap_v3_routing.py
@@ -314,24 +314,18 @@ def execution_model(web3, hot_wallet) -> UniswapV3ExecutionModel:
     return UniswapV3ExecutionModel(tx_builder)
 
 
-@pytest.fixture()
-def portfolio(web3, hot_wallet, usdc_asset) -> Portfolio:
-    """A portfolio synced to the hot wallet, starting with 10_000 usdc."""
-    portfolio = Portfolio()
+@pytest.fixture
+def state(web3, hot_wallet, usdc_asset) -> State:
+    """State used in the tests."""
+    state = State()
+
     events = sync_reserves(
         web3, datetime.datetime.utcnow(), hot_wallet.address, [], [usdc_asset]
     )
     assert len(events) > 0
-    apply_sync_events(portfolio, events)
-    reserve_currency, exchange_rate = portfolio.get_default_reserve()
+    apply_sync_events(state, events)
+    reserve_currency, exchange_rate = state.portfolio.get_default_reserve()
     assert reserve_currency == usdc_asset
-    return portfolio
-
-
-@pytest.fixture
-def state(portfolio) -> State:
-    """State used in the tests."""
-    state = State(portfolio=portfolio)
     return state
 
 

--- a/tests/test_legacy_state_dump.py
+++ b/tests/test_legacy_state_dump.py
@@ -86,13 +86,10 @@ def test_legacy_calculate_all_summary_statistics(state: State):
         state,
         ExecutionMode.unit_testing_trading,
         now_=now_,
+        legacy_workarounds=True,
     )
 
     assert summary.calculated_at
-    assert not summary.enough_data
-
-    datapoints = summary.performance_chart_90_days
-    assert len(datapoints) == 5
 
 
 def test_legacy_calculate_all_statistics(state: State):

--- a/tests/test_legacy_state_dump.py
+++ b/tests/test_legacy_state_dump.py
@@ -92,7 +92,7 @@ def test_legacy_calculate_all_summary_statistics(state: State):
     assert not summary.enough_data
 
     datapoints = summary.performance_chart_90_days
-    assert len(datapoints) == 7
+    assert len(datapoints) == 5
 
 
 def test_legacy_calculate_all_statistics(state: State):

--- a/tests/test_summary_and_metrics.py
+++ b/tests/test_summary_and_metrics.py
@@ -239,13 +239,15 @@ def test_calculate_all_summary_statistics(state: State):
     assert summary.first_trade_at == datetime.datetime(2021, 6, 1, 0, 0)
     assert summary.last_trade_at == datetime.datetime(2021, 12, 31, 0, 0)
     assert summary.current_value == pytest.approx(9541.619532761046)
-    assert summary.profitability_90_days == pytest.approx(-0.019484747529770786)
+    true_profitability = 9541.619532761046 / 10_000 - 1
+    assert true_profitability == pytest.approx(-0.045838046723895465)
+    assert summary.profitability_90_days == pytest.approx(-0.045838046723895465)
 
     datapoints = summary.performance_chart_90_days
     assert len(datapoints) == 91
 
-    assert datapoints[0] == (datetime.datetime(2021, 10, 2, 0, 0), 0.0)
-    assert datapoints[-1] == (datetime.datetime(2021, 12, 31, 0, 0), -0.019484747529770786)
+    assert datapoints[0] == (datetime.datetime(2021, 10, 2, 0, 0), -0.02687699056973558)
+    assert datapoints[-1] == (datetime.datetime(2021, 12, 31, 0, 0), -0.045838046723895576)
 
     # Make sure we do not output anything that is not JSON'able
     data = summary.to_dict()

--- a/tests/test_summary_and_metrics.py
+++ b/tests/test_summary_and_metrics.py
@@ -238,8 +238,8 @@ def test_calculate_all_summary_statistics(state: State):
     assert summary.enough_data
     assert summary.first_trade_at == datetime.datetime(2021, 6, 1, 0, 0)
     assert summary.last_trade_at == datetime.datetime(2021, 12, 31, 0, 0)
-    assert summary.profitability_90_days == pytest.approx(-0.019484747529770786)
     assert summary.current_value == pytest.approx(9541.619532761046)
+    assert summary.profitability_90_days == pytest.approx(-0.019484747529770786)
 
     datapoints = summary.performance_chart_90_days
     assert len(datapoints) == 91

--- a/tradeexecutor/backtest/backtest_pricing.py
+++ b/tradeexecutor/backtest/backtest_pricing.py
@@ -172,7 +172,8 @@ class BacktestSimplePricingModel(PricingModel):
                        reserve: Optional[Decimal]) -> TradePricing:
         """Get the price for a buy transaction."""
 
-        assert reserve is not None and reserve > 0, f"For a buy estimation, please fill in the allocated reserve amount for: {pair}. Got reserve: {reserve}"
+        assert reserve is not None and reserve > 0, f"Tried to make a buy price estimation for zero amount.\n" \
+                                                    f"For a buy estimation, please fill in the allocated reserve amount for: {pair}. Got reserve: {reserve}"
 
         # TODO: Include price impact
         pair_id = pair.internal_id

--- a/tradeexecutor/backtest/backtest_runner.py
+++ b/tradeexecutor/backtest/backtest_runner.py
@@ -17,7 +17,7 @@ from tradeexecutor.backtest.backtest_sync import BacktestSyncer, BacktestSyncMod
 from tradeexecutor.backtest.backtest_valuation import BacktestValuationModel
 from tradeexecutor.backtest.simulated_wallet import SimulatedWallet
 from tradeexecutor.cli.log import setup_notebook_logging
-from tradeexecutor.cli.loop import ExecutionLoop
+from tradeexecutor.cli.loop import ExecutionLoop, ExecutionTestHook
 from tradeexecutor.ethereum.routing_data import get_routing_model, get_backtest_routing_model
 from tradeexecutor.state.state import State
 from tradeexecutor.state.store import NoneStore
@@ -272,6 +272,7 @@ def run_backtest(
         setup: BacktestSetup,
         client: Optional[Client]=None,
         allow_missing_fees=False,
+        execution_test_hook: Optional[ExecutionTestHook] = None,
 ) -> Tuple[State, TradingStrategyUniverse, dict]:
     """Run a strategy backtest.
 
@@ -363,6 +364,7 @@ def run_backtest(
         backtest_candle_time_frame_override=setup.universe_options.candle_time_bucket_override,
         tick_offset=datetime.timedelta(seconds=1),
         trade_immediately=True,
+        execution_test_hook=execution_test_hook,
     )
 
     debug_dump = main_loop.run()

--- a/tradeexecutor/backtest/backtest_runner.py
+++ b/tradeexecutor/backtest/backtest_runner.py
@@ -13,7 +13,8 @@ import pandas as pd
 from tradeexecutor.backtest.backtest_execution import BacktestExecutionModel
 from tradeexecutor.backtest.backtest_pricing import BacktestSimplePricingModel
 from tradeexecutor.backtest.backtest_routing import BacktestRoutingModel
-from tradeexecutor.backtest.backtest_sync import BacktestSyncer, BacktestSyncModel
+from tradeexecutor.backtest.backtest_sync import BacktestSyncModel
+from tradeexecutor.backtest.legacy_backtest_sync import BacktestSyncer
 from tradeexecutor.backtest.backtest_valuation import BacktestValuationModel
 from tradeexecutor.backtest.simulated_wallet import SimulatedWallet
 from tradeexecutor.cli.log import setup_notebook_logging
@@ -161,7 +162,7 @@ def setup_backtest_for_universe(
 
     """
 
-    assert initial_deposit > 0
+    assert initial_deposit >= 0, f"Got initial deposit amount: {initial_deposit}"
 
     wallet = SimulatedWallet()
 

--- a/tradeexecutor/backtest/backtest_sync.py
+++ b/tradeexecutor/backtest/backtest_sync.py
@@ -87,7 +87,8 @@ class BacktestSyncModel(SyncModel):
                     asset=reserve_token,
                     past_balance=past_balance,
                     new_balance=self.wallet.get_balance(reserve_token.address),
-                    updated_at=strategy_cycle_ts
+                    updated_at=strategy_cycle_ts,
+                    mined_at=funding_event.timestamp,
                 )
             )
 

--- a/tradeexecutor/backtest/backtest_sync.py
+++ b/tradeexecutor/backtest/backtest_sync.py
@@ -23,11 +23,14 @@ class BacktestSyncer:
         self.initial_deposit_amount = initial_deposit_amount
         self.initial_deposit_processed_at = None
 
-    def __call__(self, portfolio: Portfolio, ts: datetime.datetime, supported_reserves: List[AssetIdentifier]) -> List[ReserveUpdateEvent]:
+    def __call__(self, state: State, ts: datetime.datetime, supported_reserves: List[AssetIdentifier]) -> List[ReserveUpdateEvent]:
         """Process the backtest initial deposit.
 
         The backtest wallet is credited once at the start.
         """
+        assert isinstance(state, State)
+
+        portfolio = state.portfolio
 
         if not self.initial_deposit_processed_at:
             self.initial_deposit_processed_at = ts
@@ -48,7 +51,7 @@ class BacktestSyncer:
             self.wallet.update_balance(reserve_token.address, self.initial_deposit_amount)
 
             # Update state
-            apply_sync_events(portfolio, [evt])
+            apply_sync_events(state, [evt])
 
             return [evt]
         else:

--- a/tradeexecutor/backtest/backtest_sync.py
+++ b/tradeexecutor/backtest/backtest_sync.py
@@ -1,9 +1,11 @@
 import datetime
+from dataclasses import dataclass
 from decimal import Decimal
 from typing import List, Optional
 
 from tradeexecutor.backtest.simulated_wallet import SimulatedWallet
 from tradeexecutor.ethereum.wallet import ReserveUpdateEvent
+from tradeexecutor.state.balance_update import BalanceUpdate
 from tradeexecutor.state.portfolio import Portfolio
 from tradeexecutor.state.identifier import AssetIdentifier
 from tradeexecutor.state.state import State
@@ -65,6 +67,21 @@ class BacktestSyncer:
             return []
 
 
+@dataclass
+class FundFlowEvent:
+    """One simulated deposit/redemption in backtest.
+
+    - Events can be triggered any time with :py:meth:`BacktestSyncModel.simulate_funding`
+
+    - Fund flow is added to the reserves during :py:meth:`BacktestSyncModel.sync_treasury`
+      as it would be with live trading
+    """
+
+
+    timestamp: datetime.datetime
+
+    amount: Decimal
+
 
 class BacktestSyncModel(SyncModel):
     """Backtest sync model.
@@ -74,14 +91,18 @@ class BacktestSyncModel(SyncModel):
     def __init__(self, wallet: SimulatedWallet, initial_deposit_amount: Decimal):
         assert isinstance(initial_deposit_amount, Decimal)
         self.wallet = wallet
-        self.initial_deposit_amount = initial_deposit_amount
-        self.initial_deposit_processed_at = None
+
+        #: Simulated deposit/redemption events pending to be processed
+        self.fund_flow_queue: List[FundFlowEvent] = [
+            FundFlowEvent(datetime.datetime.utcnow(), initial_deposit_amount)
+        ]
 
     def sync_initial(self, state: State):
-        """Set u[ initial sync details."""
+        """Set up the initial sync details.
 
+        For backtesting these are irrelevant.
+        """
         deployment = state.sync.deployment
-
         deployment.chain_id = None
         deployment.address = None
         deployment.block_number = None
@@ -94,7 +115,7 @@ class BacktestSyncModel(SyncModel):
                  strategy_cycle_ts: datetime.datetime,
                  state: State,
                  supported_reserves: Optional[List[AssetIdentifier]] = None
-                 ):
+                 ) -> List[BalanceUpdate]:
         """Apply the balance sync before each strategy cycle.
 
         .. warning::
@@ -102,51 +123,44 @@ class BacktestSyncModel(SyncModel):
             Old legacy code with wrong return signature compared to the parent class
         """
 
-        # TODO: Move this code eto sync_initial()
-        if not self.initial_deposit_processed_at:
-            self.initial_deposit_processed_at = strategy_cycle_ts
+        assert len(supported_reserves) == 1
+        reserve_token = supported_reserves[0]
+        balance_update_events = []
 
-            assert len(supported_reserves) == 1
-            reserve_token = supported_reserves[0]
+        for funding_event in self.fund_flow_queue:
+
+            # Update wallet
+            self.wallet.update_balance(reserve_token.address, funding_event.amount)
 
             # Generate a deposit event
             evt = ReserveUpdateEvent(
                 asset=reserve_token,
                 past_balance=Decimal(0),
-                new_balance=self.initial_deposit_amount,
+                new_balance=self.wallet.get_balance(reserve_token.address),
                 updated_at=strategy_cycle_ts
             )
-
-            # Update wallet
-            self.wallet.update_balance(reserve_token.address, self.initial_deposit_amount)
-
             # Update state
-            apply_sync_events(state, [evt])
+            balance_update_events = apply_sync_events(state, [evt])
 
-            return []
-        else:
-            return []
+        # Clear our pending funding simulation events
+        self.fund_flow_queue = []
 
-    def make_balance_update(self, amount: USDollarAmount):
-        """Simulate deposit of funds."""
+        return balance_update_events
 
-        assert len(supported_reserves) == 1
-        reserve_token = supported_reserves[0]
+    def simulate_funding(self, timestamp: datetime.datetime, amount: Decimal):
+        """Simulate a funding flow event.
 
-        # Generate a deposit event
-        evt = ReserveUpdateEvent(
-            asset=reserve_token,
-            past_balance=Decimal(0),
-            new_balance=self.initial_deposit_amount,
-            updated_at=strategy_cycle_ts
+        Call for the test to cause deposit or redemption for the backtest.
+        The event goes to a queue and is processed in next `tick()`
+        through `sync_portfolio()`.
+
+        :param amount:
+            Positive for deposit, negative for redemption
+
+        """
+        self.fund_flow_queue.append(
+            FundFlowEvent(timestamp, amount)
         )
 
-        # Update wallet
-        self.wallet.update_balance(reserve_token.address, self.initial_deposit_amount)
-
-        # Update state
-        apply_sync_events(state, [evt])
-
-
     def create_transaction_builder(self) -> None:
-        return None
+        """Backtesting does not need to care about how to build blockchain transactions."""

--- a/tradeexecutor/backtest/backtest_sync.py
+++ b/tradeexecutor/backtest/backtest_sync.py
@@ -92,8 +92,6 @@ class BacktestSyncModel(SyncModel):
             Old legacy code with wrong return signature compared to the parent class
         """
 
-        portfolio = state.portfolio
-
         # TODO: Move this code eto sync_initial()
         if not self.initial_deposit_processed_at:
             self.initial_deposit_processed_at = strategy_cycle_ts
@@ -114,12 +112,7 @@ class BacktestSyncModel(SyncModel):
             self.wallet.update_balance(reserve_token.address, self.initial_deposit_amount)
 
             # Update state
-            apply_sync_events(portfolio, [evt])
-
-            # Set synced flag
-            # TODO: fix - wrong event type
-            state.sync.treasury.last_updated_at = strategy_cycle_ts
-            state.sync.treasury.balance_update_refs = []
+            apply_sync_events(state, [evt])
 
             return []
         else:

--- a/tradeexecutor/backtest/legacy_backtest_sync.py
+++ b/tradeexecutor/backtest/legacy_backtest_sync.py
@@ -49,7 +49,8 @@ class BacktestSyncer:
                 asset=reserve_token,
                 past_balance=Decimal(0),
                 new_balance=self.initial_deposit_amount,
-                updated_at=ts
+                updated_at=ts,
+                mined_at=ts,
             )
 
             # Update wallet

--- a/tradeexecutor/backtest/legacy_backtest_sync.py
+++ b/tradeexecutor/backtest/legacy_backtest_sync.py
@@ -1,0 +1,63 @@
+"""Old backtest wallet top up code."""
+
+import datetime
+from _decimal import Decimal
+from typing import List
+
+from tradeexecutor.backtest.simulated_wallet import SimulatedWallet
+from tradeexecutor.ethereum.wallet import ReserveUpdateEvent
+from tradeexecutor.state.identifier import AssetIdentifier
+from tradeexecutor.state.state import State
+from tradeexecutor.testing.dummy_wallet import apply_sync_events
+
+
+class BacktestSyncer:
+    """LEGACY backtest sync model.
+
+    Simulate deposit events to the backtest wallet.
+
+    .. warning::
+
+        Does not correctly fire any balance update events.
+        Can be used to backtest with a fixed initial amount only.
+    """
+
+    def __init__(self, wallet: SimulatedWallet, initial_deposit_amount: Decimal):
+        assert isinstance(initial_deposit_amount, Decimal)
+        self.wallet = wallet
+        self.initial_deposit_amount = initial_deposit_amount
+        self.initial_deposit_processed_at = None
+
+    def __call__(self, state: State, ts: datetime.datetime, supported_reserves: List[AssetIdentifier]) -> List[ReserveUpdateEvent]:
+        """Process the backtest initial deposit.
+
+        The backtest wallet is credited once at the start.
+        """
+        assert isinstance(state, State)
+
+        portfolio = state.portfolio
+
+        if not self.initial_deposit_processed_at:
+            self.initial_deposit_processed_at = ts
+
+            assert len(supported_reserves) == 1
+
+            reserve_token = supported_reserves[0]
+
+            # Generate a deposit event
+            evt = ReserveUpdateEvent(
+                asset=reserve_token,
+                past_balance=Decimal(0),
+                new_balance=self.initial_deposit_amount,
+                updated_at=ts
+            )
+
+            # Update wallet
+            self.wallet.update_balance(reserve_token.address, self.initial_deposit_amount)
+
+            # Update state
+            apply_sync_events(state, [evt])
+
+            return [evt]
+        else:
+            return []

--- a/tradeexecutor/cli/loop.py
+++ b/tradeexecutor/cli/loop.py
@@ -401,7 +401,8 @@ class ExecutionLoop:
         self.runner.pretick_check(ts, universe)
 
         if cycle == 1 and self.backtest_setup is not None:
-            # The hook to set up backtest initial balance
+            # The hook to set up backtest initial balance.
+            # TODO: Legacy - remove.
             logger.info("Performing initial backtest account funding")
             self.backtest_setup(state, universe, self.sync_model)
 

--- a/tradeexecutor/ethereum/enzyme/vault.py
+++ b/tradeexecutor/ethereum/enzyme/vault.py
@@ -550,6 +550,9 @@ class EnzymeVaultSyncModel(SyncModel):
         reserve_position.last_sync_at = datetime.datetime.utcnow()
         reserve_position.quantity = reserve_current_balance.balance
 
+        # TODO: Assume USD stablecoins are 1:1 USD
+        usd_value = float(reserve_position.quantity)
+
         event_id = portfolio.next_balance_update_id
         portfolio.next_balance_update_id += 1
 
@@ -566,6 +569,7 @@ class EnzymeVaultSyncModel(SyncModel):
             tx_hash=None,
             log_index=None,
             position_id=None,
+            usd_value=usd_value,
             notes=f"reinit() at block {current_block}"
         )
 
@@ -582,6 +586,7 @@ class EnzymeVaultSyncModel(SyncModel):
                 cause=new_event.cause,
                 position_type=new_event.position_type,
                 position_id=new_event.position_id,
+                usd_value=new_event.usd_value,
             )
             treasury_sync.balance_update_refs.append(ref)
 

--- a/tradeexecutor/ethereum/enzyme/vault.py
+++ b/tradeexecutor/ethereum/enzyme/vault.py
@@ -202,6 +202,7 @@ class EnzymeVaultSyncModel(SyncModel):
             cause=BalanceUpdateCause.deposit,
             asset=asset,
             block_mined_at=event.timestamp,
+            strategy_cycle_included_at=strategy_cycle_ts,
             chain_id=asset.chain_id,
             old_balance=old_balance,
             usd_value=usd_value,
@@ -473,7 +474,7 @@ class EnzymeVaultSyncModel(SyncModel):
         for new_event in events:
             ref = BalanceEventRef(
                 balance_event_id=new_event.balance_update_id,
-                updated_at=new_event.block_mined_at,
+                strategy_cycle_included_at=new_event.strategy_cycle_included_at,
                 cause=new_event.cause,
                 position_type=new_event.position_type,
                 position_id=new_event.position_id,

--- a/tradeexecutor/ethereum/enzyme/vault.py
+++ b/tradeexecutor/ethereum/enzyme/vault.py
@@ -259,8 +259,6 @@ class EnzymeVaultSyncModel(SyncModel):
 
             quantity = asset.convert_to_decimal(raw_amount)
 
-            usd_value = position.calculate_quantity_usd_value(quantity)
-
             assert quantity > 0  # Sign flipped later
 
             event_id = portfolio.next_balance_update_id
@@ -271,10 +269,13 @@ class EnzymeVaultSyncModel(SyncModel):
                 old_balance = position.quantity
                 position.quantity -= quantity
                 position_type = BalanceUpdatePositionType.reserve
+                # TODO: USD stablecoin hardcoded to 1:1 with USD
+                usd_value = float(quantity)
             elif isinstance(position, TradingPosition):
                 position_id = position.position_id
                 old_balance = position.get_quantity()
                 position_type = BalanceUpdatePositionType.open_position
+                usd_value = position.calculate_quantity_usd_value(quantity)
             else:
                 raise NotImplementedError()
 

--- a/tradeexecutor/ethereum/enzyme/vault.py
+++ b/tradeexecutor/ethereum/enzyme/vault.py
@@ -564,6 +564,7 @@ class EnzymeVaultSyncModel(SyncModel):
             cause=BalanceUpdateCause.deposit,
             asset=asset,
             block_mined_at=timestamp,
+            strategy_cycle_included_at=timestamp,
             chain_id=asset.chain_id,
             old_balance=Decimal(0),
             quantity=reserve_current_balance.balance,

--- a/tradeexecutor/ethereum/enzyme/vault.py
+++ b/tradeexecutor/ethereum/enzyme/vault.py
@@ -191,6 +191,8 @@ class EnzymeVaultSyncModel(SyncModel):
         reserve_position.last_sync_at = datetime.datetime.utcnow()
         reserve_position.quantity += event.investment_amount
 
+        usd_value = float(exchange_rate) * float(event.investment_amount)
+
         event_id = portfolio.next_balance_update_id
         portfolio.next_balance_update_id += 1
 
@@ -202,6 +204,7 @@ class EnzymeVaultSyncModel(SyncModel):
             block_mined_at=event.timestamp,
             chain_id=asset.chain_id,
             old_balance=old_balance,
+            usd_value=usd_value,
             quantity=event.investment_amount,
             owner_address=event.receiver,
             tx_hash=event.event_data["transactionHash"],
@@ -256,6 +259,8 @@ class EnzymeVaultSyncModel(SyncModel):
 
             quantity = asset.convert_to_decimal(raw_amount)
 
+            usd_value = position.calculate_quantity_usd_value(quantity)
+
             assert quantity > 0  # Sign flipped later
 
             event_id = portfolio.next_balance_update_id
@@ -289,6 +294,7 @@ class EnzymeVaultSyncModel(SyncModel):
                 tx_hash=event.event_data["transactionHash"],
                 log_index=event.event_data["logIndex"],
                 position_id=position_id,
+                usd_value=usd_value,
             )
 
             position.balance_updates[event_id] = evt
@@ -469,6 +475,7 @@ class EnzymeVaultSyncModel(SyncModel):
                 cause=new_event.cause,
                 position_type=new_event.position_type,
                 position_id=new_event.position_id,
+                usd_value=new_event.usd_value,
             )
             treasury_sync.balance_update_refs.append(ref)
 

--- a/tradeexecutor/ethereum/hot_wallet_sync_model.py
+++ b/tradeexecutor/ethereum/hot_wallet_sync_model.py
@@ -61,7 +61,7 @@ class HotWalletSyncModel(SyncModel):
         # TODO: This code is not production ready - use with care
         # Needs legacy cleanup
         events = sync_reserves(self.web3, strategy_cycle_ts, self.hot_wallet.address, [], supported_reserves)
-        apply_sync_events(state.portfolio, events)
+        apply_sync_events(state, events)
         state.sync.treasury.last_updated_at = datetime.datetime.utcnow()
         state.sync.treasury.last_cycle_at = strategy_cycle_ts
         state.sync.treasury.last_block_scanned = self.web3.eth.block_number

--- a/tradeexecutor/ethereum/wallet.py
+++ b/tradeexecutor/ethereum/wallet.py
@@ -30,6 +30,11 @@ class ReserveUpdateEvent:
     TODO: This should be removed as is partially part of old treasury sync code.
     """
     asset: AssetIdentifier
+
+    #: Transfer timestamp (if known)
+    mined_at: datetime.datetime
+
+    #: Strategy cycle timestamp
     updated_at: datetime.datetime
     past_balance: Decimal
     new_balance: Decimal

--- a/tradeexecutor/ethereum/wallet.py
+++ b/tradeexecutor/ethereum/wallet.py
@@ -34,6 +34,7 @@ class ReserveUpdateEvent:
     past_balance: Decimal
     new_balance: Decimal
 
+
     @property
     def change(self) -> Decimal:
         return self.new_balance - self.past_balance

--- a/tradeexecutor/ethereum/wallet.py
+++ b/tradeexecutor/ethereum/wallet.py
@@ -32,6 +32,10 @@ class ReserveUpdateEvent:
     past_balance: Decimal
     new_balance: Decimal
 
+    @property
+    def change(self) -> Decimal:
+        return self.new_balance - self.past_balance
+
 
 def update_wallet_balances(web3: Web3, address: HexAddress, tokens: List[HexAddress]) -> Dict[HexAddress, DecimalisedHolding]:
     """Get raw balances of ERC-20 tokens."""

--- a/tradeexecutor/ethereum/wallet.py
+++ b/tradeexecutor/ethereum/wallet.py
@@ -26,6 +26,8 @@ class ReserveUpdateEvent:
     Maintained for old code compatibility.
 
     See :py:mod:`tradeeexecutor.state.sync` for the current approach.
+
+    TODO: This should be removed as is partially part of old treasury sync code.
     """
     asset: AssetIdentifier
     updated_at: datetime.datetime

--- a/tradeexecutor/ethereum/wallet.py
+++ b/tradeexecutor/ethereum/wallet.py
@@ -21,6 +21,12 @@ logger = logging.getLogger(__name__)
 @dataclass_json
 @dataclasses.dataclass
 class ReserveUpdateEvent:
+    """A legacy reserve update event.
+
+    Maintained for old code compatibility.
+
+    See :py:mod:`tradeeexecutor.state.sync` for the current approach.
+    """
     asset: AssetIdentifier
     updated_at: datetime.datetime
     past_balance: Decimal

--- a/tradeexecutor/ethereum/wallet.py
+++ b/tradeexecutor/ethereum/wallet.py
@@ -92,7 +92,8 @@ def sync_reserves(
                 asset=currency,
                 past_balance=current_value,
                 new_balance=decimal_holding.value,
-                updated_at=clock
+                updated_at=clock,
+                mined_at=clock,  # TODO: We do not have logic to get actual block_mined_at of Transfer() here
             )
             events.append(evt)
             logger.info("Reserve currency update detected. Asset: %s, past: %s, new: %s", evt.asset, evt.past_balance, evt.new_balance)

--- a/tradeexecutor/state/balance_update.py
+++ b/tradeexecutor/state/balance_update.py
@@ -63,10 +63,20 @@ class BalanceUpdate:
     #:
     asset: AssetIdentifier
 
-    #: When the update happened
+    #: When the balance event was generated
     #:
     #: The block mined timestamp
     block_mined_at: datetime.datetime
+
+    #: When balance event was included to the strategy's treasury.
+    #:
+    #: The strategy cycle timestamp.
+    #:
+    #:
+    #: It might be outside the cycle frequency if treasuries were processed
+    #: in a cron job outside the cycle for slow moving strategies.
+    #:
+    strategy_cycle_included_at: datetime.datetime
 
     #: Chain that updated the balance
     chain_id: int

--- a/tradeexecutor/state/balance_update.py
+++ b/tradeexecutor/state/balance_update.py
@@ -111,6 +111,12 @@ class BalanceUpdate:
     #:
     notes: Optional[str] = None
 
+    def __post_init__(self):
+        assert self.quantity != 0, "Balance update cannot be zero: {self}"
+
+    def __repr__(self):
+        return f"<BalanceUpdate #{self.balance_update_id} {self.cause.name} {self.quantity} for position {self.position_id}>"
+
     def __eq__(self, other: "BalanceUpdate"):
         assert isinstance(other, BalanceUpdate), f"Got {other}"
         match self.cause:

--- a/tradeexecutor/state/balance_update.py
+++ b/tradeexecutor/state/balance_update.py
@@ -15,6 +15,7 @@ from typing import Optional
 from dataclasses_json import dataclass_json
 
 from tradeexecutor.state.identifier import AssetIdentifier
+from tradingstrategy.types import USDollarAmount
 
 
 class BalanceUpdateCause(enum.Enum):
@@ -79,6 +80,13 @@ class BalanceUpdate:
     #: What was the total of the asset in the position before this event was applied.
     #:
     old_balance: Decimal
+
+    #: How much this deposit/redemption was worth
+    #:
+    #: Used for deposit/redemption inflow/outflow calculation.
+    #: This is the asset value from our internal price keeping at the time of the event.
+    #:
+    usd_value: USDollarAmount
 
     #: Investor address that the balance update is related to
     #:

--- a/tradeexecutor/state/position.py
+++ b/tradeexecutor/state/position.py
@@ -924,6 +924,13 @@ class TradingPosition:
         # Static stop loss
         return self.stop_loss
 
+    def calculate_quantity_usd_value(self, quantity: Decimal) -> USDollarAmount:
+        """Calculate value of asset amount using the latest known price."""
+        if quantity == 0:
+            return 0
+        assert self.last_token_price, f"Asset price not available when calculating price for quantity: {quantity}"
+        return float(quantity) * self.last_token_price
+
 
 class PositionType(enum.Enum):
     token_hold = "token_hold"

--- a/tradeexecutor/state/position.py
+++ b/tradeexecutor/state/position.py
@@ -792,7 +792,7 @@ class TradingPosition:
         :return:
             Percent of the portfolio value
         """
-        assert self.portfolio_value_at_open, "Portfolio value at position open was not recorded"
+        assert self.portfolio_value_at_open, f"Portfolio value at position open was not recorded for {self}"
         return self.get_value_at_open() / self.portfolio_value_at_open
 
     def get_loss_risk_at_open(self) -> USDollarAmount:
@@ -852,6 +852,9 @@ class TradingPosition:
         Calculate how many percent this profit made profit,
         adjusted to the position size compared to the available
         strategy equity at the opening of the position.
+
+        This is mostly useful to calculate the strategy performance
+        independent of funding deposits and redemptions.
 
         See :ref:`profitability` for more details.
 

--- a/tradeexecutor/state/position.py
+++ b/tradeexecutor/state/position.py
@@ -777,7 +777,7 @@ class TradingPosition:
         assert len(self.trades) > 0, "No trades available"
         return self.get_last_trade().get_executed_value()
 
-    def get_capital_tied_at_open_pct(self) -> float:
+    def get_capital_tied_at_open_pct(self) -> Percent:
         """Calculate how much portfolio capital was risk when this position was opened.
 
         - This is based on the opening values,
@@ -813,7 +813,7 @@ class TradingPosition:
         risked_value = price_diff * float(self.get_quantity_at_open())
         return risked_value
 
-    def get_loss_risk_at_open_pct(self) -> float:
+    def get_loss_risk_at_open_pct(self) -> Percent:
         """What is the maximum risk of this position.
 
         Risk relative to the portfolio size.
@@ -828,15 +828,38 @@ class TradingPosition:
         else:
             # Old invalid data
             return 0
-    
-    def get_realised_profit_percent(self) -> float:
-        """Calculated life-time profit over this position."""
+
+    def get_realised_profit_percent(self) -> Percent:
+        """Calculated life-time profit over this position.
+
+        Calculate how many percent profit this position made,
+        relative to all trades taken over the life time of the position.
+
+        See :ref:`profitability` for more details.
+
+        :return:
+            If the position made 1% profit returns 1.01.
+        """
         
         assert not self.is_open()
         buy_value = self.get_buy_value()
         sell_value = self.get_sell_value()
         return sell_value / buy_value - 1
-    
+
+    def get_size_relative_realised_profit_percent(self) -> Percent:
+        """Calculated life-time profit over this position.
+
+        Calculate how many percent this profit made profit,
+        adjusted to the position size compared to the available
+        strategy equity at the opening of the position.
+
+        See :ref:`profitability` for more details.
+
+        :return:
+            If the position made 1% profit returns 1.01.
+        """
+        return self.get_realised_profit_percent() * self.get_capital_tied_at_open_pct()
+
     def get_duration(self) -> datetime.timedelta | None:
         """How long this position was held.
         :return: None if the position is still open
@@ -846,7 +869,7 @@ class TradingPosition:
         else:
             return None
     
-    def get_total_lp_fees_paid(self) -> int:
+    def get_total_lp_fees_paid(self) -> USDollarAmount:
         """Get the total amount of swap fees paid in the position. Includes all trades."""
         
         lp_fees_paid = 0

--- a/tradeexecutor/state/statistics.py
+++ b/tradeexecutor/state/statistics.py
@@ -245,9 +245,11 @@ def calculate_naive_profitability(
         end_at: Optional[pd.Timestamp] = None) -> Tuple[Optional[float], Optional[pd.Timedelta]]:
     """Calculate the profitability as value at end - value at start.
 
-    This formula ignores any deposits and withdraws from the strategy.
+    .. warning::
 
-    TODO: This needs to include gas fee costs
+        This method assumes there are no deposits or redemptions.
+        See :py:mod:`tradeexecutor.visual.equity_curve` for more advanced
+        profit calculations.
 
     :param total_equity:
         As received from get_portfolio_statistics_dataframe()

--- a/tradeexecutor/state/sync.py
+++ b/tradeexecutor/state/sync.py
@@ -88,7 +88,10 @@ class BalanceEventRef:
     #: Balance event id we are referring to
     balance_event_id: int
 
-    #: When this update was made
+    #: When this update was made.
+    #:
+    #: Block timestamp for live trading.
+    #:
     updated_at: datetime.datetime
 
     #: Cause of the event

--- a/tradeexecutor/state/sync.py
+++ b/tradeexecutor/state/sync.py
@@ -73,7 +73,17 @@ class Deployment:
 @dataclass_json
 @dataclass
 class BalanceEventRef:
-    """Register the balance event in the treasury model."""
+    """Register the balance event in the treasury model.
+
+    Balance updates can happen for
+
+    - Treasury
+
+    - Open trading positions
+
+    We maintain a list of balance update references across all positions using :py:class:`BalanceEventRef`.
+    This allows us quickly to calculate net inflow/outflow.
+    """
 
     #: Balance event id we are referring to
     balance_event_id: int

--- a/tradeexecutor/state/sync.py
+++ b/tradeexecutor/state/sync.py
@@ -14,6 +14,7 @@ from typing import Optional, List, Iterable, Dict
 
 from dataclasses_json import dataclass_json
 
+from tradeexecutor.state.types import USDollarAmount
 from tradingstrategy.chain import ChainId
 
 from tradeexecutor.state.balance_update import BalanceUpdate, BalanceUpdateCause, BalanceUpdatePositionType
@@ -74,15 +75,27 @@ class Deployment:
 class BalanceEventRef:
     """Register the balance event in the treasury model."""
 
+    #: Balance event id we are referring to
     balance_event_id: int
 
+    #: When this update was made
     updated_at: datetime.datetime
 
+    #: Cause of the event
     cause: BalanceUpdateCause
 
+    #: Reserve currency or underlying position
     position_type: BalanceUpdatePositionType
 
+    #: Which trading positions were affected
     position_id: Optional[int]
+
+    #: How much this deposit/redemption was worth
+    #:
+    #: Used for deposit/redemption inflow/outflow calculation.
+    #: This is the asset value from our internal price keeping at the time of the event.
+    #:
+    usd_value: Optional[USDollarAmount]
 
 
 @dataclass_json

--- a/tradeexecutor/state/sync.py
+++ b/tradeexecutor/state/sync.py
@@ -90,9 +90,13 @@ class BalanceEventRef:
 
     #: When this update was made.
     #:
-    #: Block timestamp for live trading.
+    #: Strategy cycle timestamp when the deposit/redemption was included
+    #: in the strategy treasury.
     #:
-    updated_at: datetime.datetime
+    #: It might be outside the cycle frequency if treasuries were processed
+    #: in a cron job outside the cycle for slow moving strategies.
+    #:
+    strategy_cycle_included_at: datetime.datetime
 
     #: Cause of the event
     cause: BalanceUpdateCause

--- a/tradeexecutor/statistics/summary.py
+++ b/tradeexecutor/statistics/summary.py
@@ -16,7 +16,8 @@ def calculate_summary_statistics(
         state: State,
         execution_mode: ExecutionMode,
         time_window = pd.Timedelta(days=90),
-        now_: Optional[pd.Timestamp | datetime.datetime] = None
+        now_: Optional[pd.Timestamp | datetime.datetime] = None,
+        legacy_workarounds=False,
 ) -> StrategySummaryStatistics:
     """Preprocess the strategy statistics for the summary card in the web frontend.
 
@@ -42,6 +43,9 @@ def calculate_summary_statistics(
         Override current time for unit testing.
 
         Set this to the date of the last trade.
+
+    :param legacy_workarounds:
+        Skip some calculations on old data, because data is missing.
 
     :return:
         Summary calculations for the summary tile,
@@ -73,7 +77,7 @@ def calculate_summary_statistics(
     enough_data = False
     performance_chart_90_days = None
 
-    if len(stats.portfolio) > 0:
+    if len(stats.portfolio) > 0 and not legacy_workarounds:
 
         profitability = calculate_compounding_realised_profitability(state)
         enough_data = profitability.index[0] <= start_at

--- a/tradeexecutor/statistics/summary.py
+++ b/tradeexecutor/statistics/summary.py
@@ -17,7 +17,7 @@ def calculate_summary_statistics(
         time_window = pd.Timedelta(days=90),
         now_: Optional[pd.Timestamp | datetime.datetime] = None
 ) -> StrategySummaryStatistics:
-    """Preprocess the strategy statistics for the summary card.
+    """Preprocess the strategy statistics for the summary card in the web frontend.
 
     To test out in the :ref:`console`:
 

--- a/tradeexecutor/strategy/runner.py
+++ b/tradeexecutor/strategy/runner.py
@@ -121,15 +121,16 @@ class StrategyRunner(abc.ABC):
         assert len(reserve_assets) == 1, f"We only support strategies with a single reserve asset, got {self.reserve_assets}"
         token = reserve_assets[0]
         assert token.decimals and token.decimals > 0, f"Reserve asset lacked decimals"
-        reserve_update_events = self.sync_model.sync_treasury(
+
+        balance_update_events = self.sync_model.sync_treasury(
             strategy_cycle_ts,
             state,
             supported_reserves=reserve_assets,
         )
-        assert type(reserve_update_events) == list
+        assert type(balance_update_events) == list
 
         # Update the debug data for tests with our events
-        debug_details["reserve_update_events"] = reserve_update_events
+        debug_details["reserve_update_events"] = balance_update_events
         debug_details["total_equity_at_start"] = state.portfolio.get_total_equity()
         debug_details["total_cash_at_start"] = state.portfolio.get_current_cash()
 

--- a/tradeexecutor/strategy/sync_model.py
+++ b/tradeexecutor/strategy/sync_model.py
@@ -127,7 +127,14 @@ class DummySyncModel(SyncModel):
         if not self.fake_sync_done:
             state.sync.treasury.last_updated_at = datetime.datetime.utcnow()
             state.sync.treasury.last_cycle_at = strategy_cycle_ts
-            ref = BalanceEventRef(0, datetime.datetime.utcnow(), BalanceUpdateCause.deposit, BalanceUpdatePositionType.open_position, None)
+            ref = BalanceEventRef(
+                0,
+                datetime.datetime.utcnow(),
+                BalanceUpdateCause.deposit,
+                BalanceUpdatePositionType.open_position,
+                None,
+                None,
+            )
             state.sync.treasury.balance_update_refs = [ref]  # TODO: Get rid of the checks in on_clock()
             return []
         return []

--- a/tradeexecutor/testing/dummy_wallet.py
+++ b/tradeexecutor/testing/dummy_wallet.py
@@ -54,7 +54,7 @@ class DummyWalletSyncer:
             return []
 
 
-def apply_sync_events(state: State, new_reserves: List[ReserveUpdateEvent], default_price=1.0):
+def apply_sync_events(state: State, new_reserves: List[ReserveUpdateEvent], default_price=1.0) -> List[BalanceUpdate]:
     """Apply deposit and withdraws on reserves in the portfolio.
 
     - Updates :yp:class:`ReservePosition` instance to reflect the latest available balance
@@ -63,9 +63,7 @@ def apply_sync_events(state: State, new_reserves: List[ReserveUpdateEvent], defa
 
     - Marks the last treasury updated at
 
-    .. note ::
-
-        This is only used with deprecated :py:data:`tradeexecutor.strategy.sync_model.SyncMethodV0`
+    TODO: This needs to be refactored as is partially the old treasury sync code.
 
     :param default_price: Set the reserve currency price for new reserves.
     """
@@ -74,6 +72,7 @@ def apply_sync_events(state: State, new_reserves: List[ReserveUpdateEvent], defa
 
     portfolio = state.portfolio
     treasury_sync = state.sync.treasury
+    balance_update_events = []
 
     for evt in new_reserves:
 
@@ -130,9 +129,8 @@ def apply_sync_events(state: State, new_reserves: List[ReserveUpdateEvent], defa
             usd_value=bu.usd_value,
         )
 
+        balance_update_events.append(bu)
         treasury_sync.balance_update_refs.append(ref)
 
     treasury_sync.last_updated_at = datetime.datetime.utcnow()
-
-
-
+    return balance_update_events

--- a/tradeexecutor/testing/dummy_wallet.py
+++ b/tradeexecutor/testing/dummy_wallet.py
@@ -112,7 +112,8 @@ def apply_sync_events(state: State, new_reserves: List[ReserveUpdateEvent], defa
             position_type=BalanceUpdatePositionType.reserve,
             cause=cause,
             asset=asset,
-            block_mined_at=datetime.datetime.utcnow(),
+            block_mined_at=evt.mined_at,  # There is
+            strategy_cycle_included_at=evt.updated_at,
             chain_id=asset.chain_id,
             old_balance=evt.past_balance,
             usd_value=usd_value,
@@ -122,7 +123,7 @@ def apply_sync_events(state: State, new_reserves: List[ReserveUpdateEvent], defa
         res_pos.balance_updates[bu.balance_update_id] = bu
         ref = BalanceEventRef(
             balance_event_id=bu.balance_update_id,
-            updated_at=bu.block_mined_at,
+            strategy_cycle_included_at=bu.strategy_cycle_included_at,
             cause=bu.cause,
             position_type=bu.position_type,
             position_id=bu.position_id,

--- a/tradeexecutor/testing/dummy_wallet.py
+++ b/tradeexecutor/testing/dummy_wallet.py
@@ -9,9 +9,12 @@ from decimal import Decimal
 from typing import List
 
 from tradeexecutor.ethereum.wallet import ReserveUpdateEvent, logger
+from tradeexecutor.state.balance_update import BalanceUpdate, BalanceUpdatePositionType, BalanceUpdateCause
 from tradeexecutor.state.portfolio import Portfolio
 from tradeexecutor.state.identifier import AssetIdentifier
 from tradeexecutor.state.reserve import ReservePosition
+from tradeexecutor.state.state import State
+from tradeexecutor.state.sync import BalanceEventRef
 
 
 class DummyWalletSyncer:
@@ -51,8 +54,14 @@ class DummyWalletSyncer:
             return []
 
 
-def apply_sync_events(portfolio: Portfolio, new_reserves: List[ReserveUpdateEvent], default_price=1.0):
+def apply_sync_events(state: State, new_reserves: List[ReserveUpdateEvent], default_price=1.0):
     """Apply deposit and withdraws on reserves in the portfolio.
+
+    - Updates :yp:class:`ReservePosition` instance to reflect the latest available balance
+
+    - Generates balance update events needed to calculate inflows/outflows
+
+    - Marks the last treasury updated at
 
     .. note ::
 
@@ -60,6 +69,11 @@ def apply_sync_events(portfolio: Portfolio, new_reserves: List[ReserveUpdateEven
 
     :param default_price: Set the reserve currency price for new reserves.
     """
+
+    assert isinstance(state, State)
+
+    portfolio = state.portfolio
+    treasury_sync = state.sync.treasury
 
     for evt in new_reserves:
 
@@ -82,5 +96,43 @@ def apply_sync_events(portfolio: Portfolio, new_reserves: List[ReserveUpdateEven
             )
             portfolio.reserves[res_pos.get_identifier()] = res_pos
             logger.info("Portfolio reserve created. Asset: %s", evt.asset)
+
+        # Generate related balance events
+        event_id = portfolio.next_balance_update_id
+        portfolio.next_balance_update_id += 1
+
+        asset = evt.asset
+        quantity = evt.change
+        cause = BalanceUpdateCause.deposit if quantity > 0 else BalanceUpdateCause.redemption
+
+        # TODO: Assume stablecoins are 1:1 with dollar
+        usd_value = float(quantity)
+
+        bu = BalanceUpdate(
+            balance_update_id=event_id,
+            position_type=BalanceUpdatePositionType.reserve,
+            cause=cause,
+            asset=asset,
+            block_mined_at=datetime.datetime.utcnow(),
+            chain_id=asset.chain_id,
+            old_balance=evt.past_balance,
+            usd_value=usd_value,
+            quantity=quantity,
+            position_id=None,
+        )
+        res_pos.balance_updates[bu.balance_update_id] = bu
+        ref = BalanceEventRef(
+            balance_event_id=bu.balance_update_id,
+            updated_at=bu.block_mined_at,
+            cause=bu.cause,
+            position_type=bu.position_type,
+            position_id=bu.position_id,
+            usd_value=bu.usd_value,
+        )
+
+        treasury_sync.balance_update_refs.append(ref)
+
+    treasury_sync.last_updated_at = datetime.datetime.utcnow()
+
 
 

--- a/tradeexecutor/visual/equity_curve.py
+++ b/tradeexecutor/visual/equity_curve.py
@@ -276,6 +276,35 @@ def calculate_realised_profitability(
     return pd.DataFrame(data).set_index(0)[1]
 
 
+def calculate_compounding_realised_profitability(
+    state: State,
+) -> pd.Series:
+    """Calculate realised profitability of closed trading positions, with the compounding effect.
+
+    Assume the profits from the previous PnL are used in the next one.
+
+    This function returns the :term:`profitability` of individually
+    closed trading positions.
+
+    - See :py:func:`calculate_realised_profitability` for more information
+
+    - See :ref:`profitability` for more information.
+
+    :return:
+        Pandas series (DatetimeIndex, cumulative % profit).
+
+        Cumulative profit is 0% if there is no market action.
+        Cumulative profit is 1 (100%) if the equity has doubled during the period.
+
+        The last value of the series is the total trading profitability
+        of the strategy over its lifetime.
+    """
+    realised_profitability = calculate_realised_profitability(state)
+    # https://stackoverflow.com/a/42672553/315168
+    compounded = realised_profitability.add(1).cumprod().sub(1)
+    return compounded
+
+
 def calculate_deposit_adjusted_returns(
     state: State,
     freq: pd.DateOffset = pd.offsets.MonthBegin(),

--- a/tradeexecutor/visual/equity_curve.py
+++ b/tradeexecutor/visual/equity_curve.py
@@ -241,12 +241,9 @@ def visualise_returns_distribution(
 
 
 def calculate_investment_flow(
-        state: State,
+    state: State,
 ) -> pd.Series:
     """Calculate deposit/redemption i nflows/outflows of a strategy.
-
-    :param attribute_name:
-        Calculate equity curve based on this attribute of :py:class:`
 
     :return:
         Pandas series (timestamp, usd deposits/redemptions)
@@ -254,6 +251,22 @@ def calculate_investment_flow(
 
     treasury = state.sync.treasury
     balance_updates = treasury.balance_update_refs
-    index = [e.block_mined_at for e in balance_updates]
+    index = [e.updated_at for e in balance_updates]
     values = [e.usd_value for e in balance_updates]
     return pd.Series(values, index)
+
+
+def calculate_realised_profitability(
+    state: State,
+) -> pd.Series:
+    """Calculate realised profitability of closed trading positions.
+
+    This function returns the :term:`profitability` of individually
+    closed trading positions.
+
+    :return:
+        Pandas series (timestamp, % profit)
+    """
+    data = [(p.closed_at, p.get_realised_profit_percent()) for p in state.portfolio.closed_positions.values()]
+    # https://stackoverflow.com/a/66772284/315168
+    return pd.DataFrame(data).set_index(0)[1]

--- a/tradeexecutor/visual/equity_curve.py
+++ b/tradeexecutor/visual/equity_curve.py
@@ -240,54 +240,20 @@ def visualise_returns_distribution(
     return fig
 
 
-
-def calculate_flow_independent_returns(
-        state: State,
-) -> pd.Series:
-    """Calculate strategy profitability accounting for any deposit/redemption flow.
-
-    Translate the portfolio internal :py:attr:`Statistics.portfolio`
-    to :py:class:`pd.Series` that allows easy equity curve calculations.
-
-    :param attribute_name:
-        Calculate equity curve based on this attribute of :py:class:`
-
-    :return:
-        Pandas series (timestamp, profit % over the first timestamp)
-    """
-
-    stats: Statistics = state.stats
-
-    portfolio_stats: List[PortfolioStatistics] = stats.portfolio
-    index = [stat.calculated_at for stat in portfolio_stats]
-
-    assert len(index) >= 2, "Cannot calculate equity curve because there are no portfolio.stats.portfolio entries"
-
-    values = [getattr(stat, attribute_name) for stat in portfolio_stats]
-    return pd.Series(values, index)
-
-
 def calculate_investment_flow(
         state: State,
 ) -> pd.Series:
-    """Calculate deposit/redemption inflows/outflows of a strategy.
-
-
-
+    """Calculate deposit/redemption i nflows/outflows of a strategy.
 
     :param attribute_name:
         Calculate equity curve based on this attribute of :py:class:`
 
     :return:
-        Pandas series (timestamp, profit % over the first timestamp)
+        Pandas series (timestamp, usd deposits/redemptions)
     """
 
-    stats: Statistics = state.stats
-
-    portfolio_stats: List[PortfolioStatistics] = stats.portfolio
-    index = [stat.calculated_at for stat in portfolio_stats]
-
-    assert len(index) >= 2, "Cannot calculate equity curve because there are no portfolio.stats.portfolio entries"
-
-    values = [getattr(stat, attribute_name) for stat in portfolio_stats]
+    treasury = state.sync.treasury
+    balance_updates = treasury.balance_update_refs
+    index = [e.block_mined_at for e in balance_updates]
+    values = [e.usd_value for e in balance_updates]
     return pd.Series(values, index)

--- a/tradeexecutor/visual/equity_curve.py
+++ b/tradeexecutor/visual/equity_curve.py
@@ -30,7 +30,9 @@ def calculate_equity_curve(
     :return:
         Pandas series (timestamp, equity value).
 
-        Indxe is DatetimeIndex.
+        Index is DatetimeIndex.
+
+        Empty series is returned if there is no data.
 
     """
 

--- a/tradeexecutor/visual/equity_curve.py
+++ b/tradeexecutor/visual/equity_curve.py
@@ -241,5 +241,53 @@ def visualise_returns_distribution(
 
 
 
+def calculate_flow_independent_returns(
+        state: State,
+) -> pd.Series:
+    """Calculate strategy profitability accounting for any deposit/redemption flow.
+
+    Translate the portfolio internal :py:attr:`Statistics.portfolio`
+    to :py:class:`pd.Series` that allows easy equity curve calculations.
+
+    :param attribute_name:
+        Calculate equity curve based on this attribute of :py:class:`
+
+    :return:
+        Pandas series (timestamp, profit % over the first timestamp)
+    """
+
+    stats: Statistics = state.stats
+
+    portfolio_stats: List[PortfolioStatistics] = stats.portfolio
+    index = [stat.calculated_at for stat in portfolio_stats]
+
+    assert len(index) >= 2, "Cannot calculate equity curve because there are no portfolio.stats.portfolio entries"
+
+    values = [getattr(stat, attribute_name) for stat in portfolio_stats]
+    return pd.Series(values, index)
 
 
+def calculate_investment_flow(
+        state: State,
+) -> pd.Series:
+    """Calculate deposit/redemption inflows/outflows of a strategy.
+
+
+
+
+    :param attribute_name:
+        Calculate equity curve based on this attribute of :py:class:`
+
+    :return:
+        Pandas series (timestamp, profit % over the first timestamp)
+    """
+
+    stats: Statistics = state.stats
+
+    portfolio_stats: List[PortfolioStatistics] = stats.portfolio
+    index = [stat.calculated_at for stat in portfolio_stats]
+
+    assert len(index) >= 2, "Cannot calculate equity curve because there are no portfolio.stats.portfolio entries"
+
+    values = [getattr(stat, attribute_name) for stat in portfolio_stats]
+    return pd.Series(values, index)

--- a/tradeexecutor/visual/equity_curve.py
+++ b/tradeexecutor/visual/equity_curve.py
@@ -298,6 +298,30 @@ def calculate_realised_profitability(
     return pd.DataFrame(data).set_index(0)[1]
 
 
+def calculate_size_relative_realised_profitability(
+    state: State,
+) -> pd.Series:
+    """Calculate realised profitability of closed trading positions relative to the portfolio size..
+
+    This function returns the :term:`profitability` of individually
+    closed trading positions.
+
+    See :ref:`profitability` for more information.
+
+    :return:
+        Pandas series (DatetimeIndex, % profit).
+
+        Empty series if there are no trades.
+    """
+    data = [(p.closed_at, p.get_size_relative_realised_profit_percent()) for p in state.portfolio.closed_positions.values() if p.is_closed()]
+
+    if len(data) == 0:
+        return pd.Series()
+
+    # https://stackoverflow.com/a/66772284/315168
+    return pd.DataFrame(data).set_index(0)[1]
+
+
 def calculate_compounding_realised_profitability(
     state: State,
 ) -> pd.Series:
@@ -306,7 +330,7 @@ def calculate_compounding_realised_profitability(
     Assume the profits from the previous PnL are used in the next one.
 
     This function returns the :term:`profitability` of individually
-    closed trading positions.
+    closed trading positions, relative to the portfolio total equity.
 
     - See :py:func:`calculate_realised_profitability` for more information
 
@@ -321,7 +345,7 @@ def calculate_compounding_realised_profitability(
         The last value of the series is the total trading profitability
         of the strategy over its lifetime.
     """
-    realised_profitability = calculate_realised_profitability(state)
+    realised_profitability = calculate_size_relative_realised_profitability(state)
     # https://stackoverflow.com/a/42672553/315168
     compounded = realised_profitability.add(1).cumprod().sub(1)
     return compounded


### PR DESCRIPTION
- Add different options to calculate profit, funds flow, equity
- Record deposit and redemption USD values for funding calculations
- Export the web frontend summary card profitability [as the compounding realised trading profitability](https://tradingstrategy.ai/docs/programming/market-data/profitability.html), instead of total equity increase to smooth out equity changes caused by deposits and redemptions