### PR TITLE
Short position interest tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,9 +17,9 @@ python = ">=3.10,<3.11"
 
 # Use these during development
 # web3-ethereum-defi = {path = "deps/web3-ethereum-defi", develop = true}
-# trading-strategy = {path = "deps/trading-strategy", develop = true}
+trading-strategy = {path = "deps/trading-strategy", develop = true}
 requests = "^2.27.1"
-trading-strategy = "^0.20.2"
+# trading-strategy = "^0.20.2"
 matplotlib = "^3.6.0"
 jupyterlab = "^3.5.0"
 pandas-ta = "^0.3.14b"

--- a/tests/backtest/test_backtest_credit_supply_mock.py
+++ b/tests/backtest/test_backtest_credit_supply_mock.py
@@ -41,8 +41,7 @@ def interest_rate_mock():
     daily_interest = Decimal("1")
     with patch(
         "tradeexecutor.backtest.backtest_sync.BacktestSyncModel.calculate_accrued_interest",
-        # we need to produce accured interest, so it's increasing daily
-        side_effect=[i * daily_interest for i in range(1, 100)]
+        return_value=daily_interest,
     ):
         yield
 

--- a/tests/backtest/test_backtest_credit_supply_real_data.py
+++ b/tests/backtest/test_backtest_credit_supply_real_data.py
@@ -113,12 +113,12 @@ def test_backtest_open_only_credit_supply_real_data(
 
     # Backtest creates one event before each tick
     assert len(credit_position.balance_updates) == 30
-
-    assert credit_position.interest.opening_amount == Decimal("10000.00")
-    assert credit_position.get_accrued_interest() == pytest.approx(5.869650453189491)
-    assert credit_position.get_quantity() == Decimal('10005.86965045318949110985913')
-    assert credit_position.get_value() == pytest.approx(10005.869650453189491)
-    assert portfolio.get_total_equity() == pytest.approx(10005.869650453189491)
+    
+    assert credit_position.loan.collateral_interest.opening_amount == Decimal("10000.00")
+    assert credit_position.get_accrued_interest() == pytest.approx(5.8392619598023785)
+    assert credit_position.get_quantity() == Decimal('10005.83926195980237824844199')
+    assert credit_position.get_value() == pytest.approx(10005.8392619598023785)
+    assert portfolio.get_total_equity() == pytest.approx(10005.8392619598023785)
 
 
 def test_backtest_open_and_close_credit_supply_real_data(
@@ -176,13 +176,15 @@ def test_backtest_open_and_close_credit_supply_real_data(
     credit_position = portfolio.closed_positions[1]
     assert credit_position.is_credit_supply()
     assert len(credit_position.balance_updates) == 14
-    assert credit_position.interest.opening_amount == Decimal("10000.00")
-    assert credit_position.calculate_accrued_interest_quantity() == Decimal('2.66358076134408362987523')  # Non-denormalised interest
-    assert credit_position.interest.last_atoken_amount == Decimal('10002.66358076134408362987523')
-    assert credit_position.interest.last_accrued_interest == Decimal('2.66358076134408362987523')
 
-    assert credit_position.get_accrued_interest() == pytest.approx(2.663580761344)  # Denormalised interest
+    interest = credit_position.loan.collateral_interest
+    assert interest.opening_amount == Decimal("10000.00")
+    assert credit_position.calculate_accrued_interest_quantity() == Decimal('2.67867669078453209820818')  # Non-denormalised interest
+    assert interest.last_atoken_amount == Decimal('10002.67867669078453209820818')
+    assert interest.last_accrued_interest == Decimal('2.67867669078453209820818')
+
+    assert credit_position.get_accrued_interest() == pytest.approx(2.678676690784532)  # Denormalised interest
     assert credit_position.get_quantity() == Decimal('0')  # Closed positions do not have quantity left
     assert credit_position.get_value() == pytest.approx(0)  # Closed positions do not have value left
 
-    assert portfolio.get_total_equity() == pytest.approx(10002.663580761344)
+    assert portfolio.get_total_equity() == pytest.approx(10002.678676690784532)

--- a/tests/backtest/test_backtest_short_real_data.py
+++ b/tests/backtest/test_backtest_short_real_data.py
@@ -1,0 +1,120 @@
+"""Run a backtest where we open a credit supply position, using real oracle data.
+
+"""
+import os
+import logging
+import datetime
+from _decimal import Decimal
+
+import pytest
+from typing import List, Dict
+
+import pandas as pd
+
+from tradingstrategy.client import Client
+from tradingstrategy.chain import ChainId
+from tradingstrategy.lending import LendingProtocolType
+from tradingstrategy.timebucket import TimeBucket
+
+from tradeexecutor.backtest.backtest_runner import run_backtest_inline
+from tradeexecutor.strategy.trading_strategy_universe import TradingStrategyUniverse, load_partial_data
+from tradeexecutor.strategy.execution_context import ExecutionContext, unit_test_execution_context
+from tradeexecutor.strategy.cycle import CycleDuration
+from tradeexecutor.strategy.reserve_currency import ReserveCurrency
+from tradeexecutor.strategy.default_routing_options import TradeRouting
+from tradeexecutor.strategy.universe_model import UniverseOptions, default_universe_options
+from tradeexecutor.state.trade import TradeExecution
+from tradeexecutor.strategy.pricing_model import PricingModel
+from tradeexecutor.strategy.pandas_trader.position_manager import PositionManager
+from tradeexecutor.state.state import State
+
+
+# https://docs.pytest.org/en/latest/how-to/skipping.html#skip-all-test-functions-of-a-class-or-module
+pytestmark = pytest.mark.skipif(os.environ.get("TRADING_STRATEGY_API_KEY") is None, reason="Set TRADING_STRATEGY_API_KEY environment variable to run this test")
+
+
+def create_trading_universe(
+    ts: datetime.datetime,
+    client: Client,
+    execution_context: ExecutionContext,
+    universe_options: UniverseOptions,
+) -> TradingStrategyUniverse:
+
+    assert universe_options.start_at
+    assert execution_context.engine_version == "0.3"  # We changed the decide_trades() signature
+
+    pairs = [
+        (ChainId.polygon, "uniswap-v3", "WETH", "USDC", 0.0005)
+    ]
+
+    reverses = [
+        (ChainId.polygon, LendingProtocolType.aave_v3, "WETH"),
+        (ChainId.polygon, LendingProtocolType.aave_v3, "USDC"),
+    ]
+
+    dataset = load_partial_data(
+        client,
+        execution_context=unit_test_execution_context,
+        time_bucket=TimeBucket.d1,
+        pairs=pairs,
+        universe_options=default_universe_options,
+        start_at=universe_options.start_at,
+        end_at=universe_options.end_at,
+        lending_reserves=reverses,
+    )
+
+    strategy_universe = TradingStrategyUniverse.create_single_pair_universe(dataset)
+    return strategy_universe
+
+
+def test_backtest_open_only_short_real_data(
+    logger: logging.Logger,
+    persistent_test_client: Client,
+):
+    """Run the strategy backtest using inline decide_trades function.
+
+    - How much interest we can get on USDC on Polygon in one month
+    """
+
+    def decide_trades(
+        timestamp: pd.Timestamp,
+        strategy_universe: TradingStrategyUniverse,
+        state: State,
+        pricing_model: PricingModel,
+        cycle_debug_data: Dict
+    ) -> List[TradeExecution]:
+        """A simple strategy that puts all in to our lending reserve."""
+        trade_pair = strategy_universe.universe.pairs.get_single()
+
+        short_pair = strategy_universe.get_short_pair(trade_pair)
+
+        cash = state.portfolio.get_cash()
+        
+        position_manager = PositionManager(timestamp, strategy_universe, state, pricing_model)
+
+        trades = []
+
+        if not position_manager.is_any_open():
+            # buy_amount = cash * position_size
+            trades += position_manager.open_short(short_pair, cash, leverage=2)
+
+        return trades
+
+    # Run the test
+    state, universe, debug_dump = run_backtest_inline(
+        start_at=datetime.datetime(2023, 1, 1),
+        end_at=datetime.datetime(2023, 2, 1),
+        client=persistent_test_client,
+        cycle_duration=CycleDuration.cycle_1d,
+        decide_trades=decide_trades,
+        create_trading_universe=create_trading_universe,
+        initial_deposit=10_000,
+        reserve_currency=ReserveCurrency.usdc,
+        trade_routing=TradeRouting.uniswap_v3_usdc_poly,
+        engine_version="0.3",
+    )
+
+    portfolio = state.portfolio
+    assert len(portfolio.open_positions) == 1
+    credit_position = portfolio.open_positions[1]
+    assert credit_position.is_short()

--- a/tests/backtest/test_backtest_short_real_data.py
+++ b/tests/backtest/test_backtest_short_real_data.py
@@ -86,8 +86,6 @@ def test_backtest_open_only_short_real_data(
         """A simple strategy that puts all in to our lending reserve."""
         trade_pair = strategy_universe.universe.pairs.get_single()
 
-        short_pair = strategy_universe.get_short_pair(trade_pair)
-
         cash = state.portfolio.get_cash()
         
         position_manager = PositionManager(timestamp, strategy_universe, state, pricing_model)
@@ -96,7 +94,7 @@ def test_backtest_open_only_short_real_data(
 
         if not position_manager.is_any_open():
             # buy_amount = cash * position_size
-            trades += position_manager.open_short(short_pair, cash, leverage=2)
+            trades += position_manager.open_short(trade_pair, cash, leverage=2)
 
         return trades
 

--- a/tests/interest/test_state_short.py
+++ b/tests/interest/test_state_short.py
@@ -1150,7 +1150,7 @@ def test_short_unrealised_interest_and_profit(
     """Opening a short position and get some unrealised profit.
 
     - ETH price goes 1500 -> 1400 so we get unrealised PnL
-    - We have 10% interest cost on the short position
+    - We have 10% borrow cost on the ETH short position
     - We have 2% interest income on the USDC collateral
     - See ``test_short_unrealised_profit`` for a comparison calculations
       with interest payments ignored
@@ -1193,8 +1193,8 @@ def test_short_unrealised_interest_and_profit(
         1400.0,
     )
 
-    atoken_interest = 1.02
-    vtoken_interest = 1.10
+    atoken_interest = 1.02  # Receive 2% on USD collateral
+    vtoken_interest = 1.10  # Pay 10% on ETH loan
 
     # Calculate simulated interest gains
     new_atoken = estimate_interest(
@@ -1211,8 +1211,7 @@ def test_short_unrealised_interest_and_profit(
         vtoken_interest,
     )
 
-    # We have gained 15 USDC on our dollar long
-    assert new_atoken == Decimal('1815.113089799044876389054071')
+    assert new_atoken == Decimal('1815.113089799044876389054071')  # We have gained 15 USDC on our dollar long
     assert new_vtoken == Decimal('0.5552334719541217745270929036')
 
     # Tell strategy state about interest gains
@@ -1231,7 +1230,8 @@ def test_short_unrealised_interest_and_profit(
     # We gain around 15 USDC in half a year
     assert aevt.quantity == pytest.approx(Decimal('15.113089799044887491284317'))
 
-    # We need to pay ~ 0.02 ETH half a year
+    # We need to pay ~ 0.02 ETH half a year,
+    # worth 30 USD at 1400 ETH/USD
     assert vevt.quantity == pytest.approx(Decimal('0.0219001386207884485952464011'))
 
     assert aevt.get_update_period() == datetime.timedelta(days=152)

--- a/tests/interest/test_state_short.py
+++ b/tests/interest/test_state_short.py
@@ -16,6 +16,7 @@ from tradeexecutor.state.loan import calculate_sizes_for_leverage
 from tradeexecutor.state.reserve import ReservePosition
 from tradeexecutor.state.state import State
 from tradeexecutor.state.trade import TradeType
+from tradeexecutor.strategy.interest import estimate_interest, update_leveraged_position_interest
 from tradeexecutor.testing.unit_test_trader import UnitTestTrader
 from tradingstrategy.chain import ChainId
 from tradingstrategy.lending import LendingProtocolType
@@ -956,3 +957,304 @@ def test_short_unrealised_profit_leveraged(
     assert short_position.get_realised_profit_usd() == pytest.approx(133.333333)
     assert short_position.get_unrealised_profit_usd() == 0
     assert portfolio.get_cash() == pytest.approx(10133.333333)
+
+
+def test_short_unrealised_profit(
+        state: State,
+        weth_short_identifier: TradingPairIdentifier,
+        usdc: AssetIdentifier,
+):
+    """Opening a short position and get some unrealised profit.
+
+    - ETH price goes 1500 -> 1400 so we get unrealised PnL
+
+    """
+
+    trader = UnitTestTrader(state)
+
+    # Aave allows us to borrow 80% ETH against our USDC collateral
+    start_ltv = 0.8
+
+    # How many ETH (vWETH) we expect when we go in
+    # with our max leverage available
+    # based on the collateral ratio
+    expected_eth_shorted_amount = 1000 * start_ltv / 1500
+
+    # Take 1000 USDC reserves and open a ETH short using it.
+    # We should get 800 USDC worth of ETH for this.
+    short_position, trade, created = state.trade_short(
+        strategy_cycle_at=datetime.datetime.utcnow(),
+        pair=weth_short_identifier,
+        borrowed_quantity=-Decimal(expected_eth_shorted_amount),
+        collateral_quantity=Decimal(1000),
+        borrowed_asset_price=float(1500),  # USDC/ETH price we are going to sell
+        trade_type=TradeType.rebalance,
+        reserve_currency=usdc,
+        collateral_asset_price=1.0,
+    )
+
+    trader.set_perfectly_executed(trade)
+    assert state.portfolio.get_total_equity() == 10000
+
+    # ETH price 1500 -> 1400
+    short_position.revalue_base_asset(
+        datetime.datetime.utcnow(),
+        1400.0,
+    )
+
+    # New ETH loan worth of 746.6666666666666 USD
+    assert short_position.get_current_price() == 1400
+    assert short_position.get_average_price() == 1500
+    assert short_position.get_unrealised_profit_usd() == pytest.approx(800 - 746.6666666666666)
+    assert short_position.get_realised_profit_usd() is None
+
+    loan = short_position.loan
+    assert loan.borrowed.quantity == pytest.approx(Decimal(expected_eth_shorted_amount))
+    assert loan.borrowed.asset.token_symbol == "variableDebtPolWETH"
+    assert loan.borrowed.asset.underlying.token_symbol == "WETH"
+    assert loan.borrowed.last_usd_price == 1400
+    assert loan.get_loan_to_value() == pytest.approx(0.4148148148148148)
+
+    # Check that we track the equity value correctly
+    assert state.portfolio.get_loan_net_asset_value() == pytest.approx(1053.3333333333335)
+    assert state.portfolio.get_cash() == 9000
+    assert state.portfolio.get_net_asset_value() == pytest.approx(10053.333333333334)
+
+
+def test_short_unrealised_profit_partially_closed_keep_collateral(
+        state: State,
+        weth_short_identifier: TradingPairIdentifier,
+        usdc: AssetIdentifier,
+):
+    """Opening a short position and get some unrealised profit.
+
+    - ETH price goes 1500 -> 1400 so we get USD 56 unrealised PnL
+
+    - Close 50% of this position at this price, we get USD 27 realised profit
+
+    - Any closed profit is kept on the collateral
+    """
+
+    trader = UnitTestTrader(state)
+
+    portfolio = state.portfolio
+
+    # Start by shorting  ETH 2:1 with 1000 USD
+    expected_eth_shorted_amount = 1000 / 1500
+
+    # Take 1000 USDC reserves and open a ETH short using it.
+    # We should get 800 USDC worth of ETH for this.
+    # 800 USDC worth of ETH is
+    short_position, trade, created = state.create_trade(
+        strategy_cycle_at=datetime.datetime.utcnow(),
+        pair=weth_short_identifier,
+        quantity=-Decimal(expected_eth_shorted_amount),
+        reserve=Decimal(1000),
+        assumed_price=float(1500),  # USDC/ETH price we are going to sell
+        trade_type=TradeType.rebalance,
+        reserve_currency=usdc,
+        reserve_currency_price=1.0,
+    )
+
+    assert trade.planned_loan_update is not None
+    assert trade.executed_loan_update is None
+    trader.set_perfectly_executed(trade)
+    assert trade.planned_loan_update is not None
+    assert trade.executed_loan_update is not None
+
+    loan = short_position.loan
+    assert loan.borrowed.quantity == pytest.approx(Decimal(expected_eth_shorted_amount))
+    assert loan.collateral.quantity == pytest.approx(2000)
+    assert loan.get_leverage() == 2.0
+
+    assert portfolio.get_total_equity() == 10000
+    assert portfolio.get_cash() == 9000
+
+    # ETH price 1500 -> 1400
+    short_position.revalue_base_asset(
+        datetime.datetime.utcnow(),
+        1400.0,
+    )
+
+    # Loan value 1000 USD -> 933 USD
+    assert short_position.loan.borrowed.get_usd_value() == pytest.approx(933.3333333333333)
+
+    # Close 50% of the position
+    #
+    short_position_ref_2, trade_2, created = state.trade_short(
+        strategy_cycle_at=datetime.datetime.utcnow(),
+        pair=weth_short_identifier,
+        # Position quantity for short position means reduce the position
+        borrowed_quantity=Decimal(expected_eth_shorted_amount / 2),  # Short position quantity is counted as negative. When we close the quantity goes towards zero from neagtive.
+        collateral_quantity=Decimal(0),  # Reserve will be calculated generated from the released collateral
+        borrowed_asset_price=float(1400),  # USDC/ETH price we are going to sell
+        trade_type=TradeType.rebalance,
+        reserve_currency=usdc,
+        collateral_asset_price=1.0,
+    )
+
+    # Loan does not change until the trade is executed
+    assert short_position_ref_2 == short_position
+    assert not created
+    assert short_position.loan.borrowed.quantity == pytest.approx(Decimal(expected_eth_shorted_amount))
+
+    # Trade 2 will be excuted,
+    # planned loan update moves sto executed
+    # we get rid of half of the position
+    assert trade_2.planned_loan_update is not None
+    assert trade_2.executed_loan_update is None
+    trader.set_perfectly_executed(trade_2)
+    assert trade_2.planned_loan_update is not None
+    assert trade_2.executed_loan_update is not None
+    assert trade_2.planned_quantity == pytest.approx(Decimal(expected_eth_shorted_amount / 2))
+    assert trade_2.executed_quantity == pytest.approx(Decimal(expected_eth_shorted_amount / 2))
+    assert trade_2.planned_reserve == pytest.approx(Decimal(0))
+    assert trade_2.executed_reserve == pytest.approx(Decimal(0))
+
+    # Because we closed half, we realised 50% of profit, left 50% profit on the table.
+    total_profit = (1500-1400) * expected_eth_shorted_amount
+    assert total_profit == pytest.approx(66.6666666)
+    assert short_position.get_current_price() == 1400
+    assert short_position.get_average_price() == 1500
+    assert short_position.get_unrealised_profit_usd() == pytest.approx(total_profit / 2)
+    assert short_position.get_realised_profit_usd() == pytest.approx(total_profit / 2)
+
+    # Loan is 50% reduced from 0.53 ETH to 0.26 ETH.
+    # We buy the ETH to repay using the USDC loan from collateral
+    loan = short_position.loan
+    released_collateral = 1400 * expected_eth_shorted_amount / 2
+    assert released_collateral == pytest.approx(466.66666666666663)
+    left_collateral = Decimal(2000 - released_collateral)
+    assert left_collateral == pytest.approx(Decimal(1533.33333333333348491578362882137298583984375))
+    assert loan.collateral.quantity == pytest.approx(left_collateral)
+    assert loan.collateral.get_usd_value() == pytest.approx(float(left_collateral))
+    assert loan.borrowed.quantity == pytest.approx(Decimal(expected_eth_shorted_amount / 2))
+    assert loan.borrowed.last_usd_price == 1400
+    assert loan.borrowed.get_usd_value() == pytest.approx(466.66666666666663)
+    assert loan.get_loan_to_value() == pytest.approx(0.3043478260869565)
+    assert loan.get_leverage() == pytest.approx(1.4375000000000002)
+
+    # Check that we track the portfolio value correctly
+    # after realising profit
+    assert portfolio.get_cash() == 9000  # No changes in cash, because we paid back from the collateral
+    assert portfolio.get_net_asset_value() == pytest.approx(10066.66666)  # Should be same with our without reducing position as we have no fees, see test above
+    assert portfolio.get_loan_net_asset_value() == pytest.approx(1066.6666666666665)
+    assert portfolio.get_total_equity() == pytest.approx(10066.666)  # Any profits from closed short positions are not moved to equity, unless told so
+
+
+def test_short_unrealised_interest_and_profit(
+        state: State,
+        weth_short_identifier: TradingPairIdentifier,
+        usdc: AssetIdentifier,
+):
+    """Opening a short position and get some unrealised profit.
+
+    - ETH price goes 1500 -> 1400 so we get unrealised PnL
+    - We have 10% interest cost on the short position
+    - We have 2% interest income on the USDC collateral
+    """
+
+    trader = UnitTestTrader(state)
+
+    # Aave allows us to borrow 80% ETH against our USDC collateral
+    start_ltv = 0.8
+
+    # How many ETH (vWETH) we expect when we go in
+    # with our max leverage available
+    # based on the collateral ratio
+    expected_eth_shorted_amount = 1000 * start_ltv / 1500
+
+    start_at = datetime.datetime(2020, 1, 1)
+
+    # Take 1000 USDC reserves and open a ETH short using it.
+    # We should get 800 USDC worth of ETH for this.
+    short_position, trade, created = state.trade_short(
+        strategy_cycle_at=start_at,
+        pair=weth_short_identifier,
+        borrowed_quantity=-Decimal(expected_eth_shorted_amount),
+        collateral_quantity=Decimal(1000),
+        borrowed_asset_price=float(1500),  # USDC/ETH price we are going to sell
+        trade_type=TradeType.rebalance,
+        reserve_currency=usdc,
+        collateral_asset_price=1.0,
+    )
+
+    trader.set_perfectly_executed(trade)
+    assert state.portfolio.get_total_equity() == 10000
+
+    # Move forward half a year
+    now_at = datetime.datetime(2020, 6, 1)
+
+    # ETH price 1500 -> 1400
+    short_position.revalue_base_asset(
+        datetime.datetime.utcnow(),
+        1400.0,
+    )
+
+    atoken_interest = 1.02
+    vtoken_interest = -1.10
+
+    # Calculate simulated interest gains
+    new_atoken = estimate_interest(
+        start_at,
+        now_at,
+        short_position.loan.collateral.quantity,
+        atoken_interest,
+    )
+
+    new_vtoken = estimate_interest(
+        start_at,
+        now_at,
+        short_position.loan.borrowed.quantity,
+        vtoken_interest,
+    )
+
+    # We have gained 15 USDC on our dollar long
+    assert new_atoken == Decimal('1815.113089799044876389054071')
+
+    # assert Decimal('-0.5552334719541217745270929036')
+    import ipdb ; ipdb.set_trace()
+
+    # Tell strategy state about interest gains
+    # Note that this BalanceUpdate event
+    # is not stored with the state
+    vevt, aevt = update_leveraged_position_interest(
+        state,
+        short_position,
+        new_vtoken,
+        new_atoken,
+        now_at,
+        vtoken_price=1400.0,
+        atoken_price=1.0,
+    )
+
+    # We gain around 15 USDC in half a year
+    assert aevt.quantity == pytest.approx(Decimal('15.113089799044887491284317'))
+
+    # We gain around 15 USDC in half a year
+    assert vevt.quantity == pytest.approx(Decimal('15.113089799044887491284317'))
+
+    assert aevt.get_update_period() == datetime.timedelta(days=152)
+    assert vevt.get_update_period() == datetime.timedelta(days=152)
+    assert aevt.get_effective_yearly_yield() == pytest.approx(0.02)
+    assert vevt.get_effective_yearly_yield() == pytest.approx(-0.10)
+
+    import ipdb ; ipdb.set_trace()
+
+    # New ETH loan worth of 746.6666666666666 USD
+    assert short_position.get_current_price() == 1400
+    assert short_position.get_average_price() == 1500
+    assert short_position.get_unrealised_profit_usd() == pytest.approx(800 - 746.6666666666666)
+    assert short_position.get_realised_profit_usd() is None
+
+    loan = short_position.loan
+    assert loan.borrowed.quantity == pytest.approx(Decimal(expected_eth_shorted_amount))
+    assert loan.borrowed.asset.token_symbol == "variableDebtPolWETH"
+    assert loan.borrowed.asset.underlying.token_symbol == "WETH"
+    assert loan.borrowed.last_usd_price == 1400
+    assert loan.get_loan_to_value() == pytest.approx(0.4148148148148148)
+
+    # Check that we track the equity value correctly
+    assert state.portfolio.get_loan_net_asset_value() == pytest.approx(1053.3333333333335)
+    assert state.portfolio.get_cash() == 9000
+    assert state.portfolio.get_net_asset_value() == pytest.approx(10053.333333333334)

--- a/tradeexecutor/cli/loop.py
+++ b/tradeexecutor/cli/loop.py
@@ -446,7 +446,7 @@ class ExecutionLoop:
         credit_positions = state.portfolio.get_current_credit_positions()
         if credit_positions:
             logger.info("We have %d credit positions open", len(credit_positions))
-            credit_events = self.sync_model.sync_credit_supply(
+            credit_events = self.sync_model.sync_interests(
                 strategy_cycle_timestamp,
                 state,
                 cast(TradingStrategyUniverse, universe),

--- a/tradeexecutor/state/balance_update.py
+++ b/tradeexecutor/state/balance_update.py
@@ -209,7 +209,9 @@ class BalanceUpdate:
         - Calculated in tokens (exchange rate immune)
 
         :return:
-            E.g. 2% for 2% yearly interest.
+            1-based interest.
+
+            E.g. 1.02 for 2% yearly gained interest. 0.9 for 10% yearly paid interest.
 
             Positive if we are gaining interest, negative if we are paying interest.
 

--- a/tradeexecutor/state/balance_update.py
+++ b/tradeexecutor/state/balance_update.py
@@ -15,7 +15,7 @@ from typing import Optional
 from dataclasses_json import dataclass_json
 
 from tradeexecutor.state.identifier import AssetIdentifier
-from tradingstrategy.types import USDollarAmount
+from tradingstrategy.types import USDollarAmount, Percent
 
 
 class BalanceUpdateCause(enum.Enum):
@@ -82,7 +82,6 @@ class BalanceUpdate:
     #:
     #: The strategy cycle timestamp.
     #:
-    #:
     #: It might be outside the cycle frequency if treasuries were processed
     #: in a cron job outside the cycle for slow moving strategies.
     #:
@@ -113,6 +112,15 @@ class BalanceUpdate:
     #: Wall clock time when this event was created
     #:
     created_at: datetime.datetime | None = field(default_factory=datetime.datetime.utcnow)
+
+    #: What was the event time of the previous update.
+    #:
+    #: This allows us to calculate the effective interest rate
+    #: between the update cycles.
+    #:
+    #: This is the same as :py:attr:`block_mined_at` of the previous event.
+    #:
+    previous_update_at: datetime.datetime | None = None
 
     #: Investor address that the balance update is related to
     #:
@@ -146,6 +154,9 @@ class BalanceUpdate:
     def __post_init__(self):
         assert self.quantity != 0, "Balance update cannot be zero: {self}"
 
+        if self.previous_update_at:
+            assert self.previous_update_at <= self.block_mined_at, f"Travelling back in time: {self.previous_update_at} - {self.block_mined_at}"
+
     def __repr__(self):
         if self.position_id:
             position_name = f"position #{self.position_id}"
@@ -177,4 +188,37 @@ class BalanceUpdate:
         """Return whether this event updates reserve balance or open position balance"""
         return self.position_type == BalanceUpdatePositionType.reserve
 
+    def get_update_period(self) -> datetime.timedelta | None:
+        """How long it was between this event and previous sync event.
 
+        :return:
+            None if only inital update made
+        """
+        if not self.previous_update_at:
+            return None
+
+        return (self.block_mined_at - self.previous_update_at)
+
+    def get_effective_yearly_yield(self, year=datetime.timedelta(days=360)) -> Percent | None:
+        """How much we are gaining % yearly.
+
+        - Based on the this balance update and the previous balance update
+
+        - Mostly useful for interest rate events
+
+        - Calculated in tokens (exchange rate immune)
+
+        :return:
+            E.g. 2% for 2% yearly interest.
+
+            Positive if we are gaining interest, negative if we are paying interest.
+
+            ``None``  if no update period available
+        """
+
+        period = self.get_update_period()
+        if not period:
+            return None
+        gain = self.quantity / self.old_balance
+
+        return float(gain) * period / year

--- a/tradeexecutor/state/balance_update.py
+++ b/tradeexecutor/state/balance_update.py
@@ -220,5 +220,4 @@ class BalanceUpdate:
         if not period:
             return None
         gain = self.quantity / self.old_balance
-
-        return float(gain) * period / year
+        return float(gain) / (period / year)

--- a/tradeexecutor/state/interest.py
+++ b/tradeexecutor/state/interest.py
@@ -60,12 +60,12 @@ class Interest:
         assert isinstance(self.last_accrued_interest, Decimal)
 
     @staticmethod
-    def open_new(opening_amount: Decimal) -> "Interest":
+    def open_new(opening_amount: Decimal, timestamp: datetime.datetime) -> "Interest":
         assert opening_amount > 0
         return Interest(
             opening_amount=opening_amount,
-            last_updated_at=datetime.datetime.utcnow(),
-            last_event_at=datetime.datetime.utcnow(),
+            last_updated_at=timestamp,
+            last_event_at=timestamp,
             last_accrued_interest=Decimal(0),
             last_atoken_amount=opening_amount,
         )

--- a/tradeexecutor/state/loan.py
+++ b/tradeexecutor/state/loan.py
@@ -107,7 +107,7 @@ class Loan:
         return self.borrowed.get_usd_value()
 
     def get_borrow_interest(self) -> USDollarAmount:
-        """How much interest we have paid on borrows
+        """How much interest we have paid on borrows.
 
         :return:
             Always positive

--- a/tradeexecutor/state/position.py
+++ b/tradeexecutor/state/position.py
@@ -814,9 +814,9 @@ class TradingPosition(GenericPosition):
                 assert pair.kind == TradingPairKind.credit_supply, "Only credit supply supported for now"
                 if self.loan is None:
                     assert trade.is_buy(), "Opening credit position is modelled as buy"
-                    trade.planned_loan_update = create_credit_supply_loan(self, trade)
+                    trade.planned_loan_update = create_credit_supply_loan(self, trade, strategy_cycle_at)
                 else:
-                    trade.planned_loan_update = update_credit_supply_loan(self, trade)
+                    trade.planned_loan_update = update_credit_supply_loan(self, trade, strategy_cycle_at)
 
             elif pair.kind.is_leverage():
                 assert pair.get_lending_protocol() == LendingProtocolType.aave_v3, "Unsupported protocol"

--- a/tradeexecutor/state/position.py
+++ b/tradeexecutor/state/position.py
@@ -825,13 +825,16 @@ class TradingPosition(GenericPosition):
                         # Opening the position, create the first loan
                         trade.planned_loan_update = create_short_loan(
                             self,
-                            trade)
+                            trade,
+                            strategy_cycle_at,
+                        )
                     else:
                         # Loan is being increased/reduced
                         trade.planned_loan_update = plan_loan_update_for_short(
                             self.loan.clone(),
                             self,
-                            trade)
+                            trade,
+                        )
                 else:
                     raise NotImplementedError()
             else:

--- a/tradeexecutor/state/position.py
+++ b/tradeexecutor/state/position.py
@@ -1352,6 +1352,8 @@ class TradingPosition(GenericPosition):
           been moved to reserves from this position.
 
         :return:
+            Net interest PnL in USD.
+
             Positive if we have earned interest, negative if we have paid it.
         """
 

--- a/tradeexecutor/strategy/interest.py
+++ b/tradeexecutor/strategy/interest.py
@@ -94,7 +94,7 @@ def update_credit_supply_interest(
 
     # Update interest stats
     interest.last_accrued_interest = position.calculate_accrued_interest_quantity()
-    interest.last_updated_at = datetime.datetime.utcnow()
+    interest.last_updated_at = event_at
     interest.last_event_at = event_at
     interest.last_updated_block_number = block_number
     interest.last_atoken_amount = new_atoken_amount

--- a/tradeexecutor/strategy/interest.py
+++ b/tradeexecutor/strategy/interest.py
@@ -185,7 +185,12 @@ def estimate_interest(
     """Calculate new token amount, assuming fixed interest.
 
     :param interest_rate:
-        Yearly interest
+
+        Yearly interest relative to.
+
+        1 = 0%.
+
+        E.g. 1.02 for 2% yearly gained interest.
 
     :param start_quantity:
         Tokens at the start of the period
@@ -195,6 +200,10 @@ def estimate_interest(
 
         Default to the financial year.
     """
+
+    # 150x
+    assert interest_rate >= 1
+
     assert end_at >= start_at
     duration = end_at - start_at
     multiplier = (end_at - start_at) / year

--- a/tradeexecutor/strategy/interest.py
+++ b/tradeexecutor/strategy/interest.py
@@ -128,6 +128,8 @@ def update_leveraged_position_interest(
 ) -> Tuple[BalanceUpdate, BalanceUpdate]:
     """Updates accrued interest on lending protocol leveraged positions.
 
+    Updates loan interest state for both collateral and debt.
+
     :param atoken_price:
         What is the current price of aToken.
 
@@ -192,6 +194,8 @@ def estimate_interest(
 
         E.g. 1.02 for 2% yearly gained interest.
 
+        Always positive.
+
     :param start_quantity:
         Tokens at the start of the period
 
@@ -199,6 +203,9 @@ def estimate_interest(
         Year length.
 
         Default to the financial year.
+
+    :return:
+        Amount of token quantity with principal + interest after the period.
     """
 
     # 150x

--- a/tradeexecutor/strategy/lending_protocol_leverage.py
+++ b/tradeexecutor/strategy/lending_protocol_leverage.py
@@ -13,7 +13,7 @@ from tradeexecutor.state.trade import TradeExecution
 
 
 def create_credit_supply_loan(
-    position: "tradeexeecutor.state.position.TradingPosition",
+    position: "tradeexecutor.state.position.TradingPosition",
     trade: TradeExecution,
     timestamp: datetime.datetime,
 ):
@@ -62,7 +62,7 @@ def create_credit_supply_loan(
 
 
 def update_credit_supply_loan(
-    position: "tradeexeecutor.state.position.TradingPosition",
+    position: "tradeexecutor.state.position.TradingPosition",
     trade: TradeExecution,
     timestamp: datetime.datetime,
 ):
@@ -92,8 +92,9 @@ def update_credit_supply_loan(
 
 
 def create_short_loan(
-    position: "tradeexeecutor.state.position.TradingPosition",
+    position: "tradeexecutor.state.position.TradingPosition",
     trade: TradeExecution,
+    timestamp: datetime.datetime,
 ) -> Loan:
     """Create the loan data tracking for short position.
 
@@ -116,7 +117,7 @@ def create_short_loan(
     assert pair.quote.underlying, "Quote token lacks underlying asset"
 
     assert pair.base.type == AssetType.borrowed, f"Trading pair base asset is not borrowed: {pair.base}"
-    assert pair.quote.type == AssetType.collateral, f"Trading pair quote asset is not collateral: {pair.base}"
+    assert pair.quote.type == AssetType.collateral, f"Trading pair quote asset is not collateral: {pair.quote}"
 
     assert pair.quote.underlying.is_stablecoin(), f"Only stablecoin collateral supported for shorts: {pair.quote}"
 
@@ -154,8 +155,8 @@ def create_short_loan(
         pair=trade.pair,
         collateral=collateral,
         borrowed=borrowed,
-        collateral_interest=Interest.open_new(collateral.quantity),
-        borrowed_interest=Interest.open_new(borrowed.quantity),
+        collateral_interest=Interest.open_new(collateral.quantity, timestamp),
+        borrowed_interest=Interest.open_new(borrowed.quantity, timestamp),
     )
 
     # Sanity check
@@ -166,7 +167,7 @@ def create_short_loan(
 
 def plan_loan_update_for_short(
     loan: Loan,
-    position: "tradeexeecutor.state.position.TradingPosition",
+    position: "tradeexecutor.state.position.TradingPosition",
     trade: TradeExecution,
 ):
     """Update the loan data tracking for short position.

--- a/tradeexecutor/strategy/lending_protocol_leverage.py
+++ b/tradeexecutor/strategy/lending_protocol_leverage.py
@@ -15,6 +15,7 @@ from tradeexecutor.state.trade import TradeExecution
 def create_credit_supply_loan(
     position: "tradeexeecutor.state.position.TradingPosition",
     trade: TradeExecution,
+    timestamp: datetime.datetime,
 ):
     """Create a loan that supplies credit to a lending protocol.
 
@@ -49,7 +50,7 @@ def create_credit_supply_loan(
     loan = Loan(
         pair=trade.pair,
         collateral=collateral,
-        collateral_interest=Interest.open_new(trade.planned_reserve),
+        collateral_interest=Interest.open_new(trade.planned_reserve, timestamp),
         borrowed=None,
         borrowed_interest=None,
     )
@@ -63,6 +64,7 @@ def create_credit_supply_loan(
 def update_credit_supply_loan(
     position: "tradeexeecutor.state.position.TradingPosition",
     trade: TradeExecution,
+    timestamp: datetime.datetime,
 ):
     """Close/increase/reduce credit supply loan.
 

--- a/tradeexecutor/strategy/pandas_trader/position_manager.py
+++ b/tradeexecutor/strategy/pandas_trader/position_manager.py
@@ -915,6 +915,8 @@ class PositionManager:
         else:
             executor_pair = pair
 
+        shorting_pair = self.strategy_universe.get_shorting_pair(executor_pair)
+
         if type(value) == float:
             value = Decimal(value)
 
@@ -924,7 +926,7 @@ class PositionManager:
 
         position, trade, _ = self.state.trade_short(
             self.timestamp,
-            pair=executor_pair,
+            pair=shorting_pair,
             borrowed_quantity=-borrowed_quantity,
             collateral_quantity=Decimal(value),
             borrowed_asset_price=price_structure.price,

--- a/tradeexecutor/strategy/sync_model.py
+++ b/tradeexecutor/strategy/sync_model.py
@@ -136,7 +136,7 @@ class SyncModel(ABC):
             - :py:class:`tradeexecutor.ethereum.enzyme.tx.EnzymeTransactionBuilder`
         """
 
-    def sync_credit_supply(self,
+    def sync_interests(self,
                            timestamp: datetime.datetime,
                            state: State,
                            universe: TradingStrategyUniverse,


### PR DESCRIPTION
- Add `update_leveraged_position_interest` that updates both atoken and vtoken intersst amount in one go
- Add `estimate_interest` that allows to generate new atoken amount in unit tests
- Include unrealised short PnL test with interest calculations