### PR TITLE
Short position close fixes

### DIFF
--- a/tests/backtest/test_backtest_short_synthetic_data.py
+++ b/tests/backtest/test_backtest_short_synthetic_data.py
@@ -323,8 +323,8 @@ def test_backtest_open_and_close_short_synthetic_data_no_fee(
     assert float(close_trade.planned_quantity) == pytest.approx(5.573188412844795)
 
     # # Check that the portfolio looks good
-    assert portfolio.get_cash() == pytest.approx(10460.85761252383273372716427)  # TODO: should we have more already?
-    assert portfolio.get_net_asset_value(include_interest=True) == pytest.approx(10457.569761141296)
+    assert portfolio.get_cash() == pytest.approx(10460.85761252383273372716427)
+    assert portfolio.get_net_asset_value(include_interest=True) == pytest.approx(10460.857612523832)
 
     # Check token balances in the wallet
     wallet = debug_dump["wallet"]

--- a/tests/backtest/test_backtest_short_synthetic_data.py
+++ b/tests/backtest/test_backtest_short_synthetic_data.py
@@ -318,8 +318,8 @@ def test_backtest_open_and_close_short_synthetic_data(
     assert loan.get_net_interest() == pytest.approx(1.719404600852724)
 
     # # Check that the portfolio looks good
-    assert portfolio.get_cash() == 0  # TODO: should we have more already?
-    assert portfolio.get_net_asset_value(include_interest=True) == 0
+    assert portfolio.get_cash() == pytest.approx(10457.569761141296)  # TODO: should we have more already?
+    assert portfolio.get_net_asset_value(include_interest=True) == pytest.approx(10457.569761141296)
 
     # Check token balances in the wallet
     wallet = debug_dump["wallet"]
@@ -332,7 +332,7 @@ def test_backtest_open_and_close_short_synthetic_data(
     assert balances[ausdc.address] == pytest.approx(Decimal(0))
     assert balances[vweth.address] == pytest.approx(Decimal(0))
     assert balances.get(weth.address, Decimal(0)) == pytest.approx(Decimal(0))
-    assert balances[usdc.address] == pytest.approx(Decimal(20003.28785138253598178646851))
+    assert balances[usdc.address] == pytest.approx(Decimal(10457.569761141296))
 
 
 def test_backtest_short_underlying_price_feed(

--- a/tests/backtest/test_backtest_short_synthetic_data.py
+++ b/tests/backtest/test_backtest_short_synthetic_data.py
@@ -107,7 +107,7 @@ def universe() -> TradingStrategyUniverse:
     )
 
 
-def test_backtest_open_only_short_synthetic_data(
+    def test_backtest_open_only_short_synthetic_data(
     persistent_test_client: Client,
     universe,
 ):

--- a/tests/interest/test_state_short.py
+++ b/tests/interest/test_state_short.py
@@ -1541,13 +1541,30 @@ def test_short_realised_interest_and_profit(
     assert short_position.get_quantity() == pytest.approx(Decimal('-0.5552334719541217745270929036'))
 
     # Calculate unrealised and realised PnL
+    assert short_position.loan.get_collateral_value() == pytest.approx(1815.113089799045)
+    assert short_position.loan.get_borrow_value() == pytest.approx(777.3268607357704)
     assert short_position.loan.get_collateral_interest() == pytest.approx(15.113089799044888)
     assert short_position.loan.get_borrow_interest() == pytest.approx(30.66019406910382)
+    assert short_position.loan.get_net_interest() == pytest.approx(-15.54710427005894)
+    assert short_position.loan.get_net_asset_value(include_interest=False) == pytest.approx(1053.3333333333335)
+    assert short_position.loan.get_net_asset_value(include_interest=True) == pytest.approx(1037.786229063274)
     assert short_position.get_accrued_interest() == pytest.approx(-15.54710427005894)
+    assert short_position.get_quantity() == Decimal('-0.5552334719541217745270929036')
+
+    assert short_position.loan.borrowed.quantity == Decimal('0.5333333333333333259318465025')
+    assert short_position.loan.get_borrowed_principal_and_interest_quantity() == Decimal('0.5552334719541217745270929036')
+    assert short_position.get_net_quantity() == Decimal('-0.5552334719541217745270929036')
+
+    unrealised_equity = (short_position.get_current_price() - short_position.get_average_price()) * float(short_position.get_net_quantity())
+    assert unrealised_equity == pytest.approx(55.52334719541218)
+
+    assert short_position.get_accrued_interest_with_repayments() == pytest.approx(-15.54710427005894)
     assert short_position.get_unrealised_profit_usd(include_interest=False) == pytest.approx(55.52334719541218)
     assert short_position.get_unrealised_profit_usd(include_interest=True) == pytest.approx(39.97624292535324)
+
     assert short_position.get_realised_profit_usd() is None
     assert short_position.get_value() == pytest.approx(1037.7862290632745)
+    assert short_position.loan.get_net_asset_value() == pytest.approx(1037.7862290632745)
 
     # Prepare a closing trade and check it matches full vToken amount
     assert short_position.loan.borrowed.quantity == pytest.approx(Decimal('0.5333333333333333259318465025'))
@@ -1603,4 +1620,4 @@ def test_short_realised_interest_and_profit(
     assert short_position.get_realised_profit_usd(include_interest=True) == pytest.approx(39.97624292535325)
 
     portfolio = state.portfolio
-    assert portfolio.get_cash() == pytest.approx(10022.673139264229)
+    assert portfolio.get_cash() == pytest.approx(10037.786229063275)

--- a/tests/interest/test_state_short.py
+++ b/tests/interest/test_state_short.py
@@ -1089,6 +1089,8 @@ def test_short_unrealised_profit_leverage_all(
 
     loan = short_position.loan
     assert loan.get_net_asset_value() == pytest.approx(11333.333333333332)
+    assert loan.get_collateral_interest() == pytest.approx(0)
+    assert loan.collateral_interest.last_accrued_interest == 0
     assert short_position.get_unrealised_profit_usd() == pytest.approx(1333.333333)
 
     _, trade_2, _ = state.trade_short(
@@ -1105,6 +1107,9 @@ def test_short_unrealised_profit_leverage_all(
     assert short_position.get_realised_profit_usd() == pytest.approx(1333.333333)
     assert short_position.get_unrealised_profit_usd() == 0
     assert portfolio.get_cash() == pytest.approx(11333.333333)
+
+    # How much USDC gained we got from the collateral
+    assert trade_2.claimed_interest == pytest.approx(0)
 
 
 def test_short_unrealised_profit_partially_closed_keep_collateral(
@@ -1542,6 +1547,7 @@ def test_short_realised_interest_and_profit(
     assert short_position.get_unrealised_profit_usd(include_interest=False) == pytest.approx(55.52334719541218)
     assert short_position.get_unrealised_profit_usd(include_interest=True) == pytest.approx(39.97624292535324)
     assert short_position.get_realised_profit_usd() is None
+    assert short_position.get_value() == pytest.approx(1037.7862290632745)
 
     # Prepare a closing trade and check it matches full vToken amount
     assert short_position.loan.borrowed.quantity == pytest.approx(Decimal('0.5333333333333333259318465025'))

--- a/tradeexecutor/backtest/backtest_execution.py
+++ b/tradeexecutor/backtest/backtest_execution.py
@@ -167,6 +167,7 @@ class BacktestExecutionModel(ExecutionModel):
         executed_collateral_quantity = trade.planned_collateral_consumption
 
         if trade.is_sell():
+            import ipdb ; ipdb.set_trace()
             self.wallet.update_balance(borrowed_address, -executed_quantity)
             self.wallet.update_balance(collateral_address, executed_collateral_quantity)
             self.wallet.update_balance(reserve_address, -executed_reserve)

--- a/tradeexecutor/backtest/backtest_execution.py
+++ b/tradeexecutor/backtest/backtest_execution.py
@@ -333,14 +333,18 @@ class BacktestExecutionModel(ExecutionModel):
             # 3. Simulate tx broadcast
             executed_quantity, executed_reserve, executed_collateral_allocation, executed_collateral_consumption = self.simulate_trade(ts, state, idx, trade)
 
+            # TODO: Use colleteral values here
+
             # 4. execution is dummy operation where planned execution becomes actual execution
             # Assume we always get the same execution we planned
             if executed_quantity:
-                executed_price = float(abs(executed_reserve / executed_quantity))
+                if trade.is_short():
+                    executed_price = trade.planned_price
+                else:
+                    executed_price = float(abs(executed_reserve / executed_quantity))
+
             else:
                 executed_price = 0
-
-            import ipdb ; ipdb.set_trace()
 
             state.mark_trade_success(
                 ts,

--- a/tradeexecutor/backtest/backtest_execution.py
+++ b/tradeexecutor/backtest/backtest_execution.py
@@ -176,6 +176,7 @@ class BacktestExecutionModel(ExecutionModel):
         # The leveraged tokens appear in the wallet
 
         # aToken amount is original deposit + any leverage we do
+
         self.wallet.update_balance(collateral_address, executed_collateral_consumption)
         self.wallet.update_balance(collateral_address, executed_reserve)
 

--- a/tradeexecutor/backtest/backtest_sync.py
+++ b/tradeexecutor/backtest/backtest_sync.py
@@ -258,7 +258,7 @@ class BacktestSyncModel(SyncModel):
                 # Make aToken and vToken magically appear in the simulated
                 # backtest wallet. The amount must be updated, or
                 # otherwise we get errors when closing the position.
-                self.wallet.update_balance(p.pair.base.address, accrued_collateral_interest)
-                self.wallet.update_balance(p.pair.quote.address, accrued_borrow_interest)
+                self.wallet.rebase(p.pair.base.address, new_vtoken_amount)
+                self.wallet.rebase(p.pair.quote.address, new_atoken_amount)
 
         return events

--- a/tradeexecutor/backtest/simulated_wallet.py
+++ b/tradeexecutor/backtest/simulated_wallet.py
@@ -14,6 +14,10 @@ class SimulatedWallet:
         self.nonce = 0
 
     def update_balance(self, token_address: str, delta: Decimal):
+        """Change the token balance of some delta.
+
+        Check that balance does not go zero.
+        """
         assert token_address.lower() == token_address, "No checksummed addresses"
         assert isinstance(delta, Decimal), f"Expected decimal got: {delta.__class__}: {delta}"
         old_balance = self.balances.get(token_address, Decimal(0))
@@ -23,9 +27,14 @@ class SimulatedWallet:
         self.balances[token_address] = new_balance
 
     def set_balance(self, token_address: str, amount: Decimal):
+        """Directly set balance."""
         assert token_address.lower() == token_address, "No checksummed addresses"
         assert isinstance(amount, Decimal), f"Expected decimal got: {amount.__class__}: {amount}"
         self.balances[token_address] = amount
+
+    def rebase(self, token_address: str, new_amount: Decimal):
+        """Set rebase token amount."""
+        self.set_balance(token_address, new_amount)
 
     def get_balance(self, token_address: str) -> Decimal:
         assert token_address.lower() == token_address, "No checksummed addresses"

--- a/tradeexecutor/backtest/simulated_wallet.py
+++ b/tradeexecutor/backtest/simulated_wallet.py
@@ -7,7 +7,10 @@ class OutOfSimulatedBalance(Exception):
 
 
 class SimulatedWallet:
-    """A wallet that keeps token balances by ERC-20 address."""
+    """A wallet that keeps token balances by ERC-20 address.
+
+    - We also simulate incoming and outgoing aToken and vToken amounts with :py:meth:`rebalance`.
+    """
 
     def __init__(self):
         self.balances: Dict[str, Decimal] = {}

--- a/tradeexecutor/state/identifier.py
+++ b/tradeexecutor/state/identifier.py
@@ -488,6 +488,7 @@ class AssetWithTrackedValue:
         return f"<AssetWithTrackedValue {self.asset.token_symbol} {self.quantity} at price {self.last_usd_price} USD>"
 
     def __post_init__(self):
+        assert isinstance(self.quantity, Decimal), f"Got {self.quantity.__class__}"
         assert self.quantity > 0, f"Any tracked asset must have positive quantity, received {self.asset} = {self.quantity}"
         assert self.last_usd_price is not None, "Price is None - asset price must set during initialisation"
         assert self.last_usd_price > 0
@@ -528,6 +529,6 @@ class AssetWithTrackedValue:
 
         # TODO: this is a temp hack for testing to make sure the borrowed quantity can be minimum 0
         if self.quantity < 0:
-            self.quantity = 0
+            self.quantity = Decimal(0)
 
 

--- a/tradeexecutor/state/interest.py
+++ b/tradeexecutor/state/interest.py
@@ -53,7 +53,7 @@ class Interest:
     last_updated_block_number: int | None = None
 
     def __repr__(self):
-        return f"<Interest, current principal + interest {self.last_token_amount}>"
+        return f"<Interest, current principal + interest {self.last_token_amount}, current tracked interest gains {self.last_accrued_interest}>"
 
     def __post_init__(self):
         assert isinstance(self.opening_amount, Decimal)

--- a/tradeexecutor/state/position.py
+++ b/tradeexecutor/state/position.py
@@ -762,8 +762,6 @@ class TradingPosition(GenericPosition):
                         assert quantity is None, "quantity calculated automatically when closing a short position"
                         assert not planned_collateral_consumption, "planned_collateral_consumption set automatically when closing a short position"
 
-                        import ipdb ; ipdb.set_trace()
-
                         # Pay back all the debt and its interest
                         quantity = self.loan.get_borrowed_principal_and_interest_quantity()
 
@@ -1430,7 +1428,8 @@ class TradingPosition(GenericPosition):
         """How much interest payments we have made in total.
 
         See also
-        :py:meth:`get_claimed_interest`.
+
+        - :py:meth:`get_claimed_interest`.
 
         - :py:meth:`Loan.get_net_asset_value` for notes about loan interest tracking
         """

--- a/tradeexecutor/state/position.py
+++ b/tradeexecutor/state/position.py
@@ -595,11 +595,13 @@ class TradingPosition(GenericPosition):
 
         match self.pair.kind:
             case TradingPairKind.spot_market_hold | TradingPairKind.credit_supply:
+
                 value += self.calculate_value_using_price(
                     self.last_token_price,
                     self.last_reserve_price,
                     include_interest=False,
                 )
+
             case TradingPairKind.lending_protocol_short:
                 # Value for leveraged positions is net asset value from its two loans
                 return self.loan.get_net_asset_value(include_interest)
@@ -1035,6 +1037,7 @@ class TradingPosition(GenericPosition):
             return 0
 
         unrealised_equity = (self.get_current_price() - avg_price) * float(self.get_net_quantity())
+
         if include_interest:
             return unrealised_equity + self.get_accrued_interest() - self.get_claimed_interest() + self.get_repaid_interest()
 
@@ -1377,7 +1380,7 @@ class TradingPosition(GenericPosition):
         ])
 
     def get_accrued_interest(self) -> USDollarAmount:
-        """Get the USD value of currently accrued interest for this position so far.
+        """Get the USD value of currently net accrued interest for this position so far.
 
         See :py:meth:`get_accrued_interest_with_repayments` to account any interest payments.
 

--- a/tradeexecutor/state/position.py
+++ b/tradeexecutor/state/position.py
@@ -570,7 +570,7 @@ class TradingPosition(GenericPosition):
     def get_value(self, include_interest=True) -> USDollarAmount:
         """Get the current net asset value of this position.
 
-        If the position is closed, the value should be zero.
+        If the position is closed, the value should be zero
 
         :param include_interest:
             Include accrued interest in the valuation.

--- a/tradeexecutor/state/state.py
+++ b/tradeexecutor/state/state.py
@@ -605,10 +605,15 @@ class State:
         if trade.is_spot() and trade.is_sell():
             self.portfolio.return_capital_to_reserves(trade)
         elif trade.is_leverage():
-            # Release any collateral
+
+            # Release any collateral and move it back to the wallet
             if executed_collateral_allocation:
                 assert trade.pair.quote.underlying
                 self.portfolio.adjust_reserves(trade.pair.quote.underlying, -executed_collateral_allocation)
+
+            if trade.claimed_interest:
+                self.portfolio.adjust_reserves(trade.pair.quote.underlying, trade.claimed_interest)
+
         elif trade.is_credit_supply():
             if trade.is_sell():
                 self.portfolio.adjust_reserves(trade.pair.quote, executed_reserve)

--- a/tradeexecutor/state/state.py
+++ b/tradeexecutor/state/state.py
@@ -611,9 +611,6 @@ class State:
                 assert trade.pair.quote.underlying
                 self.portfolio.adjust_reserves(trade.pair.quote.underlying, -executed_collateral_allocation)
 
-            if trade.claimed_interest:
-                self.portfolio.adjust_reserves(trade.pair.quote.underlying, trade.claimed_interest)
-
         elif trade.is_credit_supply():
             if trade.is_sell():
                 self.portfolio.adjust_reserves(trade.pair.quote, executed_reserve)
@@ -637,6 +634,9 @@ class State:
                 # on the debt
                 if position.loan.borrowed:
                     trade.paid_interest = position.loan.borrowed_interest.last_accrued_interest
+
+                if trade.claimed_interest:
+                    self.portfolio.adjust_reserves(trade.pair.quote.underlying, trade.claimed_interest)
 
     def mark_trade_failed(self, failed_at: datetime.datetime, trade: TradeExecution):
         """Unroll the allocated capital."""

--- a/tradeexecutor/state/statistics.py
+++ b/tradeexecutor/state/statistics.py
@@ -96,7 +96,12 @@ class PortfolioStatistics:
 
     #: Real-time clock when these stats were calculated
     calculated_at: datetime.datetime
+
+
+    # Deprecated: Use net_asset_value
     total_equity: USDollarAmount
+
+    net_asset_value: Optional[USDollarAmount] = None
     
     free_cash: Optional[USDollarAmount] = None
     open_position_count: Optional[int] = None
@@ -111,6 +116,16 @@ class PortfolioStatistics:
 
     realised_profit_usd: Optional[USDollarAmount] = 0
     summary: Optional[TradeSummary] = None
+
+    def get_value(self) -> USDollarAmount:
+        if self.net_asset_value is not None:
+            return self.net_asset_value
+
+        # Legacy
+        return self.total_equity
+
+    def __post_init__(self):
+        assert (self.total_equity or self.net_asset_value), "PortfolioStatistics: could not calculate value for the portfolio"
 
 
 @dataclass_json
@@ -225,7 +240,7 @@ class Statistics:
         if len(self.portfolio) == 0:
             return 0.0
 
-        return (self.portfolio[-1].total_equity - self.portfolio[0].total_equity) / self.portfolio[0].total_equity
+        return (self.portfolio[-1].get_value() - self.portfolio[0].get_value()) / self.portfolio[0].get_value()
 
 
 def calculate_naive_profitability(

--- a/tradeexecutor/state/trade.py
+++ b/tradeexecutor/state/trade.py
@@ -902,6 +902,9 @@ class TradeExecution:
         """
         if not self.paid_interest:
             return 0.0
+
+        assert self.executed_price, f"executed_price missing: {self}"
+
         return float(self.paid_interest) * self.executed_price
 
     def get_fees_paid(self) -> USDollarAmount:

--- a/tradeexecutor/state/trade.py
+++ b/tradeexecutor/state/trade.py
@@ -448,6 +448,9 @@ class TradeExecution:
     #:
     #: See also :py:attr:`paid_interest`
     #:
+    #: TODO This must be converted to planned_paid_interest / executed_paid_interest,
+    #: because the actual amount may change after execution.
+    #:
     claimed_interest: Optional[Decimal] = None
 
     #: How much interest this trade paid back on the debt.
@@ -458,6 +461,9 @@ class TradeExecution:
     #: that closes a leveraged position.
     #:
     #: See also :py:attr:`claimed_interest`
+    #:
+    #: TODO This must be converted to planned_paid_interest / executed_paid_interest
+    #: because the actual amount may change after execution.
     #:
     paid_interest: Optional[Decimal] = None
 
@@ -793,6 +799,7 @@ class TradeExecution:
         return abs(float(self.executed_quantity) * (self.executed_price or 0))
 
     def get_planned_value(self) -> USDollarAmount:
+        """How much we plan to swap in this trade."""
         return abs(self.planned_price * float(abs(self.planned_quantity)))
 
     def get_planned_reserve(self) -> Decimal:

--- a/tradeexecutor/statistics/core.py
+++ b/tradeexecutor/statistics/core.py
@@ -116,6 +116,7 @@ def calculate_statistics(
         pf_stats = PortfolioStatistics(
             calculated_at=clock,
             total_equity=portfolio.get_total_equity(),
+            net_asset_value=portfolio.get_net_asset_value(),
             free_cash=float(portfolio.get_cash()),
             open_position_count=len(portfolio.open_positions),
             open_position_equity=portfolio.get_position_equity_and_loan_nav(),
@@ -132,6 +133,7 @@ def calculate_statistics(
         pf_stats = PortfolioStatistics(
             calculated_at=clock,
             total_equity=portfolio.get_total_equity(),
+            net_asset_value=portfolio.get_net_asset_value(),
         )
 
     stats = TimestampedStatistics(

--- a/tradeexecutor/strategy/interest.py
+++ b/tradeexecutor/strategy/interest.py
@@ -2,12 +2,16 @@
 import datetime
 from decimal import Decimal
 from typing import Tuple
+import logging
 
 from tradeexecutor.state.balance_update import BalanceUpdate, BalanceUpdatePositionType, BalanceUpdateCause
 from tradeexecutor.state.identifier import TradingPairKind, AssetIdentifier
 from tradeexecutor.state.position import TradingPosition
 from tradeexecutor.state.state import State
 from tradeexecutor.state.types import USDollarPrice
+
+
+logger = logging.getLogger(__name__)
 
 
 def update_interest(
@@ -111,6 +115,7 @@ def update_interest(
     interest.last_event_at = event_at
     interest.last_updated_block_number = block_number
     interest.last_token_amount = new_token_amount
+
     return evt
 
 
@@ -161,6 +166,8 @@ def update_leveraged_position_interest(
         log_index,
     )
 
+    logger.info("Updated leveraged interest %s for %s", pair.base, vevt)
+
     # aToken
     aevt = update_interest(
         state,
@@ -173,6 +180,8 @@ def update_leveraged_position_interest(
         tx_hash,
         log_index,
     )
+
+    logger.info("Updated leveraged interest %s for %s", pair.quote, aevt)
 
     return (vevt, aevt)
 

--- a/tradeexecutor/strategy/pandas_trader/position_manager.py
+++ b/tradeexecutor/strategy/pandas_trader/position_manager.py
@@ -897,7 +897,12 @@ class PositionManager:
             Trading pair where we take the position
 
         :param value:
-            How large position to open, in US dollar terms
+            How much cash reserves we allocate to open this position.
+
+            In US dollars.
+
+            For example to open 2x short where we allocate $1000
+            from our reserves, this value is $1000.
 
         :param leverage:
             Leverage level to use for the short position
@@ -939,7 +944,7 @@ class PositionManager:
         price_structure = self.pricing_model.get_sell_price(self.timestamp, pricing_pair, value)
 
         # TODO: verify calculation here and we should output the liquidation price here
-        # so it should be taken into account for stoploss
+        # so it should be takesn into account for stoploss
         borrowed_size, collateral_size = calculate_sizes_for_leverage(value, leverage)
         borrowed_quantity = borrowed_size / Decimal(price_structure.price)
 
@@ -971,7 +976,10 @@ class PositionManager:
             trade_type=TradeType.rebalance,
             reserve_currency=self.reserve_currency,
             collateral_asset_price=collateral_price,
+            planned_collateral_consumption=Decimal(collateral_size) - value,  # This is amount how much aToken is leverated besides our starting collateral
         )
+
+        import ipdb ; ipdb.set_trace()
 
         if take_profit_pct:
             position.take_profit = price_structure.mid_price * take_profit_pct

--- a/tradeexecutor/strategy/pandas_trader/position_manager.py
+++ b/tradeexecutor/strategy/pandas_trader/position_manager.py
@@ -979,8 +979,6 @@ class PositionManager:
             planned_collateral_consumption=Decimal(collateral_size) - value,  # This is amount how much aToken is leverated besides our starting collateral
         )
 
-        import ipdb ; ipdb.set_trace()
-
         if take_profit_pct:
             position.take_profit = price_structure.mid_price * take_profit_pct
 


### PR DESCRIPTION
- Update `SimulatedWallet` to correctly handle aToken and vToken 
- Make sure we correctly account for collateral leveraged quantity when opening a short position
- Make sure we correctly unwind the collateral when closing a short position
- Fix the issue where `TradeExecution.claimed_interest` was not credited back to portfolio cash reserves

TODO: There is still a future work. Currently `paid_interest` and `claimed_interest` do not have separate (planned, executed) life cycle as other `TradeExecution` variables. The live trading system will break when `paid_interest` will be different from the planned value, because aToken/vToken dynamic balance changes and the time lag before planning the trade and getting it executed.
