### PR TITLE
Add human-readable diagnostics notes to blockchain transactions

### DIFF
--- a/tests/ethereum/test_uniswap_live_stop_loss.py
+++ b/tests/ethereum/test_uniswap_live_stop_loss.py
@@ -433,6 +433,11 @@ def test_live_stop_loss(
     # We are ~500 USD on loss after stop loss trigger
     assert state.portfolio.reserves[usdc_token.address.lower()].quantity == pytest.approx(Decimal('8588.500854'))
 
+    # Check that transaction notes is filled correctly
+    assert len(t.blockchain_transactions) == 2  # Approve + swap
+    tx = t.blockchain_transactions[1]
+    assert "Sell #2" in tx.notes
+
 
 def test_live_stop_loss_missing(
         logger,

--- a/tradeexecutor/ethereum/enzyme/tx.py
+++ b/tradeexecutor/ethereum/enzyme/tx.py
@@ -97,6 +97,7 @@ class EnzymeTransactionBuilder(TransactionBuilder):
             gas_limit: Optional[int] = None,
             gas_price_suggestion: Optional[GasPriceSuggestion] = None,
             asset_deltas: Optional[List[AssetDelta]] = None,
+            notes: str = "",
     ) -> BlockchainTransaction:
         """Createa a signed tranaction and set up tx broadcast parameters.
 
@@ -166,5 +167,6 @@ class EnzymeTransactionBuilder(TransactionBuilder):
             nonce=signed_tx.nonce,
             details=enzyme_tx.as_json_friendly_dict(),
             asset_deltas=[JSONAssetDelta.from_asset_delta(a) for a in vault_asset_deltas],
-            other={"vault_slippage_tolerance": self.vault_slippage_tolerance}
+            other={"vault_slippage_tolerance": self.vault_slippage_tolerance},
+            notes=notes,
         )

--- a/tradeexecutor/ethereum/routing_model.py
+++ b/tradeexecutor/ethereum/routing_model.py
@@ -85,6 +85,7 @@ class EthereumRoutingModel(RoutingModel):
                           address_map: Dict,
                           check_balances=False,
                           asset_deltas: Optional[List[AssetDelta]] = None,
+                          notes="",
                           ) -> List[BlockchainTransaction]:
         """Prepare a trade where target pair has out reserve asset as a quote token.
 
@@ -117,6 +118,7 @@ class EthereumRoutingModel(RoutingModel):
             max_slippage,
             check_balances,
             asset_deltas=asset_deltas,
+            notes=notes,
             )
 
         # Leave note of adjustment.

--- a/tradeexecutor/ethereum/routing_model.py
+++ b/tradeexecutor/ethereum/routing_model.py
@@ -130,18 +130,17 @@ class EthereumRoutingModel(RoutingModel):
         return txs
 
     def make_multihop_trade(self,
-                          routing_state: EthereumRoutingState, # doesn't get full typing
-                              # EthereumRoutingState throws error
-                              # due to circular import
-                          target_pair: TradingPairIdentifier,
-                          intermediary_pair: TradingPairIdentifier,
-                          reserve_asset: AssetIdentifier,
-                          reserve_amount: int,
-                          max_slippage: float,
-                          address_map: Dict,
-                          check_balances=False,
-                          asset_deltas: Optional[List[AssetDelta]] = None,
-                          ) -> List[BlockchainTransaction]:
+          routing_state: EthereumRoutingState,
+          target_pair: TradingPairIdentifier,
+          intermediary_pair: TradingPairIdentifier,
+          reserve_asset: AssetIdentifier,
+          reserve_amount: int,
+          max_slippage: float,
+          address_map: Dict,
+          check_balances=False,
+          asset_deltas: Optional[List[AssetDelta]] = None,
+          notes="",
+          ) -> List[BlockchainTransaction]:
         """Prepare a trade where target pair has out reserve asset as a quote token.
 
         :return:
@@ -172,6 +171,7 @@ class EthereumRoutingModel(RoutingModel):
             max_slippage,
             check_balances,
             asset_deltas=asset_deltas,
+            notes=notes,
             )
 
         txs += trade_txs
@@ -193,6 +193,7 @@ class EthereumRoutingModel(RoutingModel):
               check_balances=False,
               intermediary_pair: Optional[TradingPairIdentifier] = None,
               asset_deltas: Optional[List[AssetDelta]] = None,
+              notes="",
               ) -> List[BlockchainTransaction]:
         """
 
