### PR TITLE
Multipair discord reporting

### DIFF
--- a/tests/test_strategy_state_visualisation_multipair.py
+++ b/tests/test_strategy_state_visualisation_multipair.py
@@ -362,9 +362,9 @@ def test_visualise_strategy_state(
         allow_missing_fees=True,
     )
 
-    images= draw_multi_pair_strategy_state(state, universe)
+    image_dict= draw_multi_pair_strategy_state(state, universe)
     
-    for image in images:
+    for pair_id, image in image_dict.items():
         png_data = render_plotly_figure_as_image_file(image)
 
         # Test the image on a local screen

--- a/tests/test_strategy_state_visualisation_multipair.py
+++ b/tests/test_strategy_state_visualisation_multipair.py
@@ -362,17 +362,16 @@ def test_visualise_strategy_state(
         allow_missing_fees=True,
     )
 
-    image_dict= draw_multi_pair_strategy_state(state, universe)
+    image= draw_multi_pair_strategy_state(state, universe)
     
-    for pair_id, image in image_dict.items():
-        png_data = render_plotly_figure_as_image_file(image)
+    png_data = render_plotly_figure_as_image_file(image)
 
-        # Test the image on a local screen
-        # using a web brower
-        if os.environ.get("SHOW_IMAGE"):
-            # https://stackoverflow.com/a/74619515/315168
-            path = Path("/tmp/test-image.png")
-            with open(path, "wb") as out:
-                out.write(png_data)
+    # Test the image on a local screen
+    # using a web brower
+    if os.environ.get("SHOW_IMAGE"):
+        # https://stackoverflow.com/a/74619515/315168
+        path = Path("/tmp/test-image.png")
+        with open(path, "wb") as out:
+            out.write(png_data)
 
-            webbrowser.open(f"file://{path.as_posix()}")
+        webbrowser.open(f"file://{path.as_posix()}")

--- a/tradeexecutor/state/visualisation.py
+++ b/tradeexecutor/state/visualisation.py
@@ -23,7 +23,7 @@ import logging
 from dataclasses_json import dataclass_json
 
 from tradeexecutor.utils.timestamp import convert_and_validate_timestamp, convert_and_validate_timestamp_as_int
-
+from tradeexecutor.state.identifier import TradingPairIdentifier
 
 logger = logging.getLogger(__name__)
 
@@ -147,6 +147,12 @@ class Plot:
     #: Are we adjusted for look ahead bias or not.
     #:
     recording_time: RecordingTime = RecordingTime.decision_making_time
+
+    #: The trading pair this plot is for.
+    #:
+    #: Plots are not necessarily restricted to a single trading pair, so this is optional.
+    #:
+    pair: Optional[TradingPairIdentifier] = None
 
     def __repr__(self):
         return f"<Plot name:{self.name} kind:{self.kind.name} with {len(self.points)} points>"

--- a/tradeexecutor/strategy/run_state.py
+++ b/tradeexecutor/strategy/run_state.py
@@ -2,6 +2,7 @@
 import datetime
 import sys
 from dataclasses import dataclass, field
+from pathlib import Path
 from typing import Optional, TypedDict
 
 import dataclasses_json
@@ -10,7 +11,6 @@ from tblib import Traceback
 
 from tradeexecutor.cli.version_info import VersionInfo
 from tradeexecutor.strategy.summary import StrategySummaryStatistics
-from tradeexecutor.state.identifier import TradingPairIdentifier
 
 
 class ExceptionData(TypedDict):
@@ -28,49 +28,6 @@ class ExceptionData(TypedDict):
 class LatestStateVisualisation:
     """The last visualisation of the strategy state."""
 
