### PR TITLE
Valuation changes

### DIFF
--- a/tests/interest/test_state_short.py
+++ b/tests/interest/test_state_short.py
@@ -1364,7 +1364,7 @@ def test_short_unrealised_interest_and_losses(
 
     # We go red
     assert state.portfolio.get_loan_net_asset_value() == pytest.approx(556)
-    assert state.portfolio.get_net_asset_value() == pytest.approx(9556.266666666666)
+    assert state.portfolio.get_net_asset_value() == pytest.approx(9556)
 
 
 def test_short_realised_interest_and_profit(
@@ -1450,11 +1450,11 @@ def test_short_realised_interest_and_profit(
     assert short_position.get_quantity() == pytest.approx(Decimal('-0.5552334719541217745270929036'))
 
     # Calculate unrealised and realised PnL
-    assert short_position.loan.get_collateral_interest() == pytest.approx(15.134989937665676)
+    assert short_position.loan.get_collateral_interest() == pytest.approx(15.113089799044888)
     assert short_position.loan.get_borrow_interest() == pytest.approx(30.66019406910382)
-    assert short_position.get_accrued_interest() == pytest.approx(-15.525204131438151)
+    assert short_position.get_accrued_interest() == pytest.approx(-15.54710427005894)
     assert short_position.get_unrealised_profit_usd(include_interest=False) == pytest.approx(55.52334719541218)
-    assert short_position.get_unrealised_profit_usd(include_interest=True) == pytest.approx(39.99814306397403)
+    assert short_position.get_unrealised_profit_usd(include_interest=True) == pytest.approx(39.97624292535324)
     assert short_position.get_realised_profit_usd() is None
 
     # Prepare a closing trade and check it matches full vToken amount
@@ -1485,7 +1485,7 @@ def test_short_realised_interest_and_profit(
     assert trade_2.get_value() == pytest.approx(777.3268607357704)
 
     # How much USDC gained we got from the collateral
-    assert trade_2.claimed_interest == pytest.approx(Decimal('15.13498993766567593987956340'))
+    assert trade_2.claimed_interest == pytest.approx(Decimal('15.113089799044887491284317'))
 
     # How much ETH this trade paid in interest cose
     assert trade_2.paid_interest == pytest.approx(Decimal('0.0219001386207884485952464011'))
@@ -1502,6 +1502,6 @@ def test_short_realised_interest_and_profit(
     assert short_position.is_closed()
     assert short_position.get_unrealised_profit_usd() == 0
     assert short_position.get_repaid_interest() == pytest.approx(30.660194069103827)
-    assert short_position.get_claimed_interest() == pytest.approx(15.134989937665676)  # Profit we got from collateral interest
+    assert short_position.get_claimed_interest() == pytest.approx(15.113089799044887491284317)  # Profit we got from collateral interest
     assert short_position.get_realised_profit_usd(include_interest=False) == pytest.approx(55.52334719541218)
-    assert short_position.get_realised_profit_usd(include_interest=True) == pytest.approx(39.99814306397403)
+    assert short_position.get_realised_profit_usd(include_interest=True) == pytest.approx(39.97624292535325)

--- a/tests/mainnet_fork/test_frozen_position_and_blacklist.py
+++ b/tests/mainnet_fork/test_frozen_position_and_blacklist.py
@@ -57,6 +57,7 @@ from tradeexecutor.strategy.bootstrap import import_strategy_file
 from tradeexecutor.strategy.description import StrategyExecutionDescription
 from tradeexecutor.strategy.runner import StrategyRunner
 from tradeexecutor.cli.log import setup_pytest_logging
+from tradeexecutor.strategy.valuation import revalue_state
 
 # https://docs.pytest.org/en/latest/how-to/skipping.html#skip-all-test-functions-of-a-class-or-module
 from tradeexecutor.utils.timer import timed_task
@@ -390,7 +391,7 @@ def test_buy_and_sell_blacklisted_asset(
     # 2nd day - cannot sell BIT
     #
     ts = datetime.datetime(2020, 1, 2)
-    state.revalue_positions(ts, UniswapV2PoolValuationMethodV0(pancakeswap_v2))
+    revalue_state(state, ts, UniswapV2PoolValuationMethodV0(pancakeswap_v2))
     debug_details = runner.tick(ts, executor_universe, state, {"cycle": 2, "check_balances": True})
     weights = debug_details["alpha_model_weights"]
 
@@ -428,7 +429,7 @@ def test_buy_and_sell_blacklisted_asset(
     # the alpha model ignores it as a blacklisted asset
     #
     ts = datetime.datetime(2020, 1, 3)
-    state.revalue_positions(ts, UniswapV2PoolValuationMethodV0(pancakeswap_v2))
+    revalue_state(state, ts, UniswapV2PoolValuationMethodV0(pancakeswap_v2))
     debug_details = runner.tick(ts, executor_universe, state, {"cycle": 3})
     weights = debug_details["alpha_model_weights"]
     assert weights[wbnb_busd.pair_id] == 1.0

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -585,7 +585,7 @@ def test_revalue(usdc, weth_usdc, start_ts: datetime.datetime):
         # ETH drops 50%
         return revalue_date, 850.0
 
-    revalue_state(state, start_ts, value_asset)
+    revalue_state(state, revalue_date, value_asset)
 
     assert position.last_pricing_at == revalue_date
     assert position.last_token_price == 850.0

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -23,6 +23,7 @@ from tradeexecutor.state.reserve import ReservePosition
 from tradeexecutor.state.identifier import AssetIdentifier, TradingPairIdentifier
 from tradeexecutor.state.validator import validate_nested_state_dict, BadStateData
 from tradeexecutor.statistics.core import update_statistics
+from tradeexecutor.strategy.valuation import revalue_state
 from tradeexecutor.testing.unit_test_trader import UnitTestTrader
 from tradingstrategy.chain import ChainId
 from tradingstrategy.types import USDollarAmount
@@ -584,7 +585,7 @@ def test_revalue(usdc, weth_usdc, start_ts: datetime.datetime):
         # ETH drops 50%
         return revalue_date, 850.0
 
-    state.revalue_positions(start_ts, value_asset)
+    revalue_state(state, start_ts, value_asset)
 
     assert position.last_pricing_at == revalue_date
     assert position.last_token_price == 850.0
@@ -688,7 +689,7 @@ def test_unrealised_profit_calculation(usdc, weth_usdc, start_ts: datetime.datet
             return ts, float(self.price)
 
     # Revalue ETH to 1500 USD
-    state.revalue_positions(start_ts, EthValuator(1500))
+    revalue_state(state, start_ts, EthValuator(1500))
     assert position.is_open()
     assert position.is_long()  # No change here
     assert position.get_realised_profit_usd() is None
@@ -696,12 +697,12 @@ def test_unrealised_profit_calculation(usdc, weth_usdc, start_ts: datetime.datet
     assert position.get_total_profit_percent() == pytest.approx(-0.15094339622641514)
 
     # Revalue ETH to 2000 USD, we are on green
-    state.revalue_positions(start_ts, EthValuator(2000))
+    revalue_state(state, start_ts, EthValuator(2000))
     assert position.get_unrealised_profit_usd() == pytest.approx(350)
     assert position.get_total_profit_percent() == pytest.approx(0.13207547169811318)
 
     # Sell half, gain 50% of the profit of the test_realised_profit_calculation
-    state.revalue_positions(start_ts, EthValuator(1850))
+    revalue_state(state, start_ts, EthValuator(1850))
     position, trade = trader.sell(weth_usdc, Decimal("0.75"), 1850.0)
     received = 1850 * 0.75
     assert not position.is_closed()

--- a/tradeexecutor/backtest/backtest_sync.py
+++ b/tradeexecutor/backtest/backtest_sync.py
@@ -234,11 +234,14 @@ class BacktestSyncModel(SyncModel):
                 new_atoken_amount = p.loan.collateral_interest.last_token_amount + accrued_collateral_interest
                 new_vtoken_amount = p.loan.borrowed_interest.last_token_amount + accrued_borrow_interest
 
-                # TODO: hardcode, need to replace with proper price
                 atoken_price = 1.0
-                vtoken_price = 1800.0
 
-                import ipdb ; ipdb.set_trace()
+                vtoken_price_structure = pricing_model.get_sell_price(
+                    timestamp,
+                    p.pair.get_pricing_pair(),
+                    p.loan.borrowed.quantity,
+                )
+                vtoken_price = vtoken_price_structure.price
 
                 vevt, aevt = update_leveraged_position_interest(
                     state,

--- a/tradeexecutor/backtest/backtest_sync.py
+++ b/tradeexecutor/backtest/backtest_sync.py
@@ -14,6 +14,7 @@ from tradeexecutor.state.position import TradingPosition
 from tradeexecutor.state.state import State
 from tradeexecutor.state.types import JSONHexAddress
 from tradeexecutor.strategy.interest import update_interest, update_leveraged_position_interest
+from tradeexecutor.strategy.pricing_model import PricingModel
 from tradeexecutor.strategy.sync_model import SyncModel
 from tradeexecutor.strategy.trading_strategy_universe import TradingStrategyUniverse
 from tradeexecutor.testing.dummy_wallet import apply_sync_events
@@ -177,6 +178,7 @@ class BacktestSyncModel(SyncModel):
         state: State,
         universe: TradingStrategyUniverse,
         positions: List[TradingPosition],
+        pricing_model: PricingModel,
     ) -> List[BalanceUpdate]:
 
         assert universe.has_lending_data(), "Cannot update credit positions if no data is available"
@@ -235,6 +237,8 @@ class BacktestSyncModel(SyncModel):
                 # TODO: hardcode, need to replace with proper price
                 atoken_price = 1.0
                 vtoken_price = 1800.0
+
+                import ipdb ; ipdb.set_trace()
 
                 vevt, aevt = update_leveraged_position_interest(
                     state,

--- a/tradeexecutor/backtest/backtest_valuation.py
+++ b/tradeexecutor/backtest/backtest_valuation.py
@@ -32,10 +32,12 @@ class BacktestValuationModel(ValuationModel):
             trade_price = self.pricing_model.get_sell_price(ts, pair, quantity)
             return ts, float(trade_price.price)
         else:
+
+            # TODO: Use position net asset pricing for leveraged positions
             assert pair.kind == TradingPairKind.lending_protocol_short
-            
             quantity = -position.get_quantity()
             trade_price = self.pricing_model.get_sell_price(ts, pair.underlying_spot_pair, quantity)
+
             return ts, float(trade_price.price)
 
 

--- a/tradeexecutor/cli/loop.py
+++ b/tradeexecutor/cli/loop.py
@@ -449,11 +449,17 @@ class ExecutionLoop:
         to_be_synced = credit_positions + leverage_positions
         if to_be_synced:
             logger.info("We have %d credit positions and %d leverage positions open", len(credit_positions), len(leverage_positions))
+
+            # TODO: This setup repeated in tick().
+            # Modify tick() to take these as argument
+            routing_state, pricing_model, valuation_model = self.runner.setup_routing(universe)
+
             sync_events = self.sync_model.sync_interests(
                 strategy_cycle_timestamp,
                 state,
                 cast(TradingStrategyUniverse, universe),
                 to_be_synced,
+                pricing_model,
             )
             logger.info("Generated %d sync interest events", len(sync_events))
 
@@ -539,7 +545,7 @@ class ExecutionLoop:
 
         with self.timed_task_context_manager("revalue_portfolio_statistics"):
             logger.info("Updating position valuations")
-            self.runner.revalue_portfolio(clock, state, valuation_method)
+            self.runner.revalue_state(clock, state, valuation_method)
 
         with self.timed_task_context_manager("update_statistics"):
             logger.info("Updating position statistics after revaluation")

--- a/tradeexecutor/state/position.py
+++ b/tradeexecutor/state/position.py
@@ -536,9 +536,10 @@ class TradingPosition(GenericPosition):
     ) -> USDollarAmount:
         """Calculate the value of this position using the given prices."""
 
+        assert self.is_spot_market()
+
         token_quantity = sum([t.get_equity_for_position() for t in self.trades.values() if t.is_accounted_for_equity()])
 
-        if
         if include_interest:
             raise NotImplementedError()
 

--- a/tradeexecutor/state/position.py
+++ b/tradeexecutor/state/position.py
@@ -536,8 +536,6 @@ class TradingPosition(GenericPosition):
     ) -> USDollarAmount:
         """Calculate the value of this position using the given prices."""
 
-        assert self.is_spot_market()
-
         token_quantity = sum([t.get_equity_for_position() for t in self.trades.values() if t.is_accounted_for_equity()])
 
         if include_interest:
@@ -550,13 +548,23 @@ class TradingPosition(GenericPosition):
     def get_equity(self) -> USDollarAmount:
         """Get equity tied to this position.
 
+        TODO: Use :py:meth:`TradingPosition.loan.get_net_asset_value` for collateral based positions.
+
         :return:
+            How much equity we have tied in this position.
+
+            TODO: Does not work for collateral positions.
         """
 
         match self.pair.kind:
             case TradingPairKind.spot_market_hold:
-                return self.calculate_value_using_price(self.last_token_price, self.last_reserve_price)
+                return self.calculate_value_using_price(
+                    self.last_token_price,
+                    self.last_reserve_price,
+                    include_interest=False,
+                )
             case _:
+                # TODO: U
                 return 0
 
     def get_value(self, include_interest=True) -> USDollarAmount:

--- a/tradeexecutor/state/position.py
+++ b/tradeexecutor/state/position.py
@@ -538,8 +538,9 @@ class TradingPosition(GenericPosition):
 
         token_quantity = sum([t.get_equity_for_position() for t in self.trades.values() if t.is_accounted_for_equity()])
 
+        if
         if include_interest:
-            token_quantity += self.calculate_accrued_interest_quantity()
+            raise NotImplementedError()
 
         reserve_quantity = sum([t.get_equity_for_reserve() for t in self.trades.values() if t.is_accounted_for_equity()])
 

--- a/tradeexecutor/state/state.py
+++ b/tradeexecutor/state/state.py
@@ -648,7 +648,7 @@ class State:
 
         Reserves are not revalued.
         """
-        self.portfolio.revalue_positions(ts, valuation_method)
+        raise RuntimeError(f"Removed. Use valuation.revalue_state()")
 
     def blacklist_asset(self, asset: AssetIdentifier):
         """Add a asset to the blacklist."""

--- a/tradeexecutor/strategy/pandas_trader/position_manager.py
+++ b/tradeexecutor/strategy/pandas_trader/position_manager.py
@@ -935,7 +935,8 @@ class PositionManager:
         if type(value) == float:
             value = Decimal(value)
 
-        price_structure = self.pricing_model.get_sell_price(self.timestamp, executor_pair, value)
+        pricing_pair = shorting_pair.get_pricing_pair()  # should be effectively the same as executor_pair
+        price_structure = self.pricing_model.get_sell_price(self.timestamp, pricing_pair, value)
 
         # TODO: verify calculation here and we should output the liquidation price here
         # so it should be taken into account for stoploss

--- a/tradeexecutor/strategy/sync_model.py
+++ b/tradeexecutor/strategy/sync_model.py
@@ -18,6 +18,7 @@ from tradeexecutor.state.state import State
 from tradeexecutor.state.sync import BalanceEventRef
 from tradeexecutor.state.types import JSONHexAddress
 from tradeexecutor.strategy.trading_strategy_universe import TradingStrategyUniverse
+from tradeexecutor.strategy.pricing_model import PricingModel
 
 # Prototype sync method that is not applicable to the future production usage
 SyncMethodV0 = Callable[[Portfolio, datetime.datetime, List[AssetIdentifier]], List[ReserveUpdateEvent]]
@@ -136,12 +137,14 @@ class SyncModel(ABC):
             - :py:class:`tradeexecutor.ethereum.enzyme.tx.EnzymeTransactionBuilder`
         """
 
-    def sync_interests(self,
-                           timestamp: datetime.datetime,
-                           state: State,
-                           universe: TradingStrategyUniverse,
-                           credit_positions: List[TradingPosition],
-                           ) -> List[BalanceUpdate]:
+    def sync_interests(
+            self,
+            timestamp: datetime.datetime,
+            state: State,
+            universe: TradingStrategyUniverse,
+            credit_positions: List[TradingPosition],
+            pricing_model: PricingModel,
+    ) -> List[BalanceUpdate]:
         """Update all credit supply positions.
 
         :param timestamp:
@@ -157,6 +160,9 @@ class SyncModel(ABC):
 
         :param credit_positions:
             Prefiltered list of credit positions to update.
+
+        :param pricing_model:
+            Used to re-value loans
 
         :return:
             All triggered balance update events

--- a/tradeexecutor/strategy/valuation.py
+++ b/tradeexecutor/strategy/valuation.py
@@ -90,7 +90,6 @@ class ValuationModel(ABC):
 
         positions = portfolio.get_open_and_frozen_positions() if revalue_frozen else portfolio.open_positions.values()
 
-
         for p in positions:
             try:
                 self.revalue_position(ts, p)

--- a/tradeexecutor/strategy/valuation.py
+++ b/tradeexecutor/strategy/valuation.py
@@ -12,12 +12,19 @@ For the simplest case, we take all open positions and estimate their sell
 value at the open market.
 """
 import datetime
+from abc import abstractmethod
 from typing import Protocol, Tuple
 
 from tradingstrategy.types import USDollarAmount
 
+from tradeexecutor.state.portfolio import Portfolio
 from tradeexecutor.state.position import TradingPosition
+from tradeexecutor.state.state import State
 from tradeexecutor.strategy.pricing_model import PricingModel
+
+
+class InvalidValuationOutput(Exception):
+    """Valuation model did not generate proper price value."""
 
 
 
@@ -29,20 +36,81 @@ class ValuationModel(Protocol):
     Used by EthereumPoolRevaluator model (which, in turn, is used by UniswapV2PoolRevaluator and UniswapV3PoolRevaluator)
     """
 
+    def revalue_position(
+        self,
+        ts: datetime.datetime,
+        position: TradingPosition,
+    ):
+        """Re-value a trading position.
+
+        - Read the spot, collateral and loan values from the pricing model
+
+        - Write the new position valuation data to the state
+
+        - For spot pairs, refresh :py:attr:`TradingPosition.last_token_price` through
+          :py:meth:`TradingPosition.revalue_base_asset`.
+
+        - For leveraged positions, refresh both collateral and borrowed asset
+        """
+        if not position.is_credit_supply():
+            spot_pair = position.pair.get_pricing_pair()
+            ts, price = self(ts, spot_pair)
+
+            position.revalue_base_asset(ts, price)
+            # TODO: Query price for the collateral asset and set it
+
+    def revalue_portfolio(
+        self,
+        ts: datetime.datetime,
+        portfolio: Portfolio,
+        revalue_frozen=True,
+    ):
+        """Revalue all open positions in the portfolio.
+
+        - Reserves are not revalued
+        - Credit supply positions are not revalued
+
+        :param ts:
+            Timestamp.
+
+            Strategy cycle time if valuation performed in pre-tick.
+            otherwise wall clock time.
+
+        :param valuation_model:
+            The model we use to reassign values to the positions
+
+        :param revalue_frozen:
+            Revalue frozen positions as well
+        """
+        try:
+            for p in portfolio.open_positions.values():
+                self.revalue_position(ts, p)
+
+            if revalue_frozen:
+                for portfolio in self.frozen_positions.values():
+                    self.revalue_position(ts, p)
+
+        except Exception as e:
+            raise InvalidValuationOutput(f"Valuation model failed to output proper price: {valuation_model}: {e}") from e
+
+    @abstractmethod
     def __call__(self,
                  ts: datetime.datetime,
                  position: TradingPosition) -> Tuple[datetime.datetime, USDollarAmount]:
-        """
+        """Calculate a new price to an asset.
+
+        TODO: Legacy. Use :py:meth:`revalue_position`
 
         :param ts:
             When to revalue. Used in backesting. Live strategies may ignore.
+
         :param position:
             Open position
+
         :return:
-            (revaluation date, price) tuple.
+            (revaluation date, position net value) tuple.
             Note that revaluation date may differ from the wantead timestamp if
             there is no data available.
-
         """
         assert isinstance(ts, datetime.datetime)
         pair = position.pair
@@ -71,3 +139,11 @@ class ValuationModelFactory(Protocol):
 
     def __call__(self, pricing_model: PricingModel) -> ValuationModel:
         pass
+
+
+def revalue_state(state: State, ts: datetime.datetime, valuation_model: ValuationModel):
+    """Revalue all open positions in the portfolio.
+
+    Reserves are not revalued.
+    """
+    state.portfolio.revalue_positions(ts, valuation_model)


### PR DESCRIPTION
- Allow sync_interests() to re-value loans as well, to make sure we have updated price available as it is needed for several loan calculations
- Re-work `ValuationModel` and move logic out from state classes to avoid circular imports
- Fix some tests that for some reason now produce US dollar values a bit off from the original