@@ -235,6 +236,7 @@ class EthereumRoutingModel(RoutingModel):
                     max_slippage=max_slippage,
                     check_balances=check_balances,
                     asset_deltas=asset_deltas,
+                    notes=notes,
                 )
             raise RuntimeError(f"Do not how to trade reserve {reserve_asset} with {target_pair}")
         else:
@@ -250,6 +252,7 @@ class EthereumRoutingModel(RoutingModel):
                 max_slippage=max_slippage,
                 check_balances=check_balances,
                 asset_deltas=asset_deltas,
+                notes=notes,
             )
     
     def execute_trades_internal(self,
@@ -291,6 +294,9 @@ class EthereumRoutingModel(RoutingModel):
 
             target_pair, intermediary_pair = self.route_trade(pair_universe, t)
 
+            notes = f"For trade: {t}\n" \
+                    f"Asset deltas: {asset_deltas}"
+
             if intermediary_pair is None:
                 # Two way trade
                 # Decide between buying and selling
@@ -303,6 +309,7 @@ class EthereumRoutingModel(RoutingModel):
                         check_balances=check_balances,
                         asset_deltas=asset_deltas,
                         max_slippage=max_slippage,
+                        notes=notes,
                     )
                     if t.is_buy()
                     else self.trade(
@@ -313,6 +320,7 @@ class EthereumRoutingModel(RoutingModel):
                         check_balances=check_balances,
                         asset_deltas=asset_deltas,
                         max_slippage=max_slippage,
+                        notes=notes,
                     )
                 )
             elif t.is_buy():
@@ -324,6 +332,7 @@ class EthereumRoutingModel(RoutingModel):
                     check_balances=check_balances,
                     intermediary_pair=intermediary_pair,
                     max_slippage=max_slippage,
+                    notes=notes,
                 )
             else:
                 trade_txs = self.trade(
@@ -335,6 +344,7 @@ class EthereumRoutingModel(RoutingModel):
                     intermediary_pair=intermediary_pair,
                     asset_deltas=asset_deltas,
                     max_slippage=max_slippage,
+                    notes=notes,
                 )
 
             t.set_blockchain_transactions(trade_txs)

--- a/tradeexecutor/ethereum/routing_state.py
+++ b/tradeexecutor/ethereum/routing_state.py
@@ -125,6 +125,7 @@ class EthereumRoutingState(RoutingState):
             max_slippage: float,
             check_balances: False,
             asset_deltas: Optional[List[AssetDelta]] = None,
+            notes="",
         ):
         """Prepare the actual swap. Same for Uniswap V2 and V3."""
         
@@ -138,6 +139,7 @@ class EthereumRoutingState(RoutingState):
             max_slippage: float,
             check_balances: False,
             asset_deltas: Optional[List[AssetDelta]] = None,
+            notes="",
         ):
         """Prepare the actual swap for three way trade."""
 

--- a/tradeexecutor/ethereum/routing_state.py
+++ b/tradeexecutor/ethereum/routing_state.py
@@ -227,13 +227,16 @@ class EthereumRoutingState(RoutingState):
             contract: Contract,
             swap_func: ContractFunction,
             gas_limit: int,
-            asset_deltas: List[AssetDelta]):
+            asset_deltas: List[AssetDelta],
+            notes="",
+    ):
         signed_tx = self.tx_builder.sign_transaction(
             contract,
             swap_func,
             gas_limit,
             gas_price_suggestion=None,
             asset_deltas=asset_deltas,
+            notes=notes,
         )
         return [signed_tx]
 

--- a/tradeexecutor/ethereum/tx.py
+++ b/tradeexecutor/ethereum/tx.py
@@ -162,6 +162,7 @@ class TransactionBuilder(ABC):
             gas_limit: Optional[int] = None,
             gas_price_suggestion: Optional[GasPriceSuggestion] = None,
             asset_deltas: Optional[List[AssetDelta]] = None,
