### PR TITLE
Safe end block number

### DIFF
--- a/tradeexecutor/backtest/backtest_execution.py
+++ b/tradeexecutor/backtest/backtest_execution.py
@@ -73,6 +73,9 @@ class BacktestExecutionModel(ExecutionModel):
         self.lp_fees = lp_fees
         self.stop_loss_data_available = stop_loss_data_available
 
+    def get_safe_latest_block(self):
+        return None
+
     def get_balance_address(self):
         return None
 

--- a/tradeexecutor/backtest/backtest_sync.py
+++ b/tradeexecutor/backtest/backtest_sync.py
@@ -2,6 +2,7 @@ import logging
 import datetime
 from dataclasses import dataclass
 from decimal import Decimal
+from types import NoneType
 from typing import List, Optional, Literal, Collection, Iterable
 
 from web3.types import BlockIdentifier
@@ -14,7 +15,7 @@ from tradeexecutor.state.balance_update import BalanceUpdate
 from tradeexecutor.state.identifier import AssetIdentifier
 from tradeexecutor.state.position import TradingPosition
 from tradeexecutor.state.state import State
-from tradeexecutor.state.types import JSONHexAddress
+from tradeexecutor.state.types import JSONHexAddress, BlockNumber
 from tradeexecutor.strategy.interest import update_interest, update_leveraged_position_interest
 from tradeexecutor.strategy.pricing_model import PricingModel
 from tradeexecutor.strategy.sync_model import SyncModel, OnChainBalance
@@ -72,11 +73,13 @@ class BacktestSyncModel(SyncModel):
         deployment.vault_token_name = None
         deployment.vault_token_symbol = None
 
