### PR TITLE
Revalue portfolio right after we see deposits

### DIFF
--- a/tradeexecutor/cli/loop.py
+++ b/tradeexecutor/cli/loop.py
@@ -503,7 +503,7 @@ class ExecutionLoop:
                 state.stats,
                 state.portfolio,
                 ExecutionMode.real_trading,
-                strategy_cycle_at=strategy_cycle_timestamp,
+                strategy_cycle_or_wall_clock=strategy_cycle_timestamp,
             )
 
         state.uptime.record_cycle_complete(cycle)

--- a/tradeexecutor/state/balance_update.py
+++ b/tradeexecutor/state/balance_update.py
@@ -167,7 +167,7 @@ class   BalanceUpdate:
         else:
             position_name = "strategy reserves"
 
-        return f"<BalanceUpdate #{self.balance_update_id} {self.cause.name} {self.quantity} for {position_name} at block {self.block_mined_at and self.block_mined_at:,}>"
+        return f"Funding event #{self.balance_update_id} {self.cause.name} {self.quantity} for {position_name} at block {self.block_mined_at and self.block_mined_at:,}"
 
     def __eq__(self, other: "BalanceUpdate"):
         assert isinstance(other, BalanceUpdate), f"Got {other}"

--- a/tradeexecutor/statistics/core.py
+++ b/tradeexecutor/statistics/core.py
@@ -155,7 +155,7 @@ def update_statistics(
         stats: Statistics,
         portfolio: Portfolio,
         execution_mode: ExecutionMode,
-        strategy_cycle_at: datetime.datetime | None = None,
+        strategy_cycle_or_wall_clock: datetime.datetime | None = None,
 ):
     """Update statistics in a portfolio.
 
@@ -179,8 +179,10 @@ def update_statistics(
 
         Always available.
 
-    :param strategy_cycle_at:
+    :param strategy_cycle_or_wall_clock:
         The strategy cycle timestamp.
+
+        Wall clock time if called outside the strategy cycle.
 
         Only available when `update_statistics()` is run
         at the end of live trading cycle.
@@ -188,7 +190,7 @@ def update_statistics(
 
     logger.info("update_statistics(), real-time clock at %s, strategy cycle at %s",
                 clock,
-                strategy_cycle_at
+                strategy_cycle_or_wall_clock
                 )
 
     new_stats = calculate_statistics(clock, portfolio, execution_mode)

--- a/tradeexecutor/strategy/runner.py
+++ b/tradeexecutor/strategy/runner.py
@@ -13,6 +13,7 @@ from pprint import pformat
 
 from typing import List, Optional, Tuple
 
+from tradeexecutor.statistics.core import update_statistics
 from tradeexecutor.strategy.account_correction import check_accounts, UnexpectedAccountingCorrectionIssue
 from tradeexecutor.strategy.approval import ApprovalModel
 from tradeexecutor.strategy.cycle import CycleDuration
@@ -192,14 +193,41 @@ class StrategyRunner(abc.ABC):
         )
         assert type(balance_update_events) == list
 
+        for e in balance_update_events:
+            logger.trade("Funding flow event: %s", e)
+
         # Update the debug data for tests with our events
         debug_details["reserve_update_events"] = balance_update_events
         debug_details["total_equity_at_start"] = state.portfolio.get_total_equity()
         debug_details["total_cash_at_start"] = state.portfolio.get_cash()
 
-    def revalue_state(self, ts: datetime.datetime, state: State, valuation_method: ValuationModel):
+        # If we have any new deposits, let's refresh our stats right away
+        # to reflect the new balances
+        if len(balance_update_events) > 0:
+
+            with self.timed_task_context_manager("sync_portfolio_stats_refresh"):
+                routing_state, pricing_model, valuation_model = self.setup_routing(universe)
+
+                timestamp = datetime.datetime.utcnow()
+
+                # Re-value the portfolio with new deposits
+                self.revalue_state(
+                    timestamp,
+                    state,
+                    valuation_model,
+                )
+
+                update_statistics(
+                    timestamp,
+                    state.stats,
+                    state.portfolio,
+                    self.execution_context.mode,
+                    strategy_cycle_or_wall_clock=timestamp,
+                )
+
+    def revalue_state(self, ts: datetime.datetime, state: State, valuation_model: ValuationModel):
         """Revalue portfolio based on the latest prices."""
-        revalue_state(state, ts, valuation_method)
+        revalue_state(state, ts, valuation_model)
         logger.info("After revaluation at %s our portfolio value is %f USD", ts, state.portfolio.get_total_equity())
 
     def collect_post_execution_data(
@@ -652,7 +680,7 @@ class StrategyRunner(abc.ABC):
 
             # Sync treasure before the trigger checks
             with self.timed_task_context_manager("sync_portfolio_before_triggers"):
-                self.check_accounts(universe, state,report_only=True)
+                self.check_accounts(universe, state, report_only=True)
                 self.sync_portfolio(clock, universe, state, debug_details)
 
             # Check that our on-chain balances are good
@@ -752,12 +780,20 @@ class StrategyRunner(abc.ABC):
                 self.sync_model,
             )
 
+            log_level = logging.INFO if report_only else logging.ERROR
+
             if not clean:
-                logger.error("Accounting errors detected\n"
-                             "Aborting execution as we cannot reliable trade with incorrect balances.\n"
-                             "Accounting errors are:\n"
-                             "%s", df.to_string())
+                logger.log(
+                    log_level,
+                    "Accounting differences detected\n"                    
+                    "Differences are:\n"
+                    "%s",
+                    df.to_string()
+                )
+
                 if not report_only:
-                    raise UnexpectedAccountingCorrectionIssue("Accounting errors detected")
+                    logger.error("Aborting execution as we cannot reliable trade with incorrect balances.")
+                    raise UnexpectedAccountingCorrectionIssue("Aborting execution as we cannot reliable trade with incorrect balances.")
         else:
+            # Path taken by some legacy tests
             logger.info("Accounting checks disabled - skipping")

--- a/tradeexecutor/strategy/runner.py
+++ b/tradeexecutor/strategy/runner.py
@@ -208,7 +208,7 @@ class StrategyRunner(abc.ABC):
             with self.timed_task_context_manager("sync_portfolio_stats_refresh"):
                 routing_state, pricing_model, valuation_model = self.setup_routing(universe)
 
-                timestamp = datetime.datetime.utcnow()
+                timestamp = strategy_cycle_or_trigger_check_ts
 
                 # Re-value the portfolio with new deposits
                 self.revalue_state(

--- a/tradeexecutor/visual/equity_curve.py
+++ b/tradeexecutor/visual/equity_curve.py
@@ -14,9 +14,10 @@ from tradeexecutor.state.statistics import Statistics, PortfolioStatistics
 
 
 def calculate_equity_curve(
-        state: State,
-        attribute_name="total_equity",
-        fill_time_gaps=False,
+    state: State,
+    attribute_name="total_equity",
+    fill_time_gaps=False,
+    resample="D",
 ) -> pd.Series:
     """Calculate equity curve for the portfolio.
 