+            notes: str = "",
     ) -> BlockchainTransaction:
         """Createa a signed tranaction and set up tx broadcast parameters.
 
@@ -259,6 +260,7 @@ class HotWalletTransactionBuilder(TransactionBuilder):
             gas_limit: Optional[int] = None,
             gas_price_suggestion: Optional[GasPriceSuggestion] = None,
             asset_deltas: Optional[List[AssetDelta]] = None,
+            notes: str = "",
     ) -> BlockchainTransaction:
         """Sign a transaction with the hot wallet private key."""
 
@@ -300,4 +302,5 @@ class HotWalletTransactionBuilder(TransactionBuilder):
             nonce=signed_tx.nonce,
             details=tx,
             asset_deltas=[JSONAssetDelta.from_asset_delta(a) for a in asset_deltas],
+            notes=notes,
         )

--- a/tradeexecutor/ethereum/uniswap_v2/uniswap_v2_routing.py
+++ b/tradeexecutor/ethereum/uniswap_v2/uniswap_v2_routing.py
@@ -108,7 +108,9 @@ class UniswapV2RoutingState(EthereumRoutingState):
             reserve_amount: int,
             max_slippage: float,
             check_balances: False,
-            asset_deltas: Optional[List[AssetDelta]] = None):
+            asset_deltas: Optional[List[AssetDelta]] = None,
+            notes: str = "",
+        ):
         """Prepare the actual swap for three way trade.
 
         :param check_balances:
@@ -157,7 +159,8 @@ class UniswapV2RoutingState(EthereumRoutingState):
             uniswap.router,
             bound_swap_func,
             self.swap_gas_limit,
-            asset_deltas=asset_deltas
+            asset_deltas=asset_deltas,
+            notes=notes,
         )
         return [tx]
 
@@ -262,6 +265,7 @@ class UniswapV2SimpleRoutingModel(EthereumRoutingModel):
         max_slippage: float,
         check_balances=False,
         asset_deltas: Optional[List[AssetDelta]] = None,
+        notes="",
     ) -> List[BlockchainTransaction]:
         
         return super().make_direct_trade(
@@ -273,6 +277,7 @@ class UniswapV2SimpleRoutingModel(EthereumRoutingModel):
             self.factory_router_map,
             check_balances,
             asset_deltas=asset_deltas,
+            notes=notes,
         )
     
     def make_multihop_trade(
@@ -285,6 +290,7 @@ class UniswapV2SimpleRoutingModel(EthereumRoutingModel):
         max_slippage: float,
         check_balances=False,
         asset_deltas: Optional[List[AssetDelta]] = None,
+        notes="",
     ) -> List[BlockchainTransaction]:
         
         return super().make_multihop_trade(
@@ -297,6 +303,7 @@ class UniswapV2SimpleRoutingModel(EthereumRoutingModel):
             self.factory_router_map,
             check_balances,
             asset_deltas=asset_deltas,
+            notes=notes,
         )
     
     

--- a/tradeexecutor/ethereum/uniswap_v2/uniswap_v2_routing.py
+++ b/tradeexecutor/ethereum/uniswap_v2/uniswap_v2_routing.py
@@ -57,6 +57,7 @@ class UniswapV2RoutingState(EthereumRoutingState):
             max_slippage: float,
             check_balances: False,
             asset_deltas: Optional[List[AssetDelta]] = None,
+            notes="",
         ):
         """Prepare the actual swap. Same for Uniswap V2 and V3.
 
@@ -98,6 +99,7 @@ class UniswapV2RoutingState(EthereumRoutingState):
             bound_swap_func,
             self.swap_gas_limit,
             asset_deltas,
+            notes=notes,
         )
 
     def trade_on_router_three_way(self,

--- a/tradeexecutor/ethereum/uniswap_v3/uniswap_v3_routing.py
+++ b/tradeexecutor/ethereum/uniswap_v3/uniswap_v3_routing.py
@@ -54,6 +54,7 @@ class UniswapV3RoutingState(EthereumRoutingState):
             max_slippage: float,
             check_balances: False,
             asset_deltas: Optional[List[AssetDelta]] = None,
+            notes="",
         ):
         """Prepare the actual swap. Same for Uniswap V2 and V3.
 
@@ -91,7 +92,9 @@ class UniswapV3RoutingState(EthereumRoutingState):
             uniswap.swap_router,
             bound_swap_func,
             self.swap_gas_limit,