-    def sync_treasury(self,
-                 strategy_cycle_ts: datetime.datetime,
-                 state: State,
-                 supported_reserves: Optional[List[AssetIdentifier]] = None
-                 ) -> List[BalanceUpdate]:
+    def sync_treasury(
+        self,
+        strategy_cycle_ts: datetime.datetime,
+        state: State,
+        supported_reserves: Optional[List[AssetIdentifier]] = None,
+        end_block: BlockNumber | NoneType = None,
+    ) -> List[BalanceUpdate]:
         """Apply the balance sync before each strategy cycle.
 
         .. warning::
@@ -86,6 +89,8 @@ class BacktestSyncModel(SyncModel):
 
         assert len(supported_reserves) == 1
         reserve_token = supported_reserves[0]
+
+        assert end_block is None, "Cannot use block ranges with backtesting"
 
         reserve_update_events = []  # TODO: Legacy
 

--- a/tradeexecutor/cli/loop.py
+++ b/tradeexecutor/cli/loop.py
@@ -503,6 +503,7 @@ class ExecutionLoop:
             trades = debug_details.get("approved_trades")
             if trades:
                 # This will raise an exception if there are issues
+                # TODO: Handle deposits during trade executoin
                 try:
                     self.runner.check_balances_post_execution(
                         universe,

--- a/tradeexecutor/ethereum/enzyme/vault.py
+++ b/tradeexecutor/ethereum/enzyme/vault.py
@@ -513,7 +513,7 @@ class EnzymeVaultSyncModel(SyncModel):
             # Legacy
             end_block = get_almost_latest_block_number(web3)
 
-        logger.info(f"Starting treasury sync for vault %s, comptroller %s, looking block range {start_block:,} - {end_block:,}, block tip latency is %d", self.vault.address, self.vault.comptroller.address, latency)
+        logger.info(f"Starting treasury sync for vault %s, comptroller %s, looking block range {start_block:,} - {end_block:,}, block tip latency is %d", self.vault.address, self.vault.comptroller.address)
 
         reader, broken_quicknode = self.create_event_reader()
 

--- a/tradeexecutor/ethereum/enzyme/vault.py
+++ b/tradeexecutor/ethereum/enzyme/vault.py
@@ -5,6 +5,7 @@ import datetime
 import pprint
 from _decimal import Decimal
 from functools import partial
+from types import NoneType
 from typing import cast, List, Optional, Tuple, Iterable
 
 from eth_defi.event_reader.conversion import convert_jsonrpc_value_to_int
@@ -32,6 +33,7 @@ from tradeexecutor.state.reserve import ReservePosition
 from tradeexecutor.state.state import State
 from tradeexecutor.state.balance_update import BalanceUpdate, BalanceUpdateCause, BalanceUpdatePositionType
 from tradeexecutor.state.sync import BalanceEventRef
+from tradeexecutor.state.types import BlockNumber
 from tradeexecutor.strategy.account_correction import check_accounts
 from tradeexecutor.strategy.sync_model import SyncModel, OnChainBalance
 from tradingstrategy.chain import ChainId
@@ -489,20 +491,8 @@ class EnzymeVaultSyncModel(SyncModel):
                       strategy_cycle_ts: datetime.datetime,
                       state: State,
                       supported_reserves: Optional[List[AssetIdentifier]] = None,
+                      end_block: BlockNumber | NoneType = None,
                       ) -> List[BalanceUpdate]:
-        """Apply the balance sync before each strategy cycle.
-
-        - Deposits by shareholders
-
-        - Redemptions
-
-        :return:
-            List of new treasury balance events
-
-        :raise ChainReorganisationDetected:
-            When any if the block data in our internal buffer
-            does not match those provided by events.
-        """
 
         web3 = self.web3
         sync = state.sync
@@ -518,8 +508,10 @@ class EnzymeVaultSyncModel(SyncModel):
             start_block = sync.deployment.block_number
 
         web3 = self.web3
-        latency = get_block_tip_latency(web3)
-        end_block = max(1, web3.eth.block_number - latency)
+
+        if not end_block:
+            # Legacy
+            end_block = get_almost_latest_block_number(web3)
 
         logger.info(f"Starting treasury sync for vault %s, comptroller %s, looking block range {start_block:,} - {end_block:,}, block tip latency is %d", self.vault.address, self.vault.comptroller.address, latency)
 

--- a/tradeexecutor/ethereum/execution.py
+++ b/tradeexecutor/ethereum/execution.py
@@ -10,6 +10,7 @@ from typing import List, Dict, Set, Tuple
 from abc import abstractmethod
 
 from eth_account.datastructures import SignedTransaction
+from eth_defi.provider.broken_provider import get_almost_latest_block_number
 from eth_typing import HexAddress, HexStr
 from hexbytes import HexBytes
 from web3 import Web3
@@ -36,6 +37,7 @@ from tradeexecutor.state.freeze import freeze_position_on_failed_trade
 from tradeexecutor.state.identifier import AssetIdentifier
 from tradeexecutor.ethereum.uniswap_v2.uniswap_v2_routing import UniswapV2SimpleRoutingModel, UniswapV2RoutingState
 from tradeexecutor.ethereum.uniswap_v3.uniswap_v3_routing import UniswapV3SimpleRoutingModel, UniswapV3RoutingState
+from tradeexecutor.state.types import BlockNumber
 from tradeexecutor.strategy.execution_model import ExecutionModel, RoutingStateDetails
 from tradingstrategy.chain import ChainId
 
@@ -109,7 +111,11 @@ class EthereumExecutionModel(ExecutionModel):
 
     def get_balance_address(self) -> str:
         return self.tx_builder.get_erc_20_balance_address()
-    
+
+    def get_safe_latest_block(self) -> BlockNumber:
+        web3 = self.web3
+        return get_almost_latest_block_number(web3)
+
     @staticmethod
     def pre_execute_assertions(
         ts: datetime.datetime, 

--- a/tradeexecutor/ethereum/hot_wallet_sync_model.py
+++ b/tradeexecutor/ethereum/hot_wallet_sync_model.py
@@ -1,6 +1,7 @@
 """Sync model for strategies using a single hot wallet."""
 import datetime
 import logging
+from types import NoneType
 from typing import List, Optional, Iterable
 
 from web3.types import BlockIdentifier
@@ -17,6 +18,7 @@ from tradeexecutor.ethereum.wallet import sync_reserves
 from tradeexecutor.state.identifier import AssetIdentifier
 
 from tradeexecutor.state.state import State
+from tradeexecutor.state.types import BlockNumber
 from tradeexecutor.strategy.sync_model import SyncModel, OnChainBalance
 from tradeexecutor.testing.dummy_wallet import apply_sync_events
 
@@ -62,12 +64,17 @@ class HotWalletSyncModel(SyncModel):
         deployment.vault_token_symbol = None
         deployment.initialised_at = datetime.datetime.utcnow()
 
-    def sync_treasury(self,
-                 strategy_cycle_ts: datetime.datetime,
-                 state: State,
-                 supported_reserves: Optional[List[AssetIdentifier]] = None
-                 ) -> List[BalanceUpdate]:
-        """Apply the balance sync before each strategy cycle."""
+    def sync_treasury(
+        self,
+        strategy_cycle_ts: datetime.datetime,
+        state: State,
+        supported_reserves: Optional[List[AssetIdentifier]] = None,
+        end_block: BlockNumber | NoneType = None,
+    ) -> List[BalanceUpdate]:
+        """Apply the balance sync before each strategy cycle.
+
+        TODO: end_block is being ignored
+        """
 
         # TODO: This code is not production ready - use with care
         # Needs legacy cleanup

--- a/tradeexecutor/ethereum/uniswap_v2/uniswap_v2_execution_v0.py
+++ b/tradeexecutor/ethereum/uniswap_v2/uniswap_v2_execution_v0.py
@@ -8,6 +8,8 @@ import datetime
 from decimal import Decimal
 from typing import List, Tuple, Optional
 import logging
+
+from eth_defi.provider.broken_provider import get_almost_latest_block_number
 from hexbytes import HexBytes
 from web3 import Web3
 
@@ -25,6 +27,7 @@ from tradeexecutor.state.freeze import freeze_position_on_failed_trade
 from tradeexecutor.state.state import State
 from tradeexecutor.state.trade import TradeExecution
 from tradeexecutor.state.blockhain_transaction import BlockchainTransaction
+from tradeexecutor.state.types import BlockNumber
 from tradeexecutor.strategy.execution_model import ExecutionModel
 from tradeexecutor.strategy.routing import RoutingModel, RoutingState
 
@@ -80,6 +83,10 @@ class UniswapV2ExecutionModelVersion0(ExecutionModel):
 
     def get_balance_address(self):
         return None
+
+    def get_safe_latest_block(self) -> BlockNumber:
+        web3 = self.web3
+        return get_almost_latest_block_number(web3)
 
     @property
     def chain_id(self) -> int:

--- a/tradeexecutor/state/types.py
+++ b/tradeexecutor/state/types.py
@@ -64,7 +64,7 @@ Percent: TypeAlias = float
 #: - Cannot be negative
 #:
 #: - Cannot be zero
-BlockNumber: int
+BlockNumber: TypeAlias = int
 
 #: Unix timestamp as seconds
 UnixTimestamp: TypeAlias = float
@@ -77,3 +77,4 @@ UnixTimestamp: TypeAlias = float
 #: For over collateralised position. E.g. 8 USDC and then 6 USD worth of ETH this is ``0.8``.
 #:
 LeverageMultiplier: TypeAlias = float
+

--- a/tradeexecutor/strategy/dummy.py
+++ b/tradeexecutor/strategy/dummy.py
@@ -19,6 +19,9 @@ class DummyExecutionModel(ExecutionModel):
     def __init__(self, web3: Web3):
         self.web3 = web3
 
+    def get_safe_latest_block(self):
+        return None
+
     def get_balance_address(self):
         return None
 

--- a/tradeexecutor/strategy/execution_model.py
+++ b/tradeexecutor/strategy/execution_model.py
@@ -9,6 +9,7 @@ Currently supported models
 import abc
 import datetime
 import enum
+from types import NoneType
 from typing import List, Dict, Tuple, TypedDict, Optional
 from web3 import Web3
 from hexbytes import HexBytes
@@ -17,6 +18,7 @@ from eth_defi.hotwallet import HotWallet
 from tradeexecutor.ethereum.tx import TransactionBuilder
 from tradeexecutor.state.state import State
 from tradeexecutor.state.trade import TradeExecution
+from tradeexecutor.state.types import BlockNumber
 from tradeexecutor.strategy.routing import RoutingModel, RoutingState
 from tradeexecutor.state.blockhain_transaction import BlockchainTransaction
 
@@ -82,6 +84,26 @@ class ExecutionModel(abc.ABC):
         Read any on-chain, etc., data to get synced.
 
         - Read EVM nonce for the hot wallet from the chain
+        """
+
+    @abc.abstractmethod
+    def get_safe_latest_block(self) -> BlockNumber | NoneType:
+        """Fix the block number for all checks and actions.
+
+        - At the start of each action cycle (strategy decision, position triggers)
+          we fix ourselves to a certain block number we know is "safe"
+          and the data in at this block number is unlike to change
+
+        - We then perform all deposit and redemptions and accounting
+          checks using this block number as end block,
+          to get a
+
+        :return:
+            A good safe latest block number.
+
+            Return `None` if the
+            block number is irrelevant for the execution,
+            like backtesting and such.
         """
 
     @abc.abstractmethod

