### PR TITLE
Auto backtest range

### DIFF
--- a/strategies/ema-crossover-long-only-no-stop-loss.py
+++ b/strategies/ema-crossover-long-only-no-stop-loss.py
@@ -128,7 +128,7 @@ def decide_trades(
     # We could have candles for multiple trading pairs in a different strategy,
     # but this strategy only operates on single pair candle.
     # We also limit our sample size to N latest candles to speed up calculations.
-    candles: pd.DataFrame = universe.candles.get_single_pair_data(sample_count=batch_size)
+    candles: pd.DataFrame = universe.candles.get_single_pair_data(sample_count=batch_size, raise_on_not_enough_data=False)
 
     # We have data for open, high, close, etc.
     # We only operate using candle close values in this strategy.

--- a/tests/backtest/test_backtest_ema_crossover.py
+++ b/tests/backtest/test_backtest_ema_crossover.py
@@ -12,9 +12,9 @@ To run:
 import datetime
 import logging
 import os
+import pandas as pd
 
 from pathlib import Path
-
 
 import pytest
 from tradeexecutor.backtest.backtest_runner import run_backtest, setup_backtest
@@ -60,6 +60,10 @@ def test_ema_crossover_real_data(
 
     state, universe, debug_dump = run_backtest(setup, client)
 
+    start, end = state.get_strategy_start_and_end()
+    assert start == pd.Timestamp('2021-06-01 00:00:00')
+    assert end == pd.Timestamp('2021-12-31 00:00:00')
+
     assert len(debug_dump) == 214
 
     # TODO: Not sure if we have any meaningful results to verify
@@ -84,27 +88,10 @@ def test_start_end_automation(
 
     state, universe, debug_dump = run_backtest(setup, client)
 
-    assert len(debug_dump) == 28
+    start, end = state.get_strategy_start_and_end()
 
-
-def test_start_end_automation(
-    strategy_path,
-    logger: logging.Logger,
-    persistent_test_client,
-    ):
-    """Check that EMA crossover strategy against real data."""
-
-    client = persistent_test_client
-
-    # Run backtest over 6 months, daily
-    setup = setup_backtest(
-        strategy_path,
-        initial_deposit=10_000,
-        cycle_duration=CycleDuration.cycle_30d,  # Override to use monthly cycles to speed up the test
-        candle_time_frame=TimeBucket.d30,  # Override to use monthly data to speed up the test
-    )
-
-    state, universe, debug_dump = run_backtest(setup, client)
+    assert start == pd.Timestamp('2021-04-01 00:00:00')
+    assert end >= pd.Timestamp('2023-06-20 00:00:00')  # end is dynamic
 
     assert len(debug_dump) == 28
 
@@ -128,6 +115,13 @@ def test_minimum_lookback_data_range(
     )
 
     state, universe, debug_dump = run_backtest(setup, client)
+
+    start, end = state.get_strategy_start_and_end()
+
+    # both start and end are dynamic
+    assert start >= pd.Timestamp('2023-07-03 00:00:00')
+    assert end >= pd.Timestamp('2023-07-26 00:00:00')
+    assert end - start == pd.Timedelta('23 days 00:00:00')
 
     assert len(debug_dump) == 24
     

--- a/tests/backtest/test_backtest_ema_crossover.py
+++ b/tests/backtest/test_backtest_ema_crossover.py
@@ -63,3 +63,71 @@ def test_ema_crossover_real_data(
     assert len(debug_dump) == 214
 
     # TODO: Not sure if we have any meaningful results to verify
+
+
+def test_start_end_automation(
+    strategy_path,
+    logger: logging.Logger,
+    persistent_test_client,
+    ):
+    """Check that EMA crossover strategy against real data."""
+
+    client = persistent_test_client
+
+    # Run backtest over 6 months, daily
+    setup = setup_backtest(
+        strategy_path,
+        initial_deposit=10_000,
+        cycle_duration=CycleDuration.cycle_30d,  # Override to use monthly cycles to speed up the test
+        candle_time_frame=TimeBucket.d30,  # Override to use monthly data to speed up the test
+    )
+
+    state, universe, debug_dump = run_backtest(setup, client)
+
+    assert len(debug_dump) == 28
+
+
+def test_start_end_automation(
+    strategy_path,
+    logger: logging.Logger,
+    persistent_test_client,
+    ):
+    """Check that EMA crossover strategy against real data."""
+
+    client = persistent_test_client
+
+    # Run backtest over 6 months, daily
+    setup = setup_backtest(
+        strategy_path,
+        initial_deposit=10_000,
+        cycle_duration=CycleDuration.cycle_30d,  # Override to use monthly cycles to speed up the test
+        candle_time_frame=TimeBucket.d30,  # Override to use monthly data to speed up the test
+    )
+
+    state, universe, debug_dump = run_backtest(setup, client)
+
+    assert len(debug_dump) == 28
+
+
+def test_minimum_lookback_data_range(
+    strategy_path,
+    logger: logging.Logger,
+    persistent_test_client,
+    ):
+    """Check that EMA crossover strategy against real data."""
+
+    client = persistent_test_client
+
+    # Run backtest over 6 months, daily
+    setup = setup_backtest(
+        strategy_path,
+        initial_deposit=10_000,
+        cycle_duration=CycleDuration.cycle_1d,  # Override to use monthly cycles to speed up the test
+        candle_time_frame=TimeBucket.d1,  # Override to use monthly data to speed up the test
+        minimum_data_lookback_range=datetime.timedelta(days=23),
+    )
+
+    state, universe, debug_dump = run_backtest(setup, client)
+
+    assert len(debug_dump) == 24
+    

--- a/tradeexecutor/backtest/backtest_runner.py
+++ b/tradeexecutor/backtest/backtest_runner.py
@@ -46,10 +46,10 @@ class BacktestSetup:
     """Describe backtest setup, ready to run."""
 
     #: Test start
-    start_at: datetime.datetime
+    start_at: datetime.datetime | None
 
     #: Test end
-    end_at: datetime.datetime
+    end_at: datetime.datetime | None
 
     #: Override trading_strategy_cycle from strategy module
     universe_options: UniverseOptions
@@ -74,6 +74,8 @@ class BacktestSetup:
 
     #: Name for this backtest
     name: str = "backtest"
+
+    minimum_data_lookback_range: Optional[datetime.timedelta] = None
 
     # strategy_module: StrategyModuleInformation
 
@@ -214,14 +216,15 @@ def setup_backtest_for_universe(
 
 def setup_backtest(
         strategy_path: Path,
-        start_at: datetime.datetime,
-        end_at: datetime.datetime,
-        initial_deposit: USDollarAmount,
-        max_slippage=0.01,
+        start_at: Optional[datetime.datetime] = None,
+        end_at: Optional[datetime.datetime] = None,
+        initial_deposit: Optional[USDollarAmount] = None,
+        max_slippage: Optional[float] = 0.01,
         cycle_duration: Optional[CycleDuration]=None,
         candle_time_frame: Optional[TimeBucket]=None,
         strategy_module: Optional[StrategyModuleInformation]=None,
         name: Optional[str] = None,
+        minimum_data_lookback_range: Optional[datetime.timedelta] = None,
     ) -> BacktestSetup:
     """High-level entry point for setting up a backtest from a strategy module.
 
@@ -240,6 +243,9 @@ def setup_backtest(
     :param strategy_module:
         If strategy module was previously loaded
     """
+
+    assert initial_deposit, "You must give initial_deposit"
+    assert max_slippage >= 0, f"You must give max slippage. Got max slippage {max_slippage}"
 
     assert isinstance(strategy_path, Path), f"Got {strategy_path}"
     assert initial_deposit > 0, "Remember to set the backtest variables in your strategy module. See https://tradingstrategy.ai/docs/deployment/vault-deployment.html#run-a-backtest-on-the-strategy-module"
@@ -284,6 +290,7 @@ def setup_backtest(
         trade_routing=strategy_module.trade_routing,
         trading_strategy_engine_version=strategy_module.trading_strategy_engine_version,
         name=name,
+        minimum_data_lookback_range=minimum_data_lookback_range,
     )
 
 
@@ -384,6 +391,7 @@ def run_backtest(
         tick_offset=datetime.timedelta(seconds=1),
         trade_immediately=True,
         execution_test_hook=execution_test_hook,
+        minimum_data_lookback_range=setup.minimum_data_lookback_range,
     )
 
     debug_dump = main_loop.run()
@@ -499,13 +507,6 @@ def run_backtest_inline(
         # https://www.python.org/dev/peps/pep-3102/
         raise TypeError("Only keyword arguments accepted")
 
-    if minimum_data_lookback_range:
-        assert not start_at or not end_at, "You must not give start_at and end_at if you give minimum_data_lookback_range. minimum_data_lookback_range automatically ends at the current time."
-        assert isinstance(minimum_data_lookback_range, datetime.timedelta), "minimum_data_lookback_range must be a datetime.timedelta"
-
-        end_at = datetime.datetime.now()
-        start_at = end_at - minimum_data_lookback_range
-
     if start_at:
         assert isinstance(start_at, datetime.datetime)
         assert end_at, "You must give end_at if you give start_at"
@@ -577,6 +578,7 @@ def run_backtest_inline(
         trading_strategy_engine_version=CURRENT_ENGINE_VERSION,
         name=name,
         data_preload=data_preload,
+        minimum_data_lookback_range=minimum_data_lookback_range,
     )
 
     return run_backtest(backtest_setup, client, allow_missing_fees=True)

--- a/tradeexecutor/backtest/backtest_runner.py
+++ b/tradeexecutor/backtest/backtest_runner.py
@@ -427,6 +427,9 @@ def run_backtest_inline(
     :param end_at:
         When backtesting ends
 
+    :param minimum_data_lookback_range:
+        If start_at and end_at are not given, use this range to determine the backtesting period. Cannot be used with start_at and end_at.
+
     :param client:
         You need to set up a Trading Strategy client for fetching the data
 

--- a/tradeexecutor/backtest/backtest_runner.py
+++ b/tradeexecutor/backtest/backtest_runner.py
@@ -428,7 +428,7 @@ def run_backtest_inline(
         When backtesting ends
 
     :param minimum_data_lookback_range:
-        If start_at and end_at are not given, use this range to determine the backtesting period. Cannot be used with start_at and end_at.
+        If start_at and end_at are not given, use this range to determine the backtesting period. Cannot be used with start_at and end_at. Automatically ends at the current time.
 
     :param client:
         You need to set up a Trading Strategy client for fetching the data
@@ -499,16 +499,21 @@ def run_backtest_inline(
         # https://www.python.org/dev/peps/pep-3102/
         raise TypeError("Only keyword arguments accepted")
 
-    if not (start_at and end_at):
-        assert isinstance(minimum_data_lookback_range, datetime.timedelta), "You must give minimum_data_lookback_range if you do not give start_at and end_at"
+    if minimum_data_lookback_range:
+        assert not start_at or not end_at, "You must not give start_at and end_at if you give minimum_data_lookback_range. minimum_data_lookback_range automatically ends at the current time."
+        assert isinstance(minimum_data_lookback_range, datetime.timedelta), "minimum_data_lookback_range must be a datetime.timedelta"
 
-        end_at = datetime.datetime.now() - datetime.timedelta(days=1)
+        end_at = datetime.datetime.now()
         start_at = end_at - minimum_data_lookback_range
-    else:
-        assert not minimum_data_lookback_range, "You must not give minimum_data_lookback_range if you give start_at and end_at"
 
-    assert isinstance(start_at, datetime.datetime)
-    assert isinstance(end_at, datetime.datetime)
+    if start_at:
+        assert isinstance(start_at, datetime.datetime)
+        assert end_at, "You must give end_at if you give start_at"
+    
+    if end_at:
+        assert isinstance(end_at, datetime.datetime)
+        assert start_at, "You must give start_at if you give end_at"
+    
     assert initial_deposit > 0
 
     # Setup our special logging level if not done yet.

--- a/tradeexecutor/backtest/backtest_runner.py
+++ b/tradeexecutor/backtest/backtest_runner.py
@@ -393,8 +393,9 @@ def run_backtest(
 
 def run_backtest_inline(
     *ignore,
-    start_at: datetime.datetime,
-    end_at: datetime.datetime,
+    start_at: Optional[datetime.datetime] = None,
+    end_at: Optional[datetime.datetime] = None,
+    minimum_data_lookback_range: Optional[datetime.timedelta] = None,
     client: Optional[Client],
     decide_trades: DecideTradesProtocol,
     cycle_duration: CycleDuration,
@@ -494,6 +495,14 @@ def run_backtest_inline(
     if ignore:
         # https://www.python.org/dev/peps/pep-3102/
         raise TypeError("Only keyword arguments accepted")
+
+    if not (start_at and end_at):
+        assert isinstance(minimum_data_lookback_range, datetime.timedelta), "You must give minimum_data_lookback_range if you do not give start_at and end_at"
+
+        end_at = datetime.datetime.now() - datetime.timedelta(days=1)
+        start_at = end_at - minimum_data_lookback_range
+    else:
+        assert not minimum_data_lookback_range, "You must not give minimum_data_lookback_range if you give start_at and end_at"
 
     assert isinstance(start_at, datetime.datetime)
     assert isinstance(end_at, datetime.datetime)

--- a/tradeexecutor/cli/loop.py
+++ b/tradeexecutor/cli/loop.py
@@ -140,6 +140,7 @@ class ExecutionLoop:
             execution_test_hook: Optional[ExecutionTestHook] = None,
             metadata: Optional[Metadata] = None,
             check_accounts: Optional[bool] = None,
+            minimum_data_lookback_range: Optional[datetime.timedelta] = None,
     ):
         """See main.py for details."""
 
@@ -195,6 +196,8 @@ class ExecutionLoop:
             candle_time_bucket_override=self.backtest_candle_time_frame_override,
             stop_loss_time_bucket_override=self.backtest_stop_loss_time_frame_override,
         )
+
+        self.minimum_data_lookback_range = minimum_data_lookback_range
 
     def is_backtest(self) -> bool:
         """Are we doing a backtest execution."""
@@ -1090,20 +1093,8 @@ class ExecutionLoop:
         # TODO: Pass this as a constructor argument
         # TODO: Accounting checks only supports Enzyme currently
         self.runner.accounting_checks = self.check_accounts and isinstance(self.sync_model, EnzymeVaultSyncModel)
-
-        # set start and end automatically if not set
-        u = self.universe_model.construct_universe(
-            self.backtest_start,
-            self.execution_context.mode,
-            self.universe_options,
-        )
-
-        if self.backtest_start is None:
-            s,e  = u.universe.candles.get_timestamp_range()
-            self.backtest_start = s.to_pydatetime().replace(tzinfo=None)
-            self.backtest_end = e.to_pydatetime().replace(tzinfo=None)
-
-            logger.info("Automatically using %s - %s for backtest start and end", self.backtest_start, self.backtest_end)
+        
+        self.set_start_and_end()
 
         # Load cycle_duration from v0.1 strategies,
         # if not given from the command line to override backtesting data
@@ -1113,6 +1104,29 @@ class ExecutionLoop:
         assert self.cycle_duration is not None, "Did not get strategy cycle duration from constructor or strategy run description"
 
         return state
+
+    def set_start_and_end(self):
+        """Set up backtesting start and end times. If no start, end, or lookback info provided, will set automatically to the entire available data range."""
+        if self.minimum_data_lookback_range is not None:
+            assert not self.backtest_start or not self.backtest_end, "You must not give start_at and end_at if you give minimum_data_lookback_range. minimum_data_lookback_range automatically ends at the current time."
+            assert isinstance(self.minimum_data_lookback_range, datetime.timedelta), "minimum_data_lookback_range must be a datetime.timedelta"
+
+            self.backtest_end = datetime.datetime.now()
+            self.backtest_start = self.backtest_end - self.minimum_data_lookback_range
+
+        # set automatically if not given
+        if self.backtest_start is None:
+            u = self.universe_model.construct_universe(
+                self.backtest_start,
+                self.execution_context.mode,
+                self.universe_options,
+            )
+
+            s,e  = u.universe.candles.get_timestamp_range()
+            self.backtest_start = s.to_pydatetime().replace(tzinfo=None)
+            self.backtest_end = e.to_pydatetime().replace(tzinfo=None)
+
+            logger.info("Automatically using %s - %s for backtest start and end", self.backtest_start, self.backtest_end)
 
     def run_with_state(self, state: State) -> dict:
         """Start the execution.

--- a/tradeexecutor/cli/loop.py
+++ b/tradeexecutor/cli/loop.py
@@ -1122,11 +1122,12 @@ class ExecutionLoop:
                 self.universe_options,
             )
 
-            s,e  = u.universe.candles.get_timestamp_range()
-            self.backtest_start = s.to_pydatetime().replace(tzinfo=None)
-            self.backtest_end = e.to_pydatetime().replace(tzinfo=None)
+            if u.universe.candles is not None:
+                s,e  = u.universe.candles.get_timestamp_range()
+                self.backtest_start = s.to_pydatetime().replace(tzinfo=None)
+                self.backtest_end = e.to_pydatetime().replace(tzinfo=None)
 
-            logger.info("Automatically using %s - %s for backtest start and end", self.backtest_start, self.backtest_end)
+                logger.info("Automatically using %s - %s for backtest start and end", self.backtest_start, self.backtest_end)
 
     def run_with_state(self, state: State) -> dict:
         """Start the execution.

--- a/tradeexecutor/cli/loop.py
+++ b/tradeexecutor/cli/loop.py
@@ -1069,6 +1069,20 @@ class ExecutionLoop:
         self.runner: StrategyRunner = run_description.runner
         self.universe_model = run_description.universe_model
 
+        # set start and end automatically if not set
+        u = self.universe_model.construct_universe(
+            self.backtest_start,
+            self.execution_context.mode,
+            self.universe_options,
+        )
+
+        if self.backtest_start is None:
+            s,e  = u.universe.candles.get_timestamp_range()
+            self.backtest_start = s.to_pydatetime().replace(tzinfo=None)
+            self.backtest_end = e.to_pydatetime().replace(tzinfo=None)
+
+            logger.info("Automatically using %s - %s for backtest start and end", self.backtest_start, self.backtest_end)
+
         # Load cycle_duration from v0.1 strategies,
         # if not given from the command line to override backtesting data
         if run_description.cycle_duration and not self.cycle_duration:

--- a/tradeexecutor/state/state.py
+++ b/tradeexecutor/state/state.py
@@ -504,7 +504,7 @@ class State:
         with path.open("wt") as out:
             out.write(txt)
 
-    def get_strategy_start_and_end(self) -> tuple[datetime.datetime, datetime.datetime]:
+    def get_strategy_start_and_end(self) -> tuple[pd.Timestamp, pd.Timestamp]:
         """Get the time range for which the strategy should have data.
         """
         

--- a/tradeexecutor/state/state.py
+++ b/tradeexecutor/state/state.py
@@ -500,6 +500,17 @@ class State:
         with path.open("wt") as out:
             out.write(txt)
 
+    def get_strategy_start_and_end(self) -> tuple[datetime.datetime, datetime.datetime]:
+        """Get the time range for which the strategy should have data.
+        """
+        assert self.stats.portfolio, "No portfolio statistics, this is required for the time range"
+
+
+        start_at = pd.Timestamp(self.stats.portfolio[0].calculated_at)
+        end_at = pd.Timestamp(self.stats.portfolio[-1].calculated_at)
+
+        return start_at, end_at
+
     @staticmethod
     def read_json_file(path: Path) -> "State":
         """Read state from the JSON file.

--- a/tradeexecutor/state/state.py
+++ b/tradeexecutor/state/state.py
@@ -7,6 +7,7 @@ Any datetime must be naive, without timezone, and is assumed to be UTC.
 import json
 from dataclasses import dataclass, field
 import datetime
+import logging
 from decimal import Decimal
 from pathlib import Path
 from typing import List, Callable, Tuple, Set, Optional
@@ -28,6 +29,9 @@ from .visualisation import Visualisation
 
 from tradeexecutor.strategy.trade_pricing import TradePricing
 from ..strategy.cycle import CycleDuration
+
+
+logger = logging.getLogger(__name__)
 
 
 class UncleanState(Exception):
@@ -503,7 +507,10 @@ class State:
     def get_strategy_start_and_end(self) -> tuple[datetime.datetime, datetime.datetime]:
         """Get the time range for which the strategy should have data.
         """
-        assert self.stats.portfolio, "No portfolio statistics, this is required for the time range"
+        
+        if not self.stats.portfolio:
+            logger.warn("No portfolio statistics, this is required for the time range")
+            return None, None
 
 
         start_at = pd.Timestamp(self.stats.portfolio[0].calculated_at)

--- a/tradeexecutor/strategy/cycle.py
+++ b/tradeexecutor/strategy/cycle.py
@@ -77,6 +77,9 @@ class CycleDuration(enum.Enum):
     #: Run `decide_trades()` for every week
     cycle_7d = "7d"
 
+    #: Run `decide_trades()` for every month
+    cycle_30d = "30d"
+
     #: Don't really know or care about the trade cycle duration.
     #:
     #: Used when doing a simulated execution loop
@@ -217,6 +220,7 @@ _TICK_DURATIONS = {
     CycleDuration.cycle_1d: datetime.timedelta(hours=24),
     CycleDuration.cycle_4d: datetime.timedelta(days=4),
     CycleDuration.cycle_7d: datetime.timedelta(days=7),
+    CycleDuration.cycle_30d: datetime.timedelta(days=30),
     CycleDuration.cycle_unknown: datetime.timedelta(days=0),
 }
 

--- a/tradeexecutor/visual/multiple_pairs.py
+++ b/tradeexecutor/visual/multiple_pairs.py
@@ -210,6 +210,9 @@ def visualise_multiple_pairs(
 
     pair_ids = [int(pair_id) for pair_id in pair_ids]
 
+    if not (start_at and end_at):
+        start_at, end_at = state.get_strategy_start_and_end()
+
     start_at, end_at = get_start_and_end_full(candles, start_at, end_at)
 
     logger.info(f"Visualising multipair strategy for range {start_at} - {end_at}")

--- a/tradeexecutor/visual/multiple_pairs.py
+++ b/tradeexecutor/visual/multiple_pairs.py
@@ -101,7 +101,7 @@ def get_start_and_end_full(candles: pd.DataFrame | GroupedCandleUniverse, start_
 
 
 def visualise_multiple_pairs(
-    state: Optional[State],
+    state: State,
     candle_universe: GroupedCandleUniverse | pd.DataFrame,
     start_at: Optional[Union[pd.Timestamp, datetime.datetime]] = None,
     end_at: Optional[Union[pd.Timestamp, datetime.datetime]] = None,

--- a/tradeexecutor/visual/single_pair.py
+++ b/tradeexecutor/visual/single_pair.py
@@ -365,6 +365,9 @@ def visualise_single_pair(
     
     logger.info("Visualising %s", state)
 
+    if not (start_at and end_at):
+        start_at, end_at = state.get_strategy_start_and_end()
+
     start_at, end_at = get_start_and_end(start_at, end_at)
 
     if isinstance(candle_universe, GroupedCandleUniverse):
@@ -521,6 +524,9 @@ def visualise_single_pair_positions_with_duration_and_slippage(
     """
 
     logger.info("Visualising %s", state)
+
+    if not (start_at and end_at):
+        start_at, end_at = state.get_strategy_start_and_end()
 
     start_at, end_at = get_start_and_end(start_at, end_at)
 


### PR DESCRIPTION
### Details

- Adds `minimum_data_lookback_range` that can be used instead of `start_at` and `end_at` for backtesting
- Automatically uses entire data range for token if not dates specified
- Allows visualisations to automatically pick start and end for the full strategy time range after the strategy is run

### Tasks

- fixes #370 