-            asset_deltas)
+            asset_deltas,
+            notes=notes,
+        )
 
     def trade_on_router_three_way(self,
             uniswap: UniswapV3Deployment,
@@ -102,6 +105,7 @@ class UniswapV3RoutingState(EthereumRoutingState):
             max_slippage: float,
             check_balances: False,
             asset_deltas: Optional[List[AssetDelta]] = None,
+            notes="",
         ):
         """Prepare the actual swap for three way trade.
 
@@ -137,7 +141,9 @@ class UniswapV3RoutingState(EthereumRoutingState):
             uniswap.swap_router,
             bound_swap_func,
             self.swap_gas_limit,
-            asset_deltas)
+            asset_deltas,
+            notes=notes,
+        )
 
 
 class UniswapV3SimpleRoutingModel(EthereumRoutingModel):
@@ -226,6 +232,7 @@ class UniswapV3SimpleRoutingModel(EthereumRoutingModel):
         max_slippage: float,
         check_balances=False,
         asset_deltas: Optional[List[AssetDelta]] = None,
+        notes="",
     ) -> list[BlockchainTransaction]:
         
         return super().make_direct_trade(
@@ -237,6 +244,7 @@ class UniswapV3SimpleRoutingModel(EthereumRoutingModel):
             self.address_map,
             check_balances,
             asset_deltas=asset_deltas,
+            notes="",
         )
     
     def make_multihop_trade(
@@ -249,6 +257,7 @@ class UniswapV3SimpleRoutingModel(EthereumRoutingModel):
         max_slippage: float,
         check_balances=False,
         asset_deltas: Optional[List[AssetDelta]] = None,
+        notes="",
     ) -> list[BlockchainTransaction]:
         
         return super().make_multihop_trade(
@@ -261,6 +270,7 @@ class UniswapV3SimpleRoutingModel(EthereumRoutingModel):
             self.address_map,
             check_balances,
             asset_deltas=asset_deltas,
+            notes="",
         )
 
 def get_uniswap_for_pair(web3: Web3, address_map: dict, target_pair: TradingPairIdentifier) -> UniswapV3Deployment:

--- a/tradeexecutor/state/blockhain_transaction.py
+++ b/tradeexecutor/state/blockhain_transaction.py
@@ -9,6 +9,7 @@
 """
 import datetime
 import enum
+import textwrap
 from dataclasses import dataclass, field
 from typing import Optional, Any, Dict, Tuple, List
 
@@ -277,6 +278,9 @@ class BlockchainTransaction:
     notes: str = ""
 
     def __repr__(self):
+
+        notes = "\n" + textwrap.indent(self.notes, prefix="      ")
+
         if self.status is True:
             return f"<Tx success \n" \
                    f"    from:{self.from_address}\n" \
@@ -287,7 +291,7 @@ class BlockchainTransaction:
                    f"    wrapped args:{_clean_print_args(self.wrapped_args)}\n" \
                    f"    gas limit:{self.get_gas_limit():,}\n" \
                    f"    gas spent:{self.realised_gas_units_consumed:,}\n" \
-                   f"    notes:{self.notes}\n" \
+                   f"    notes:{notes}\n" \
                    f"    >"
         elif self.status is False:
             return f"<Tx reverted \n" \
@@ -300,7 +304,7 @@ class BlockchainTransaction:
                    f"    fail reason:{self.revert_reason}\n" \
                    f"    gas limit:{self.get_gas_limit():,}\n" \
                    f"    gas spent:{self.realised_gas_units_consumed:,}\n" \
-                   f"    notes:{self.notes}\n" \
+                   f"    notes:{notes}\n" \
                    f"    >"
         else:
             return f"<Tx unresolved\n" \
@@ -310,7 +314,7 @@ class BlockchainTransaction:
                    f"    func:{self.function_selector}\n" \
                    f"    args:{_clean_print_args(self.transaction_args)}\n" \
                    f"    wrapped args:{_clean_print_args(self.wrapped_args)}\n" \
-                   f"    notes:{self.notes}\n" \
+                   f"    notes:{notes}\n" \
                    f"    >"
 
     def get_transaction(self) -> dict:

--- a/tradeexecutor/state/blockhain_transaction.py
+++ b/tradeexecutor/state/blockhain_transaction.py
@@ -265,9 +265,20 @@ class BlockchainTransaction:
     #: Currently used for `vault_slippage_tolerance`.
     other: dict = field(default_factory=dict)
 
+    #: Human readable notes on this transaction.
+    #:
+    #: - Used for diagnostics
+    #:
+    #: - E.g. the text line of the controlling trade that is causing this transaction,
+    #:   with information about expected tokens, slippage, etc.
+    #:
+    #: - Newline separated
+    #:
+    notes: str = ""
+
     def __repr__(self):
         if self.status is True:
-            return f"<Tx \n" \
+            return f"<Tx success \n" \
                    f"    from:{self.from_address}\n" \
                    f"    nonce:{self.nonce}\n" \
                    f"    to:{self.contract_address}\n" \
@@ -276,10 +287,10 @@ class BlockchainTransaction:
                    f"    wrapped args:{_clean_print_args(self.wrapped_args)}\n" \
                    f"    gas limit:{self.get_gas_limit():,}\n" \
                    f"    gas spent:{self.realised_gas_units_consumed:,}\n" \
-                   f"    success\n" \
+                   f"    notes:{self.notes}\n" \
                    f"    >"
         elif self.status is False:
-            return f"<Tx \n" \
+            return f"<Tx reverted \n" \
                    f"    from:{self.from_address}\n" \
                    f"    nonce:{self.nonce}\n" \
                    f"    to:{self.contract_address}\n" \
@@ -289,16 +300,17 @@ class BlockchainTransaction:
                    f"    fail reason:{self.revert_reason}\n" \
                    f"    gas limit:{self.get_gas_limit():,}\n" \
                    f"    gas spent:{self.realised_gas_units_consumed:,}\n" \
+                   f"    notes:{self.notes}\n" \
                    f"    >"
         else:
-            return f"<Tx \n" \
+            return f"<Tx unresolved\n" \
                    f"    from:{self.from_address}\n" \
                    f"    nonce:{self.nonce}\n" \
                    f"    to:{self.contract_address}\n" \
                    f"    func:{self.function_selector}\n" \
                    f"    args:{_clean_print_args(self.transaction_args)}\n" \
                    f"    wrapped args:{_clean_print_args(self.wrapped_args)}\n" \
-                   f"    unresolved\n" \
+                   f"    notes:{self.notes}\n" \
                    f"    >"
 
     def get_transaction(self) -> dict:

--- a/tradeexecutor/strategy/account_correction.py
+++ b/tradeexecutor/strategy/account_correction.py
@@ -475,6 +475,7 @@ def transfer_away_assets_without_position(
         args_bound_func,
         gas_limit=250_000,
         asset_deltas=[asset_delta],
+        notes="Accounting correction transaction, removing assets",
     )
 
     tx_hash = web3.eth.send_raw_transaction(blockchain_data.get_prepared_raw_transaction())

--- a/tradeexecutor/strategy/output.py
+++ b/tradeexecutor/strategy/output.py
@@ -52,7 +52,7 @@ def format_trade(portfolio: Portfolio, trade: TradeExecution) -> List[str]:
         ]
 
     if link:
-        lines.append(f"      link: {link}")
+        lines.append(f"Trading pair link: {link}")
 
     return lines
 

--- a/tradeexecutor/strategy/pandas_trader/position_manager.py
+++ b/tradeexecutor/strategy/pandas_trader/position_manager.py
@@ -778,7 +778,7 @@ class PositionManager:
 
         slippage_tolerance = slippage_tolerance or self.default_slippage_tolerance
 
-        logger.info("Preparing to close position %s, quantity %s, pricing %s, slippage tolerance: %f %", position, quantity, price_structure, slippage_tolerance * 100)
+        logger.info("Preparing to close position %s, quantity %s, pricing %s, slippage tolerance: %f %%", position, quantity, price_structure, slippage_tolerance * 100)
 
         position2, trade, created = self.state.create_trade(
             self.timestamp,


### PR DESCRIPTION
- Add `BlockchainTransaction.notes` text field
- Fill this field with text information about the trade controlling the transaction
- Have this information in the log output

-> Allows us to diagnose what goes wrong with the transactions.