-    #: Dict of pair visualisations
-    #:
-    #: Key is the pair internal id
-    #:
-    pair_visualisations: dict = field(default_factory=dict)
-
-    def __repr__(self) -> str:
-        """Don't dump binary"""
-        return f"<LatestStateVisualisation at {self.last_refreshed_at}>"
-
-    def update_image_data(self,
-                          small_image: bytes,
-                          large_image: bytes,
-                          small_image_dark: bytes,
-                          large_image_dark: bytes,
-                          pair_id: int
-                          ):
-        """Update the visualisation image data for a pair.
-        
-        Assumes only one pair visualisation per pair. Can be updated in the future.
-
-        :param small_image: 512 x 512 image PNG
-        :param large_image: 1024 x 512 image SVG
-        :param small_image_dark: Dark theme version
-        :param large_image_dark: Dark theme version
-        :param pair_id: The id of the pair this visualisation is for
-        """
-
-        self.pair_visualisations[pair_id] = LatestPairVisualisation(
-            last_refreshed_at=datetime.datetime.now(datetime.timezone.utc),
-            small_image=small_image,
-            large_image=large_image,
-            small_image_dark=small_image_dark,
-            large_image_dark=large_image_dark,
-            pair_id=pair_id,
-        )
-
-
-@dataclass_json
-@dataclass
-class LatestPairVisualisation:
-    """The last visualisation of the strategy state for a specific pair."""
-    
     #: When the execution state was updated last time
     last_refreshed_at: datetime.datetime = field(default_factory=datetime.datetime.utcnow)
 
@@ -86,8 +43,21 @@ class LatestPairVisualisation:
     #: Dark theme version
     large_image_dark: Optional[bytes] = None
 
-    #: The id of the pair this visualisation is for
-    pair_id: Optional[int] = None
+    def __repr__(self) -> str:
+        """Don't dump binary"""
+        return f"<LatestStateVisualisation at {self.last_refreshed_at}>"
+
+    def update_image_data(self,
+                          small_image,
+                          large_image,
+                          small_image_dark,
+                          large_image_dark,
+                          ):
+        self.small_image = small_image
+        self.small_image_dark = small_image_dark
+        self.large_image = large_image
+        self.large_image_dark = large_image_dark
+        self.last_refreshed_at = datetime.datetime.utcnow()
 
 
 @dataclass_json

--- a/tradeexecutor/strategy/run_state.py
+++ b/tradeexecutor/strategy/run_state.py
@@ -37,7 +37,7 @@ class LatestStateVisualisation:
     #: Dark theme version
     small_image_dark: Optional[bytes] = None
 
-    #: 1920 x 1920 image SVG
+    #: 1024 x 1024 image SVG
     large_image: Optional[bytes] = None
 
     #: Dark theme version

--- a/tradeexecutor/strategy/run_state.py
+++ b/tradeexecutor/strategy/run_state.py
@@ -10,6 +10,7 @@ from tblib import Traceback
 
 from tradeexecutor.cli.version_info import VersionInfo
 from tradeexecutor.strategy.summary import StrategySummaryStatistics
+from tradeexecutor.state.identifier import TradingPairIdentifier
 
 
 class ExceptionData(TypedDict):
@@ -27,37 +28,66 @@ class ExceptionData(TypedDict):
 class LatestStateVisualisation:
     """The last visualisation of the strategy state."""
 
-    #: When the execution state was updated last time
-    last_refreshed_at: datetime.datetime = field(default_factory=datetime.datetime.utcnow)
-
-    #: 512 x 512 image PNG
-    small_images: list[bytes] | None = None
-
-    #: Dark theme version
-    small_images_dark: list[bytes] | None = None
-
-    #: 1920 x 1920 image SVG
-    large_images: list[bytes] | None = None
-
-    #: Dark theme version
-    large_images_dark: list[bytes] | None = None
+    #: Dict of pair visualisations
+    #:
+    #: Key is the pair internal id
+    #:
+    pair_visualisations: dict = field(default_factory=dict)
 
     def __repr__(self) -> str:
         """Don't dump binary"""
         return f"<LatestStateVisualisation at {self.last_refreshed_at}>"
 
     def update_image_data(self,
-                          small_images,
-                          large_images,
-                          small_images_dark,
-                          large_images_dark,
+                          small_image: bytes,
+                          large_image: bytes,
+                          small_image_dark: bytes,
+                          large_image_dark: bytes,
+                          pair_id: int
                           ):
