### PR TITLE
Backtest CLI command

### DIFF
--- a/.github/workflows/test-and-build-image.yml
+++ b/.github/workflows/test-and-build-image.yml
@@ -39,7 +39,8 @@ jobs:
           poetry install --no-interaction -E web-server -E execution -E quantstats
       - name: Run test scripts
         run: |
-          poetry run pytest --tb=native
+          # Run tests and print 20 slowest
+          poetry run pytest --tb=native --durations=20 "not slow_test_group"
         env:
           TRADING_STRATEGY_API_KEY: ${{ secrets.TRADING_STRATEGY_API_KEY }}
           BNB_CHAIN_JSON_RPC: ${{ secrets.BNB_CHAIN_JSON_RPC }}      

--- a/.github/workflows/test-and-build-image.yml
+++ b/.github/workflows/test-and-build-image.yml
@@ -1,4 +1,4 @@
-name: Automated test suite and Docker image build
+name: Test suite and Docker image
 on:
   push:
     branches: [ master ]

--- a/.github/workflows/test-and-build-image.yml
+++ b/.github/workflows/test-and-build-image.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   automated-test-suite:
-    timeout-minutes: 20
+    timeout-minutes: 30
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -40,7 +40,7 @@ jobs:
       - name: Run test scripts
         run: |
           # Run tests and print 20 slowest
-          poetry run pytest --tb=native --durations=20 "not slow_test_group"
+          poetry run pytest --tb=native --durations=20 -m "not slow_test_group"
         env:
           TRADING_STRATEGY_API_KEY: ${{ secrets.TRADING_STRATEGY_API_KEY }}
           BNB_CHAIN_JSON_RPC: ${{ secrets.BNB_CHAIN_JSON_RPC }}      

--- a/.github/workflows/test-slow.yml
+++ b/.github/workflows/test-slow.yml
@@ -7,8 +7,8 @@ on:
     branches: [ master ]
 
 jobs:
-  automated-test-suite:
-    timeout-minutes: 20
+  slow-test-suite:
+    timeout-minutes: 30
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/test-slow.yml
+++ b/.github/workflows/test-slow.yml
@@ -1,0 +1,46 @@
+name: Automated test suite for slow test group
+on:
+  push:
+    branches: [ master ]
+    tags: [ v* ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  automated-test-suite:
+    timeout-minutes: 20
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          submodules: 'recursive'
+      - name: Set up Python 3.10
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.10"
+      - name: Install Poetry
+        uses: snok/install-poetry@v1
+        with:
+          virtualenvs-create: true
+          virtualenvs-in-project: true
+          installer-parallel: true
+      - name: Load cached venv
+        uses: actions/cache@v2
+        with:
+          path: .venv
+          key: venv-${{ runner.os }}-${{ steps.setup-python.outputs.python-version }}-${{ hashFiles('**/poetry.lock') }}
+      - name: Install Foundry
+        uses: foundry-rs/foundry-toolchain@v1
+      - name: Install dependencies
+        if: steps.cached-poetry-dependencies.outputs.cache-hit != 'true'
+        # We don't install -E qstrader and run legacy tests on CI as they
+        # download too much data
+        run: |          
+          poetry install --no-interaction -E web-server -E execution -E quantstats
+      - name: Run test scripts
+        run: |
+          # Run tests marked with slow_test_group, print durations of slowest 20
+          poetry run pytest --tb=native -m slow_test_group --durations=20
+        env:
+          TRADING_STRATEGY_API_KEY: ${{ secrets.TRADING_STRATEGY_API_KEY }}
+          BNB_CHAIN_JSON_RPC: ${{ secrets.BNB_CHAIN_JSON_RPC }}      

--- a/.github/workflows/test-slow.yml
+++ b/.github/workflows/test-slow.yml
@@ -1,4 +1,4 @@
-name: Automated test suite for slow test group
+name: Slow test group
 on:
   push:
     branches: [ master ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,6 +80,7 @@ quantstats = {version="^0.0.59", optional = true}
 #
 tqdm = "^4.64.1"
 tblib = "^1.7.0"
+beautifulsoup4 = "^4.12.2"
 [tool.poetry.extras]
 
 # Legacy strats

--- a/strategies/test_only/backtest-cli-command.py
+++ b/strategies/test_only/backtest-cli-command.py
@@ -46,11 +46,10 @@ TRADING_PAIR = ("WAVAX", "USDC")
 
 POSITION_SIZE = 0.70
 
-BATCH_SIZE = 90
+BATCH_SIZE = 10
 
-SLOW_EMA_CANDLE_COUNT = 10
-FAST_EMA_CANDLE_COUNT = 3
-
+SLOW_EMA_CANDLE_COUNT = 5
+FAST_EMA_CANDLE_COUNT = 2
 
 BACKTEST_START = datetime.datetime(2022, 1, 1)
 
@@ -122,18 +121,14 @@ def decide_trades(
         # We buy if we just crossed over the slow EMA or if this is a very first
         # trading cycle and the price is already above the slow EMA.
 
-        logger.trade("Starting a new trade")
-
         if (
                 slow_ema_crossunder
-                or price_latest < slow_ema_latest and timestamp == START_AT
+                or price_latest < slow_ema_latest and timestamp == BACKTEST_START
         ):
             buy_amount = cash * POSITION_SIZE
             new_trades = position_manager.open_1x_long(pair, buy_amount, stop_loss_pct=STOP_LOSS_PCT)
             trades.extend(new_trades)
     else:
-
-        logger.trade("Checking for close")
 
         # We have an open position, decide if SELL in this cycle.
         # We do that if we fall below any of the two moving averages.
@@ -180,7 +175,5 @@ def create_trading_universe(
         TRADING_PAIR[0],
         TRADING_PAIR[1],
     )
-
-    logger.warning("Universe created, we have %d pairs", universe.get_pair_count())
 
     return universe

--- a/strategies/test_only/backtest-cli-command.py
+++ b/strategies/test_only/backtest-cli-command.py
@@ -1,0 +1,186 @@
+"""Strategy module used to test trade-executor backtest CLI command."""
+
+import logging
+import datetime
+import pandas as pd
+from pandas_ta import ema
+
+from tradingstrategy.chain import ChainId
+from tradingstrategy.timebucket import TimeBucket
+from tradingstrategy.universe import Universe
+
+from tradeexecutor.state.state import State
+from tradeexecutor.state.trade import TradeExecution
+from tradeexecutor.state.visualisation import PlotKind
+from tradeexecutor.strategy.cycle import CycleDuration
+from tradeexecutor.strategy.pandas_trader.position_manager import PositionManager
+from tradeexecutor.strategy.pricing_model import PricingModel
+from tradeexecutor.strategy.strategy_module import StrategyType, TradeRouting, ReserveCurrency
+
+from typing import Optional, List, Dict
+from tradeexecutor.strategy.trading_strategy_universe import load_pair_data_for_single_exchange, TradingStrategyUniverse
+from tradeexecutor.strategy.execution_context import ExecutionContext
+from tradingstrategy.client import Client
+
+from tradeexecutor.strategy.universe_model import UniverseOptions
+
+# NOTE: this setting has currently no effect
+TRADING_STRATEGY_ENGINE_VERSION = "0.2"
+
+# NOTE: this setting has currently no effect
+TRADING_STRATEGY_TYPE = StrategyType.managed_positions
+
+TRADE_ROUTING = TradeRouting.trader_joe_usdc
+
+TRADING_STRATEGY_CYCLE = CycleDuration.cycle_1h
+
+RESERVE_CURRENCY = ReserveCurrency.usdc
+
+CANDLE_TIME_BUCKET = TimeBucket.d1
+
+CHAIN_ID = ChainId.avalanche
+
+EXCHANGE_SLUG = "trader-joe"
+
+TRADING_PAIR = ("WAVAX", "USDC")
+
+POSITION_SIZE = 0.70
+
+BATCH_SIZE = 90
+
+SLOW_EMA_CANDLE_COUNT = 10
+FAST_EMA_CANDLE_COUNT = 3
+
+
+BACKTEST_START = datetime.datetime(2022, 1, 1)
+
+BACKTEST_END = datetime.datetime(2022, 10, 18)
+
+INITIAL_CASH = 10_000
+
+STOP_LOSS_PCT = 0.993
+
+STOP_LOSS_TIME_BUCKET = TimeBucket.h4
+
+
+logger = logging.getLogger(__name__)
+
+def decide_trades(
+        timestamp: pd.Timestamp,
+        universe: Universe,
+        state: State,
+        pricing_model: PricingModel,
+        cycle_debug_data: Dict) -> List[TradeExecution]:
+
+    pair = universe.pairs.get_single()
+
+    cash = state.portfolio.get_current_cash()
+
+    candles: pd.DataFrame = universe.candles.get_single_pair_data(timestamp, sample_count=BATCH_SIZE)
+
+    close_prices = candles["close"]
+
+    slow_ema_series = ema(close_prices, length=SLOW_EMA_CANDLE_COUNT)
+    fast_ema_series = ema(close_prices, length=FAST_EMA_CANDLE_COUNT)
+
+    if slow_ema_series is None or fast_ema_series is None:
+        # Cannot calculate EMA, because
+        # not enough samples in backtesting
+        logger.warning("slow_ema_series or fast_ema_series None")
+        return []
+
+    if len(slow_ema_series) < 2 or len(fast_ema_series) < 2:
+        # We need at least two data points to determine if EMA crossover (or crossunder)
+        # occurred at current timestamp.
+        logger.warning("series too short")
+        return []
+
+    slow_ema_latest = slow_ema_series.iloc[-1]
+    fast_ema_latest = fast_ema_series.iloc[-1]
+    price_latest = close_prices.iloc[-1]
+
+    # Compute technical indicators needed for trade decisions.
+    slow_ema_crossover = (
+            close_prices.iloc[-3] < slow_ema_series.iloc[-2]
+            and price_latest > slow_ema_latest
+    )
+    slow_ema_crossunder = (
+            close_prices.iloc[-2] > slow_ema_series.iloc[-2]
+            and price_latest < slow_ema_latest
+    )
+    fast_ema_crossunder = (
+            close_prices.iloc[-2] > fast_ema_series.iloc[-2]
+            and price_latest < fast_ema_latest
+    )
+
+    trades = []
+
+    position_manager = PositionManager(timestamp, universe, state, pricing_model)
+
+    if not position_manager.is_any_open():
+        # No open positions, decide if BUY in this cycle.
+        # We buy if we just crossed over the slow EMA or if this is a very first
+        # trading cycle and the price is already above the slow EMA.
+
+        logger.trade("Starting a new trade")
+
+        if (
+                slow_ema_crossunder
+                or price_latest < slow_ema_latest and timestamp == START_AT
+        ):
+            buy_amount = cash * POSITION_SIZE
+            new_trades = position_manager.open_1x_long(pair, buy_amount, stop_loss_pct=STOP_LOSS_PCT)
+            trades.extend(new_trades)
+    else:
+
+        logger.trade("Checking for close")
+
+        # We have an open position, decide if SELL in this cycle.
+        # We do that if we fall below any of the two moving averages.
+        if slow_ema_crossover or (fast_ema_crossunder and fast_ema_latest > slow_ema_latest):
+            new_trades = position_manager.close_all()
+            assert len(new_trades) == 1
+            trades.extend(new_trades)
+
+    # Visualize strategy
+    # See available Plotly colours here
+    # https://community.plotly.com/t/plotly-colours-list/11730/3?u=miohtama
+    visualisation = state.visualisation
+    visualisation.plot_indicator(timestamp, "Slow EMA", PlotKind.technical_indicator_on_price, slow_ema_latest,
+                                 colour="green")
+    visualisation.plot_indicator(timestamp, "Fast EMA", PlotKind.technical_indicator_on_price, fast_ema_latest,
+                                 colour="red")
+
+    return trades
+
+
+def create_trading_universe(
+        ts: datetime.datetime,
+        client: Client,
+        execution_context: ExecutionContext,
+        universe_options: UniverseOptions,
+) -> TradingStrategyUniverse:
+
+    dataset = load_pair_data_for_single_exchange(
+        client,
+        execution_context,
+        CANDLE_TIME_BUCKET,
+        CHAIN_ID,
+        EXCHANGE_SLUG,
+        [TRADING_PAIR],
+        universe_options,
+        stop_loss_time_bucket=STOP_LOSS_TIME_BUCKET,
+    )
+
+    # Filter down to the single pair we are interested in
+    universe = TradingStrategyUniverse.create_single_pair_universe(
+        dataset,
+        CHAIN_ID,
+        EXCHANGE_SLUG,
+        TRADING_PAIR[0],
+        TRADING_PAIR[1],
+    )
+
+    logger.warning("Universe created, we have %d pairs", universe.get_pair_count())
+
+    return universe

--- a/tests/backtest/test_backtest_open_position.py
+++ b/tests/backtest/test_backtest_open_position.py
@@ -173,7 +173,7 @@ def backtest_result(
     # Run the test
     state, universe, debug_dump = run_backtest_inline(
         start_at=start_at.to_pydatetime(),
-        end_at=end_at,
+        end_at=end_at.to_pydatetime(),
         client=None,  # None of downloads needed, because we are using synthetic data
         cycle_duration=CycleDuration.cycle_1d,  # Override to use 24h cycles despite what strategy file says
         decide_trades=decide_trades,

--- a/tests/backtest/test_backtest_report.py
+++ b/tests/backtest/test_backtest_report.py
@@ -1,0 +1,187 @@
+"""Generate Python notebook report from the backtest results.
+"""
+import datetime
+import logging
+import os
+from pathlib import Path
+from tempfile import NamedTemporaryFile
+from typing import Tuple, Any
+
+import pytest
+
+import pandas as pd
+from nbformat import NotebookNode
+
+from tradeexecutor.backtest.report import export_backtest_report
+from tradingstrategy.candle import GroupedCandleUniverse
+from tradingstrategy.chain import ChainId
+from tradingstrategy.exchange import Exchange
+from tradingstrategy.timebucket import TimeBucket
+from tradingstrategy.universe import Universe
+
+from tradeexecutor.analysis.advanced_metrics import calculate_advanced_metrics
+from tradeexecutor.backtest.backtest_routing import BacktestRoutingModel
+from tradeexecutor.backtest.backtest_runner import run_backtest, setup_backtest_for_universe
+from tradeexecutor.cli.log import setup_pytest_logging
+from tradeexecutor.state.identifier import AssetIdentifier, TradingPairIdentifier
+from tradeexecutor.state.state import State
+from tradeexecutor.state.statistics import Statistics, calculate_naive_profitability
+from tradeexecutor.state.validator import validate_nested_state_dict
+from tradeexecutor.statistics.key_metric import calculate_key_metrics
+from tradeexecutor.statistics.summary import calculate_summary_statistics
+from tradeexecutor.strategy.cycle import CycleDuration
+from tradeexecutor.strategy.execution_context import ExecutionMode
+from tradeexecutor.strategy.summary import KeyMetricSource
+from tradeexecutor.strategy.trading_strategy_universe import TradingStrategyUniverse, create_pair_universe_from_code
+from tradeexecutor.testing.synthetic_ethereum_data import generate_random_ethereum_address
+from tradeexecutor.testing.synthetic_exchange_data import generate_exchange, generate_simple_routing_model
+from tradeexecutor.testing.synthetic_price_data import generate_ohlcv_candles
+
+from tradeexecutor.visual.equity_curve import calculate_equity_curve, calculate_returns, calculate_deposit_adjusted_returns
+
+
+@pytest.fixture(scope="module")
+def logger(request):
+    """Setup test logger."""
+    return setup_pytest_logging(request, mute_requests=False)
+
+
+@pytest.fixture(scope="module")
+def mock_chain_id() -> ChainId:
+    """Mock a chai id."""
+    return ChainId.ethereum
+
+
+@pytest.fixture(scope="module")
+def mock_exchange(mock_chain_id) -> Exchange:
+    """Mock an exchange."""
+    return generate_exchange(exchange_id=1, chain_id=mock_chain_id, address=generate_random_ethereum_address())
+
+
+@pytest.fixture(scope="module")
+def usdc() -> AssetIdentifier:
+    """Mock some assets"""
+    return AssetIdentifier(ChainId.ethereum.value, generate_random_ethereum_address(), "USDC", 6, 1)
+
+
+@pytest.fixture(scope="module")
+def weth() -> AssetIdentifier:
+    """Mock some assets"""
+    return AssetIdentifier(ChainId.ethereum.value, generate_random_ethereum_address(), "WETH", 18, 2)
+
+
+@pytest.fixture(scope="module")
+def weth_usdc(mock_exchange, usdc, weth) -> TradingPairIdentifier:
+    """Mock some assets"""
+    return TradingPairIdentifier(
+        weth,
+        usdc,
+        generate_random_ethereum_address(),
+        mock_exchange.address,
+        internal_id=555,
+        internal_exchange_id=mock_exchange.exchange_id,
+        fee=0.0030
+    )
+
+
+@pytest.fixture(scope="module")
+def strategy_path() -> Path:
+    """Where do we load our strategy file."""
+    return Path(os.path.join(os.path.dirname(__file__), "..", "..", "strategies", "test_only", "pandas_buy_every_second_day.py"))
+
+
+@pytest.fixture(scope="module")
+def synthetic_universe(mock_chain_id, mock_exchange, weth_usdc) -> TradingStrategyUniverse:
+    """Generate synthetic trading data universe for a single trading pair.
+
+    - Single mock exchange
+
+    - Single mock trading pair
+
+    - Random candles
+
+    - No liquidity data available
+    """
+
+    start_date = datetime.datetime(2021, 6, 1)
+    end_date = datetime.datetime(2022, 1, 1)
+
+    time_bucket = TimeBucket.d1
+
+    pair_universe = create_pair_universe_from_code(mock_chain_id, [weth_usdc])
+
+    # Generate candles for pair_id = 1
+    candles = generate_ohlcv_candles(time_bucket, start_date, end_date, pair_id=weth_usdc.internal_id)
+    candle_universe = GroupedCandleUniverse.create_from_single_pair_dataframe(candles)
+
+    universe = Universe(
+        time_bucket=time_bucket,
+        chains={mock_chain_id},
+        exchanges={mock_exchange},
+        pairs=pair_universe,
+        candles=candle_universe,
+        liquidity=None
+    )
+
+    return TradingStrategyUniverse(universe=universe, reserve_assets=[weth_usdc.quote])
+
+
+@pytest.fixture(scope="module")
+def routing_model(synthetic_universe) -> BacktestRoutingModel:
+    return generate_simple_routing_model(synthetic_universe)
+
+
+@pytest.fixture(scope="module")
+def state(
+        logger: logging.Logger,
+        strategy_path: Path,
+        synthetic_universe: TradingStrategyUniverse,
+        routing_model: BacktestRoutingModel,
+    ):
+    """Run a simple strategy backtest.
+
+    Calculate some statistics based on it.
+    """
+
+    # Run the test
+    setup = setup_backtest_for_universe(
+        strategy_path,
+        start_at=datetime.datetime(2021, 6, 1),
+        end_at=datetime.datetime(2022, 1, 1),
+        cycle_duration=CycleDuration.cycle_1d,  # Override to use 24h cycles despite what strategy file says
+        candle_time_frame=TimeBucket.d1,  # Override to use 24h cycles despite what strategy file says
+        initial_deposit=10_000,
+        universe=synthetic_universe,
+        routing_model=routing_model,
+    )
+
+    state, universe, debug_dump = run_backtest(setup)
+    state.name = "Backtest example"
+    return state
+
+@pytest.fixture(scope="module")
+def notebook(state) -> NotebookNode:
+    with NamedTemporaryFile(suffix='.ipynb', prefix=os.path.basename(__file__)) as temp:
+        nb = export_backtest_report(
+            state,
+            output_notebook=Path(temp.name),
+        )
+        return nb
+
+
+def test_generate_backtest_pass_state(notebook: NotebookNode):
+    """We can convert any of our statistics to dataframes"""
+    # We filled in parameter cell correctly
+    parameter_cell = notebook.cells[0]
+    assert ".json" in parameter_cell.source  # Check for generated .json file path
+
+
+def test_generate_backtest_pass_state(notebook: NotebookNode):
+    """We can convert any of our statistics to dataframes"""
+    # We filled in parameter cell correctly
+    parameter_cell = notebook.cells[0]
+    assert ".json" in parameter_cell.source  # Check for generated .json file path
+
+
+
+

--- a/tests/backtest/test_backtest_report.py
+++ b/tests/backtest/test_backtest_report.py
@@ -186,6 +186,7 @@ def html_report(state, synthetic_universe) -> Path:
         yield html_report
 
 
+@pytest.mark.slow_test_group
 def test_generate_backtest_pass_state(notebook: NotebookNode):
     """We can convert any of our statistics to dataframes"""
     # We filled in parameter cell correctly
@@ -193,6 +194,7 @@ def test_generate_backtest_pass_state(notebook: NotebookNode):
     assert ".json" in parameter_cell.source  # Check for generated .json file path
 
 
+@pytest.mark.slow_test_group
 def test_generate_html_report(html_report: Path):
     """We can generate a HTML report"""
     assert os.path.exists(html_report), f"Did not create: {html_report}"
@@ -202,6 +204,7 @@ def test_generate_html_report(html_report: Path):
     assert "/* trade-executor backtest report generator custom CSS */" in html_content
 
 
+@pytest.mark.slow_test_group
 @pytest.mark.skipif(os.environ.get("SHOW_REPORT_IN_BROWSER") is None, reason="Manual web browser based test")
 def test_show_backtest_report(html_report: Path):
     """Manual test to view the result.

--- a/tests/backtest/test_backtest_report.py
+++ b/tests/backtest/test_backtest_report.py
@@ -162,22 +162,24 @@ def state(
     return state
 
 @pytest.fixture(scope="module")
-def notebook(state) -> NotebookNode:
+def notebook(state, synthetic_universe) -> NotebookNode:
     with NamedTemporaryFile(suffix='.ipynb', prefix=os.path.basename(__file__)) as temp:
         nb = export_backtest_report(
             state,
+            synthetic_universe,
             output_notebook=Path(temp.name),
         )
         return nb
 
 
 @pytest.fixture(scope="module")
-def html_report(state) -> Path:
+def html_report(state, synthetic_universe) -> Path:
     with NamedTemporaryFile(suffix='.ipynb', prefix=os.path.basename(__file__)) as temp_notebook, \
         NamedTemporaryFile(suffix='.html', prefix=os.path.basename(__file__)) as temp_html:
         html_report = Path(temp_html.name)
         nb = export_backtest_report(
             state,
+            synthetic_universe,
             output_notebook=Path(temp_notebook.name),
             output_html=html_report
         )

--- a/tests/cli/test_cli_commands.py
+++ b/tests/cli/test_cli_commands.py
@@ -2,6 +2,8 @@
 
 import os
 import tempfile
+from contextlib import redirect_stdout
+from io import StringIO
 from pathlib import Path
 from unittest.mock import patch
 

--- a/tests/cli/test_cli_commands.py
+++ b/tests/cli/test_cli_commands.py
@@ -2,11 +2,10 @@
 
 import os
 import tempfile
-from contextlib import redirect_stdout
-from io import StringIO
 from pathlib import Path
 from unittest.mock import patch
 
+import nbformat
 import pytest
 from typer.main import get_command
 from typer.testing import CliRunner
@@ -98,7 +97,37 @@ def test_cli_check_wallet(
         raise AssertionError("runner launch failed")
 
 
-def test_cli_backtest(
+def test_cli_legacy_backtest_no_wrap(
+        logger,
+        strategy_path: str,
+        unit_test_cache_path: str,
+    ):
+    """start backtest command works.
+
+    Don't use Typer CLI wrapper, because it prevents using debuggeres.
+    """
+
+    environment = {
+        "TRADING_STRATEGY_API_KEY": os.environ["TRADING_STRATEGY_API_KEY"],
+        "STRATEGY_FILE": strategy_path,
+        "CACHE_PATH": unit_test_cache_path,
+        "BACKTEST_CANDLE_TIME_FRAME_OVERRIDE": "1d",
+        "BACKTEST_STOP_LOSS_TIME_FRAME_OVERRIDE": "1d",
+        "BACKTEST_START": "2021-06-01",
+        "BACKTEST_END": "2022-07-01",
+        "ASSET_MANAGEMENT_MODE": "backtest",
+        "UNIT_TESTING": "true",
+        "LOG_LEVEL": "disabled",
+    }
+
+    cli = get_command(app)
+    with patch.dict(os.environ, environment, clear=True):
+        with pytest.raises(SystemExit) as e:
+            cli.main(args=["start"])
+        assert e.value.code == 0
+
+
+def test_cli_legacy_backtest(
         logger,
         strategy_path: str,
         unit_test_cache_path: str,
@@ -130,36 +159,6 @@ def test_cli_backtest(
         for line in result.stdout.split('\n'):
             print(line)
         raise AssertionError("runner launch failed")
-
-
-def test_cli_backtest_no_wrap(
-        logger,
-        strategy_path: str,
-        unit_test_cache_path: str,
-    ):
-    """start backtest command works.
-
-    Don't use Typer CLI wrapper, because it prevents using debuggeres.
-    """
-
-    environment = {
-        "TRADING_STRATEGY_API_KEY": os.environ["TRADING_STRATEGY_API_KEY"],
-        "STRATEGY_FILE": strategy_path,
-        "CACHE_PATH": unit_test_cache_path,
-        "BACKTEST_CANDLE_TIME_FRAME_OVERRIDE": "1d",
-        "BACKTEST_STOP_LOSS_TIME_FRAME_OVERRIDE": "1d",
-        "BACKTEST_START": "2021-06-01",
-        "BACKTEST_END": "2022-07-01",
-        "ASSET_MANAGEMENT_MODE": "backtest",
-        "UNIT_TESTING": "true",
-        "LOG_LEVEL": "disabled",
-    }
-
-    cli = get_command(app)
-    with patch.dict(os.environ, environment, clear=True):
-        with pytest.raises(SystemExit) as e:
-            cli.main(args=["start"])
-        assert e.value.code == 0
 
 
 @pytest.mark.skipif(os.environ.get("BNB_CHAIN_JSON_RPC") is None, reason="Set BNB_CHAIN_JSON_RPC environment variable to Binance Smart Chain node to run this test")
@@ -274,6 +273,55 @@ def test_cli_console(
         for line in result.stdout.split('\n'):
             print(line)
         raise AssertionError("runner launch failed")
+
+
+def test_cli_backtest(
+        logger,
+        unit_test_cache_path: str,
+    ):
+    """backtest command works.
+
+    - Run backtest command
+
+    - Check for the resulting files that should have been generated
+    """
+
+    strategy_path = os.path.join(os.path.dirname(__file__), "../strategies", "test_only", "backtest-cli-command.py")
+
+    backtest_result = os.path.join(tempfile.mkdtemp(), 'test_cli_backtest.json')
+    notebook_result = os.path.join(tempfile.mkdtemp(), 'test_cli_backtest.ipynb')
+    html_result = os.path.join(tempfile.mkdtemp(), 'test_cli_backtest.html')
+
+    environment = {
+        "TRADING_STRATEGY_API_KEY": os.environ["TRADING_STRATEGY_API_KEY"],
+        "STRATEGY_FILE": strategy_path,
+        "CACHE_PATH": unit_test_cache_path,
+        "UNIT_TESTING": "true",
+        "LOG_LEVEL": "disabled",
+        "HTML_REPORT":  html_result,
+        "NOTEBOOK_REPORT":  notebook_result,
+        "BACKTEST_RESULT":  backtest_result,
+    }
+
+    cli = get_command(app)
+    with patch.dict(os.environ, environment, clear=True):
+        with pytest.raises(SystemExit) as e:
+            cli.main(args=["backtest"])
+
+        assert e.value.code == 0, f"Exit code: {e}"
+
+    # Check generated state file is good
+    state = State.read_json_file(Path(backtest_result))
+    assert len(state.portfolio.closed_position) > 0
+
+    # Check generated HTML file is good
+    html = Path(html_result).open("rt").read()
+    assert "/* trade-executor backtest report generator custom CSS */" in html
+
+    # Check generated notebook is good
+    with open(notebook_result, "rt") as inp:
+        nb = nbformat.read(inp, as_version=4)
+        assert len(nb.cells) > 0
 
 
 def test_cli_show_positions(

--- a/tests/cli/test_cli_commands.py
+++ b/tests/cli/test_cli_commands.py
@@ -286,9 +286,14 @@ def test_cli_backtest(
     - Run backtest command
 
     - Check for the resulting files that should have been generated
+
+    .. note ::
+
+        This test is somewhat slow due to high number of charts generated.
+        But no way to speed it up.
     """
 
-    strategy_path = os.path.join(os.path.dirname(__file__), "../strategies", "test_only", "backtest-cli-command.py")
+    strategy_path = os.path.join(os.path.dirname(__file__), "..", "..", "strategies", "test_only", "backtest-cli-command.py")
 
     backtest_result = os.path.join(tempfile.mkdtemp(), 'test_cli_backtest.json')
     notebook_result = os.path.join(tempfile.mkdtemp(), 'test_cli_backtest.ipynb')
@@ -314,7 +319,7 @@ def test_cli_backtest(
 
     # Check generated state file is good
     state = State.read_json_file(Path(backtest_result))
-    assert len(state.portfolio.closed_position) > 0
+    assert len(state.portfolio.closed_positions) > 0
 
     # Check generated HTML file is good
     html = Path(html_result).open("rt").read()

--- a/tests/cli/test_cli_commands.py
+++ b/tests/cli/test_cli_commands.py
@@ -277,6 +277,7 @@ def test_cli_console(
         raise AssertionError("runner launch failed")
 
 
+@pytest.mark.slow_test_group
 def test_cli_backtest(
         logger,
         unit_test_cache_path: str,

--- a/tests/strategy_tests/test_pancake_momentum_v2.py
+++ b/tests/strategy_tests/test_pancake_momentum_v2.py
@@ -30,6 +30,7 @@ def strategy_path() -> Path:
     return Path(os.path.join(os.path.dirname(__file__), "..", "..", "strategies", "test_only", "pancake-momentum-weekly.py"))
 
 
+@pytest.mark.slow_test_group
 @pytest.mark.skipif(os.environ.get("SKIP_SLOW_TEST"), reason="Slow tests skipping enabled")
 def test_pancake_momentum_v2(
     strategy_path,

--- a/tests/test_data_age.py
+++ b/tests/test_data_age.py
@@ -33,6 +33,7 @@ def universe_model(persistent_test_client: Client) -> DataAgeTestUniverseModel:
     return DataAgeTestUniverseModel(persistent_test_client, timed_task)
 
 
+@pytest.mark.slow_test_group
 def test_data_fresh(universe_model: DataAgeTestUniverseModel):
     """Fresh data passes our data check."""
     # d1 data is used by other tests and cached

--- a/tests/test_decision_trigger.py
+++ b/tests/test_decision_trigger.py
@@ -89,6 +89,7 @@ def multipair_universe(execution_context, persistent_test_client) -> TradingStra
     return universe
 
 
+@pytest.mark.slow_test_group
 def test_decision_trigger_ready_data(persistent_test_client, universe):
     """Test that we can immedidately trigger trades for old data.
 
@@ -117,6 +118,7 @@ def test_decision_trigger_ready_data(persistent_test_client, universe):
     )
 
 
+@pytest.mark.slow_test_group
 def test_decision_trigger_multipair(persistent_test_client, multipair_universe: TradingStrategyUniverse):
     """Wait for the multipair decision trigger to be ready."""
 

--- a/tests/test_summary_and_metrics.py
+++ b/tests/test_summary_and_metrics.py
@@ -341,3 +341,4 @@ def test_calculate_key_metrics_live_and_backtesting(state: State):
 
     assert metrics["started_at"].source == KeyMetricSource.live_trading
     assert metrics["started_at"].value >= datetime.datetime(2023, 1, 1, 0, 0)
+

--- a/tests/test_webhook_api.py
+++ b/tests/test_webhook_api.py
@@ -1,5 +1,8 @@
 """Check API endpoints."""
 import datetime
+import os
+import tempfile
+from pathlib import Path
 from queue import Queue
 
 import pytest
@@ -39,8 +42,13 @@ def server_url(store):
 
     metadata = Metadata("Foobar", "Short desc", "Long desc", None, datetime.datetime.utcnow(), True)
 
-    # Inject some fake files
-    backtest_notebook =
+    # Inject some fake files for the backtest content
+    notebook_result = Path(tempfile.mkdtemp()) / 'test_cli_backtest.ipynb'
+    notebook_result.open("wt").write("Foo")
+    html_result = Path(tempfile.mkdtemp()) / 'test_cli_backtest.html'
+    html_result.open("wt").write("Bar")
+    metadata.backtest_notebook = notebook_result
+    metadata.backtest_html = html_result
 
     server = create_webhook_server("127.0.0.1", 5000, "test", "test", queue, store, metadata, execution_state)
     server_url = "http://test:test@127.0.0.1:5000"
@@ -155,3 +163,16 @@ def test_run_state(logger, server_url):
     assert data["version"]["tag"] == "v1"
     assert data["version"]["commit_message"] == "Foobar"
 
+
+def test_download_backtest_notebook(logger, server_url):
+    """Download the backtest notebook."""
+    resp = requests.get(f"{server_url}/file", {"type": "notebook"})
+    assert resp.status_code == 200
+    assert resp.content == b"Foo"
+
+
+def test_download_backtest_html(logger, server_url):
+    """Download the backtest HTML report."""
+    resp = requests.get(f"{server_url}/file", {"type": "html"})
+    assert resp.status_code == 200
+    assert resp.content == b"Bar"

--- a/tests/test_webhook_api.py
+++ b/tests/test_webhook_api.py
@@ -36,7 +36,12 @@ def server_url(store):
     execution_state.version.commit_message = "Foobar"
 
     queue = Queue()
+
     metadata = Metadata("Foobar", "Short desc", "Long desc", None, datetime.datetime.utcnow(), True)
+
+    # Inject some fake files
+    backtest_notebook =
+
     server = create_webhook_server("127.0.0.1", 5000, "test", "test", queue, store, metadata, execution_state)
     server_url = "http://test:test@127.0.0.1:5000"
     yield server_url

--- a/tradeexecutor/backtest/backtest_report_template.ipynb
+++ b/tradeexecutor/backtest/backtest_report_template.ipynb
@@ -5,26 +5,12 @@
    "execution_count": null,
    "outputs": [],
    "source": [
+    "#\n",
+    "# All code cells are hidden in the output by default\n",
+    "#\n",
+    "\n",
     "# Parameter cell. Wilk be replaced by export_backtest_report()\n",
     "parameters = {}"
-   ],
-   "metadata": {
-    "collapsed": false
-   }
-  },
-  {
-   "cell_type": "markdown",
-   "source": [
-    "# Backtest results for {NAME}"
-   ],
-   "metadata": {
-    "collapsed": false
-   }
-  },
-  {
-   "cell_type": "markdown",
-   "source": [
-    "## Setting up"
    ],
    "metadata": {
     "collapsed": false
@@ -35,6 +21,11 @@
    "execution_count": null,
    "outputs": [],
    "source": [
+    "#\n",
+    "# Setting up\n",
+    "#\n",
+    "\n",
+    "\n",
     "# Loads strategy module and other backtest parameters\n",
     "from tradeexecutor.backtest.report import BacktestReporter\n",
     "reporter = BacktestReporter.setup_report(parameters)\n",
@@ -45,21 +36,13 @@
    }
   },
   {
-   "cell_type": "markdown",
-   "source": [
-    "## Metric calculations\n",
-    "\n",
-    "Calculate different chart data and metrics."
-   ],
-   "metadata": {
-    "collapsed": false
-   }
-  },
-  {
    "cell_type": "code",
    "execution_count": null,
    "outputs": [],
    "source": [
+    "## Metric calculations\n",
+    "\n",
+    "# Calculate different chart data and metrics.\n",
     "from tradeexecutor.visual.equity_curve import calculate_equity_curve, calculate_returns\n",
     "\n",
     "curve = calculate_equity_curve(state)\n",
@@ -74,11 +57,7 @@
   {
    "cell_type": "markdown",
    "source": [
-    "## Results\n",
-    "\n",
-    "The results of the backtest run.\n",
-    "\n",
-    "### Preface"
+    "# Preface"
    ],
    "metadata": {
     "collapsed": false
@@ -102,7 +81,7 @@
   {
    "cell_type": "markdown",
    "source": [
-    "### Equity curve\n",
+    "# Equity curve\n",
     "\n",
     "Equity curve, maximum drawdown and daily profit."
    ],
@@ -124,11 +103,28 @@
    }
   },
   {
+   "cell_type": "markdown",
+   "source": [
+    "# Performance metrics\n",
+    "\n",
+    "Portfolio key performance metrics."
+   ],
+   "metadata": {
+    "collapsed": false
+   }
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "outputs": [],
    "source": [
-    "raise RuntimeError(\"Haha\")"
+    "import pandas as pd\n",
+    "from tradeexecutor.analysis.advanced_metrics import visualise_advanced_metrics, AdvancedMetricsMode\n",
+    "\n",
+    "metrics = visualise_advanced_metrics(returns, mode=AdvancedMetricsMode.full)\n",
+    "\n",
+    "with pd.option_context(\"display.max_row\", None):\n",
+    "    display(metrics)"
    ],
    "metadata": {
     "collapsed": false

--- a/tradeexecutor/backtest/backtest_report_template.ipynb
+++ b/tradeexecutor/backtest/backtest_report_template.ipynb
@@ -26,10 +26,12 @@
     "#\n",
     "\n",
     "\n",
-    "# Loads strategy module and other backtest parameters\n",
+    "# Loads strategy trades and universe as passed over\n",
+    "# by the host Python system as temp files\n",
     "from tradeexecutor.backtest.report import BacktestReporter\n",
     "reporter = BacktestReporter.setup_report(parameters)\n",
-    "state = reporter.get_state()"
+    "state = reporter.get_state()\n",
+    "universe = reporter.get_universe()"
    ],
    "metadata": {
     "collapsed": false
@@ -48,6 +50,8 @@
     "curve = calculate_equity_curve(state)\n",
     "returns = calculate_returns(curve)\n",
     "first_trade, last_trade = state.portfolio.get_first_and_last_executed_trade()\n",
+    "start_at = state.backtest_data.start_at\n",
+    "end_at = state.backtest_data.end_at\n",
     "trades = list(state.portfolio.get_all_trades())"
    ],
    "metadata": {
@@ -70,7 +74,7 @@
    "source": [
     "\n",
     "print(f\"This report contains backtest results for {state.name} run.\\n\"\n",
-    "      f\"Backtest trading period was {first_trade and first_trade.executed_at}-{last_trade and last_trade.executed_at}\\n\"\n",
+    "      f\"Backtest trading period was {start_at}-{end_at}\\n\"\n",
     "      f\"Total {len(trades)} trades were made\\n\"\n",
     "      )\n"
    ],
@@ -131,11 +135,11 @@
    }
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
-   "outputs": [],
+   "cell_type": "markdown",
    "source": [
-    "### Equity curve"
+    "# Trading positions\n",
+    "\n",
+    "Display trading positions over time.\n"
    ],
    "metadata": {
     "collapsed": false
@@ -146,7 +150,38 @@
    "execution_count": null,
    "outputs": [],
    "source": [
-    "###"
+    "\n",
+    "from tradeexecutor.visual.single_pair import visualise_single_pair_positions_with_duration_and_slippage\n",
+    "\n",
+    "if universe.universe.pairs.get_count() == 1:\n",
+    "    pair_id = int(universe.get_single_pair().internal_id)\n",
+    "    candles = universe.universe.candles.get_candles_by_pair(pair_id)\n",
+    "\n",
+    "    fig = visualise_single_pair_positions_with_duration_and_slippage(\n",
+    "        state,\n",
+    "        candles,\n",
+    "        start_at=start_at,\n",
+    "        end_at=end_at,\n",
+    "        pair_id=pair_id,\n",
+    "    )\n",
+    "\n",
+    "    fig.show()\n",
+    "else:\n",
+    "    print(\"\")"
+   ],
+   "metadata": {
+    "collapsed": false
+   }
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "# Benchmark\n",
+    "\n",
+    "Compare the strategy results against\n",
+    "\n",
+    "- Buy and hold benchmark\n",
+    "- All-cash benchmark"
    ],
    "metadata": {
     "collapsed": false
@@ -157,7 +192,22 @@
    "execution_count": null,
    "outputs": [],
    "source": [
-    "### Trading performance"
+    "from tradeexecutor.visual.benchmark import visualise_benchmark\n",
+    "\n",
+    "traded_pair = universe.universe.pairs.get_single()\n",
+    "\n",
+    "fig = visualise_benchmark(\n",
+    "    \"Bollinger bands example strategy\",\n",
+    "    portfolio_statistics=state.stats.portfolio,\n",
+    "    all_cash=state.portfolio.get_initial_deposit(),\n",
+    "    buy_and_hold_asset_name=traded_pair.base_token_symbol,\n",
+    "    buy_and_hold_price_series=universe.universe.candles.get_single_pair_data()[\"close\"],\n",
+    "    start_at=start_at,\n",
+    "    end_at=end_at,\n",
+    "    height=800\n",
+    ")\n",
+    "\n",
+    "fig.show()"
    ],
    "metadata": {
     "collapsed": false

--- a/tradeexecutor/backtest/backtest_report_template.ipynb
+++ b/tradeexecutor/backtest/backtest_report_template.ipynb
@@ -1,6 +1,18 @@
 {
  "cells": [
   {
+   "cell_type": "code",
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "# Parameter cell. Wilk be replaced by export_backtest_report()\n",
+    "parameters = {}"
+   ],
+   "metadata": {
+    "collapsed": false
+   }
+  },
+  {
    "cell_type": "markdown",
    "source": [
     "# Backtest results for {NAME}"
@@ -24,8 +36,20 @@
    "outputs": [],
    "source": [
     "# Loads strategy module and other backtest parameters\n",
-    "from tradeexecutor.backtest.report import setup_backtest_report\n",
-    "backtest_setup = setup_backtest_report()"
+    "from tradeexecutor.backtest.report import BacktestReporter\n",
+    "reporter = BacktestReporter.setup_report(parameters)\n",
+    "state = reporter.get_state()"
+   ],
+   "metadata": {
+    "collapsed": false
+   }
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "## Metric calculations\n",
+    "\n",
+    "Calculate different chart data and metrics."
    ],
    "metadata": {
     "collapsed": false
@@ -36,8 +60,12 @@
    "execution_count": null,
    "outputs": [],
    "source": [
-    "# Run the backtest\n",
-    "state = backtest_setup.run()"
+    "from tradeexecutor.visual.equity_curve import calculate_equity_curve, calculate_returns\n",
+    "\n",
+    "curve = calculate_equity_curve(state)\n",
+    "returns = calculate_returns(curve)\n",
+    "first_trade, last_trade = state.portfolio.get_first_and_last_executed_trade()\n",
+    "trades = list(state.portfolio.get_all_trades())"
    ],
    "metadata": {
     "collapsed": false
@@ -46,7 +74,61 @@
   {
    "cell_type": "markdown",
    "source": [
-    "## Results\n"
+    "## Results\n",
+    "\n",
+    "The results of the backtest run.\n",
+    "\n",
+    "### Preface"
+   ],
+   "metadata": {
+    "collapsed": false
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "\n",
+    "print(f\"This report contains backtest results for {state.name} run.\\n\"\n",
+    "      f\"Backtest trading period was {first_trade and first_trade.executed_at}-{last_trade and last_trade.executed_at}\\n\"\n",
+    "      f\"Total {len(trades)} trades were made\\n\"\n",
+    "      )\n"
+   ],
+   "metadata": {
+    "collapsed": false
+   }
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "### Equity curve\n",
+    "\n",
+    "Equity curve, maximum drawdown and daily profit."
+   ],
+   "metadata": {
+    "collapsed": false
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "from tradeexecutor.visual.equity_curve import visualise_equity_curve\n",
+    "\n",
+    "visualise_equity_curve(returns)"
+   ],
+   "metadata": {
+    "collapsed": false
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "raise RuntimeError(\"Haha\")"
    ],
    "metadata": {
     "collapsed": false

--- a/tradeexecutor/backtest/backtest_report_template.ipynb
+++ b/tradeexecutor/backtest/backtest_report_template.ipynb
@@ -1,0 +1,110 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "source": [
+    "# Backtest results for {NAME}"
+   ],
+   "metadata": {
+    "collapsed": false
+   }
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "## Setting up"
+   ],
+   "metadata": {
+    "collapsed": false
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "# Loads strategy module and other backtest parameters\n",
+    "from tradeexecutor.backtest.report import setup_backtest_report\n",
+    "backtest_setup = setup_backtest_report()"
+   ],
+   "metadata": {
+    "collapsed": false
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "# Run the backtest\n",
+    "state = backtest_setup.run()"
+   ],
+   "metadata": {
+    "collapsed": false
+   }
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "## Results\n"
+   ],
+   "metadata": {
+    "collapsed": false
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "### Equity curve"
+   ],
+   "metadata": {
+    "collapsed": false
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "###"
+   ],
+   "metadata": {
+    "collapsed": false
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "### Trading performance"
+   ],
+   "metadata": {
+    "collapsed": false
+   }
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 2
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython2",
+   "version": "2.7.6"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 0
+}

--- a/tradeexecutor/backtest/backtest_report_template.ipynb
+++ b/tradeexecutor/backtest/backtest_report_template.ipynb
@@ -52,7 +52,8 @@
     "first_trade, last_trade = state.portfolio.get_first_and_last_executed_trade()\n",
     "start_at = state.backtest_data.start_at\n",
     "end_at = state.backtest_data.end_at\n",
-    "trades = list(state.portfolio.get_all_trades())"
+    "trades = list(state.portfolio.get_all_trades())\n",
+    "name = state.name"
    ],
    "metadata": {
     "collapsed": false
@@ -61,7 +62,9 @@
   {
    "cell_type": "markdown",
    "source": [
-    "# Preface"
+    "# Preface\n",
+    "\n",
+    "Information about the executed backtest."
    ],
    "metadata": {
     "collapsed": false
@@ -72,11 +75,19 @@
    "execution_count": null,
    "outputs": [],
    "source": [
+    "import pandas as pd\n",
     "\n",
-    "print(f\"This report contains backtest results for {state.name} run.\\n\"\n",
-    "      f\"Backtest trading period was {start_at}-{end_at}\\n\"\n",
-    "      f\"Total {len(trades)} trades were made\\n\"\n",
-    "      )\n"
+    "data = {\n",
+    "    \"Name\": name,\n",
+    "    \"Run at\": state.created_at,\n",
+    "    \"Backtesting period start\": start_at,\n",
+    "    \"Backtesting period end\": end_at,\n",
+    "    \"Trades\": len(trades),\n",
+    "}\n",
+    "\n",
+    "# Display dictionary as a pretty table output\n",
+    "# display(pd.DataFrame(data.items()).style.hide(axis=\"columns\").hide(axis=\"index\"))\n",
+    "display(pd.DataFrame(data.values(), index=data.keys()).style.hide(axis=\"columns\"))"
    ],
    "metadata": {
     "collapsed": false
@@ -129,6 +140,35 @@
     "\n",
     "with pd.option_context(\"display.max_row\", None):\n",
     "    display(metrics)"
+   ],
+   "metadata": {
+    "collapsed": false
+   }
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "# Trading metrics\n",
+    "\n",
+    "Calculate key trading metrics.\n",
+    "\n"
+   ],
+   "metadata": {
+    "collapsed": false
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "from tradeexecutor.analysis.trade_analyser import build_trade_analysis\n",
+    "\n",
+    "analysis = build_trade_analysis(state.portfolio)\n",
+    "summary = analysis.calculate_summary_statistics()\n",
+    "\n",
+    "with pd.option_context(\"display.max_row\", None):\n",
+    "    display(summary.to_dataframe())"
    ],
    "metadata": {
     "collapsed": false
@@ -192,22 +232,106 @@
    "execution_count": null,
    "outputs": [],
    "source": [
-    "from tradeexecutor.visual.benchmark import visualise_benchmark\n",
+    "if universe.universe.pairs.get_count() == 1:\n",
+    "    from tradeexecutor.visual.benchmark import visualise_benchmark\n",
     "\n",
-    "traded_pair = universe.universe.pairs.get_single()\n",
+    "    traded_pair = universe.universe.pairs.get_single()\n",
     "\n",
-    "fig = visualise_benchmark(\n",
-    "    \"Bollinger bands example strategy\",\n",
-    "    portfolio_statistics=state.stats.portfolio,\n",
-    "    all_cash=state.portfolio.get_initial_deposit(),\n",
-    "    buy_and_hold_asset_name=traded_pair.base_token_symbol,\n",
-    "    buy_and_hold_price_series=universe.universe.candles.get_single_pair_data()[\"close\"],\n",
-    "    start_at=start_at,\n",
-    "    end_at=end_at,\n",
-    "    height=800\n",
-    ")\n",
+    "    fig = visualise_benchmark(\n",
+    "        name,\n",
+    "        portfolio_statistics=state.stats.portfolio,\n",
+    "        all_cash=state.portfolio.get_initial_deposit(),\n",
+    "        buy_and_hold_asset_name=traded_pair.base_token_symbol,\n",
+    "        buy_and_hold_price_series=universe.universe.candles.get_single_pair_data()[\"close\"],\n",
+    "        start_at=start_at,\n",
+    "        end_at=end_at,\n",
+    "        height=800\n",
+    "    )\n",
     "\n",
-    "fig.show()"
+    "    fig.show()\n",
+    "else:\n",
+    "    print(\"Benchmark part for a multipair strategy not yet implemented\")"
+   ],
+   "metadata": {
+    "collapsed": false
+   }
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "# Monthly returns\n",
+    "\n",
+    "Returns by a month.\n"
+   ],
+   "metadata": {
+    "collapsed": false
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "from tradeexecutor.visual.equity_curve import visualise_returns_over_time\n",
+    "\n",
+    "visualise_returns_over_time(returns)"
+   ],
+   "metadata": {
+    "collapsed": false
+   }
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "# Periodic return distribution\n",
+    "\n",
+    "Show performance variations for different timeframes."
+   ],
+   "metadata": {
+    "collapsed": false
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "from tradeexecutor.visual.equity_curve import visualise_returns_distribution\n",
+    "\n",
+    "visualise_returns_distribution(returns)"
+   ],
+   "metadata": {
+    "collapsed": false
+   }
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "# Trade details\n",
+    "\n",
+    "Show details of every position open and close."
+   ],
+   "metadata": {
+    "collapsed": false
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "from tradeexecutor.analysis.trade_analyser import expand_timeline\n",
+    "\n",
+    "timeline = analysis.create_timeline()\n",
+    "\n",
+    "expanded_timeline, apply_styles = expand_timeline(\n",
+    "        universe.universe.exchanges,\n",
+    "        universe.universe.pairs,\n",
+    "        timeline)\n",
+    "\n",
+    "# Do not truncate the row output\n",
+    "with pd.option_context(\"display.max_row\", None):\n",
+    "    display(apply_styles(expanded_timeline))"
    ],
    "metadata": {
     "collapsed": false

--- a/tradeexecutor/backtest/backtest_runner.py
+++ b/tradeexecutor/backtest/backtest_runner.py
@@ -22,13 +22,14 @@ from tradeexecutor.cli.loop import ExecutionLoop, ExecutionTestHook
 from tradeexecutor.ethereum.routing_data import get_routing_model, get_backtest_routing_model
 from tradeexecutor.state.state import State
 from tradeexecutor.state.store import NoneStore
+from tradeexecutor.state.types import USDollarAmount
 from tradeexecutor.strategy.approval import UncheckedApprovalModel, ApprovalModel
 from tradeexecutor.strategy.cycle import CycleDuration
 from tradeexecutor.strategy.description import StrategyExecutionDescription
 from tradeexecutor.strategy.execution_context import ExecutionContext, ExecutionMode
 from tradeexecutor.strategy.pandas_trader.runner import PandasTraderRunner
-from tradeexecutor.strategy.strategy_module import parse_strategy_module,  \
-    DecideTradesProtocol, CreateTradingUniverseProtocol, CURRENT_ENGINE_VERSION
+from tradeexecutor.strategy.strategy_module import parse_strategy_module, \
+    DecideTradesProtocol, CreateTradingUniverseProtocol, CURRENT_ENGINE_VERSION, StrategyModuleInformation
 from tradeexecutor.strategy.reserve_currency import ReserveCurrency
 from tradeexecutor.strategy.default_routing_options import TradeRouting
 from tradeexecutor.strategy.trading_strategy_universe import TradingStrategyUniverse,  \
@@ -183,7 +184,7 @@ def setup_backtest_for_universe(
 
     # Load strategy Python file
     strategy_mod_exports: dict = runpy.run_path(strategy_path)
-    strategy_module = parse_strategy_module(strategy_mod_exports)
+    strategy_module = parse_strategy_module(strategy_path, strategy_mod_exports)
 
     if validate_strategy_module:
         # Allow partial strategies to be used in unit testing
@@ -215,21 +216,28 @@ def setup_backtest(
         strategy_path: Path,
         start_at: datetime.datetime,
         end_at: datetime.datetime,
-        initial_deposit: int,
+        initial_deposit: USDollarAmount,
         max_slippage=0.01,
         cycle_duration: Optional[CycleDuration]=None,
         candle_time_frame: Optional[TimeBucket]=None,
-    ):
+        strategy_module: Optional[StrategyModuleInformation]=None,
+    ) -> BacktestSetup:
     """High-level entry point for setting up a backtest from a strategy module.
 
     This function is useful for running backtests for strategies in
     notebooks and tests.
+
+    :param max_slippage:
+        Legacy
 
     :param cycle_duration:
         Override the default strategy cycle duration
 
     :param candle_time_frame:
         Override the default strategy candle time bucket
+
+    :param strategy_module:
+        If strategy module was previously loaded
     """
 
     assert isinstance(strategy_path, Path), f"Got {strategy_path}"
@@ -242,10 +250,15 @@ def setup_backtest(
     execution_model = BacktestExecutionModel(wallet, max_slippage)
 
     # Load strategy Python file
-    strategy_mod_exports: dict = runpy.run_path(strategy_path)
-    strategy_module = parse_strategy_module(strategy_mod_exports)
+    if strategy_module is None:
+        strategy_mod_exports: dict = runpy.run_path(strategy_path)
+        strategy_module = parse_strategy_module(strategy_path, strategy_mod_exports)
 
-    strategy_module.validate()
+    if strategy_module.is_version_greater_or_equal_than(0, 2, 0):
+        # Backtest variables were injected later in the development
+        strategy_module.validate_backtest()
+    else:
+        strategy_module.validate()
 
     universe_options = UniverseOptions(candle_time_bucket_override=candle_time_frame)
 

--- a/tradeexecutor/backtest/backtest_runner.py
+++ b/tradeexecutor/backtest/backtest_runner.py
@@ -221,6 +221,7 @@ def setup_backtest(
         cycle_duration: Optional[CycleDuration]=None,
         candle_time_frame: Optional[TimeBucket]=None,
         strategy_module: Optional[StrategyModuleInformation]=None,
+        name: Optional[str] = None,
     ) -> BacktestSetup:
     """High-level entry point for setting up a backtest from a strategy module.
 
@@ -262,6 +263,9 @@ def setup_backtest(
 
     universe_options = UniverseOptions(candle_time_bucket_override=candle_time_frame)
 
+    if not name:
+        name = f"Backtest for {strategy_module.path.stem}"
+
     return BacktestSetup(
         start_at,
         end_at,
@@ -279,6 +283,7 @@ def setup_backtest(
         reserve_currency=strategy_module.reserve_currency,
         trade_routing=strategy_module.trade_routing,
         trading_strategy_engine_version=strategy_module.trading_strategy_engine_version,
+        name=name,
     )
 
 

--- a/tradeexecutor/backtest/report.py
+++ b/tradeexecutor/backtest/report.py
@@ -1,28 +1,123 @@
 """Create Jupyter Notebook based report."""
+import logging
 import os.path
-from zipfile import Path
+from pathlib import Path
+from tempfile import NamedTemporaryFile
+from typing import Optional
 
+import nbformat
 from nbconvert.preprocessors import ExecutePreprocessor
-from nbformat.v4 import nbformat
+from nbformat import NotebookNode
+
+from tradeexecutor.state.state import State
 from tradingstrategy.client import BaseClient
 
+from tradeexecutor.backtest.notebook import setup_charting_and_output
 from tradeexecutor.strategy.strategy_module import StrategyModuleInformation
 
 
-def create_backtest_report(
-        mod: StrategyModuleInformation,
-        client: BaseClient,
+logger = logging.getLogger(__name__)
+
+
+class BacktestReporter:
+    """Shared between host environment and IPython report notebook.
+
+    A singleton instance used to communicate to IPython notebook.
+    """
+
+    def __init__(self, state: State):
+        self.state = state
+
+    def get_state(self) -> State:
+        return self.state
+
+    @classmethod
+    def setup_host(cls, state):
+        cls._singleton = BacktestReporter(state)
+
+    @classmethod
+    def setup_report(cls, parameters) -> "BacktestReporter":
+        """Set-up notebook side reporting.
+
+        - Output formatting
+
+        - Reading data from the host instance
+        """
+        setup_charting_and_output()
+
+        state_file = parameters["state_file"]
+        state = State.read_json_file(Path(state_file))
+        return BacktestReporter(
+            state=state,
+        )
+
+
+def export_backtest_report(
+        state: State,
         report_template: Path | None = None,
         output_notebook: Path | None = None,
-        output_state: Path | None = None,
-):
-    """Runs a strategy test using a notebook and generates a report."""
+) -> NotebookNode:
+    """Creates the backtest visual report.
+
+    - Opens a master template notebook
+
+    - Injects the backtested state to this notebook by modifying
+      the first cell of the notebook and writes a temporary state
+      file path there
+
+    - Runs the notebook
+
+    - Writes the output notebook if specified
+
+    - Writes the output HTML file if specified
+
+    :return:
+        Returns the executed notebook contents
+    """
+
+    assert isinstance(state, State), f"Expected State, got {state}"
+
+    logger.info("Creating backtest result report for %s", state.name)
 
     if report_template is None:
-        report_template = os.path.dirname(__file__) / "backtest_report_template.ipynb"
+        report_template = Path(os.path.join(os.path.dirname(__file__), "backtest_report_template.ipynb"))
 
-    # https://nbconvert.readthedocs.io/en/latest/execute_api.html
-    with open(report_template) as f:
-        nb = nbformat.read(f, as_version=4)
+    assert report_template.exists(), f"Does not exist: {report_template}"
 
+    # Pass over the state to the notebook as JSON file dump
+    with NamedTemporaryFile(suffix='.json', prefix=os.path.basename(__file__)) as state_temp:
+        state_path = Path(state_temp.name).absolute()
+
+        state.write_json_file(state_path)
+
+        # https://nbconvert.readthedocs.io/en/latest/execute_api.html
+        with open(report_template) as f:
+            nb = nbformat.read(f, as_version=4)
+
+        # Replace the first cell that allows us to pass parameters
+        # See
+        # - https://github.com/nteract/papermill/blob/main/papermill/parameterize.py
+        # - https://github.com/takluyver/nbparameterise/blob/master/nbparameterise/code.py
+        # for inspiration
+        cell = nb.cells[0]
+        assert cell.cell_type == "code", f"Assumed first cell is parameter cell, got {cell}"
+        assert "parameters =" in cell.source, f"Did not see parameters = definition in the cell source: {cell.source}"
+        cell.source = f"""parameters = {{"state_file": "{state_path}"}} """
+
+        # Run the notebook
         ep = ExecutePreprocessor(timeout=600, kernel_name='python3')
+        ep.preprocess(nb, {'metadata': {'path': '.'}})
+
+        if output_notebook is not None:
+            with open(output_notebook, 'w', encoding='utf-8') as f:
+                nbformat.write(nb, f)
+
+        return nb
+
+
+
+def run_backtest_and_report(
+    mod: StrategyModuleInformation,
+    client: BaseClient,
+):
+    pass

--- a/tradeexecutor/backtest/report.py
+++ b/tradeexecutor/backtest/report.py
@@ -1,0 +1,28 @@
+"""Create Jupyter Notebook based report."""
+import os.path
+from zipfile import Path
+
+from nbconvert.preprocessors import ExecutePreprocessor
+from nbformat.v4 import nbformat
+from tradingstrategy.client import BaseClient
+
+from tradeexecutor.strategy.strategy_module import StrategyModuleInformation
+
+
+def create_backtest_report(
+        mod: StrategyModuleInformation,
+        client: BaseClient,
+        report_template: Path | None = None,
+        output_notebook: Path | None = None,
+        output_state: Path | None = None,
+):
+    """Runs a strategy test using a notebook and generates a report."""
+
+    if report_template is None:
+        report_template = os.path.dirname(__file__) / "backtest_report_template.ipynb"
+
+    # https://nbconvert.readthedocs.io/en/latest/execute_api.html
+    with open(report_template) as f:
+        nb = nbformat.read(f, as_version=4)
+
+        ep = ExecutePreprocessor(timeout=600, kernel_name='python3')

--- a/tradeexecutor/backtest/report.py
+++ b/tradeexecutor/backtest/report.py
@@ -224,13 +224,6 @@ def export_backtest_report(
         return nb
 
 
-def run_backtest_and_report(
-    mod: StrategyModuleInformation,
-    client: BaseClient,
-):
-    pass
-
-
 def _inject_custom_css(html: str, css_code: str) -> str:
     """Injects new <style> tag to HTML code.
 

--- a/tradeexecutor/cli/bootstrap.py
+++ b/tradeexecutor/cli/bootstrap.py
@@ -246,6 +246,8 @@ def create_metadata(
         chain_id: ChainId,
         vault: Optional[Vault],
         backtest_result: Optional[Path]=None,
+        backtest_notebook: Optional[Path]=None,
+        backtest_html: Optional[Path]=None,
 ) -> Metadata:
     """Create metadata object from the configuration variables."""
 
@@ -282,6 +284,8 @@ def create_metadata(
         executor_running=True,
         on_chain_data=on_chain_data,
         backtested_state=backtested_state,
+        backtest_notebook=backtest_notebook,
+        backtest_html=backtest_html,
     )
 
     return metadata

--- a/tradeexecutor/cli/commands/backtest.py
+++ b/tradeexecutor/cli/commands/backtest.py
@@ -108,13 +108,8 @@ def backtest(
         if state_file.exists():
             os.remove(state_file)
 
-    # Avoid polluting user caches during test runs,
-    # so we use different default
     if not cache_path:
-        if unit_testing:
-            cache_path = Path("/tmp/trading-strategy-tests")
-        else:
-            cache_path = prepare_cache(id, cache_path)
+        cache_path = prepare_cache(id, cache_path)
 
     if not html_report:
         html_report = Path(f"state/{id}-backtest.html")

--- a/tradeexecutor/cli/commands/backtest.py
+++ b/tradeexecutor/cli/commands/backtest.py
@@ -71,8 +71,8 @@ def backtest(
     backtest_result: Optional[Path] = shared_options.backtest_result,
     cache_path: Optional[Path] = shared_options.cache_path,
 
-    notebook_report: Optional[Path] = Option(None, envvar="NOTEBOOK_REPORT", help="Jupyter Notebook file where the store the notebook results. If not given defaults to state/{executor-id}-backtest.ipynb."),
-    html_report: Optional[Path] = Option(None, envvar="HTML_REPORT", help="HTML file where the store the notebook results. If not given defaults to state/{executor-id}-backtest.html."),
+    notebook_report: Optional[Path] = shared_options.notebook_report,
+    html_report: Optional[Path] = shared_options.html_report,
     ):
     """Backtest a given strategy module.
 

--- a/tradeexecutor/cli/commands/backtest.py
+++ b/tradeexecutor/cli/commands/backtest.py
@@ -1,0 +1,191 @@
+"""bacltest command
+
+"""
+
+import datetime
+import logging
+import os
+import time
+from decimal import Decimal
+from pathlib import Path
+from queue import Queue
+from typing import Optional
+
+import typer
+
+from eth_defi.gas import GasPriceMethod
+from tradingstrategy.chain import ChainId
+from tradingstrategy.client import Client
+from tradingstrategy.testing.uniswap_v2_mock_client import UniswapV2MockClient
+from tradingstrategy.timebucket import TimeBucket
+
+from . import shared_options
+from .app import app, TRADE_EXECUTOR_VERSION
+from ..bootstrap import prepare_executor_id, prepare_cache, create_web3_config, create_state_store, \
+    create_execution_and_sync_model, create_metadata, create_approval_model, create_client
+from ..log import setup_logging, setup_discord_logging, setup_logstash_logging, setup_file_logging, \
+    setup_custom_log_levels
+from ..loop import ExecutionLoop
+from ..result import display_backtesting_results
+from ..version_info import VersionInfo
+from ..watchdog import stop_watchdog
+from ...ethereum.enzyme.vault import EnzymeVaultSyncModel
+from ...ethereum.uniswap_v2.uniswap_v2_routing import UniswapV2SimpleRoutingModel
+from ...state.state import State
+from ...state.store import NoneStore, JSONFileStore
+from ...strategy.approval import ApprovalType
+from ...strategy.bootstrap import import_strategy_file
+from ...strategy.cycle import CycleDuration
+from ...strategy.default_routing_options import TradeRouting
+from ...strategy.execution_context import ExecutionContext, ExecutionMode
+from ...strategy.execution_model import AssetManagementMode
+from ...strategy.routing import RoutingModel
+from ...strategy.run_state import RunState
+from ...strategy.strategy_cycle_trigger import StrategyCycleTrigger
+from ...strategy.strategy_module import read_strategy_module, StrategyModuleInformation
+from ...utils.timer import timed_task
+from ...webhook.server import create_webhook_server
+
+
+logger = logging.getLogger(__name__)
+
+
+@app.command()
+def backtest(
+
+    id: str = shared_options.id,
+    name: Optional[str] = shared_options.name,
+    strategy_file: Path = shared_options.strategy_file,
+
+    trading_strategy_api_key: str = shared_options.trading_strategy_api_key,
+
+    log_level: str = shared_options.log_level,
+
+    # Debugging and unit testing
+    unit_testing: bool = shared_options.unit_testing,
+
+    # Unsorted options
+    state_file: Optional[Path] = shared_options.state_file,
+    cache_path: Optional[Path] = shared_options.cache_path,
+    ):
+    """Backtest a given strategy module.
+
+    - Run a backtest on a strategy module.
+
+    - Writes the resulting state file report,
+      as it is being used by the webhook server to read backtest results
+
+    - Writes the resulting Jupyter Notebook report,
+      as it is being used by the webhook server to display backtest results
+
+    """
+    global logger
+
+    # Guess id from the strategy file
+    id = prepare_executor_id(id, strategy_file)
+
+    # We always need a name-*-
+    if not name:
+        if strategy_file:
+            name = os.path.basename(strategy_file)
+        else:
+            name = "Unnamed backtest"
+
+    if not log_level:
+        log_level = logging.WARNING
+
+    # Make sure unit tests run logs do not get polluted
+    # Don't touch any log levels, but
+    # make sure we have logger.trading() available when
+    # log_level is "disabled"
+    logger = setup_logging(log_level)
+
+    if not unit_testing:
+        state_file = Path(f"state/{id}-backtest.json")
+        if state_file.exists():
+            os.remove(state_file)
+
+    # Avoid polluting user caches during test runs,
+    # so we use different default
+    if not cache_path:
+        if unit_testing:
+            cache_path = Path("/tmp/trading-strategy-tests")
+
+    cache_path = prepare_cache(id, cache_path)
+
+    # TODO: This strategy file is reloaded again in ExecutionLoop.run()
+    # We do an extra hop here, because we need to know chain_id associated with the strategy,
+    # because there is an inversion of control issue for passing web3 connection around.
+    # Clean this up in the future versions, by changing the order of initialzation.
+    mod = read_strategy_module(strategy_file)
+
+    execution_model, sync_model, valuation_model_factory, pricing_model_factory = create_execution_and_sync_model(
+        asset_management_mode=asset_management_mode,
+        private_key=private_key,
+        web3config=web3config,
+        confirmation_timeout=confirmation_timeout,
+        confirmation_block_count=confirmation_block_count,
+        max_slippage=max_slippage,
+        min_gas_balance=min_gas_balance,
+        vault_address=vault_address,
+        vault_adapter_address=vault_adapter_address,
+        vault_payment_forwarder_address=vault_payment_forwarder_address,
+        routing_hint=mod.trade_routing,
+    )
+
+    if state_file:
+        store = create_state_store(Path(state_file))
+    else:
+        # Backtests do not have persistent state
+        if asset_management_mode == AssetManagementMode.backtest:
+            logger.info("This backtest run won't create a state file")
+            store = NoneStore(State())
+        else:
+            raise RuntimeError("Does not know how to set up a state file for this run")
+
+    client = client = Client.create_live_client(trading_strategy_api_key, cache_path=cache_path)
+
+    # We cannot have real-time triggered trades when doing backtesting
+    strategy_cycle_trigger = StrategyCycleTrigger.cycle_offset
+
+    # Running as a backtest
+    execution_context = ExecutionContext(
+        mode=ExecutionMode.backtesting,
+        timed_task_context_manager=timed_task,
+    )
+
+    loop = ExecutionLoop(
+        name=name,
+        command_queue=command_queue,
+        execution_model=execution_model,
+        execution_context=execution_context,
+        sync_model=sync_model,
+        approval_model=approval_model,
+        pricing_model_factory=pricing_model_factory,
+        valuation_model_factory=valuation_model_factory,
+        store=store,
+        client=client,
+        strategy_factory=strategy_factory,
+        reset=reset_state,
+        max_cycles=max_cycles,
+        debug_dump_file=debug_dump_file,
+        backtest_start=backtest_start,
+        backtest_end=backtest_end,
+        backtest_stop_loss_time_frame_override=backtest_stop_loss_time_frame_override,
+        backtest_candle_time_frame_override=backtest_candle_time_frame_override,
+        stop_loss_check_frequency=stop_loss_check_frequency,
+        cycle_duration=cycle_duration,
+        tick_offset=tick_offset,
+        max_data_delay=max_data_delay,
+        trade_immediately=trade_immediately,
+        stats_refresh_frequency=stats_refresh_frequency,
+        position_trigger_check_frequency=position_trigger_check_frequency,
+        run_state=run_state,
+        strategy_cycle_trigger=strategy_cycle_trigger,
+        routing_model=routing_model,
+        metadata=metadata,
+    )
+
+    state = loop.setup()
+    loop.run_with_state(state)
+    display_backtesting_results(store.state)

--- a/tradeexecutor/cli/commands/backtest.py
+++ b/tradeexecutor/cli/commands/backtest.py
@@ -1,4 +1,4 @@
-"""bacltest command
+"""backtest CLI command
 
 """
 

--- a/tradeexecutor/cli/commands/backtest.py
+++ b/tradeexecutor/cli/commands/backtest.py
@@ -130,6 +130,7 @@ def backtest(
         end_at=mod.backtest_end,
         initial_deposit=mod.initial_cash,
         strategy_module=mod,
+        name=name,
     )
 
     state, universe, debug_data = run_backtest(

--- a/tradeexecutor/cli/commands/shared_options.py
+++ b/tradeexecutor/cli/commands/shared_options.py
@@ -45,6 +45,9 @@ state_file = Option(None, envvar="STATE_FILE", help="JSON file where we serialis
 
 backtest_result = Option(None, envvar="BACKTEST_RESULT", help="JSON file that contains the results of an earlier backtest run. Needed for the web server to display backtest information. If not given defaults to state/{executor-id}-backtest.json is assumed when the webhook server is started.")
 
+notebook_report = Option(None, envvar="NOTEBOOK_REPORT", help="Jupyter Notebook file where the store the notebook results. If not given defaults to state/{executor-id}-backtest.ipynb.")
+html_report = Option(None, envvar="HTML_REPORT", help="HTML file where the store the notebook results. If not given defaults to state/{executor-id}-backtest.html.")
+
 trading_strategy_api_key = Option(None, envvar="TRADING_STRATEGY_API_KEY", help="Trading Strategy API key")
 
 cache_path = Option("cache/", envvar="CACHE_PATH", help="Where to cache downloaded datasets on a local filesystem")

--- a/tradeexecutor/cli/commands/start.py
+++ b/tradeexecutor/cli/commands/start.py
@@ -128,11 +128,15 @@ def start(
     trade_immediately: bool = typer.Option(False, "--trade-immediately", envvar="TRADE_IMMEDIATELY", help="Perform the first rebalance immediately, do not wait for the next trading universe refresh"),
     strategy_cycle_trigger: StrategyCycleTrigger = typer.Option("cycle_offset", envvar="STRATEGY_CYCLE_TRIGGER", help="How do decide when to start executing the next live trading strategy cycle"),
 
-    # Unsorted options
+    # Logging
+    log_level: str = shared_options.log_level,
+
+    # Various file configurations
     state_file: Optional[Path] = shared_options.state_file,
     backtest_result: Optional[Path] = shared_options.backtest_result,
+    notebook_report: Optional[Path] = shared_options.notebook_report,
+    html_report: Optional[Path] = shared_options.html_report,
     cache_path: Optional[Path] = shared_options.cache_path,
-    log_level: str = shared_options.log_level,
     ):
     """Launch Trade Executor instance."""
     global logger
@@ -293,6 +297,12 @@ def start(
                 assert backtest_result.exists(), f"Previous backtest results are needed to have the live webhook server.\n" \
                                                  f"The BACKTEST_RESULT file {backtest_result.absolute()} does not exist."
 
+        if not html_report:
+            html_report = Path(f"state/{id}-backtest.html")
+
+        if not notebook_report:
+            notebook_report = Path(f"state/{id}-backtest.ipynb")
+
         metadata = create_metadata(
             name,
             short_description,
@@ -302,6 +312,8 @@ def start(
             chain_id=mod.chain_id,
             vault=vault,
             backtest_result=backtest_result,
+            backtest_notebook=notebook_report,
+            backtest_html=html_report,
         )
 
         # Start the queue that relays info from the web server to the strategy executor

--- a/tradeexecutor/cli/commands/start.py
+++ b/tradeexecutor/cli/commands/start.py
@@ -56,7 +56,6 @@ def start(
 
     # Strategy assets
     id: str = shared_options.id,
-    log_level: str = shared_options.log_level,
     name: Optional[str] = shared_options.name,
     short_description: Optional[str] = typer.Option(None, envvar="SHORT_DESCRIPTION", help="Short description for metadata"),
     long_description: Optional[str] = typer.Option(None, envvar="LONG_DESCRIPTION", help="Long description for metadata"),
@@ -133,6 +132,7 @@ def start(
     state_file: Optional[Path] = shared_options.state_file,
     backtest_result: Optional[Path] = shared_options.backtest_result,
     cache_path: Optional[Path] = shared_options.cache_path,
+    log_level: str = shared_options.log_level,
     ):
     """Launch Trade Executor instance."""
     global logger

--- a/tradeexecutor/cli/loop.py
+++ b/tradeexecutor/cli/loop.py
@@ -43,7 +43,7 @@ except ImportError:
     from tqdm.auto import tqdm
 
 from tradeexecutor.backtest.backtest_pricing import BacktestSimplePricingModel
-from tradeexecutor.state.state import State
+from tradeexecutor.state.state import State, BacktestData
 from tradeexecutor.state.store import StateStore
 from tradeexecutor.strategy.sync_model import SyncMethodV0, SyncModel
 from tradeexecutor.state.trade import TradeExecution
@@ -644,6 +644,12 @@ class ExecutionLoop:
         cycle_name = backtest_step.value
 
         assert backtest_step != CycleDuration.cycle_unknown
+
+        state.backtest_data = BacktestData(
+            start_at=self.backtest_start,
+            end_at=self.backtest_end,
+            decision_cycle_duration=backtest_step,
+        )
 
         execution_test_hook =  self.execution_test_hook or ExecutionTestHook()
 

--- a/tradeexecutor/cli/loop.py
+++ b/tradeexecutor/cli/loop.py
@@ -156,6 +156,9 @@ class ExecutionLoop:
         self.execution_test_hook = execution_test_hook
         self.metadata = metadata
 
+        self.backtest_start = backtest_start
+        self.backtest_end = backtest_end
+
         args = locals().copy()
         args.pop("self")
 
@@ -615,7 +618,6 @@ class ExecutionLoop:
         if self.backtest_end or self.backtest_start:
             assert self.backtest_start and self.backtest_end, f"If backtesting both start and end must be given, we have {self.backtest_start} - {self.backtest_end}"
 
-        assert self.backtest_start < self.backtest_end
 
         ts = self.backtest_start
 
@@ -644,6 +646,12 @@ class ExecutionLoop:
         cycle_name = backtest_step.value
 
         assert backtest_step != CycleDuration.cycle_unknown
+
+        assert isinstance(self.backtest_start, datetime.datetime)
+        assert not isinstance(self.backtest_start, pd.Timestamp)
+        assert not isinstance(self.backtest_end, pd.Timestamp)
+        assert isinstance(self.backtest_end, datetime.datetime)
+        assert self.backtest_start < self.backtest_end
 
         state.backtest_data = BacktestData(
             start_at=self.backtest_start,
@@ -742,12 +750,12 @@ class ExecutionLoop:
 
                 cycle += 1
 
-            # Validate the backtest state at the end.
-            # We want to avoid situation where we have stored
-            # non-serialisable types in the state
-            validate_state_serialisation(state)
+        # Validate the backtest state at the end.
+        # We want to avoid situation where we have stored
+        # non-serialisable types in the state
+        validate_state_serialisation(state)
 
-            return self.debug_dump_state
+        return self.debug_dump_state
 
     def run_live(self, state: State):
         """Run live trading cycle.

--- a/tradeexecutor/cli/main.py
+++ b/tradeexecutor/cli/main.py
@@ -1,6 +1,7 @@
 """Command-line entry point for the daemon build on the top of Typer."""
 from .commands import console, enzyme_deploy_vault
 from .commands.app import app
+from .commands.backtest import backtest
 from .commands.check_universe import check_universe
 from .commands.check_wallet import check_wallet
 from .commands.close_all import close_all
@@ -17,4 +18,4 @@ from .commands.init import init
 # Dummy export commands even though they are already registered
 # to make the linter happy
 __all__ = [app, check_wallet, check_universe, hello, start, perform_test_trade, version, repair, console, init, reinit, enzyme_asset_list, enzyme_deploy_vault,
-           close_all, show_positions]
+           close_all, show_positions, backtest]

--- a/tradeexecutor/state/metadata.py
+++ b/tradeexecutor/state/metadata.py
@@ -5,6 +5,7 @@ on the executor start up.
 """
 import datetime
 from dataclasses import dataclass, field
+from pathlib import Path
 from typing import Optional, Dict, TypedDict
 
 from dataclasses_json import dataclass_json
@@ -112,6 +113,16 @@ class Metadata:
     #: Used in the web frontend to display the backtested values.
     #:
     backtested_state: Optional[State] = None
+
+    #: Backtest notebook .ipynb file
+    #:
+    #:
+    backtest_notebook: Optional[Path] = None
+
+    #: Backtest notebook .html file
+    #:
+    #:
+    backtest_html: Optional[Path] = None
 
     @staticmethod
     def create_dummy() -> "Metadata":

--- a/tradeexecutor/state/state.py
+++ b/tradeexecutor/state/state.py
@@ -453,6 +453,18 @@ class State:
         txt = json.dumps(data, cls=_ExtendedEncoder)
         return txt
 
+    def write_json_file(self, path: Path):
+        """Write JSON to a file.
+
+        - Validates state before writing it out
+
+        - Work around any serialisation quirks
+        """
+        assert isinstance(path, Path)
+        txt = self.to_json_safe()
+        with path.open("wt") as out:
+            out.write(txt)
+
     @staticmethod
     def read_json_file(path: Path) -> "State":
         """Read state from the JSON file.
@@ -460,7 +472,7 @@ class State:
         - Deal with all serialisation quirks
         """
 
-        assert isinstance(path, Path)
+        assert isinstance(path, Path), f"Expected Path, got {path.__class__}"
 
         with open(path, "rt") as inp:
             return State.read_json_blob(inp.read())

--- a/tradeexecutor/state/state.py
+++ b/tradeexecutor/state/state.py
@@ -27,10 +27,27 @@ from .uptime import Uptime
 from .visualisation import Visualisation
 
 from tradeexecutor.strategy.trade_pricing import TradePricing
+from ..strategy.cycle import CycleDuration
 
 
 class UncleanState(Exception):
     """State containst trades that need manual intervention."""
+
+
+@dataclass_json
+@dataclass
+class BacktestData:
+    """Miscancellous data needed only for backtests."""
+
+    #: The start of backtest period
+    start_at: datetime. datetime
+
+    #: The end of backtest period
+    end_at: datetime.datetime
+
+    #: What has the decision cycle duratino
+    #:
+    decision_cycle_duration: CycleDuration
 
 
 @dataclass_json
@@ -119,6 +136,12 @@ class State:
     uptime: Uptime = field(default_factory=Uptime)
 
     sync: Sync = field(default_factory=Sync)
+
+    #: Backtest data related to this backtest result
+    #:
+    #: Data that is relevant only for backtest results,
+    #: not live trading.
+    backtest_data: BacktestData | None = None
 
     def __repr__(self):
         return f"<State for {self.name}>"

--- a/tradeexecutor/strategy/run_state.py
+++ b/tradeexecutor/strategy/run_state.py
@@ -2,6 +2,7 @@
 import datetime
 import sys
 from dataclasses import dataclass, field
+from pathlib import Path
 from typing import Optional, TypedDict
 
 import dataclasses_json

--- a/tradeexecutor/strategy/strategy_module.py
+++ b/tradeexecutor/strategy/strategy_module.py
@@ -301,10 +301,10 @@ class StrategyModuleInformation:
 
 
     #: Only needed for backtests
-    backtest_start: Optional[pd.Timestamp] = None
+    backtest_start: Optional[datetime.datetime] = None
 
     #: Only needed for backtests
-    backtest_end: Optional[pd.Timestamp] = None
+    backtest_end: Optional[datetime.datetime] = None
 
     #: Only needed for backtests
     initial_cash: Optional[float] = None
@@ -400,8 +400,8 @@ def parse_strategy_module(
         python_module_exports.get("decide_trades"),
         python_module_exports.get("create_trading_universe"),
         python_module_exports.get("chain_id"),
-        python_module_exports.get("backtest_start"),
-        python_module_exports.get("backtest_end"),
+        _ensure_dt(python_module_exports.get("backtest_start")),
+        _ensure_dt(python_module_exports.get("backtest_end")),
         python_module_exports.get("initial_cash"),
     )
 
@@ -449,3 +449,10 @@ def read_strategy_module(path: Path) -> Union[StrategyModuleInformation, Strateg
     mod_info.validate()
 
     return mod_info
+
+
+def _ensure_dt(v: datetime.datetime | pd.Timestamp | None) -> datetime.datetime | None:
+    """Allow pd.Timestamp in a file but use datetime internally"""
+    if isinstance(v, pd.Timestamp):
+        return v.to_pydatetime()
+    return v

--- a/tradeexecutor/strategy/strategy_module.py
+++ b/tradeexecutor/strategy/strategy_module.py
@@ -1,12 +1,16 @@
 """Describe strategy modules and their loading."""
+import datetime
 import logging
 import runpy
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Callable, Dict, Protocol, List, Optional, Union
-import pandas
-from tradingstrategy.chain import ChainId
+from packaging import version
 
+import pandas
+import pandas as pd
+
+from tradingstrategy.chain import ChainId
 from tradeexecutor.state.state import State
 from tradeexecutor.state.trade import TradeExecution
 from tradeexecutor.strategy.cycle import CycleDuration
@@ -267,6 +271,10 @@ class StrategyModuleInformation:
 
     """
 
+    #: Path to the module
+    #:
+    path: Path
+
     #: The source code of the strategy
     #:
     #: Can be set `None` for strategies that are not public.
@@ -291,6 +299,22 @@ class StrategyModuleInformation:
     #: Valid for single chain strategies only
     chain_id: Optional[ChainId] = None
 
+
+    #: Only needed for backtests
+    backtest_start: Optional[pd.Timestamp] = None
+
+    #: Only needed for backtests
+    backtest_end: Optional[pd.Timestamp] = None
+
+    #: Only needed for backtests
+    initial_cash: Optional[float] = None
+
+    def is_version_greater_or_equal_than(self, major: int, minor: int, patch: int) -> bool:
+        """Check strategy module for its version compatibility."""
+        assert self.trading_strategy_engine_version, f"Strategy module does not contain trading_strategy_engine_version varible: {self.path}"
+        required_version = f"{major}.{minor}.{patch}"
+        return version.parse(self.trading_strategy_engine_version) >= version.parse(required_version)
+
     def validate(self):
         """Check that the user inputted variable names look good.
 
@@ -299,13 +323,14 @@ class StrategyModuleInformation:
         """
 
         if not self.trading_strategy_engine_version:
-            raise StrategyModuleNotValid(f"trading_strategy_engine_version missing in the module")
+            raise StrategyModuleNotValid(f"trading_strategy_engine_version missing in the module {self.path}")
 
         if not type(self.trading_strategy_engine_version) == str:
             raise StrategyModuleNotValid(f"trading_strategy_engine_version is not string")
 
-        if self.trading_strategy_engine_version != "0.1":
-            raise StrategyModuleNotValid(f"Only version 0.1 supported for now, got {self.trading_strategy_engine_version}")
+        supported_versions = ("0.1", "0.2",)
+        if self.trading_strategy_engine_version not in supported_versions:
+            raise StrategyModuleNotValid(f"Only versions {supported_versions} supported, got {self.trading_strategy_engine_version}")
 
         if not self.trading_strategy_type:
             raise StrategyModuleNotValid(f"trading_strategy_type missing in the module")
@@ -334,15 +359,38 @@ class StrategyModuleInformation:
         if self.chain_id:
             assert isinstance(self.chain_id, ChainId), f"Strategy module chain_in varaible expected ChainId instance, got {self.chain_id}"
 
+        if self.backtest_start:
+            assert isinstance(self.backtest_start, datetime.datetime), f"Strategy module backtest_start variable, expected datetime.datetime instance, got {self.backtest_start}"
 
-def parse_strategy_module(python_module_exports: dict, source_code: Optional[str]=None) -> StrategyModuleInformation:
+        if self.backtest_end:
+            assert isinstance(self.backtest_end, datetime.datetime), f"Strategy module backtest_start variable, expected datetime.datetime instance, got {self.backtest_end}"
+
+        if self.initial_cash:
+            assert type(self.initial_cash) in (int, float), f"Strategy module initial_cash variable, expected float instance, got {self.initial_cash.__class__}"
+
+    def validate_backtest(self):
+        """Validate that the module is backtest runnable."""
+        self.validate()
+        assert self.backtest_start is not None, f"BACKTEST_START variable is not set in the strategy module {self.path}"
+        assert self.backtest_end is not None, f"BACKTEST_END variable is not set in the strategy module {self.path}"
+        assert self.initial_cash is not None, f"INITIAL_CASH variable is not set in the strategy module {self.path}"
+
+
+def parse_strategy_module(
+        path,
+        python_module_exports: dict,
+        source_code: Optional[str]=None) -> StrategyModuleInformation:
     """Parse a loaded .py module that describes a trading strategy.
 
     :param python_module_exports:
         Python module
 
     """
+
+    assert isinstance(path, Path)
+
     return StrategyModuleInformation(
+        path,
         source_code,
         python_module_exports.get("trading_strategy_engine_version"),
         python_module_exports.get("trading_strategy_type"),
@@ -352,6 +400,9 @@ def parse_strategy_module(python_module_exports: dict, source_code: Optional[str
         python_module_exports.get("decide_trades"),
         python_module_exports.get("create_trading_universe"),
         python_module_exports.get("chain_id"),
+        python_module_exports.get("backtest_start"),
+        python_module_exports.get("backtest_end"),
+        python_module_exports.get("initial_cash"),
     )
 
 
@@ -394,7 +445,7 @@ def read_strategy_module(path: Path) -> Union[StrategyModuleInformation, Strateg
 
     logger.info("Strategy module %s, engine version %s", path, version)
 
-    mod_info = parse_strategy_module(strategy_exports, source_code)
+    mod_info = parse_strategy_module(path, strategy_exports, source_code)
     mod_info.validate()
 
     return mod_info

--- a/tradeexecutor/strategy/summary.py
+++ b/tradeexecutor/strategy/summary.py
@@ -174,6 +174,12 @@ class StrategySummaryStatistics:
     #:
     key_metrics: Dict[str, KeyMetric] = field(default_factory=dict)
 
+    #: After which period the default metrics will switch from backtested data to live data.
+    #:
+    #: This mostly affects strategy summary tiles.
+    #:
+    backtest_metrics_cut_off_period: Optional[datetime.timedelta] = None
+
 
 @dataclass_json
 @dataclass(frozen=True)

--- a/tradeexecutor/strategy/trading_strategy_universe.py
+++ b/tradeexecutor/strategy/trading_strategy_universe.py
@@ -8,11 +8,13 @@ See :ref:`trading universe` for more information.
 
 import contextlib
 import datetime
+import pickle
 import textwrap
 from abc import abstractmethod
 from dataclasses import dataclass
 import logging
 from math import isnan
+from pathlib import Path
 from typing import List, Optional, Callable, Tuple, Set, Dict, Iterable, Collection
 
 import pandas as pd
@@ -154,6 +156,27 @@ class TradingStrategyUniverse(StrategyExecutionUniverse):
             reserve_assets=self.reserve_assets,
             required_history_period=self.required_history_period,
         )
+
+    def write_pickle(self, path: Path):
+        """Write a pickled ouput of this universe"""
+        assert isinstance(path, Path)
+        with path.open("wb") as out:
+            pickle.dump(self, out)
+
+    @staticmethod
+    def read_pickle_dangerous(path: Path) -> "TradingStrategyUniverse":
+        """Write a pickled ouput of this universe.
+
+        .. warning::
+
+            Only use for trusted input. Python pickle issue.
+
+        """
+        assert isinstance(path, Path)
+        with path.open("rb") as inp:
+            item = pickle.load(inp)
+            assert isinstance(item, TradingStrategyUniverse)
+            return item
 
     def get_pair_count(self) -> int:
         return self.universe.pairs.get_count()

--- a/tradeexecutor/webhook/api.py
+++ b/tradeexecutor/webhook/api.py
@@ -4,6 +4,7 @@ import os
 import logging
 import time
 from importlib.metadata import version
+from typing import cast
 
 from pyramid.request import Request
 from pyramid.response import Response, FileResponse
@@ -192,3 +193,29 @@ def web_visulisation(request: Request):
         # Use 501 Not implemented error code
         return exception_response(501, detail=f"Not implemented. Unknown type {type}")
 
+
+@view_config(route_name='web_file', permission='view')
+def web_file(request: Request):
+    """/file endpoint.
+
+    Serve some trading strategy related files.
+    """
+    metadata = cast(Metadata, request.registry["metadata"])
+
+    type = request.params.get("type")
+    match type:
+        case "notebook":
+            path = metadata.backtest_notebook
+            # https://docs.jupyter.org/en/latest/reference/mimetype.html
+            content_type = "application/x-ipynb+json"
+        case "html":
+            path = metadata.backtest_html
+            content_type = "text/html"
+        case _:
+            return exception_response(501, detail=f"Not implemented. Unknown type {type}")
+
+    if not path or not path.exists():
+        return exception_response(404, detail=f"Backtest data not available for {type}")
+
+    r = FileResponse(path.as_posix(), content_type=content_type)
+    return r


### PR DESCRIPTION
- Move `backtest` to a separate CLI command from `start`
- Change strategy module structure to `0.2` that contains the default backtest parameters in the strategy module itself
- `backtest` generates a backtested state file
- `backtest` generates a static HTML file to be displayed in the web frontend for the backtest results
- Because we exceeded 20 minutes run-time for Github Actions, split slow tests to their own `slow_test_group` pytest marker and run these tests in a separate Github Actions workflow