### PR TITLE
Working on post-trade execution bugs

### DIFF
--- a/tests/enzyme/test_enzyme_correct_accounting.py
+++ b/tests/enzyme/test_enzyme_correct_accounting.py
@@ -236,7 +236,8 @@ def test_enzyme_correct_accounting_errors(
     # Make two deposits from separate parties
     usdc.functions.transfer(user_1, 1000 * 10**6).transact({"from": deployer})
     usdc.functions.approve(vault.comptroller.address, 500 * 10**6).transact({"from": user_1})
-    vault.comptroller.functions.buyShares(500 * 10**6, 1).transact({"from": user_1})
+    tx_hash = vault.comptroller.functions.buyShares(500 * 10**6, 1).transact({"from": user_1})
+    assert_transaction_success_with_explanation(web3, tx_hash)
 
     # Strategy has its reserve balances updated
     sync_model.sync_treasury(datetime.datetime.utcnow(), state)

--- a/tradeexecutor/backtest/backtest_execution.py
+++ b/tradeexecutor/backtest/backtest_execution.py
@@ -73,6 +73,9 @@ class BacktestExecutionModel(ExecutionModel):
         self.lp_fees = lp_fees
         self.stop_loss_data_available = stop_loss_data_available
 
+    def get_balance_address(self):
+        return None
+
     def is_live_trading(self):
         return False
 

--- a/tradeexecutor/ethereum/execution.py
+++ b/tradeexecutor/ethereum/execution.py
@@ -106,6 +106,9 @@ class EthereumExecutionModel(ExecutionModel):
     def chain_id(self) -> int:
         """Which chain the live execution is connected to."""
         return self.web3.eth.chain_id
+
+    def get_balance_address(self) -> str:
+        return self.tx_builder.get_erc_20_balance_address()
     
     @staticmethod
     def pre_execute_assertions(
@@ -519,7 +522,7 @@ class EthereumExecutionModel(ExecutionModel):
                     else:
                         price = 1 / result.price
 
-                    executed_reserve = result.amount_in / Decimal(10**quote_token_details.decimals)
+                    executed_reserve = result.amount_in / Decimal(10**reserve.decimals)
                     executed_amount = result.amount_out / Decimal(10**base_token_details.decimals)
 
                     # lp fee is already in terms of quote token

--- a/tradeexecutor/ethereum/uniswap_v2/uniswap_v2_execution_v0.py
+++ b/tradeexecutor/ethereum/uniswap_v2/uniswap_v2_execution_v0.py
@@ -49,7 +49,7 @@ class UniswapV2RoutingInstructions:
 class UniswapV2ExecutionModelVersion0(ExecutionModel):
     """Run order execution on a single Uniswap v2 style exchanges.
 
-    TODO: This model was used in the first prototype and later discarded.
+    TODO: This model was used in the first prototype and will be later discarded.
     """
 
     def __init__(self,
@@ -77,6 +77,9 @@ class UniswapV2ExecutionModelVersion0(ExecutionModel):
         self.confirmation_block_count = confirmation_block_count
         self.confirmation_timeout = confirmation_timeout
         self.max_slippage = max_slippage
+
+    def get_balance_address(self):
+        return None
 
     @property
     def chain_id(self) -> int:

--- a/tradeexecutor/state/position.py
+++ b/tradeexecutor/state/position.py
@@ -725,6 +725,7 @@ class TradingPosition(GenericPosition):
                    closing: Optional[bool] = False,
                    planned_collateral_consumption: Optional[Decimal] = None,
                    planned_collateral_allocation: Optional[Decimal] = None,
+                   exchange_name: Optional[str] = None,
                    ) -> TradeExecution:
         """Open a new trade on position.
 
@@ -901,6 +902,7 @@ class TradingPosition(GenericPosition):
             reserve_currency_exchange_rate=reserve_currency_price,
             planned_collateral_allocation=planned_collateral_allocation,
             planned_collateral_consumption=planned_collateral_consumption,
+            exchange_name=exchange_name,
         )
 
         self.trades[trade.trade_id] = trade

--- a/tradeexecutor/state/trade.py
+++ b/tradeexecutor/state/trade.py
@@ -488,6 +488,15 @@ class TradeExecution:
     #:
     paid_interest: Optional[Decimal] = None
 
+    #: The DEX name where this trade was executed.
+    #:
+    #: A human-readable debugging hint.
+    #: :py:attr:`pair` will contain the exchange address itself.
+    #:
+    #: Optional, to be more used in the future versions.
+    #:
+    exchange_name: Optional[str] = None
+
     def __repr__(self) -> str:
         if self.is_spot():
             if self.is_buy():
@@ -558,8 +567,13 @@ class TradeExecution:
         assert self.opened_at.tzinfo is None, f"We got a datetime {self.opened_at} with tzinfo {self.opened_at.tzinfo}"
         
     @property
-    def strategy_cycle_at(self):
-        """Alias for oepned_at"""
+    def strategy_cycle_at(self) -> datetime.datetime:
+        """Alias for :py:attr:`opened_at`.
+
+        - Get the timestamp of the strategy cycle this trade is related to
+
+        - If this trade is outside the strategy cycle, then it is wall clock time
+        """
         return self.opened_at
     
     @property

--- a/tradeexecutor/strategy/account_correction.py
+++ b/tradeexecutor/strategy/account_correction.py
@@ -314,6 +314,10 @@ def apply_accounting_correction(
     assert correction.type == AccountingCorrectionCause.unknown_cause, f"Not supported: {correction}"
     assert correction.timestamp
 
+    frozen_count = len(state.portfolio.frozen_positions)
+    if frozen_count > 0:
+        raise AssertionError(f"We have {frozen_count} frozen positions. Run repair for these first before attempting an accounting correction.")
+
     portfolio = state.portfolio
     asset = correction.asset
     position = correction.position

--- a/tradeexecutor/strategy/dummy.py
+++ b/tradeexecutor/strategy/dummy.py
@@ -19,6 +19,9 @@ class DummyExecutionModel(ExecutionModel):
     def __init__(self, web3: Web3):
         self.web3 = web3
 
+    def get_balance_address(self):
+        return None
+
     def preflight_check(self):
         """Check that we can start the trade executor
 

--- a/tradeexecutor/strategy/execution_model.py
+++ b/tradeexecutor/strategy/execution_model.py
@@ -61,8 +61,12 @@ class ExecutionModel(abc.ABC):
     """
 
     @abc.abstractmethod
-    def get_balance_address(self) -> str:
-        """Get the address where the strat holds tokens."""
+    def get_balance_address(self) -> str | None:
+        """Get the address where the strat holds tokens.
+
+        :return:
+            None if this executor does not use on-chain addresses.
+        """
 
     @abc.abstractmethod
     def preflight_check(self):

--- a/tradeexecutor/strategy/execution_model.py
+++ b/tradeexecutor/strategy/execution_model.py
@@ -61,6 +61,10 @@ class ExecutionModel(abc.ABC):
     """
 
     @abc.abstractmethod
+    def get_balance_address(self) -> str:
+        """Get the address where the strat holds tokens."""
+
+    @abc.abstractmethod
     def preflight_check(self):
         """Check that we can start the trade executor
 


### PR DESCRIPTION
- Figure out why there are still some mismatch on-chain amounts vs. expected
- Warn about frozen positions in `check-accounts` and `correct-accounts`
- Don't allow `correct-accounts` before `repair` has been run