+        """Update the visualisation image data for a pair.
         
-        self.small_images = small_images
-        self.small_images_dark = small_images_dark
-        self.large_images = large_images
-        self.large_images_dark = large_images_dark
-        self.last_refreshed_at = datetime.datetime.utcnow()
+        Assumes only one pair visualisation per pair. Can be updated in the future.
+
+        :param small_image: 512 x 512 image PNG
+        :param large_image: 1024 x 512 image SVG
+        :param small_image_dark: Dark theme version
+        :param large_image_dark: Dark theme version
+        :param pair_id: The id of the pair this visualisation is for
+        """
+
+        self.pair_visualisation[pair_id] = LatestPairVisualisation(
+            last_refreshed_at=datetime.datetime.now(datetime.timezone.utc),
+            small_image=small_image,
+            large_image=large_image,
+            small_image_dark=small_image_dark,
+            large_image_dark=large_image_dark,
+            pair_id=pair_id,
+        )
+
+
+@dataclass_json
+@dataclass
+class LatestPairVisualisation:
+    """The last visualisation of the strategy state for a specific pair."""
+    
+    #: When the execution state was updated last time
+    last_refreshed_at: datetime.datetime = field(default_factory=datetime.datetime.utcnow)
+
+    #: 512 x 512 image PNG
+    small_image: Optional[bytes] = None
+
+    #: Dark theme version
+    small_image_dark: Optional[bytes] = None
+
+    #: 1920 x 1920 image SVG
+    large_image: Optional[bytes] = None
+
+    #: Dark theme version
+    large_image_dark: Optional[bytes] = None
+
+    #: The id of the pair this visualisation is for
+    pair_id: Optional[int] = None
 
 
 @dataclass_json

--- a/tradeexecutor/strategy/run_state.py
+++ b/tradeexecutor/strategy/run_state.py
@@ -31,31 +31,32 @@ class LatestStateVisualisation:
     last_refreshed_at: datetime.datetime = field(default_factory=datetime.datetime.utcnow)
 
     #: 512 x 512 image PNG
-    small_image: Optional[bytes] = None
+    small_images: list[bytes] | None = None
 
     #: Dark theme version
-    small_image_dark: Optional[bytes] = None
+    small_images_dark: list[bytes] | None = None
 
     #: 1920 x 1920 image SVG
-    large_image: Optional[bytes] = None
+    large_images: list[bytes] | None = None
 
     #: Dark theme version
-    large_image_dark: Optional[bytes] = None
+    large_images_dark: list[bytes] | None = None
 
     def __repr__(self) -> str:
         """Don't dump binary"""
         return f"<LatestStateVisualisation at {self.last_refreshed_at}>"
 
     def update_image_data(self,
-                          small_image,
-                          large_image,
-                          small_image_dark,
-                          large_image_dark,
+                          small_images,
+                          large_images,
+                          small_images_dark,
+                          large_images_dark,
                           ):
-        self.small_image = small_image
-        self.small_image_dark = small_image_dark
-        self.large_image = large_image
-        self.large_image_dark = large_image_dark
+        
+        self.small_images = small_images
+        self.small_images_dark = small_images_dark
+        self.large_images = large_images
+        self.large_images_dark = large_images_dark
         self.last_refreshed_at = datetime.datetime.utcnow()
 
 

--- a/tradeexecutor/strategy/run_state.py
+++ b/tradeexecutor/strategy/run_state.py
@@ -56,7 +56,7 @@ class LatestStateVisualisation:
         :param pair_id: The id of the pair this visualisation is for
         """
 
-        self.pair_visualisation[pair_id] = LatestPairVisualisation(
+        self.pair_visualisations[pair_id] = LatestPairVisualisation(
             last_refreshed_at=datetime.datetime.now(datetime.timezone.utc),
             small_image=small_image,
             large_image=large_image,

--- a/tradeexecutor/visual/strategy_state.py
+++ b/tradeexecutor/visual/strategy_state.py
@@ -79,7 +79,7 @@ def draw_multi_pair_strategy_state(
         end_at: Optional[datetime.datetime] = None,
         technical_indicators=True,
 ) -> list[go.Figure]:
-    """Draw mini price chart images for multiple pairs.
+    """Draw mini price chart images for multiple pairs. Returns a dict.
 
     See also
 
@@ -112,7 +112,7 @@ def draw_multi_pair_strategy_state(
         Whether to draw technical indicators or not
 
     :return:
-        The strategy state visualisation as a list of Plotly figures
+        The strategy state visualisation as a dict of Plotly figures with the pair_id as the key for each figure
     """
 
     assert universe.get_pair_count() <= 3, "This visualisation can be done only for less than 3 pairs"