@@ -65,7 +66,22 @@ def calculate_equity_curve(
             data.append((end, end_val))
 
     # https://stackoverflow.com/a/66772284/315168
-    return pd.DataFrame(data).set_index(0)[1]
+    df = pd.DataFrame(data).set_index(0)[1]
+
+    # Remove duplicates
+    #
+    # Happens in unit tests as we get a calculate event from deposit
+    # and recalculatin at the same timestam
+
+    # ipdb> curve
+    # 0
+    # 2021-06-01 00:00:00.000000        0.000000
+    # 2023-10-18 10:04:05.834542    10000.000000
+    # 2021-06-01 00:00:00.000000    10000.000000
+
+    # https://stackoverflow.com/a/34297689/315168
+    df = df[~df.index.duplicated(keep='last')]
+    return df
 
 
 def calculate_returns(equity_curve: pd.Series) -> pd.Series:

--- a/tradeexecutor/visual/equity_curve.py
+++ b/tradeexecutor/visual/equity_curve.py
@@ -17,7 +17,6 @@ def calculate_equity_curve(
     state: State,
     attribute_name="total_equity",
     fill_time_gaps=False,
-    resample="D",
 ) -> pd.Series:
     """Calculate equity curve for the portfolio.
 
@@ -43,6 +42,9 @@ def calculate_equity_curve(
         Index is DatetimeIndex.
 
         Empty series is returned if there is no data.
+
+        We ensure only one entry per timestamp through
+        filtering out duplicate indices.
 
     """
 


### PR DESCRIPTION
- Current deposit/redemption was reflected in the state, but not in the statistics
- Frontend displayed a wrong TVL amount for a while until there was a refresh
- Log deposits and redemptions to Discord
- Tune `check_accounts()` logging level according to the situation