--- a/tradeexecutor/strategy/execution_model.py
+++ b/tradeexecutor/strategy/execution_model.py
@@ -10,17 +10,15 @@ import abc
 import datetime
 import enum
 from types import NoneType
-from typing import List, Dict, Tuple, TypedDict, Optional
+from typing import List,TypedDict
 from web3 import Web3
-from hexbytes import HexBytes
 
 from eth_defi.hotwallet import HotWallet
+from tradeexecutor.state.types import BlockNumber
 from tradeexecutor.ethereum.tx import TransactionBuilder
 from tradeexecutor.state.state import State
 from tradeexecutor.state.trade import TradeExecution
-from tradeexecutor.state.types import BlockNumber
 from tradeexecutor.strategy.routing import RoutingModel, RoutingState
-from tradeexecutor.state.blockhain_transaction import BlockchainTransaction
 
 
 class AutoClosingOrderUnsupported(Exception):

--- a/tradeexecutor/strategy/sync_model.py
+++ b/tradeexecutor/strategy/sync_model.py
@@ -4,6 +4,7 @@ import datetime
 from _decimal import Decimal
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
+from types import NoneType
 from typing import Callable, List, Optional, Iterable, Collection
 
 from web3.types import BlockIdentifier
@@ -18,7 +19,7 @@ from tradeexecutor.state.position import TradingPosition
 from tradeexecutor.state.reserve import ReservePosition
 from tradeexecutor.state.state import State
 from tradeexecutor.state.sync import BalanceEventRef
