### PR TITLE
Make winning stop loss a different colour

### DIFF
--- a/tradeexecutor/state/portfolio.py
+++ b/tradeexecutor/state/portfolio.py
@@ -604,8 +604,12 @@ class Portfolio:
         return sum([p.get_total_profit_usd() for p in self.closed_positions.values()])
 
     def find_position_for_trade(self, trade) -> Optional[TradingPosition]:
-        """Find a position tha trade belongs for."""
-        return self.open_positions[trade.position_id]
+        """Find a position that a trade belongs for."""
+        if trade.position_id in self.open_positions:
+            return self.open_positions[trade.position_id]
+        else:
+            return self.closed_positions[trade.position_id]
+
 
     def get_reserve_position(self, asset: AssetIdentifier) -> ReservePosition:
         """Get reserves for a certain reserve asset.


### PR DESCRIPTION
- Makes winning stop losses a different colour from losing stop losses in the visualisations
- Fixes #624

![winning_losing_stop_losses](https://github.com/tradingstrategy-ai/trade-executor/assets/74208897/c5b2c956-58ac-44a4-873a-12e6c501d1b6)
