### PR TITLE
Adding block identifier logic to account correction

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -5629,13 +5629,13 @@ tester = ["eth-tester[py-evm] (==v0.8.0-b.3)", "py-geth (>=3.11.0)"]
 
 [[package]]
 name = "web3-ethereum-defi"
-version = "0.22.22"
+version = "0.22.23"
 description = "Python library for Uniswap, Aave, ChainLink, Enzyme and other protocols on BNB Chain, Polygon, Ethereum and other blockchains"
 optional = false
 python-versions = ">=3.10,<3.11"
 files = [
-    {file = "web3_ethereum_defi-0.22.22-py3-none-any.whl", hash = "sha256:79ed4383d7afe832c1ad58b560d8334914f7bf2237aa6411f4669be0f2eb8043"},
-    {file = "web3_ethereum_defi-0.22.22.tar.gz", hash = "sha256:26e349531d919641560deecffcab9aae24e222ef3360835d0405578be1377121"},
+    {file = "web3_ethereum_defi-0.22.23-py3-none-any.whl", hash = "sha256:8ff1cc9843fcb984c3e5d288982a60feecdba0fdf45ba22f33fb63ef18448a91"},
+    {file = "web3_ethereum_defi-0.22.23.tar.gz", hash = "sha256:f7273854ffbbd518945033927dc89b49c80131060266a73115a1d5d826d3953e"},
 ]
 
 [package.dependencies]