-from tradeexecutor.state.types import JSONHexAddress
+from tradeexecutor.state.types import JSONHexAddress, BlockNumber
 from tradeexecutor.strategy.trading_strategy_universe import TradingStrategyUniverse
 from tradeexecutor.strategy.pricing_model import PricingModel
 
@@ -224,11 +225,14 @@ class DummySyncModel(SyncModel):
     def get_safe_latest_block(self):
         return None
 
-    def sync_treasury(self,
-                      strategy_cycle_ts: datetime.datetime,
-                      state: State,
-                      supported_reserves: Optional[List[AssetIdentifier]] = None
-                      ) -> List[BalanceUpdate]:
+    def sync_treasury(
+        self,
+        strategy_cycle_ts: datetime.datetime,
+        state: State,
+        supported_reserves: Optional[List[AssetIdentifier]] = None,
+        end_block: BlockNumber | NoneType = None,
+    ) -> List[BalanceUpdate]:
+        assert end_block is None, "Dummy does not understand end_block"
         if not self.fake_sync_done:
             state.sync.treasury.last_updated_at = datetime.datetime.utcnow()
             state.sync.treasury.last_cycle_at = strategy_cycle_ts

--- a/tradeexecutor/strategy/sync_model.py
+++ b/tradeexecutor/strategy/sync_model.py
@@ -99,7 +99,8 @@ class SyncModel(ABC):
     def sync_treasury(self,
                       strategy_cycle_ts: datetime.datetime,
                       state: State,
-                      supported_reserves: Optional[List[AssetIdentifier]] = None
+                      supported_reserves: Optional[List[AssetIdentifier]] = None,
+                      end_block: BlockNumber | NoneType = None,
                       ) -> List[BalanceUpdate]:
         """Apply the balance sync before each strategy cycle.
 
@@ -115,6 +116,9 @@ class SyncModel(ABC):
             List of assets the strategy module wants to use as its reserves.
 
             May be None in testing.
+
+        :param end_block:
+            Sync until this block.
 
         :return:
             List of balance updates detected.
@@ -215,6 +219,9 @@ class DummySyncModel(SyncModel):
         pass
 
     def get_token_storage_address(self) -> Optional[JSONHexAddress]:
+        return None
+
+    def get_safe_latest_block(self):
         return None
 
     def sync_treasury(self,


### PR DESCRIPTION
- Make execution more deterministic by enforcing certain `end_block` parameter until which we take account deposits/redemptions and relevant balance checks
- Note that the current method is not safe until we have atomic rebalances; it is impractical for high number of trades