### PR TITLE
Short position interest tests

### DIFF
--- a/tests/interest/test_state_short.py
+++ b/tests/interest/test_state_short.py
@@ -1150,7 +1150,7 @@ def test_short_unrealised_interest_and_profit(
     """Opening a short position and get some unrealised profit.
 
     - ETH price goes 1500 -> 1400 so we get unrealised PnL
-    - We have 10% interest cost on the short position
+    - We have 10% borrow cost on the ETH short position
     - We have 2% interest income on the USDC collateral
     - See ``test_short_unrealised_profit`` for a comparison calculations
       with interest payments ignored
@@ -1193,8 +1193,8 @@ def test_short_unrealised_interest_and_profit(
         1400.0,
     )
 
-    atoken_interest = 1.02
-    vtoken_interest = 1.10
+    atoken_interest = 1.02  # Receive 2% on USD collateral
+    vtoken_interest = 1.10  # Pay 10% on ETH loan
 
     # Calculate simulated interest gains
     new_atoken = estimate_interest(
@@ -1211,8 +1211,7 @@ def test_short_unrealised_interest_and_profit(
         vtoken_interest,
     )
 
-    # We have gained 15 USDC on our dollar long
-    assert new_atoken == Decimal('1815.113089799044876389054071')
+    assert new_atoken == Decimal('1815.113089799044876389054071')  # We have gained 15 USDC on our dollar long
     assert new_vtoken == Decimal('0.5552334719541217745270929036')
 
     # Tell strategy state about interest gains
@@ -1231,7 +1230,8 @@ def test_short_unrealised_interest_and_profit(
     # We gain around 15 USDC in half a year
     assert aevt.quantity == pytest.approx(Decimal('15.113089799044887491284317'))
 
-    # We need to pay ~ 0.02 ETH half a year
+    # We need to pay ~ 0.02 ETH half a year,
+    # worth 30 USD at 1400 ETH/USD
     assert vevt.quantity == pytest.approx(Decimal('0.0219001386207884485952464011'))
 
     assert aevt.get_update_period() == datetime.timedelta(days=152)

--- a/tests/interest/test_state_short.py
+++ b/tests/interest/test_state_short.py
@@ -16,6 +16,7 @@ from tradeexecutor.state.loan import calculate_sizes_for_leverage
 from tradeexecutor.state.reserve import ReservePosition
 from tradeexecutor.state.state import State
 from tradeexecutor.state.trade import TradeType
+from tradeexecutor.strategy.interest import estimate_interest, update_leveraged_position_interest
 from tradeexecutor.testing.unit_test_trader import UnitTestTrader
 from tradingstrategy.chain import ChainId
 from tradingstrategy.lending import LendingProtocolType
@@ -956,3 +957,304 @@ def test_short_unrealised_profit_leveraged(
     assert short_position.get_realised_profit_usd() == pytest.approx(133.333333)
     assert short_position.get_unrealised_profit_usd() == 0
     assert portfolio.get_cash() == pytest.approx(10133.333333)
+
+
+def test_short_unrealised_profit(
+        state: State,
+        weth_short_identifier: TradingPairIdentifier,
+        usdc: AssetIdentifier,
+):
+    """Opening a short position and get some unrealised profit.
+
+    - ETH price goes 1500 -> 1400 so we get unrealised PnL
+
+    """
+
+    trader = UnitTestTrader(state)
+
+    # Aave allows us to borrow 80% ETH against our USDC collateral
+    start_ltv = 0.8
+
+    # How many ETH (vWETH) we expect when we go in
+    # with our max leverage available
+    # based on the collateral ratio
+    expected_eth_shorted_amount = 1000 * start_ltv / 1500
+
+    # Take 1000 USDC reserves and open a ETH short using it.
+    # We should get 800 USDC worth of ETH for this.
+    short_position, trade, created = state.trade_short(
+        strategy_cycle_at=datetime.datetime.utcnow(),
+        pair=weth_short_identifier,
+        borrowed_quantity=-Decimal(expected_eth_shorted_amount),
+        collateral_quantity=Decimal(1000),
+        borrowed_asset_price=float(1500),  # USDC/ETH price we are going to sell
+        trade_type=TradeType.rebalance,
+        reserve_currency=usdc,
+        collateral_asset_price=1.0,
+    )
+
+    trader.set_perfectly_executed(trade)
+    assert state.portfolio.get_total_equity() == 10000
+
+    # ETH price 1500 -> 1400
+    short_position.revalue_base_asset(
+        datetime.datetime.utcnow(),
+        1400.0,
+    )
+
+    # New ETH loan worth of 746.6666666666666 USD
+    assert short_position.get_current_price() == 1400
+    assert short_position.get_average_price() == 1500
+    assert short_position.get_unrealised_profit_usd() == pytest.approx(800 - 746.6666666666666)
+    assert short_position.get_realised_profit_usd() is None
+
+    loan = short_position.loan
+    assert loan.borrowed.quantity == pytest.approx(Decimal(expected_eth_shorted_amount))
+    assert loan.borrowed.asset.token_symbol == "variableDebtPolWETH"
+    assert loan.borrowed.asset.underlying.token_symbol == "WETH"
+    assert loan.borrowed.last_usd_price == 1400
+    assert loan.get_loan_to_value() == pytest.approx(0.4148148148148148)
+
+    # Check that we track the equity value correctly
+    assert state.portfolio.get_loan_net_asset_value() == pytest.approx(1053.3333333333335)
+    assert state.portfolio.get_cash() == 9000
+    assert state.portfolio.get_net_asset_value() == pytest.approx(10053.333333333334)
+
+
+def test_short_unrealised_profit_partially_closed_keep_collateral(
+        state: State,
+        weth_short_identifier: TradingPairIdentifier,
+        usdc: AssetIdentifier,
+):
+    """Opening a short position and get some unrealised profit.
+
+    - ETH price goes 1500 -> 1400 so we get USD 56 unrealised PnL
+
+    - Close 50% of this position at this price, we get USD 27 realised profit
+
+    - Any closed profit is kept on the collateral
+    """
+
+    trader = UnitTestTrader(state)
+
+    portfolio = state.portfolio
+
+    # Start by shorting  ETH 2:1 with 1000 USD
+    expected_eth_shorted_amount = 1000 / 1500
+
+    # Take 1000 USDC reserves and open a ETH short using it.
+    # We should get 800 USDC worth of ETH for this.
+    # 800 USDC worth of ETH is
+    short_position, trade, created = state.create_trade(
+        strategy_cycle_at=datetime.datetime.utcnow(),
+        pair=weth_short_identifier,
+        quantity=-Decimal(expected_eth_shorted_amount),
+        reserve=Decimal(1000),
+        assumed_price=float(1500),  # USDC/ETH price we are going to sell
+        trade_type=TradeType.rebalance,
+        reserve_currency=usdc,
+        reserve_currency_price=1.0,
+    )
+
+    assert trade.planned_loan_update is not None
+    assert trade.executed_loan_update is None
+    trader.set_perfectly_executed(trade)
+    assert trade.planned_loan_update is not None
+    assert trade.executed_loan_update is not None
+
+    loan = short_position.loan
+    assert loan.borrowed.quantity == pytest.approx(Decimal(expected_eth_shorted_amount))
+    assert loan.collateral.quantity == pytest.approx(2000)
+    assert loan.get_leverage() == 2.0
+
+    assert portfolio.get_total_equity() == 10000
+    assert portfolio.get_cash() == 9000
+
+    # ETH price 1500 -> 1400
+    short_position.revalue_base_asset(
+        datetime.datetime.utcnow(),
+        1400.0,
+    )
+
+    # Loan value 1000 USD -> 933 USD
+    assert short_position.loan.borrowed.get_usd_value() == pytest.approx(933.3333333333333)
+
+    # Close 50% of the position
+    #
+    short_position_ref_2, trade_2, created = state.trade_short(
+        strategy_cycle_at=datetime.datetime.utcnow(),
+        pair=weth_short_identifier,
+        # Position quantity for short position means reduce the position
+        borrowed_quantity=Decimal(expected_eth_shorted_amount / 2),  # Short position quantity is counted as negative. When we close the quantity goes towards zero from neagtive.
+        collateral_quantity=Decimal(0),  # Reserve will be calculated generated from the released collateral
+        borrowed_asset_price=float(1400),  # USDC/ETH price we are going to sell
+        trade_type=TradeType.rebalance,
+        reserve_currency=usdc,
+        collateral_asset_price=1.0,
+    )
+
+    # Loan does not change until the trade is executed
+    assert short_position_ref_2 == short_position
+    assert not created
+    assert short_position.loan.borrowed.quantity == pytest.approx(Decimal(expected_eth_shorted_amount))
+
+    # Trade 2 will be excuted,
+    # planned loan update moves sto executed
+    # we get rid of half of the position
+    assert trade_2.planned_loan_update is not None
+    assert trade_2.executed_loan_update is None
+    trader.set_perfectly_executed(trade_2)
+    assert trade_2.planned_loan_update is not None
+    assert trade_2.executed_loan_update is not None
+    assert trade_2.planned_quantity == pytest.approx(Decimal(expected_eth_shorted_amount / 2))
+    assert trade_2.executed_quantity == pytest.approx(Decimal(expected_eth_shorted_amount / 2))
+    assert trade_2.planned_reserve == pytest.approx(Decimal(0))
+    assert trade_2.executed_reserve == pytest.approx(Decimal(0))
+
+    # Because we closed half, we realised 50% of profit, left 50% profit on the table.
+    total_profit = (1500-1400) * expected_eth_shorted_amount
+    assert total_profit == pytest.approx(66.6666666)
+    assert short_position.get_current_price() == 1400
+    assert short_position.get_average_price() == 1500
+    assert short_position.get_unrealised_profit_usd() == pytest.approx(total_profit / 2)
+    assert short_position.get_realised_profit_usd() == pytest.approx(total_profit / 2)
+
+    # Loan is 50% reduced from 0.53 ETH to 0.26 ETH.
+    # We buy the ETH to repay using the USDC loan from collateral
+    loan = short_position.loan
+    released_collateral = 1400 * expected_eth_shorted_amount / 2
+    assert released_collateral == pytest.approx(466.66666666666663)
+    left_collateral = Decimal(2000 - released_collateral)
+    assert left_collateral == pytest.approx(Decimal(1533.33333333333348491578362882137298583984375))
+    assert loan.collateral.quantity == pytest.approx(left_collateral)
+    assert loan.collateral.get_usd_value() == pytest.approx(float(left_collateral))
+    assert loan.borrowed.quantity == pytest.approx(Decimal(expected_eth_shorted_amount / 2))
+    assert loan.borrowed.last_usd_price == 1400
+    assert loan.borrowed.get_usd_value() == pytest.approx(466.66666666666663)
+    assert loan.get_loan_to_value() == pytest.approx(0.3043478260869565)
+    assert loan.get_leverage() == pytest.approx(1.4375000000000002)
+
+    # Check that we track the portfolio value correctly
+    # after realising profit
+    assert portfolio.get_cash() == 9000  # No changes in cash, because we paid back from the collateral
+    assert portfolio.get_net_asset_value() == pytest.approx(10066.66666)  # Should be same with our without reducing position as we have no fees, see test above
+    assert portfolio.get_loan_net_asset_value() == pytest.approx(1066.6666666666665)
+    assert portfolio.get_total_equity() == pytest.approx(10066.666)  # Any profits from closed short positions are not moved to equity, unless told so
+
+
+def test_short_unrealised_interest_and_profit(
+        state: State,
+        weth_short_identifier: TradingPairIdentifier,
+        usdc: AssetIdentifier,
+):
+    """Opening a short position and get some unrealised profit.
+
+    - ETH price goes 1500 -> 1400 so we get unrealised PnL
+    - We have 10% interest cost on the short position
+    - We have 2% interest income on the USDC collateral
+    """
+
+    trader = UnitTestTrader(state)
+
+    # Aave allows us to borrow 80% ETH against our USDC collateral
+    start_ltv = 0.8
+
+    # How many ETH (vWETH) we expect when we go in
+    # with our max leverage available
+    # based on the collateral ratio
+    expected_eth_shorted_amount = 1000 * start_ltv / 1500
+
+    start_at = datetime.datetime(2020, 1, 1)
+
+    # Take 1000 USDC reserves and open a ETH short using it.
+    # We should get 800 USDC worth of ETH for this.
+    short_position, trade, created = state.trade_short(
+        strategy_cycle_at=start_at,
+        pair=weth_short_identifier,
+        borrowed_quantity=-Decimal(expected_eth_shorted_amount),
+        collateral_quantity=Decimal(1000),
+        borrowed_asset_price=float(1500),  # USDC/ETH price we are going to sell
+        trade_type=TradeType.rebalance,
+        reserve_currency=usdc,
+        collateral_asset_price=1.0,
+    )
+
+    trader.set_perfectly_executed(trade)
+    assert state.portfolio.get_total_equity() == 10000
+
+    # Move forward half a year
+    now_at = datetime.datetime(2020, 6, 1)
+
+    # ETH price 1500 -> 1400
+    short_position.revalue_base_asset(
+        datetime.datetime.utcnow(),
+        1400.0,
+    )
+
+    atoken_interest = 1.02
+    vtoken_interest = -1.10
+
+    # Calculate simulated interest gains
+    new_atoken = estimate_interest(
+        start_at,
+        now_at,
+        short_position.loan.collateral.quantity,
+        atoken_interest,
+    )
+
+    new_vtoken = estimate_interest(
+        start_at,
+        now_at,
+        short_position.loan.borrowed.quantity,
+        vtoken_interest,
+    )
+
+    # We have gained 15 USDC on our dollar long
+    assert new_atoken == Decimal('1815.113089799044876389054071')
+
+    # assert Decimal('-0.5552334719541217745270929036')
+    import ipdb ; ipdb.set_trace()
+
+    # Tell strategy state about interest gains
+    # Note that this BalanceUpdate event
+    # is not stored with the state
+    vevt, aevt = update_leveraged_position_interest(
+        state,
+        short_position,
+        new_vtoken,
+        new_atoken,
+        now_at,
+        vtoken_price=1400.0,
+        atoken_price=1.0,
+    )
+
+    # We gain around 15 USDC in half a year
+    assert aevt.quantity == pytest.approx(Decimal('15.113089799044887491284317'))
+
+    # We gain around 15 USDC in half a year
+    assert vevt.quantity == pytest.approx(Decimal('15.113089799044887491284317'))
+
+    assert aevt.get_update_period() == datetime.timedelta(days=152)
+    assert vevt.get_update_period() == datetime.timedelta(days=152)
+    assert aevt.get_effective_yearly_yield() == pytest.approx(0.02)
+    assert vevt.get_effective_yearly_yield() == pytest.approx(-0.10)
+
+    import ipdb ; ipdb.set_trace()
+
+    # New ETH loan worth of 746.6666666666666 USD
+    assert short_position.get_current_price() == 1400
+    assert short_position.get_average_price() == 1500
+    assert short_position.get_unrealised_profit_usd() == pytest.approx(800 - 746.6666666666666)
+    assert short_position.get_realised_profit_usd() is None
+
+    loan = short_position.loan
+    assert loan.borrowed.quantity == pytest.approx(Decimal(expected_eth_shorted_amount))
+    assert loan.borrowed.asset.token_symbol == "variableDebtPolWETH"
+    assert loan.borrowed.asset.underlying.token_symbol == "WETH"
+    assert loan.borrowed.last_usd_price == 1400
+    assert loan.get_loan_to_value() == pytest.approx(0.4148148148148148)
+
+    # Check that we track the equity value correctly
+    assert state.portfolio.get_loan_net_asset_value() == pytest.approx(1053.3333333333335)
+    assert state.portfolio.get_cash() == 9000
+    assert state.portfolio.get_net_asset_value() == pytest.approx(10053.333333333334)

--- a/tradeexecutor/state/balance_update.py
+++ b/tradeexecutor/state/balance_update.py
@@ -209,7 +209,9 @@ class BalanceUpdate:
         - Calculated in tokens (exchange rate immune)
 
         :return:
-            E.g. 2% for 2% yearly interest.
+            1-based interest.
+
+            E.g. 1.02 for 2% yearly gained interest. 0.9 for 10% yearly paid interest.
 
             Positive if we are gaining interest, negative if we are paying interest.
 

--- a/tradeexecutor/state/balance_update.py
+++ b/tradeexecutor/state/balance_update.py
@@ -15,7 +15,7 @@ from typing import Optional
 from dataclasses_json import dataclass_json
 
 from tradeexecutor.state.identifier import AssetIdentifier
-from tradingstrategy.types import USDollarAmount
+from tradingstrategy.types import USDollarAmount, Percent
 
 
 class BalanceUpdateCause(enum.Enum):
@@ -82,7 +82,6 @@ class BalanceUpdate:
     #:
     #: The strategy cycle timestamp.
     #:
-    #:
     #: It might be outside the cycle frequency if treasuries were processed
     #: in a cron job outside the cycle for slow moving strategies.
     #:
@@ -113,6 +112,15 @@ class BalanceUpdate:
     #: Wall clock time when this event was created
     #:
     created_at: datetime.datetime | None = field(default_factory=datetime.datetime.utcnow)
+
+    #: What was the event time of the previous update.
+    #:
+    #: This allows us to calculate the effective interest rate
+    #: between the update cycles.
+    #:
+    #: This is the same as :py:attr:`block_mined_at` of the previous event.
+    #:
+    previous_update_at: datetime.datetime | None = None
 
     #: Investor address that the balance update is related to
     #:
@@ -146,6 +154,9 @@ class BalanceUpdate:
     def __post_init__(self):
         assert self.quantity != 0, "Balance update cannot be zero: {self}"
 
+        if self.previous_update_at:
+            assert self.previous_update_at <= self.block_mined_at, f"Travelling back in time: {self.previous_update_at} - {self.block_mined_at}"
+
     def __repr__(self):
         if self.position_id:
             position_name = f"position #{self.position_id}"
@@ -177,4 +188,37 @@ class BalanceUpdate:
         """Return whether this event updates reserve balance or open position balance"""
         return self.position_type == BalanceUpdatePositionType.reserve
 
+    def get_update_period(self) -> datetime.timedelta | None:
+        """How long it was between this event and previous sync event.
 
+        :return:
+            None if only inital update made
+        """
+        if not self.previous_update_at:
+            return None
+
+        return (self.block_mined_at - self.previous_update_at)
+
+    def get_effective_yearly_yield(self, year=datetime.timedelta(days=360)) -> Percent | None:
+        """How much we are gaining % yearly.
+
+        - Based on the this balance update and the previous balance update
+
+        - Mostly useful for interest rate events
+
+        - Calculated in tokens (exchange rate immune)
+
+        :return:
+            E.g. 2% for 2% yearly interest.
+
+            Positive if we are gaining interest, negative if we are paying interest.
+
+            ``None``  if no update period available
+        """
+
+        period = self.get_update_period()
+        if not period:
+            return None
+        gain = self.quantity / self.old_balance
+
+        return float(gain) * period / year

--- a/tradeexecutor/state/balance_update.py
+++ b/tradeexecutor/state/balance_update.py
@@ -220,5 +220,4 @@ class BalanceUpdate:
         if not period:
             return None
         gain = self.quantity / self.old_balance
-
-        return float(gain) * period / year
+        return float(gain) / (period / year)

--- a/tradeexecutor/state/loan.py
+++ b/tradeexecutor/state/loan.py
@@ -107,7 +107,7 @@ class Loan:
         return self.borrowed.get_usd_value()
 
     def get_borrow_interest(self) -> USDollarAmount:
-        """How much interest we have paid on borrows
+        """How much interest we have paid on borrows.
 
         :return:
             Always positive

--- a/tradeexecutor/state/position.py
+++ b/tradeexecutor/state/position.py
@@ -1352,6 +1352,8 @@ class TradingPosition(GenericPosition):
           been moved to reserves from this position.
 
         :return:
+            Net interest PnL in USD.
+
             Positive if we have earned interest, negative if we have paid it.
         """
 

--- a/tradeexecutor/strategy/interest.py
+++ b/tradeexecutor/strategy/interest.py
@@ -185,7 +185,12 @@ def estimate_interest(
     """Calculate new token amount, assuming fixed interest.
 
     :param interest_rate:
-        Yearly interest
+
+        Yearly interest relative to.
+
+        1 = 0%.
+
+        E.g. 1.02 for 2% yearly gained interest.
 
     :param start_quantity:
         Tokens at the start of the period
@@ -195,6 +200,10 @@ def estimate_interest(
 
         Default to the financial year.
     """
+
+    # 150x
+    assert interest_rate >= 1
+
     assert end_at >= start_at
     duration = end_at - start_at
     multiplier = (end_at - start_at) / year

--- a/tradeexecutor/strategy/interest.py
+++ b/tradeexecutor/strategy/interest.py
@@ -128,6 +128,8 @@ def update_leveraged_position_interest(
 ) -> Tuple[BalanceUpdate, BalanceUpdate]:
     """Updates accrued interest on lending protocol leveraged positions.
 
+    Updates loan interest state for both collateral and debt.
+
     :param atoken_price:
         What is the current price of aToken.
 
@@ -192,6 +194,8 @@ def estimate_interest(
 
         E.g. 1.02 for 2% yearly gained interest.
 
+        Always positive.
+
     :param start_quantity:
         Tokens at the start of the period
 
@@ -199,6 +203,9 @@ def estimate_interest(
         Year length.
 
         Default to the financial year.
+
+    :return:
+        Amount of token quantity with principal + interest after the period.
     """
 
     # 150x


### PR DESCRIPTION
- We need to pass the US dollar price of `vToken` for some calculations to be correct
- Add `update_leveraged_position_interest` that updates both atoken and vtoken intersst amount in one go
- Add `estimate_interest` that allows to generate new atoken amount in unit tests
- Include unrealised short PnL test with interest calculations