@@ -6143,4 +6143,4 @@ web-server = ["WebTest", "openapi-core", "pyramid", "pyramid-openapi3", "waitres
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.10,<3.11"
-content-hash = "104d11d92f10102384320d258504166de9d8aec6f2082c99e5788d42688596e4"
+content-hash = "6e9170473739ccccadb03d3d52b6f27700021d1568023443d6e60782cca4b3a2"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ tqdm-loggable = "0.1.4"
 
 
 # web3-ethereum-defi = {path = "deps/web3-ethereum-defi", develop = true, extras=["data", "test"]}
-web3-ethereum-defi = {version="0.22.22", extras=["data", "test"]}
+web3-ethereum-defi = {version="0.22.23", extras=["data", "test"]}
 
 # tqdm progress bar doesn't show up in VScode Jupyter with ipywidgets>=8
 # https://github.com/microsoft/vscode-jupyter/issues/11014

--- a/tradeexecutor/backtest/backtest_sync.py
+++ b/tradeexecutor/backtest/backtest_sync.py
@@ -4,6 +4,8 @@ from dataclasses import dataclass
 from decimal import Decimal
 from typing import List, Optional, Literal, Collection, Iterable
 
+from web3.types import BlockIdentifier
+
 from eth_defi.aave_v3.rates import SECONDS_PER_YEAR
 
 from tradeexecutor.backtest.simulated_wallet import SimulatedWallet
@@ -266,6 +268,7 @@ class BacktestSyncModel(SyncModel):
     def fetch_onchain_balances(
             self,
             assets: Collection[AssetIdentifier],
-            filter_zero=True
+            filter_zero=True,
+            block_identifier: BlockIdentifier = None,
     ) -> Iterable[OnChainBalance]:
         raise NotImplementedError("Backtesting does not know about on-chain balances")

--- a/tradeexecutor/cli/commands/correct_accounts.py
+++ b/tradeexecutor/cli/commands/correct_accounts.py
@@ -264,7 +264,7 @@ def correct_accounts(
         block_timestamp=block_timestamp,
     )
     balance_updates = list(balance_updates)
-    logger.info("Applied %d balance updates", len(balance_updates))
+    logger.info(f"Applied {len(balance_updates)} balance updates, new block height is {block_number:,} at {block_timestamp}")
 
     store.sync(state)
     web3config.close()

--- a/tradeexecutor/strategy/account_correction.py
+++ b/tradeexecutor/strategy/account_correction.py
@@ -395,13 +395,14 @@ def apply_accounting_correction(
 
 
 def correct_accounts(
-        state: State,
-        corrections: List[AccountingBalanceCheck],
-        strategy_cycle_included_at: datetime.datetime | None,
-        tx_builder: TransactionBuilder,
-        interactive=True,
-        unknown_token_receiver: HexAddress | str | None = None,
-        block_identifier: BlockIdentifier = None,
+    state: State,
+    corrections: List[AccountingBalanceCheck],
+    strategy_cycle_included_at: datetime.datetime | None,
+    tx_builder: TransactionBuilder,
+    interactive=True,
+    unknown_token_receiver: HexAddress | str | None = None,
+    block_identifier: BlockIdentifier = None,
+    block_timestamp: datetime.datetime = None,
 ) -> Iterable[BalanceUpdate]:
     """Apply the accounting corrections on the state (internal ledger).
 
@@ -447,6 +448,9 @@ def correct_accounts(
     # Update last scanned block, so we do not rescan events we might have skipped
     if block_identifier is not None:
         state.sync.treasury.last_block_scanned = block_identifier
+        if block_timestamp:
+            state.sync.treasury.last_updated_at = block_timestamp
+
     else:
         logger.warning("Treasury sync block identifier missing")
 

--- a/tradeexecutor/strategy/account_correction.py
+++ b/tradeexecutor/strategy/account_correction.py
@@ -18,7 +18,9 @@ from typing import List, Iterable, Collection, Tuple
 
 import pandas as pd
 from web3 import Web3
+from web3.types import BlockIdentifier
 
+from eth_defi.provider.broken_provider import get_almost_latest_block_number
 from eth_defi.token import fetch_erc20_details
 from eth_defi.trace import assert_transaction_success_with_explanation
 from eth_typing import HexAddress
@@ -195,6 +197,7 @@ def calculate_account_corrections(
     sync_model: SyncModel,
     relative_epsilon=RELATIVE_EPSILON,
     all_balances=False,
+    block_identifier: BlockIdentifier = None,
 ) -> Iterable[AccountingBalanceCheck]:
     """Figure out differences between our internal ledger (state) and on-chain balances.
 
@@ -217,6 +220,9 @@ def calculate_account_corrections(
     :param all_balances:
         If `True` iterate all balances even if there are no mismatch.
 
+    :param block_identifier:
+        Check at certain account height
+
     :raise UnexpectedAccountingCorrectionIssue:
         If we find on-chain tokens we do not know how to map any of our strategy positions
 
@@ -231,7 +237,7 @@ def calculate_account_corrections(
     logger.info("Scanning for account corrections, we have %d open positions", len(state.portfolio.open_positions))
 
     assets = get_relevant_assets(pair_universe, reserve_assets, state)
-    asset_balances = list(sync_model.fetch_onchain_balances(assets, filter_zero=False))
+    asset_balances = list(sync_model.fetch_onchain_balances(assets, filter_zero=False, block_identifier=block_identifier))
 
     logger.info("Found %d on-chain tokens", len(asset_balances))
 
@@ -395,6 +401,7 @@ def correct_accounts(
         tx_builder: TransactionBuilder,
         interactive=True,
         unknown_token_receiver: HexAddress | str | None = None,
+        block_identifier: BlockIdentifier = None,
 ) -> Iterable[BalanceUpdate]:
     """Apply the accounting corrections on the state (internal ledger).
 
@@ -436,6 +443,12 @@ def correct_accounts(
         else:
             # Change open position balance to match the on-chain balance
             yield apply_accounting_correction(state, correction, strategy_cycle_included_at)
+
+    # Update last scanned block, so we do not rescan events we might have skipped
+    if block_identifier is not None:
+        state.sync.treasury.last_block_scanned = block_identifier
+    else:
+        logger.warning("Treasury sync block identifier missing")
 
 
 def transfer_away_assets_without_position(
@@ -500,13 +513,35 @@ def check_accounts(
     reserve_assets: Collection[AssetIdentifier],
     state: State,
     sync_model: SyncModel,
+    block_identifier: BlockIdentifier = None,
 ) -> Tuple[bool, pd.DataFrame]:
-    """Get a table output of accounting corrections needed.
+    """Create a summary accounting corrections needed.
+
+    Create a human-readable DataFrame of accounting inconsistencies.
+
+    :param pair_universe:
+        Trading pairs we have.
+
+        Needed to get token addresses we read on-chain.
+
+    :param reserve_assets:
+        Cannot be deducted from pair universe.
+
+    :param state:
+        Current strategy state we check
+
+    :param block_identifier:
+        Check at certain block height
 
     :return:
-
         Tuple (accounts clean, accounting clean Dataframe that can be printed to the console)
     """
+
+    if block_identifier is None:
+        web3 = sync_model.web3
+        block_identifier = get_almost_latest_block_number(web3)
+
+    logger.info(f"Checking accounts at block {block_identifier:,}")
 
     clean = True
     corrections = calculate_account_corrections(
@@ -516,6 +551,7 @@ def check_accounts(
         sync_model,
         relative_epsilon=RELATIVE_EPSILON,
         all_balances=True,
+        block_identifier=block_identifier,
     )
 
     idx = []

--- a/tradeexecutor/strategy/sync_model.py
+++ b/tradeexecutor/strategy/sync_model.py
@@ -6,6 +6,8 @@ from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from typing import Callable, List, Optional, Iterable, Collection
 
+from web3.types import BlockIdentifier
+
 from eth_defi.hotwallet import HotWallet
 from tradeexecutor.ethereum.tx import TransactionBuilder
 from tradeexecutor.ethereum.wallet import ReserveUpdateEvent
@@ -124,24 +126,11 @@ class SyncModel(ABC):
         """
 
     @abstractmethod
-    def create_transaction_builder(self) -> Optional[TransactionBuilder]:
-        """Creates a transaction builder instance to make trades against this asset management model.
-
-        Only needed when trades are being executed.
-
-        :return:
-            Depending on the asset management mode.
-
-            - :py:class:`tradeexecutor.ethereum.tx.HotWalletTransactionBuilder`
-
-            - :py:class:`tradeexecutor.ethereum.enzyme.tx.EnzymeTransactionBuilder`
-        """
-
-    @abstractmethod
     def fetch_onchain_balances(
             self,
             assets: Collection[AssetIdentifier],
-            filter_zero=True
+            filter_zero=True,
+            block_identifier: BlockIdentifier = None,
     ) -> Iterable[OnChainBalance]:
         """Read the on-chain asset details.
 
@@ -153,8 +142,25 @@ class SyncModel(ABC):
         :param filter_zero:
             Do not return zero balances
 
+        :param block_identifier:
+            Cbeck at certain block height.
+
         :return:
             Iterator for assets by the sort order.
+        """
+
+    @abstractmethod
+    def create_transaction_builder(self) -> Optional[TransactionBuilder]:
+        """Creates a transaction builder instance to make trades against this asset management model.
+
+        Only needed when trades are being executed.
+
+        :return:
+            Depending on the asset management mode.
+
+            - :py:class:`tradeexecutor.ethereum.tx.HotWalletTransactionBuilder`
+
+            - :py:class:`tradeexecutor.ethereum.enzyme.tx.EnzymeTransactionBuilder`
         """
 
     def sync_interests(

--- a/tradeexecutor/strategy/sync_model.py
+++ b/tradeexecutor/strategy/sync_model.py
@@ -243,6 +243,7 @@ class DummySyncModel(SyncModel):
     def fetch_onchain_balances(
             self,
             assets: Collection[AssetIdentifier],
-            filter_zero=True
+            filter_zero=True,
+            block_identifier: BlockIdentifier = None,
     ) -> Iterable[OnChainBalance]:
         raise NotImplementedError("Backtesting does not know about on-chain balances")

--- a/tradeexecutor/utils/blockchain.py
+++ b/tradeexecutor/utils/blockchain.py
@@ -2,15 +2,42 @@
 import datetime
 
 from web3 import Web3
+from web3.types import BlockIdentifier
 
 
 def get_latest_block_timestamp(web3: Web3) -> datetime.datetime:
     """Get the latest block timestamp.
 
+    .. warning::
+
+        Do not use
+
+        See :py:func:`eth_defi.provider.broken_provider.get_almost_latest_block_number`
+
     :return:
         Timezone naive datetime
     """
     last_block = web3.eth.get_block("latest")
+    ts_str = last_block["timestamp"]
+
+    # Depending on middleware, response might be converted or not
+    if type(ts_str) == str:
+        ts = int(ts_str, 16)
+    else:
+        ts = ts_str
+
+    return datetime.datetime.utcfromtimestamp(ts)
+
+
+def get_block_timestamp(web3: Web3, block_identifier: BlockIdentifier) -> datetime.datetime:
+    """Get a  block timestamp.
+
+    Slow method. Use only for individual queries.
+
+    :return:
+        Timezone naive datetime
+    """
+    last_block = web3.eth.get_block(block_identifier)
     ts_str = last_block["timestamp"]
 
     # Depending on middleware, response might be converted or not

--- a/tradeexecutor/utils/blockchain.py
+++ b/tradeexecutor/utils/blockchain.py
@@ -4,6 +4,8 @@ import datetime
 from web3 import Web3
 from web3.types import BlockIdentifier
 
+from eth_defi.event_reader.conversion import convert_jsonrpc_value_to_int
+
 
 def get_latest_block_timestamp(web3: Web3) -> datetime.datetime:
     """Get the latest block timestamp.
@@ -15,7 +17,7 @@ def get_latest_block_timestamp(web3: Web3) -> datetime.datetime:
         See :py:func:`eth_defi.provider.broken_provider.get_almost_latest_block_number`
 
     :return:
-        Timezone naive datetime
+        Timezone naive UTC datetime
     """
     last_block = web3.eth.get_block("latest")
     ts_str = last_block["timestamp"]
@@ -35,14 +37,14 @@ def get_block_timestamp(web3: Web3, block_identifier: BlockIdentifier) -> dateti
     Slow method. Use only for individual queries.
 
     :return:
-        Timezone naive datetime
+        Timezone naive UTC datetime
     """
     last_block = web3.eth.get_block(block_identifier)
     ts_str = last_block["timestamp"]
 
     # Depending on middleware, response might be converted or not
     if type(ts_str) == str:
-        ts = int(ts_str, 16)
+        ts = convert_jsonrpc_value_to_int(ts_str)
     else:
         ts = ts_str
 


### PR DESCRIPTION
- Make sure we update treasury last block scanned correctly when directly reading correction balances on-chain