### PR TITLE
Empty summary statistics fix #2

### DIFF
--- a/tradeexecutor/cli/bootstrap.py
+++ b/tradeexecutor/cli/bootstrap.py
@@ -248,6 +248,7 @@ def create_metadata(
         backtest_result: Optional[Path]=None,
         backtest_notebook: Optional[Path]=None,
         backtest_html: Optional[Path]=None,
+        key_metrics_backtest_cut_off_days: float = 90,
 ) -> Metadata:
     """Create metadata object from the configuration variables."""
 
@@ -286,6 +287,7 @@ def create_metadata(
         backtested_state=backtested_state,
         backtest_notebook=backtest_notebook,
         backtest_html=backtest_html,
+        key_metrics_backtest_cut_off=datetime.timedelta(days=key_metrics_backtest_cut_off_days),
     )
 
     return metadata

--- a/tradeexecutor/cli/commands/start.py
+++ b/tradeexecutor/cli/commands/start.py
@@ -127,6 +127,7 @@ def start(
     max_data_delay_minutes: int = typer.Option(1*60, envvar="MAX_DATA_DELAY_MINUTES", help="If our data feed is delayed more than this minutes, abort the execution. Defaults to 1 hours. Used by both strategy cycle trigger types."),
     trade_immediately: bool = typer.Option(False, "--trade-immediately", envvar="TRADE_IMMEDIATELY", help="Perform the first rebalance immediately, do not wait for the next trading universe refresh"),
     strategy_cycle_trigger: StrategyCycleTrigger = typer.Option("cycle_offset", envvar="STRATEGY_CYCLE_TRIGGER", help="How do decide when to start executing the next live trading strategy cycle"),
+    key_metrics_backtest_cut_off_days: float = typer.Option(90, envvar="KEY_METRIC_BACKTEST_CUT_OFF_DAYS", help="How many days live data is collected until key metrics are switched from backtest to live trading based"),
 
     # Logging
     log_level: str = shared_options.log_level,
@@ -314,6 +315,7 @@ def start(
             backtest_result=backtest_result,
             backtest_notebook=notebook_report,
             backtest_html=html_report,
+            key_metrics_backtest_cut_off_days=key_metrics_backtest_cut_off_days,
         )
 
         # Start the queue that relays info from the web server to the strategy executor

--- a/tradeexecutor/cli/loop.py
+++ b/tradeexecutor/cli/loop.py
@@ -298,7 +298,7 @@ class ExecutionLoop:
             state,
             self.execution_context.mode,
             backtested_state=self.metadata.backtested_state,
-            self.metadata.key_metrics_backtest_cut_off,
+            key_metrics_backtest_cut_off=self.metadata.key_metrics_backtest_cut_off,
         )
         self.run_state.summary_statistics = stats
 

--- a/tradeexecutor/cli/loop.py
+++ b/tradeexecutor/cli/loop.py
@@ -298,6 +298,7 @@ class ExecutionLoop:
             state,
             self.execution_context.mode,
             backtested_state=self.metadata.backtested_state,
+            self.metadata.key_metrics_backtest_cut_off,
         )
         self.run_state.summary_statistics = stats
 

--- a/tradeexecutor/state/metadata.py
+++ b/tradeexecutor/state/metadata.py
@@ -124,6 +124,10 @@ class Metadata:
     #:
     backtest_html: Optional[Path] = None
 
+    #: How many days live data is collected until key metrics are switched from backtest to live trading based
+    #:
+    key_metrics_backtest_cut_off: datetime.timedelta = datetime.timedelta(days=90)
+
     @staticmethod
     def create_dummy() -> "Metadata":
         return Metadata(

--- a/tradeexecutor/statistics/summary.py
+++ b/tradeexecutor/statistics/summary.py
@@ -25,7 +25,6 @@ def calculate_summary_statistics(
         now_: Optional[pd.Timestamp | datetime.datetime] = None,
         legacy_workarounds=False,
         backtested_state: State | None = None,
-        time_window = pd.Timedelta(days=90),
         key_metrics_backtest_cut_off = datetime.timedelta(days=90),
 ) -> StrategySummaryStatistics:
     """Preprocess the strategy statistics for the summary card in the web frontend.

--- a/tradeexecutor/statistics/summary.py
+++ b/tradeexecutor/statistics/summary.py
@@ -25,6 +25,8 @@ def calculate_summary_statistics(
         now_: Optional[pd.Timestamp | datetime.datetime] = None,
         legacy_workarounds=False,
         backtested_state: State | None = None,
+        time_window = pd.Timedelta(days=90),
+        key_metrics_backtest_cut_off = datetime.timedelta(days=90),
 ) -> StrategySummaryStatistics:
     """Preprocess the strategy statistics for the summary card in the web frontend.
 
@@ -59,6 +61,9 @@ def calculate_summary_statistics(
 
         The live web server needs to show backtested metrics on the side of
         live trading metrics. This state is used to calculate them.
+
+    :param key_metrics_backtest_cut_off:
+        How many days live data is collected until key metrics are switched from backtest to live trading based,
 
     :return:
         Summary calculations for the summary tile,
@@ -103,7 +108,7 @@ def calculate_summary_statistics(
             profitability_90_days = None
             performance_chart_90_days = None
 
-    key_metrics = {m.kind.value: m for m in calculate_key_metrics(state, backtested_state)}
+    key_metrics = {m.kind.value: m for m in calculate_key_metrics(state, backtested_state, required_history=key_metrics_backtest_cut_off)}
 
     logger.info("calculate_summary_statistics() finished, took %s seconds", perf_counter() - func_started_at)
 


### PR DESCRIPTION
- Make sure key metrics is always called
- Make key metrics backtest vs. live trading cut off period configurable