--- a/tradeexecutor/visual/strategy_state.py
+++ b/tradeexecutor/visual/strategy_state.py
@@ -79,7 +79,7 @@ def draw_multi_pair_strategy_state(
         end_at: Optional[datetime.datetime] = None,
         technical_indicators=True,
 ) -> list[go.Figure]:
-    """Draw mini price chart images for multiple pairs. Returns a dict.
+    """Draw mini price chart images for multiple pairs.
 
     See also
 
@@ -112,12 +112,12 @@ def draw_multi_pair_strategy_state(
         Whether to draw technical indicators or not
 
     :return:
-        The strategy state visualisation as a dict of Plotly figures with the pair_id as the key for each figure
+        The strategy state visualisation as a list of Plotly figures
     """
 
     assert universe.get_pair_count() <= 3, "This visualisation can be done only for less than 3 pairs"
 
-    figures = {}
+    figures = []
 
     for pair_id, data in universe.universe.candles.get_all_pairs():
         
@@ -138,7 +138,7 @@ def draw_multi_pair_strategy_state(
 
         figure = visualise_single_pair_strategy_state(state, target_pair_candles, start_at, end_at, technical_indicators=technical_indicators)
 
-        figures[pair_id] = figure
+        figures.append(figure)
 
     return figures
 

--- a/tradeexecutor/visual/strategy_state.py
+++ b/tradeexecutor/visual/strategy_state.py
@@ -117,7 +117,7 @@ def draw_multi_pair_strategy_state(
 
     assert universe.get_pair_count() <= 3, "This visualisation can be done only for less than 3 pairs"
 
-    figures = []
+    figures = {}
 
     for pair_id, data in universe.universe.candles.get_all_pairs():
         
@@ -138,7 +138,7 @@ def draw_multi_pair_strategy_state(
 
         figure = visualise_single_pair_strategy_state(state, target_pair_candles, start_at, end_at, technical_indicators=technical_indicators)
 
-        figures.append(figure)
+        figures[pair_id] = figure
 
     return figures
 

--- a/tradeexecutor/visual/strategy_state.py
+++ b/tradeexecutor/visual/strategy_state.py
@@ -17,6 +17,7 @@ from tradeexecutor.strategy.trading_strategy_universe import TradingStrategyUniv
 from tradeexecutor.visual.single_pair import visualise_single_pair
 
 import plotly.graph_objects as go
+import plotly.subplots as sp
 
 from tradingstrategy.charting.candle_chart import VolumeBarMode
 
@@ -79,7 +80,7 @@ def draw_multi_pair_strategy_state(
         end_at: Optional[datetime.datetime] = None,
         technical_indicators=True,
 ) -> list[go.Figure]:
-    """Draw mini price chart images for multiple pairs.
+    """Draw mini price chart images for multiple pairs. Returns a single figure with multiple subplots.
 
     See also
 
@@ -112,7 +113,7 @@ def draw_multi_pair_strategy_state(
         Whether to draw technical indicators or not
 
     :return:
-        The strategy state visualisation as a list of Plotly figures
+        The strategy state visualisation as a single Plotly figure with multiple subplots
     """
 
     assert universe.get_pair_count() <= 3, "This visualisation can be done only for less than 3 pairs"
@@ -140,7 +141,20 @@ def draw_multi_pair_strategy_state(
 
         figures.append(figure)
 
-    return figures
+    combined_image = combine_images(figures, width, height)
+
+    return combined_image
+
+
+def combine_images(figures, width, height):
+    """Combine multiple Plotly Figures into one image."""
+
+    combined_image = sp.make_subplots(rows=len(figures), cols=1, shared_xaxes=True, vertical_spacing=0.02)
+
+    for i, figure in enumerate(figures):
+        combined_image.add_trace(figure.data[0], row=i + 1, col=1)
+
+    return combined_image
 
 
 def visualise_single_pair_strategy_state(


### PR DESCRIPTION
### Details

- Allows reporting of multipair charts in Discord for strategies with up to 3 pairs
- Fixes bugs in the image generation for the frontend 
- Combines multiple small images into one using subplots, instead of providing list of figures