### PR TITLE
Sync treasury before stop position trigger check

### DIFF
--- a/tradeexecutor/state/position.py
+++ b/tradeexecutor/state/position.py
@@ -1269,7 +1269,7 @@ class TradingPosition(GenericPosition):
         assert self.stop_loss, f"Stop loss price must be set to calculate the maximum risk"
         # Calculate how much value we can lose
 
-        opening_price = self.get_price_at_open()
+        opening_price = self.get_opening_price()
         if opening_price is None:
             # Legacy data
             return 0.0

--- a/tradeexecutor/visual/utils.py
+++ b/tradeexecutor/visual/utils.py
@@ -104,19 +104,10 @@ def export_trade_for_dataframe(p: Portfolio, t: TradeExecution) -> dict:
             # "",
         ]
 
-        if t.lp_fees_estimated is not None:
-            if t.executed_price and t.planned_mid_price:
-                realised_fees = abs(1 - t.planned_mid_price / t.executed_price)
-                label += [
-                    f"Fees paid: {format_fees_dollars(t.get_fees_paid())}",
-                    # f"Fees planned: {format_fees_dollars(t.lp_fees_estimated)}",
-                    # f"Fees: {realised_fees:.4f} %",
-                ]
-            else:
-                label += [
-                    f"Fees paid: {format_fees_dollars(t.get_fees_paid())}",
-                    # f"Fees planned: {format_fees_dollars(t.lp_fees_estimated)}",
-                ]
+        if t.is_success() and t.lp_fees_paid is not None:
+            label += [
+                f"Fees paid: {format_fees_dollars(t.get_fees_paid())}",
+            ]
         
         if t.cost_of_gas:
             label += [f"Gas fee: {t.cost_of_gas:.4f}"]


### PR DESCRIPTION
- Currently the treasury was not synced before stop loss trigger
- If there was a deposit before a trigger executed a trade it would fail 