### PR TITLE
Cache datsets

### DIFF
--- a/.github/workflows/test-and-build-image.yml
+++ b/.github/workflows/test-and-build-image.yml
@@ -67,8 +67,7 @@ jobs:
         uses: actions/cache/save@v3
         with:
           path: |
-            path/to/dependencies
-            some/other/dependencies
+            /tmp/trading-strategy-tests
           key: ${{ steps.unit-test-dataset.outputs.cache-primary-key }}
 
   build:

--- a/.github/workflows/test-and-build-image.yml
+++ b/.github/workflows/test-and-build-image.yml
@@ -14,21 +14,35 @@ jobs:
       - uses: actions/checkout@v3
         with:
           submodules: 'recursive'
+
       - name: Set up Python 3.10
         uses: actions/setup-python@v4
         with:
           python-version: "3.10"
+
       - name: Install Poetry
         uses: snok/install-poetry@v1
         with:
           virtualenvs-create: true
           virtualenvs-in-project: true
           installer-parallel: true
+
       - name: Load cached venv
         uses: actions/cache@v2
         with:
           path: .venv
           key: venv-${{ runner.os }}-${{ steps.setup-python.outputs.python-version }}-${{ hashFiles('**/poetry.lock') }}
+
+      # Speed up tests by caching our datasets
+      # test code downloads
+      - name: Restore downloaded unit test datasets
+        id: unit-test-dataset-restore
+        uses: actions/cache/restore@v3
+        with:
+          path: |
+            /tmp/trading-strategy-tests
+          key: ${{ runner.os }}-unit-test-dataset
+      .
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
       - name: Install dependencies
@@ -47,6 +61,15 @@ jobs:
         env:
           TRADING_STRATEGY_API_KEY: ${{ secrets.TRADING_STRATEGY_API_KEY }}
           BNB_CHAIN_JSON_RPC: ${{ secrets.BNB_CHAIN_JSON_RPC }}      
+
+      - name: Save unit test datasets
+        id: unit-test-dataset-save
+        uses: actions/cache/save@v3
+        with:
+          path: |
+            path/to/dependencies
+            some/other/dependencies
+          key: ${{ steps.unit-test-dataset.outputs.cache-primary-key }}
 
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/test-and-build-image.yml
+++ b/.github/workflows/test-and-build-image.yml
@@ -27,6 +27,7 @@ jobs:
           virtualenvs-in-project: true
           installer-parallel: true
 
+      # Do not let Poetry to install again if we do not detect a lock file change
       - name: Load cached venv
         uses: actions/cache@v2
         with:
@@ -62,6 +63,7 @@ jobs:
           TRADING_STRATEGY_API_KEY: ${{ secrets.TRADING_STRATEGY_API_KEY }}
           BNB_CHAIN_JSON_RPC: ${{ secrets.BNB_CHAIN_JSON_RPC }}      
 
+      # Save our current datasets for the next test run
       - name: Save unit test datasets
         id: unit-test-dataset-save
         uses: actions/cache/save@v3

--- a/.github/workflows/test-and-build-image.yml
+++ b/.github/workflows/test-and-build-image.yml
@@ -43,15 +43,16 @@ jobs:
           path: |
             /tmp/trading-strategy-tests
           key: ${{ runner.os }}-unit-test-dataset
-      .
+
+      # Needed for Anvil
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
+
       - name: Install dependencies
         if: steps.cached-poetry-dependencies.outputs.cache-hit != 'true'
-        # We don't install -E qstrader and run legacy tests on CI as they
-        # download too much data
         run: |          
-          poetry install --no-interaction -E web-server -E execution -E quantstats
+          poetry install --no-interaction --all-extras
+
       # Run testa parallel, do not run slow tests before Docker image build.
       # Note that we limit concurrency to 2 workers as 4 workers crashed without an error message on Github CI.
       # I suspect out of memory situation that is not reported to the user.


### PR DESCRIPTION
- Use Github cache action to avoid redownloading datasets between test runs
- This flow is already enabled by default in local testing (`/tmp/trading-strategy-tests/ ` stays intact)