### PR TITLE
Allow reporting for up to 5 pairs

### DIFF
--- a/tradeexecutor/strategy/pandas_trader/runner.py
+++ b/tradeexecutor/strategy/pandas_trader/runner.py
@@ -121,6 +121,13 @@ class PandasTraderRunner(StrategyRunner):
 
             self.update_strategy_thinking_image_data(small_figure_combined, large_figure_combined)
 
+        elif 3 < universe.get_pair_count() <=5 :
+            
+            small_figure_combined = draw_multi_pair_strategy_state(state, universe, height=2048, technical_indicators=False)
+            large_figure_combined = draw_multi_pair_strategy_state(state, universe, height=3840, width = 2160, technical_indicators=False)
+
+            self.update_strategy_thinking_image_data(small_figure_combined, large_figure_combined)
+
         else:
             logger.warning("Charts not yet available for this strategy type. Pair count: %s", universe.get_pair_count())
     
@@ -273,9 +280,9 @@ class PandasTraderRunner(StrategyRunner):
             logger.trade(buf.getvalue())
 
             # there is already a warning in refresh_visualisations for pair count > 3
-            if universe.get_pair_count() <= 3:
+            if universe.get_pair_count() <= 5:
                 large_image = self.run_state.visualisation.large_image
                 post_logging_discord_image(large_image)
             else:
-                logger.info(f"Strategy visualisation not posted to Discord because pair count of {universe.get_pair_count()} is greater than 3.")
+                logger.info(f"Strategy visualisation not posted to Discord because pair count of {universe.get_pair_count()} is greater than 5.")
 

--- a/tradeexecutor/visual/multiple_pairs.py
+++ b/tradeexecutor/visual/multiple_pairs.py
@@ -119,6 +119,7 @@ def visualise_multiple_pairs(
     volume_axis_name: str = "Volume USD",
     candle_decimals: int = 4,
     show_trades: bool = True,
+    detached_indicators: bool = True,
 ) -> go.Figure:
     """Visualise single-pair trade execution.
 
@@ -184,6 +185,9 @@ def visualise_multiple_pairs(
 
     :param candle_decimals:
         Number of decimal places to round the candlesticks to. Default is 4.
+
+    :param detached_indicators:
+        If set, draw detached indicators. Has no effect if `technical_indicators` is False.
 
     """
 
@@ -388,6 +392,7 @@ def visualise_multiple_pairs(
                 pair_subplot_info.volume_bar_mode,
                 pair_subplot_info.pair_id,
                 start_row=pair_subplot_info.candlestick_row,
+                detached_indicators=detached_indicators,
             )
 
         # Add trade markers if any trades have been made

--- a/tradeexecutor/visual/single_pair.py
+++ b/tradeexecutor/visual/single_pair.py
@@ -295,6 +295,7 @@ def visualise_single_pair(
         relative_sizing: list[float] = None,
         volume_axis_name: str = "Volume USD",
         candle_decimals: int = 4,
+        detached_indicators: bool = True,
 ) -> go.Figure:
     """Visualise single-pair trade execution.
 
@@ -360,6 +361,9 @@ def visualise_single_pair(
     
     :param candle_decimals:
         Number of decimal places to round the candlesticks to. Default is 4.
+
+    :param detached_indicators:
+        If set, draw detached indicators. Has no effect if `technical_indicators` is False.
 
     """
     
@@ -430,6 +434,7 @@ def visualise_single_pair(
         labels=labels,
         volume_axis_name=volume_axis_name,
         pair_id=pair_id,
+        detached_indicators=detached_indicators,
     )
 
 
@@ -611,6 +616,7 @@ def _get_grid_with_candles_volume_indicators(
     labels: pd.Series,
     volume_axis_name: str = "Volume USD",
     pair_id: int | None = None,
+    detached_indicators: bool = True,
 ):
     """Gets figure grid with candles, volume, and indicators overlayed."""
     
@@ -654,6 +660,7 @@ def _get_grid_with_candles_volume_indicators(
             end_at,
             volume_bar_mode,
             pair_id,
+            detached_indicators=detached_indicators,
         )
         
     return fig

--- a/tradeexecutor/visual/technical_indicator.py
+++ b/tradeexecutor/visual/technical_indicator.py
@@ -30,6 +30,7 @@ def overlay_all_technical_indicators(
         volume_bar_mode: VolumeBarMode = None,
         pair_id: Optional[int] = None,
         start_row: int = None,
+        detached_indicators: bool = True,
 ):
     """Draw all technical indicators from the visualisation over candle chart.
 
@@ -41,6 +42,15 @@ def overlay_all_technical_indicators(
     
     :param volume_bar_mode:
         How to draw volume bars e.g. overlay, seperate, hidden
+
+    :param pair_id:
+        If set, only draw indicators for this pair
+
+    :param start_row:
+        If set, start drawing indicators from this row. Used for multipair visualisation.
+
+    :param detached_indicators:
+        If set, draw detached indicators.
     """
 
     # get starting row for indicators
@@ -60,6 +70,9 @@ def overlay_all_technical_indicators(
 
     # https://plotly.com/python/graphing-multiple-chart-types/
     for plot in plots:
+
+        if plot.kind == PlotKind.technical_indicator_detached and not detached_indicators:
+            continue
 
         # get trace which is unattached to plot
         trace = visualise_technical_indicator(


### PR DESCRIPTION
- allows reporting for up to 5 pairs
- doesn't show detached indicators for more than 3 pairs (still shows overlaid indicators)
- goes some way to fixing #395