### PR TITLE
Adding in-kind redemptions fix for realised PnL

### DIFF
--- a/notebooks/live-strategy-analysis/analyse-balance-events.ipynb
+++ b/notebooks/live-strategy-analysis/analyse-balance-events.ipynb
@@ -19,22 +19,35 @@
    "outputs": [],
    "source": [
     "trade_executors = [\n",
-    "    \"https://enzyme-polygon-eth-usdc-sls.tradingstrategy.ai\",\n",
+    "    \"https://enzyme-polygon-eth-usdc.tradingstrategy.ai\",\n",
     "]\n",
     "\n"
    ],
    "metadata": {
     "collapsed": false,
     "ExecuteTime": {
-     "end_time": "2023-07-25T08:53:26.565881Z",
-     "start_time": "2023-07-25T08:53:26.561871Z"
+     "end_time": "2023-11-20T14:15:42.895040Z",
+     "start_time": "2023-11-20T14:15:42.822895Z"
     }
    }
   },
   {
    "cell_type": "code",
    "execution_count": 2,
-   "outputs": [],
+   "outputs": [
+    {
+     "ename": "FileNotFoundError",
+     "evalue": "[Errno 2] No such file or directory: '../enzyme-polygon-eth-usdc.json'",
+     "output_type": "error",
+     "traceback": [
+      "\u001B[0;31m---------------------------------------------------------------------------\u001B[0m",
+      "\u001B[0;31mFileNotFoundError\u001B[0m                         Traceback (most recent call last)",
+      "Cell \u001B[0;32mIn[2], line 4\u001B[0m\n\u001B[1;32m      1\u001B[0m \u001B[38;5;28;01mfrom\u001B[39;00m \u001B[38;5;21;01mpathlib\u001B[39;00m \u001B[38;5;28;01mimport\u001B[39;00m Path\n\u001B[1;32m      2\u001B[0m \u001B[38;5;28;01mfrom\u001B[39;00m \u001B[38;5;21;01mtradeexecutor\u001B[39;00m\u001B[38;5;21;01m.\u001B[39;00m\u001B[38;5;21;01mstate\u001B[39;00m\u001B[38;5;21;01m.\u001B[39;00m\u001B[38;5;21;01mstate\u001B[39;00m \u001B[38;5;28;01mimport\u001B[39;00m State\n\u001B[0;32m----> 4\u001B[0m state \u001B[38;5;241m=\u001B[39m \u001B[43mState\u001B[49m\u001B[38;5;241;43m.\u001B[39;49m\u001B[43mread_json_file\u001B[49m\u001B[43m(\u001B[49m\u001B[43mPath\u001B[49m\u001B[43m(\u001B[49m\u001B[38;5;124;43m\"\u001B[39;49m\u001B[38;5;124;43m../enzyme-polygon-eth-usdc.json\u001B[39;49m\u001B[38;5;124;43m\"\u001B[39;49m\u001B[43m)\u001B[49m\u001B[43m)\u001B[49m\n",
+      "File \u001B[0;32m~/code/ts/trade-executor/tradeexecutor/state/state.py:880\u001B[0m, in \u001B[0;36mState.read_json_file\u001B[0;34m(path)\u001B[0m\n\u001B[1;32m    873\u001B[0m \u001B[38;5;250m\u001B[39m\u001B[38;5;124;03m\"\"\"Read state from the JSON file.\u001B[39;00m\n\u001B[1;32m    874\u001B[0m \n\u001B[1;32m    875\u001B[0m \u001B[38;5;124;03m- Deal with all serialisation quirks\u001B[39;00m\n\u001B[1;32m    876\u001B[0m \u001B[38;5;124;03m\"\"\"\u001B[39;00m\n\u001B[1;32m    878\u001B[0m \u001B[38;5;28;01massert\u001B[39;00m \u001B[38;5;28misinstance\u001B[39m(path, Path), \u001B[38;5;124mf\u001B[39m\u001B[38;5;124m\"\u001B[39m\u001B[38;5;124mExpected Path, got \u001B[39m\u001B[38;5;132;01m{\u001B[39;00mpath\u001B[38;5;241m.\u001B[39m\u001B[38;5;18m__class__\u001B[39m\u001B[38;5;132;01m}\u001B[39;00m\u001B[38;5;124m\"\u001B[39m\n\u001B[0;32m--> 880\u001B[0m \u001B[38;5;28;01mwith\u001B[39;00m \u001B[38;5;28;43mopen\u001B[39;49m\u001B[43m(\u001B[49m\u001B[43mpath\u001B[49m\u001B[43m,\u001B[49m\u001B[43m \u001B[49m\u001B[38;5;124;43m\"\u001B[39;49m\u001B[38;5;124;43mrt\u001B[39;49m\u001B[38;5;124;43m\"\u001B[39;49m\u001B[43m)\u001B[49m \u001B[38;5;28;01mas\u001B[39;00m inp:\n\u001B[1;32m    881\u001B[0m     \u001B[38;5;28;01mreturn\u001B[39;00m State\u001B[38;5;241m.\u001B[39mread_json_blob(inp\u001B[38;5;241m.\u001B[39mread())\n",
+      "\u001B[0;31mFileNotFoundError\u001B[0m: [Errno 2] No such file or directory: '../enzyme-polygon-eth-usdc.json'"
+     ]
+    }
+   ],
    "source": [
     "\n",
     "from pathlib import Path\n",
@@ -45,8 +58,8 @@
    "metadata": {
     "collapsed": false,
     "ExecuteTime": {
-     "end_time": "2023-07-25T08:53:27.814346Z",
-     "start_time": "2023-07-25T08:53:26.568632Z"
+     "end_time": "2023-11-20T14:15:46.296483Z",
+     "start_time": "2023-11-20T14:15:42.823988Z"
     }
    }
   },
@@ -61,23 +74,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Number of reserve assets: 1\n",
-      "Reserves: <USDC at 0x2791bca1f2de4661ed88a30c99a7a9449aa84174> at 1.0 USDC / USD\n",
-      "Amount: 42.82953700000000044423131840 USDC\n",
-      "Equity: 42.829537 USD\n",
-      "Value: 42.829537 USD\n",
-      "Balance updates: -2.1552182261E-16 USDC\n",
-      "Number of balance updates events: 2\n",
-      "Number of events references in the portfolio overall: 1\n"
-     ]
-    }
-   ],
+   "execution_count": null,
+   "outputs": [],
    "source": [
     "\n",
     "\n",
@@ -94,11 +92,7 @@
     "print(f\"Number of events references in the portfolio overall: {len(state.sync.treasury.balance_update_refs)}\")"
    ],
    "metadata": {
-    "collapsed": false,
-    "ExecuteTime": {
-     "end_time": "2023-07-25T08:53:27.818116Z",
-     "start_time": "2023-07-25T08:53:27.815760Z"
-    }
+    "collapsed": false
    }
   },
   {
@@ -112,17 +106,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Vault deployment: <Deployment chain:polygon address:0x6E321256BE0ABd2726A234E8dBFc4d3caf255AE0 name:Degen Fault I token:DEGE1>\n",
-      "Treasury sync status: <Treasury updated:2023-07-23 18:04:40 cycle:2023-07-23 18:00:00 block scanned:45,431,463 refs:1>\n"
-     ]
-    }
-   ],
+   "execution_count": null,
+   "outputs": [],
    "source": [
     "treasury = state.sync.treasury\n",
     "deployment = state.sync.deployment\n",
@@ -131,11 +116,7 @@
     "print(f\"Treasury sync status: {treasury}\")"
    ],
    "metadata": {
-    "collapsed": false,
-    "ExecuteTime": {
-     "end_time": "2023-07-25T08:53:27.820762Z",
-     "start_time": "2023-07-25T08:53:27.818770Z"
-    }
+    "collapsed": false
    }
   },
   {
@@ -151,17 +132,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
-   "outputs": [
-    {
-     "data": {
-      "text/plain": "        Cause                  At                       Quantity  \\\n1     deposit 2023-07-04 19:07:40                       7.165562   \n2  correction 2023-07-13 23:47:27  -7.16556200000000021552182261   \n\n   Dollar value Address                                              Notes  \n1      7.165562                                 reinit() at block 44683317  \n2     -7.165562          Accounting correction based on the actual on-c...  ",
-      "text/html": "<div>\n<style scoped>\n    .dataframe tbody tr th:only-of-type {\n        vertical-align: middle;\n    }\n\n    .dataframe tbody tr th {\n        vertical-align: top;\n    }\n\n    .dataframe thead th {\n        text-align: right;\n    }\n</style>\n<table border=\"1\" class=\"dataframe\">\n  <thead>\n    <tr style=\"text-align: right;\">\n      <th></th>\n      <th>Cause</th>\n      <th>At</th>\n      <th>Quantity</th>\n      <th>Dollar value</th>\n      <th>Address</th>\n      <th>Notes</th>\n    </tr>\n  </thead>\n  <tbody>\n    <tr>\n      <th>1</th>\n      <td>deposit</td>\n      <td>2023-07-04 19:07:40</td>\n      <td>7.165562</td>\n      <td>7.165562</td>\n      <td></td>\n      <td>reinit() at block 44683317</td>\n    </tr>\n    <tr>\n      <th>2</th>\n      <td>correction</td>\n      <td>2023-07-13 23:47:27</td>\n      <td>-7.16556200000000021552182261</td>\n      <td>-7.165562</td>\n      <td></td>\n      <td>Accounting correction based on the actual on-c...</td>\n    </tr>\n  </tbody>\n</table>\n</div>"
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "execution_count": null,
+   "outputs": [],
    "source": [
     "from tradeexecutor.analysis.position import display_reserve_position_events\n",
     "\n",
@@ -169,24 +141,16 @@
     "display(df)\n"
    ],
    "metadata": {
-    "collapsed": false,
-    "ExecuteTime": {
-     "end_time": "2023-07-25T08:53:27.829033Z",
-     "start_time": "2023-07-25T08:53:27.822416Z"
-    }
+    "collapsed": false
    }
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "outputs": [],
    "source": [],
    "metadata": {
-    "collapsed": false,
-    "ExecuteTime": {
-     "end_time": "2023-07-25T08:53:27.830311Z",
-     "start_time": "2023-07-25T08:53:27.829469Z"
-    }
+    "collapsed": false
    }
   }
  ],

--- a/notebooks/live-strategy-analysis/analyse-eth-usdc.ipynb
+++ b/notebooks/live-strategy-analysis/analyse-eth-usdc.ipynb
@@ -13,7 +13,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 33,
+   "execution_count": 1,
    "outputs": [],
    "source": [
     "from tradeexecutor.utils.state_downloader import download_state\n",
@@ -29,14 +29,14 @@
    "metadata": {
     "collapsed": false,
     "ExecuteTime": {
-     "end_time": "2023-11-20T14:29:48.132242Z",
-     "start_time": "2023-11-20T14:29:48.093539Z"
+     "end_time": "2023-11-20T20:20:41.487149Z",
+     "start_time": "2023-11-20T20:20:40.197517Z"
     }
    }
   },
   {
    "cell_type": "code",
-   "execution_count": 34,
+   "execution_count": 2,
    "outputs": [],
    "source": [
     "from tradeexecutor.state.state import State\n",
@@ -46,8 +46,8 @@
    "metadata": {
     "collapsed": false,
     "ExecuteTime": {
-     "end_time": "2023-11-20T14:29:50.182367Z",
-     "start_time": "2023-11-20T14:29:48.097102Z"
+     "end_time": "2023-11-20T20:20:43.567619Z",
+     "start_time": "2023-11-20T20:20:41.488022Z"
     }
    }
   },
@@ -64,7 +64,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 35,
+   "execution_count": 3,
    "outputs": [
     {
      "name": "stdout",
@@ -97,8 +97,8 @@
    "metadata": {
     "collapsed": false,
     "ExecuteTime": {
-     "end_time": "2023-11-20T14:29:50.186062Z",
-     "start_time": "2023-11-20T14:29:50.183304Z"
+     "end_time": "2023-11-20T20:20:43.570999Z",
+     "start_time": "2023-11-20T20:20:43.568498Z"
     }
    }
   },
@@ -113,7 +113,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 36,
+   "execution_count": 4,
    "outputs": [
     {
      "name": "stdout",
@@ -134,8 +134,8 @@
    "metadata": {
     "collapsed": false,
     "ExecuteTime": {
-     "end_time": "2023-11-20T14:29:50.189489Z",
-     "start_time": "2023-11-20T14:29:50.187144Z"
+     "end_time": "2023-11-20T20:20:43.573839Z",
+     "start_time": "2023-11-20T20:20:43.571184Z"
     }
    }
   },
@@ -152,7 +152,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 37,
+   "execution_count": 5,
    "outputs": [
     {
      "data": {
@@ -172,8 +172,8 @@
    "metadata": {
     "collapsed": false,
     "ExecuteTime": {
-     "end_time": "2023-11-20T14:29:50.197195Z",
-     "start_time": "2023-11-20T14:29:50.191076Z"
+     "end_time": "2023-11-20T20:20:43.584375Z",
+     "start_time": "2023-11-20T20:20:43.575154Z"
     }
    }
   },
@@ -188,14 +188,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 38,
+   "execution_count": 6,
    "outputs": [
     {
      "data": {
-      "text/plain": "                     position id  position profit %  failed trades\ndate                                                              \n2023-11-02 14:05:02           22         -64.368452          False\n2023-10-30 18:05:35           21         -48.749665          False\n2023-09-12 09:39:08           16          -4.199076           True\n2023-11-10 12:21:15           27          -2.146519          False\n2023-10-26 11:51:24           20          -2.117160          False\n2023-11-13 21:15:16           28          -2.009435          False\n2023-11-09 16:15:16           25          -1.813267          False\n2023-09-06 19:01:04           15          -1.537973          False\n2023-07-12 23:04:40            3          -1.202649          False\n2023-08-30 15:00:33           14          -1.064243          False\n2023-08-07 07:01:38           11          -0.637925          False\n2023-07-30 07:02:17           10          -0.518624          False\n2023-08-28 01:02:17           13          -0.488777          False\n2023-08-09 16:01:48           12          -0.089955          False\n2023-07-11 07:39:28            2           0.000000           True\n2023-07-13 23:49:10            4           0.000000           True\n2023-07-13 23:49:10            5           0.000000           True\n2023-10-26 16:22:35           19           0.000000           True\n2023-07-13 23:49:10            6           0.000000           True\n2023-07-13 23:49:10            7           0.000000           True\n2023-07-13 23:49:10            8           0.000000           True\n2023-07-11 07:39:28            1           0.000000           True\n2023-07-27 16:03:52            9           0.030003          False\n2023-10-22 16:05:07           17           0.060015          False\n2023-11-05 22:03:06           23           0.501227          False\n2023-11-09 23:06:15           26           3.416912          False\n2023-11-09 15:15:14           24           5.717179          False\n2023-10-25 15:03:53           18           8.523430          False",
-      "text/html": "<div>\n<style scoped>\n    .dataframe tbody tr th:only-of-type {\n        vertical-align: middle;\n    }\n\n    .dataframe tbody tr th {\n        vertical-align: top;\n    }\n\n    .dataframe thead th {\n        text-align: right;\n    }\n</style>\n<table border=\"1\" class=\"dataframe\">\n  <thead>\n    <tr style=\"text-align: right;\">\n      <th></th>\n      <th>position id</th>\n      <th>position profit %</th>\n      <th>failed trades</th>\n    </tr>\n    <tr>\n      <th>date</th>\n      <th></th>\n      <th></th>\n      <th></th>\n    </tr>\n  </thead>\n  <tbody>\n    <tr>\n      <th>2023-11-02 14:05:02</th>\n      <td>22</td>\n      <td>-64.368452</td>\n      <td>False</td>\n    </tr>\n    <tr>\n      <th>2023-10-30 18:05:35</th>\n      <td>21</td>\n      <td>-48.749665</td>\n      <td>False</td>\n    </tr>\n    <tr>\n      <th>2023-09-12 09:39:08</th>\n      <td>16</td>\n      <td>-4.199076</td>\n      <td>True</td>\n    </tr>\n    <tr>\n      <th>2023-11-10 12:21:15</th>\n      <td>27</td>\n      <td>-2.146519</td>\n      <td>False</td>\n    </tr>\n    <tr>\n      <th>2023-10-26 11:51:24</th>\n      <td>20</td>\n      <td>-2.117160</td>\n      <td>False</td>\n    </tr>\n    <tr>\n      <th>2023-11-13 21:15:16</th>\n      <td>28</td>\n      <td>-2.009435</td>\n      <td>False</td>\n    </tr>\n    <tr>\n      <th>2023-11-09 16:15:16</th>\n      <td>25</td>\n      <td>-1.813267</td>\n      <td>False</td>\n    </tr>\n    <tr>\n      <th>2023-09-06 19:01:04</th>\n      <td>15</td>\n      <td>-1.537973</td>\n      <td>False</td>\n    </tr>\n    <tr>\n      <th>2023-07-12 23:04:40</th>\n      <td>3</td>\n      <td>-1.202649</td>\n      <td>False</td>\n    </tr>\n    <tr>\n      <th>2023-08-30 15:00:33</th>\n      <td>14</td>\n      <td>-1.064243</td>\n      <td>False</td>\n    </tr>\n    <tr>\n      <th>2023-08-07 07:01:38</th>\n      <td>11</td>\n      <td>-0.637925</td>\n      <td>False</td>\n    </tr>\n    <tr>\n      <th>2023-07-30 07:02:17</th>\n      <td>10</td>\n      <td>-0.518624</td>\n      <td>False</td>\n    </tr>\n    <tr>\n      <th>2023-08-28 01:02:17</th>\n      <td>13</td>\n      <td>-0.488777</td>\n      <td>False</td>\n    </tr>\n    <tr>\n      <th>2023-08-09 16:01:48</th>\n      <td>12</td>\n      <td>-0.089955</td>\n      <td>False</td>\n    </tr>\n    <tr>\n      <th>2023-07-11 07:39:28</th>\n      <td>2</td>\n      <td>0.000000</td>\n      <td>True</td>\n    </tr>\n    <tr>\n      <th>2023-07-13 23:49:10</th>\n      <td>4</td>\n      <td>0.000000</td>\n      <td>True</td>\n    </tr>\n    <tr>\n      <th>2023-07-13 23:49:10</th>\n      <td>5</td>\n      <td>0.000000</td>\n      <td>True</td>\n    </tr>\n    <tr>\n      <th>2023-10-26 16:22:35</th>\n      <td>19</td>\n      <td>0.000000</td>\n      <td>True</td>\n    </tr>\n    <tr>\n      <th>2023-07-13 23:49:10</th>\n      <td>6</td>\n      <td>0.000000</td>\n      <td>True</td>\n    </tr>\n    <tr>\n      <th>2023-07-13 23:49:10</th>\n      <td>7</td>\n      <td>0.000000</td>\n      <td>True</td>\n    </tr>\n    <tr>\n      <th>2023-07-13 23:49:10</th>\n      <td>8</td>\n      <td>0.000000</td>\n      <td>True</td>\n    </tr>\n    <tr>\n      <th>2023-07-11 07:39:28</th>\n      <td>1</td>\n      <td>0.000000</td>\n      <td>True</td>\n    </tr>\n    <tr>\n      <th>2023-07-27 16:03:52</th>\n      <td>9</td>\n      <td>0.030003</td>\n      <td>False</td>\n    </tr>\n    <tr>\n      <th>2023-10-22 16:05:07</th>\n      <td>17</td>\n      <td>0.060015</td>\n      <td>False</td>\n    </tr>\n    <tr>\n      <th>2023-11-05 22:03:06</th>\n      <td>23</td>\n      <td>0.501227</td>\n      <td>False</td>\n    </tr>\n    <tr>\n      <th>2023-11-09 23:06:15</th>\n      <td>26</td>\n      <td>3.416912</td>\n      <td>False</td>\n    </tr>\n    <tr>\n      <th>2023-11-09 15:15:14</th>\n      <td>24</td>\n      <td>5.717179</td>\n      <td>False</td>\n    </tr>\n    <tr>\n      <th>2023-10-25 15:03:53</th>\n      <td>18</td>\n      <td>8.523430</td>\n      <td>False</td>\n    </tr>\n  </tbody>\n</table>\n</div>"
+      "text/plain": "                     position id  position profit %  failed trades\ndate                                                              \n2023-09-12 09:39:08           16          -4.199076           True\n2023-11-02 14:05:02           22          -2.959408          False\n2023-11-10 12:21:15           27          -2.146519          False\n2023-10-26 11:51:24           20          -2.117160          False\n2023-11-13 21:15:16           28          -2.009435          False\n2023-11-09 16:15:16           25          -1.813267          False\n2023-09-06 19:01:04           15          -1.537973          False\n2023-10-30 18:05:35           21          -1.207879          False\n2023-07-12 23:04:40            3          -1.202649          False\n2023-08-30 15:00:33           14          -1.064243          False\n2023-08-07 07:01:38           11          -0.637925          False\n2023-07-30 07:02:17           10          -0.518624          False\n2023-08-28 01:02:17           13          -0.488777          False\n2023-08-09 16:01:48           12          -0.089955          False\n2023-07-11 07:39:28            2           0.000000           True\n2023-07-13 23:49:10            4           0.000000           True\n2023-07-13 23:49:10            5           0.000000           True\n2023-10-26 16:22:35           19           0.000000           True\n2023-07-13 23:49:10            6           0.000000           True\n2023-07-13 23:49:10            7           0.000000           True\n2023-07-13 23:49:10            8           0.000000           True\n2023-07-11 07:39:28            1           0.000000           True\n2023-07-27 16:03:52            9           0.030003          False\n2023-10-22 16:05:07           17           0.060015          False\n2023-11-05 22:03:06           23           0.501227          False\n2023-11-09 23:06:15           26           3.416912          False\n2023-11-09 15:15:14           24           5.717179          False\n2023-10-25 15:03:53           18           8.523430          False",
+      "text/html": "<div>\n<style scoped>\n    .dataframe tbody tr th:only-of-type {\n        vertical-align: middle;\n    }\n\n    .dataframe tbody tr th {\n        vertical-align: top;\n    }\n\n    .dataframe thead th {\n        text-align: right;\n    }\n</style>\n<table border=\"1\" class=\"dataframe\">\n  <thead>\n    <tr style=\"text-align: right;\">\n      <th></th>\n      <th>position id</th>\n      <th>position profit %</th>\n      <th>failed trades</th>\n    </tr>\n    <tr>\n      <th>date</th>\n      <th></th>\n      <th></th>\n      <th></th>\n    </tr>\n  </thead>\n  <tbody>\n    <tr>\n      <th>2023-09-12 09:39:08</th>\n      <td>16</td>\n      <td>-4.199076</td>\n      <td>True</td>\n    </tr>\n    <tr>\n      <th>2023-11-02 14:05:02</th>\n      <td>22</td>\n      <td>-2.959408</td>\n      <td>False</td>\n    </tr>\n    <tr>\n      <th>2023-11-10 12:21:15</th>\n      <td>27</td>\n      <td>-2.146519</td>\n      <td>False</td>\n    </tr>\n    <tr>\n      <th>2023-10-26 11:51:24</th>\n      <td>20</td>\n      <td>-2.117160</td>\n      <td>False</td>\n    </tr>\n    <tr>\n      <th>2023-11-13 21:15:16</th>\n      <td>28</td>\n      <td>-2.009435</td>\n      <td>False</td>\n    </tr>\n    <tr>\n      <th>2023-11-09 16:15:16</th>\n      <td>25</td>\n      <td>-1.813267</td>\n      <td>False</td>\n    </tr>\n    <tr>\n      <th>2023-09-06 19:01:04</th>\n      <td>15</td>\n      <td>-1.537973</td>\n      <td>False</td>\n    </tr>\n    <tr>\n      <th>2023-10-30 18:05:35</th>\n      <td>21</td>\n      <td>-1.207879</td>\n      <td>False</td>\n    </tr>\n    <tr>\n      <th>2023-07-12 23:04:40</th>\n      <td>3</td>\n      <td>-1.202649</td>\n      <td>False</td>\n    </tr>\n    <tr>\n      <th>2023-08-30 15:00:33</th>\n      <td>14</td>\n      <td>-1.064243</td>\n      <td>False</td>\n    </tr>\n    <tr>\n      <th>2023-08-07 07:01:38</th>\n      <td>11</td>\n      <td>-0.637925</td>\n      <td>False</td>\n    </tr>\n    <tr>\n      <th>2023-07-30 07:02:17</th>\n      <td>10</td>\n      <td>-0.518624</td>\n      <td>False</td>\n    </tr>\n    <tr>\n      <th>2023-08-28 01:02:17</th>\n      <td>13</td>\n      <td>-0.488777</td>\n      <td>False</td>\n    </tr>\n    <tr>\n      <th>2023-08-09 16:01:48</th>\n      <td>12</td>\n      <td>-0.089955</td>\n      <td>False</td>\n    </tr>\n    <tr>\n      <th>2023-07-11 07:39:28</th>\n      <td>2</td>\n      <td>0.000000</td>\n      <td>True</td>\n    </tr>\n    <tr>\n      <th>2023-07-13 23:49:10</th>\n      <td>4</td>\n      <td>0.000000</td>\n      <td>True</td>\n    </tr>\n    <tr>\n      <th>2023-07-13 23:49:10</th>\n      <td>5</td>\n      <td>0.000000</td>\n      <td>True</td>\n    </tr>\n    <tr>\n      <th>2023-10-26 16:22:35</th>\n      <td>19</td>\n      <td>0.000000</td>\n      <td>True</td>\n    </tr>\n    <tr>\n      <th>2023-07-13 23:49:10</th>\n      <td>6</td>\n      <td>0.000000</td>\n      <td>True</td>\n    </tr>\n    <tr>\n      <th>2023-07-13 23:49:10</th>\n      <td>7</td>\n      <td>0.000000</td>\n      <td>True</td>\n    </tr>\n    <tr>\n      <th>2023-07-13 23:49:10</th>\n      <td>8</td>\n      <td>0.000000</td>\n      <td>True</td>\n    </tr>\n    <tr>\n      <th>2023-07-11 07:39:28</th>\n      <td>1</td>\n      <td>0.000000</td>\n      <td>True</td>\n    </tr>\n    <tr>\n      <th>2023-07-27 16:03:52</th>\n      <td>9</td>\n      <td>0.030003</td>\n      <td>False</td>\n    </tr>\n    <tr>\n      <th>2023-10-22 16:05:07</th>\n      <td>17</td>\n      <td>0.060015</td>\n      <td>False</td>\n    </tr>\n    <tr>\n      <th>2023-11-05 22:03:06</th>\n      <td>23</td>\n      <td>0.501227</td>\n      <td>False</td>\n    </tr>\n    <tr>\n      <th>2023-11-09 23:06:15</th>\n      <td>26</td>\n      <td>3.416912</td>\n      <td>False</td>\n    </tr>\n    <tr>\n      <th>2023-11-09 15:15:14</th>\n      <td>24</td>\n      <td>5.717179</td>\n      <td>False</td>\n    </tr>\n    <tr>\n      <th>2023-10-25 15:03:53</th>\n      <td>18</td>\n      <td>8.523430</td>\n      <td>False</td>\n    </tr>\n  </tbody>\n</table>\n</div>"
      },
-     "execution_count": 38,
+     "execution_count": 6,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -224,8 +224,8 @@
    "metadata": {
     "collapsed": false,
     "ExecuteTime": {
-     "end_time": "2023-11-20T14:29:50.204001Z",
-     "start_time": "2023-11-20T14:29:50.201654Z"
+     "end_time": "2023-11-20T20:20:43.647886Z",
+     "start_time": "2023-11-20T20:20:43.588618Z"
     }
    }
   },
@@ -240,14 +240,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 40,
+   "execution_count": 7,
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
       "Position <Closed position #22 <Pair WETH-USDC spot_market_hold at 0x45dda9cb7c25131df268515131f647d726f50608 (0.0500% fee) on exchange 0x1f98431c8ad98523631ae4a59f267346ea31f984> $14.087609495767193>\n",
-      "Realised profit -0.6436845170373768\n",
+      "Realised profit -0.029594079573601384\n",
       "Avg buy 1852.935512317986\n",
       "Avg sell 1826.4457494181925\n",
       "Buy value 14.087609495767193\n",
@@ -273,21 +273,21 @@
    "metadata": {
     "collapsed": false,
     "ExecuteTime": {
-     "end_time": "2023-11-20T14:30:30.440036Z",
-     "start_time": "2023-11-20T14:30:30.422340Z"
+     "end_time": "2023-11-20T20:20:43.648227Z",
+     "start_time": "2023-11-20T20:20:43.592362Z"
     }
    }
   },
   {
    "cell_type": "code",
-   "execution_count": 39,
+   "execution_count": 7,
    "outputs": [],
    "source": [],
    "metadata": {
     "collapsed": false,
     "ExecuteTime": {
-     "end_time": "2023-11-20T14:29:50.223755Z",
-     "start_time": "2023-11-20T14:29:50.207554Z"
+     "end_time": "2023-11-20T20:20:43.648282Z",
+     "start_time": "2023-11-20T20:20:43.594521Z"
     }
    }
   }

--- a/notebooks/live-strategy-analysis/analyse-eth-usdc.ipynb
+++ b/notebooks/live-strategy-analysis/analyse-eth-usdc.ipynb
@@ -1,0 +1,316 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "source": [
+    "# Analyse ETH-USDC strategy profit calculation issues\n",
+    "\n",
+    "Fix issues with bad profit calculations.\n"
+   ],
+   "metadata": {
+    "collapsed": false
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 33,
+   "outputs": [],
+   "source": [
+    "from tradeexecutor.utils.state_downloader import download_state\n",
+    "import os\n",
+    "\n",
+    "url = \"https://enzyme-polygon-eth-usdc.tradingstrategy.ai\"\n",
+    "name = \"enzyme-polygon-eth-usdc.json\"\n",
+    "\n",
+    "if not os.path.exists(f\"/tmp/{name}\"):\n",
+    "    state = download_state(url)\n",
+    "    state.write_json_file(f\"/tmp/{name}\")\n"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "ExecuteTime": {
+     "end_time": "2023-11-20T14:29:48.132242Z",
+     "start_time": "2023-11-20T14:29:48.093539Z"
+    }
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 34,
+   "outputs": [],
+   "source": [
+    "from tradeexecutor.state.state import State\n",
+    "\n",
+    "state = State.read_json_file(f\"/tmp/{name}\")\n"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "ExecuteTime": {
+     "end_time": "2023-11-20T14:29:50.182367Z",
+     "start_time": "2023-11-20T14:29:48.097102Z"
+    }
+   }
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "## Balance checks\n",
+    "\n",
+    "Check for current balances and abnormal balance update events."
+   ],
+   "metadata": {
+    "collapsed": false
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 35,
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Number of reserve assets: 1\n",
+      "Reserves: <USDC at 0x2791bca1f2de4661ed88a30c99a7a9449aa84174> at 1.0 USDC / USD\n",
+      "Amount: 5.156454136718750034958702606 USDC\n",
+      "Equity: 5.15645413671875 USD\n",
+      "Value: 5.15645413671875 USD\n",
+      "Balance updates: -53.65080607812499814014017827 USDC\n",
+      "Number of balance updates events: 35\n",
+      "Number of events references in the portfolio overall: 32\n"
+     ]
+    }
+   ],
+   "source": [
+    "portfolio = state.portfolio\n",
+    "asset, exchange_rate = state.portfolio.get_default_reserve_asset()\n",
+    "position = portfolio.get_default_reserve_position()\n",
+    "print(f\"Number of reserve assets: {len(portfolio.reserves)}\")\n",
+    "print(f\"Reserves: {asset} at {exchange_rate} {asset.token_symbol} / USD\")\n",
+    "print(f\"Amount: {position.get_quantity()} {asset.token_symbol}\")\n",
+    "print(f\"Equity: {position.get_total_equity()} USD\")\n",
+    "print(f\"Value: {position.get_value()} USD\")\n",
+    "print(f\"Balance updates: {position.get_base_token_balance_update_quantity()} {asset.token_symbol}\")\n",
+    "print(f\"Number of balance updates events: {len(position.balance_updates)}\")\n",
+    "print(f\"Number of events references in the portfolio overall: {len(state.sync.treasury.balance_update_refs)}\")"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "ExecuteTime": {
+     "end_time": "2023-11-20T14:29:50.186062Z",
+     "start_time": "2023-11-20T14:29:50.183304Z"
+    }
+   }
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "# Vault sync status"
+   ],
+   "metadata": {
+    "collapsed": false
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 36,
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Vault deployment: <Deployment chain:polygon address:0x6E321256BE0ABd2726A234E8dBFc4d3caf255AE0 name:Degen Fault I token:DEGE1>\n",
+      "Treasury sync status: <Treasury updated:2023-11-20 14:18:00 cycle:2023-11-20 14:18:00 block scanned:50,175,386 refs:32>\n"
+     ]
+    }
+   ],
+   "source": [
+    "treasury = state.sync.treasury\n",
+    "deployment = state.sync.deployment\n",
+    "\n",
+    "print(f\"Vault deployment: {deployment}\")\n",
+    "print(f\"Treasury sync status: {treasury}\")"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "ExecuteTime": {
+     "end_time": "2023-11-20T14:29:50.189489Z",
+     "start_time": "2023-11-20T14:29:50.187144Z"
+    }
+   }
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "## Individual events\n",
+    "\n",
+    "For the last analysed executor."
+   ],
+   "metadata": {
+    "collapsed": false
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 37,
+   "outputs": [
+    {
+     "data": {
+      "text/plain": "         Cause                  At                        Quantity  \\\n1      deposit 2023-07-04 19:07:40                        7.165562   \n2   correction 2023-07-13 23:47:27   -7.16556200000000021552182261   \n3   correction 2023-07-25 10:27:30  -35.71078500000000044423131840   \n4   correction 2023-09-18 12:37:03  -6.780573828125000014239276424   \n5      deposit 2023-10-17 19:54:48                               1   \n6   redemption 2023-10-18 00:48:28                       -0.999997   \n7      deposit 2023-10-18 08:33:51                              70   \n8      deposit 2023-10-18 12:07:21                              10   \n9   redemption 2023-10-18 12:08:55                      -69.999855   \n10     deposit 2023-10-18 12:09:49                              10   \n11     deposit 2023-10-18 12:14:41                              10   \n12  redemption 2023-10-19 06:50:54                       -9.999894   \n13  redemption 2023-10-19 06:53:20                       -9.999893   \n14  redemption 2023-10-19 06:55:56                       -9.999894   \n15     deposit 2023-10-20 12:12:21                      101.158809   \n16  correction 2023-10-26 16:23:43   -52.7048502499999996239239408   \n17  redemption 2023-10-30 09:24:05                      -25.070579   \n19  redemption 2023-10-31 08:21:51                      -53.708681   \n20  correction 2023-11-01 10:23:06   17.99884100000000215777617996   \n21     deposit 2023-11-01 11:34:59                               5   \n22     deposit 2023-11-01 11:40:39                            3.48   \n23     deposit 2023-11-01 11:40:39                              10   \n24     deposit 2023-11-01 11:42:05                        7.004605   \n25  redemption 2023-11-01 11:43:35                       -6.330391   \n26  redemption 2023-11-01 11:44:17                       -6.330391   \n27  redemption 2023-11-01 11:45:07                      -12.823826   \n28     deposit 2023-11-01 11:45:41                              15   \n29     deposit 2023-11-01 11:46:13                       10.484608   \n30  redemption 2023-11-01 11:49:09                      -15.323184   \n31  redemption 2023-11-02 06:45:51                       -8.999303   \n33     deposit 2023-11-02 06:57:05                        8.999303   \n34     deposit 2023-11-02 06:58:25                               4   \n35     deposit 2023-11-02 06:58:47                               8   \n36     deposit 2023-11-02 07:00:21                        2.948809   \n37  redemption 2023-11-07 12:57:28                      -23.943684   \n\n    Dollar value                                     Address  \\\n1       7.165562                                               \n2      -7.165562                                               \n3     -35.710785                                               \n4      -6.780574                                               \n5       1.000000  0xEFD90a79feE79aba176A7E1B0E101193fb7d7bda   \n6       0.999997  0xEFD90a79feE79aba176A7E1B0E101193fb7d7bda   \n7      70.000000  0x57c111CBc7EEb27497277D165e095E44C5B64076   \n8      10.000000  0x575A8d31ab7B82B327cB8e994f8d898624D9Cc3c   \n9      69.999855  0x57c111CBc7EEb27497277D165e095E44C5B64076   \n10     10.000000  0x57c111CBc7EEb27497277D165e095E44C5B64076   \n11     10.000000  0xA804C6a9E3B76D42F75D16427Aa2098DEcD87e1D   \n12      9.999894  0x575A8d31ab7B82B327cB8e994f8d898624D9Cc3c   \n13      9.999893  0xA804C6a9E3B76D42F75D16427Aa2098DEcD87e1D   \n14      9.999894  0x57c111CBc7EEb27497277D165e095E44C5B64076   \n15    101.158809  0x57c111CBc7EEb27497277D165e095E44C5B64076   \n16    -52.704850                                               \n17     25.070579  0x57c111CBc7EEb27497277D165e095E44C5B64076   \n19     53.708681  0x57c111CBc7EEb27497277D165e095E44C5B64076   \n20     17.998841                                               \n21      5.000000  0x575A8d31ab7B82B327cB8e994f8d898624D9Cc3c   \n22      3.480000  0x575A8d31ab7B82B327cB8e994f8d898624D9Cc3c   \n23     10.000000  0x575A8d31ab7B82B327cB8e994f8d898624D9Cc3c   \n24      7.004605  0x575A8d31ab7B82B327cB8e994f8d898624D9Cc3c   \n25      6.330391  0x575A8d31ab7B82B327cB8e994f8d898624D9Cc3c   \n26      6.330391  0x575A8d31ab7B82B327cB8e994f8d898624D9Cc3c   \n27     12.823826  0x575A8d31ab7B82B327cB8e994f8d898624D9Cc3c   \n28     15.000000  0x575A8d31ab7B82B327cB8e994f8d898624D9Cc3c   \n29     10.484608  0x575A8d31ab7B82B327cB8e994f8d898624D9Cc3c   \n30     15.323184  0x575A8d31ab7B82B327cB8e994f8d898624D9Cc3c   \n31      8.999303  0x57c111CBc7EEb27497277D165e095E44C5B64076   \n33      8.999303  0x57c111CBc7EEb27497277D165e095E44C5B64076   \n34      4.000000  0x57c111CBc7EEb27497277D165e095E44C5B64076   \n35      8.000000  0x57c111CBc7EEb27497277D165e095E44C5B64076   \n36      2.948809  0x57c111CBc7EEb27497277D165e095E44C5B64076   \n37     23.943684  0x57c111CBc7EEb27497277D165e095E44C5B64076   \n\n                                                Notes  \n1                          reinit() at block 44683317  \n2   Accounting correction based on the actual on-c...  \n3   Accounting correction based on the actual on-c...  \n4   Accounting correction based on the actual on-c...  \n5                                                      \n6                                                      \n7                                                      \n8                                                      \n9                                                      \n10                                                     \n11                                                     \n12                                                     \n13                                                     \n14                                                     \n15                                                     \n16  Accounting correction based on the actual on-c...  \n17                                                     \n19                                                     \n20  Accounting correction based on the actual on-c...  \n21                                                     \n22                                                     \n23                                                     \n24                                                     \n25                                                     \n26                                                     \n27                                                     \n28                                                     \n29                                                     \n30                                                     \n31                                                     \n33                                                     \n34                                                     \n35                                                     \n36                                                     \n37                                                     ",
+      "text/html": "<div>\n<style scoped>\n    .dataframe tbody tr th:only-of-type {\n        vertical-align: middle;\n    }\n\n    .dataframe tbody tr th {\n        vertical-align: top;\n    }\n\n    .dataframe thead th {\n        text-align: right;\n    }\n</style>\n<table border=\"1\" class=\"dataframe\">\n  <thead>\n    <tr style=\"text-align: right;\">\n      <th></th>\n      <th>Cause</th>\n      <th>At</th>\n      <th>Quantity</th>\n      <th>Dollar value</th>\n      <th>Address</th>\n      <th>Notes</th>\n    </tr>\n  </thead>\n  <tbody>\n    <tr>\n      <th>1</th>\n      <td>deposit</td>\n      <td>2023-07-04 19:07:40</td>\n      <td>7.165562</td>\n      <td>7.165562</td>\n      <td></td>\n      <td>reinit() at block 44683317</td>\n    </tr>\n    <tr>\n      <th>2</th>\n      <td>correction</td>\n      <td>2023-07-13 23:47:27</td>\n      <td>-7.16556200000000021552182261</td>\n      <td>-7.165562</td>\n      <td></td>\n      <td>Accounting correction based on the actual on-c...</td>\n    </tr>\n    <tr>\n      <th>3</th>\n      <td>correction</td>\n      <td>2023-07-25 10:27:30</td>\n      <td>-35.71078500000000044423131840</td>\n      <td>-35.710785</td>\n      <td></td>\n      <td>Accounting correction based on the actual on-c...</td>\n    </tr>\n    <tr>\n      <th>4</th>\n      <td>correction</td>\n      <td>2023-09-18 12:37:03</td>\n      <td>-6.780573828125000014239276424</td>\n      <td>-6.780574</td>\n      <td></td>\n      <td>Accounting correction based on the actual on-c...</td>\n    </tr>\n    <tr>\n      <th>5</th>\n      <td>deposit</td>\n      <td>2023-10-17 19:54:48</td>\n      <td>1</td>\n      <td>1.000000</td>\n      <td>0xEFD90a79feE79aba176A7E1B0E101193fb7d7bda</td>\n      <td></td>\n    </tr>\n    <tr>\n      <th>6</th>\n      <td>redemption</td>\n      <td>2023-10-18 00:48:28</td>\n      <td>-0.999997</td>\n      <td>0.999997</td>\n      <td>0xEFD90a79feE79aba176A7E1B0E101193fb7d7bda</td>\n      <td></td>\n    </tr>\n    <tr>\n      <th>7</th>\n      <td>deposit</td>\n      <td>2023-10-18 08:33:51</td>\n      <td>70</td>\n      <td>70.000000</td>\n      <td>0x57c111CBc7EEb27497277D165e095E44C5B64076</td>\n      <td></td>\n    </tr>\n    <tr>\n      <th>8</th>\n      <td>deposit</td>\n      <td>2023-10-18 12:07:21</td>\n      <td>10</td>\n      <td>10.000000</td>\n      <td>0x575A8d31ab7B82B327cB8e994f8d898624D9Cc3c</td>\n      <td></td>\n    </tr>\n    <tr>\n      <th>9</th>\n      <td>redemption</td>\n      <td>2023-10-18 12:08:55</td>\n      <td>-69.999855</td>\n      <td>69.999855</td>\n      <td>0x57c111CBc7EEb27497277D165e095E44C5B64076</td>\n      <td></td>\n    </tr>\n    <tr>\n      <th>10</th>\n      <td>deposit</td>\n      <td>2023-10-18 12:09:49</td>\n      <td>10</td>\n      <td>10.000000</td>\n      <td>0x57c111CBc7EEb27497277D165e095E44C5B64076</td>\n      <td></td>\n    </tr>\n    <tr>\n      <th>11</th>\n      <td>deposit</td>\n      <td>2023-10-18 12:14:41</td>\n      <td>10</td>\n      <td>10.000000</td>\n      <td>0xA804C6a9E3B76D42F75D16427Aa2098DEcD87e1D</td>\n      <td></td>\n    </tr>\n    <tr>\n      <th>12</th>\n      <td>redemption</td>\n      <td>2023-10-19 06:50:54</td>\n      <td>-9.999894</td>\n      <td>9.999894</td>\n      <td>0x575A8d31ab7B82B327cB8e994f8d898624D9Cc3c</td>\n      <td></td>\n    </tr>\n    <tr>\n      <th>13</th>\n      <td>redemption</td>\n      <td>2023-10-19 06:53:20</td>\n      <td>-9.999893</td>\n      <td>9.999893</td>\n      <td>0xA804C6a9E3B76D42F75D16427Aa2098DEcD87e1D</td>\n      <td></td>\n    </tr>\n    <tr>\n      <th>14</th>\n      <td>redemption</td>\n      <td>2023-10-19 06:55:56</td>\n      <td>-9.999894</td>\n      <td>9.999894</td>\n      <td>0x57c111CBc7EEb27497277D165e095E44C5B64076</td>\n      <td></td>\n    </tr>\n    <tr>\n      <th>15</th>\n      <td>deposit</td>\n      <td>2023-10-20 12:12:21</td>\n      <td>101.158809</td>\n      <td>101.158809</td>\n      <td>0x57c111CBc7EEb27497277D165e095E44C5B64076</td>\n      <td></td>\n    </tr>\n    <tr>\n      <th>16</th>\n      <td>correction</td>\n      <td>2023-10-26 16:23:43</td>\n      <td>-52.7048502499999996239239408</td>\n      <td>-52.704850</td>\n      <td></td>\n      <td>Accounting correction based on the actual on-c...</td>\n    </tr>\n    <tr>\n      <th>17</th>\n      <td>redemption</td>\n      <td>2023-10-30 09:24:05</td>\n      <td>-25.070579</td>\n      <td>25.070579</td>\n      <td>0x57c111CBc7EEb27497277D165e095E44C5B64076</td>\n      <td></td>\n    </tr>\n    <tr>\n      <th>19</th>\n      <td>redemption</td>\n      <td>2023-10-31 08:21:51</td>\n      <td>-53.708681</td>\n      <td>53.708681</td>\n      <td>0x57c111CBc7EEb27497277D165e095E44C5B64076</td>\n      <td></td>\n    </tr>\n    <tr>\n      <th>20</th>\n      <td>correction</td>\n      <td>2023-11-01 10:23:06</td>\n      <td>17.99884100000000215777617996</td>\n      <td>17.998841</td>\n      <td></td>\n      <td>Accounting correction based on the actual on-c...</td>\n    </tr>\n    <tr>\n      <th>21</th>\n      <td>deposit</td>\n      <td>2023-11-01 11:34:59</td>\n      <td>5</td>\n      <td>5.000000</td>\n      <td>0x575A8d31ab7B82B327cB8e994f8d898624D9Cc3c</td>\n      <td></td>\n    </tr>\n    <tr>\n      <th>22</th>\n      <td>deposit</td>\n      <td>2023-11-01 11:40:39</td>\n      <td>3.48</td>\n      <td>3.480000</td>\n      <td>0x575A8d31ab7B82B327cB8e994f8d898624D9Cc3c</td>\n      <td></td>\n    </tr>\n    <tr>\n      <th>23</th>\n      <td>deposit</td>\n      <td>2023-11-01 11:40:39</td>\n      <td>10</td>\n      <td>10.000000</td>\n      <td>0x575A8d31ab7B82B327cB8e994f8d898624D9Cc3c</td>\n      <td></td>\n    </tr>\n    <tr>\n      <th>24</th>\n      <td>deposit</td>\n      <td>2023-11-01 11:42:05</td>\n      <td>7.004605</td>\n      <td>7.004605</td>\n      <td>0x575A8d31ab7B82B327cB8e994f8d898624D9Cc3c</td>\n      <td></td>\n    </tr>\n    <tr>\n      <th>25</th>\n      <td>redemption</td>\n      <td>2023-11-01 11:43:35</td>\n      <td>-6.330391</td>\n      <td>6.330391</td>\n      <td>0x575A8d31ab7B82B327cB8e994f8d898624D9Cc3c</td>\n      <td></td>\n    </tr>\n    <tr>\n      <th>26</th>\n      <td>redemption</td>\n      <td>2023-11-01 11:44:17</td>\n      <td>-6.330391</td>\n      <td>6.330391</td>\n      <td>0x575A8d31ab7B82B327cB8e994f8d898624D9Cc3c</td>\n      <td></td>\n    </tr>\n    <tr>\n      <th>27</th>\n      <td>redemption</td>\n      <td>2023-11-01 11:45:07</td>\n      <td>-12.823826</td>\n      <td>12.823826</td>\n      <td>0x575A8d31ab7B82B327cB8e994f8d898624D9Cc3c</td>\n      <td></td>\n    </tr>\n    <tr>\n      <th>28</th>\n      <td>deposit</td>\n      <td>2023-11-01 11:45:41</td>\n      <td>15</td>\n      <td>15.000000</td>\n      <td>0x575A8d31ab7B82B327cB8e994f8d898624D9Cc3c</td>\n      <td></td>\n    </tr>\n    <tr>\n      <th>29</th>\n      <td>deposit</td>\n      <td>2023-11-01 11:46:13</td>\n      <td>10.484608</td>\n      <td>10.484608</td>\n      <td>0x575A8d31ab7B82B327cB8e994f8d898624D9Cc3c</td>\n      <td></td>\n    </tr>\n    <tr>\n      <th>30</th>\n      <td>redemption</td>\n      <td>2023-11-01 11:49:09</td>\n      <td>-15.323184</td>\n      <td>15.323184</td>\n      <td>0x575A8d31ab7B82B327cB8e994f8d898624D9Cc3c</td>\n      <td></td>\n    </tr>\n    <tr>\n      <th>31</th>\n      <td>redemption</td>\n      <td>2023-11-02 06:45:51</td>\n      <td>-8.999303</td>\n      <td>8.999303</td>\n      <td>0x57c111CBc7EEb27497277D165e095E44C5B64076</td>\n      <td></td>\n    </tr>\n    <tr>\n      <th>33</th>\n      <td>deposit</td>\n      <td>2023-11-02 06:57:05</td>\n      <td>8.999303</td>\n      <td>8.999303</td>\n      <td>0x57c111CBc7EEb27497277D165e095E44C5B64076</td>\n      <td></td>\n    </tr>\n    <tr>\n      <th>34</th>\n      <td>deposit</td>\n      <td>2023-11-02 06:58:25</td>\n      <td>4</td>\n      <td>4.000000</td>\n      <td>0x57c111CBc7EEb27497277D165e095E44C5B64076</td>\n      <td></td>\n    </tr>\n    <tr>\n      <th>35</th>\n      <td>deposit</td>\n      <td>2023-11-02 06:58:47</td>\n      <td>8</td>\n      <td>8.000000</td>\n      <td>0x57c111CBc7EEb27497277D165e095E44C5B64076</td>\n      <td></td>\n    </tr>\n    <tr>\n      <th>36</th>\n      <td>deposit</td>\n      <td>2023-11-02 07:00:21</td>\n      <td>2.948809</td>\n      <td>2.948809</td>\n      <td>0x57c111CBc7EEb27497277D165e095E44C5B64076</td>\n      <td></td>\n    </tr>\n    <tr>\n      <th>37</th>\n      <td>redemption</td>\n      <td>2023-11-07 12:57:28</td>\n      <td>-23.943684</td>\n      <td>23.943684</td>\n      <td>0x57c111CBc7EEb27497277D165e095E44C5B64076</td>\n      <td></td>\n    </tr>\n  </tbody>\n</table>\n</div>"
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "from tradeexecutor.analysis.position import display_reserve_position_events\n",
+    "\n",
+    "df = display_reserve_position_events(position)\n",
+    "display(df)\n"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "ExecuteTime": {
+     "end_time": "2023-11-20T14:29:50.197195Z",
+     "start_time": "2023-11-20T14:29:50.191076Z"
+    }
+   }
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "## Position profit history"
+   ],
+   "metadata": {
+    "collapsed": false
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 38,
+   "outputs": [
+    {
+     "data": {
+      "text/plain": "                     position id  position profit %  failed trades\ndate                                                              \n2023-11-02 14:05:02           22         -64.368452          False\n2023-10-30 18:05:35           21         -48.749665          False\n2023-09-12 09:39:08           16          -4.199076           True\n2023-11-10 12:21:15           27          -2.146519          False\n2023-10-26 11:51:24           20          -2.117160          False\n2023-11-13 21:15:16           28          -2.009435          False\n2023-11-09 16:15:16           25          -1.813267          False\n2023-09-06 19:01:04           15          -1.537973          False\n2023-07-12 23:04:40            3          -1.202649          False\n2023-08-30 15:00:33           14          -1.064243          False\n2023-08-07 07:01:38           11          -0.637925          False\n2023-07-30 07:02:17           10          -0.518624          False\n2023-08-28 01:02:17           13          -0.488777          False\n2023-08-09 16:01:48           12          -0.089955          False\n2023-07-11 07:39:28            2           0.000000           True\n2023-07-13 23:49:10            4           0.000000           True\n2023-07-13 23:49:10            5           0.000000           True\n2023-10-26 16:22:35           19           0.000000           True\n2023-07-13 23:49:10            6           0.000000           True\n2023-07-13 23:49:10            7           0.000000           True\n2023-07-13 23:49:10            8           0.000000           True\n2023-07-11 07:39:28            1           0.000000           True\n2023-07-27 16:03:52            9           0.030003          False\n2023-10-22 16:05:07           17           0.060015          False\n2023-11-05 22:03:06           23           0.501227          False\n2023-11-09 23:06:15           26           3.416912          False\n2023-11-09 15:15:14           24           5.717179          False\n2023-10-25 15:03:53           18           8.523430          False",
+      "text/html": "<div>\n<style scoped>\n    .dataframe tbody tr th:only-of-type {\n        vertical-align: middle;\n    }\n\n    .dataframe tbody tr th {\n        vertical-align: top;\n    }\n\n    .dataframe thead th {\n        text-align: right;\n    }\n</style>\n<table border=\"1\" class=\"dataframe\">\n  <thead>\n    <tr style=\"text-align: right;\">\n      <th></th>\n      <th>position id</th>\n      <th>position profit %</th>\n      <th>failed trades</th>\n    </tr>\n    <tr>\n      <th>date</th>\n      <th></th>\n      <th></th>\n      <th></th>\n    </tr>\n  </thead>\n  <tbody>\n    <tr>\n      <th>2023-11-02 14:05:02</th>\n      <td>22</td>\n      <td>-64.368452</td>\n      <td>False</td>\n    </tr>\n    <tr>\n      <th>2023-10-30 18:05:35</th>\n      <td>21</td>\n      <td>-48.749665</td>\n      <td>False</td>\n    </tr>\n    <tr>\n      <th>2023-09-12 09:39:08</th>\n      <td>16</td>\n      <td>-4.199076</td>\n      <td>True</td>\n    </tr>\n    <tr>\n      <th>2023-11-10 12:21:15</th>\n      <td>27</td>\n      <td>-2.146519</td>\n      <td>False</td>\n    </tr>\n    <tr>\n      <th>2023-10-26 11:51:24</th>\n      <td>20</td>\n      <td>-2.117160</td>\n      <td>False</td>\n    </tr>\n    <tr>\n      <th>2023-11-13 21:15:16</th>\n      <td>28</td>\n      <td>-2.009435</td>\n      <td>False</td>\n    </tr>\n    <tr>\n      <th>2023-11-09 16:15:16</th>\n      <td>25</td>\n      <td>-1.813267</td>\n      <td>False</td>\n    </tr>\n    <tr>\n      <th>2023-09-06 19:01:04</th>\n      <td>15</td>\n      <td>-1.537973</td>\n      <td>False</td>\n    </tr>\n    <tr>\n      <th>2023-07-12 23:04:40</th>\n      <td>3</td>\n      <td>-1.202649</td>\n      <td>False</td>\n    </tr>\n    <tr>\n      <th>2023-08-30 15:00:33</th>\n      <td>14</td>\n      <td>-1.064243</td>\n      <td>False</td>\n    </tr>\n    <tr>\n      <th>2023-08-07 07:01:38</th>\n      <td>11</td>\n      <td>-0.637925</td>\n      <td>False</td>\n    </tr>\n    <tr>\n      <th>2023-07-30 07:02:17</th>\n      <td>10</td>\n      <td>-0.518624</td>\n      <td>False</td>\n    </tr>\n    <tr>\n      <th>2023-08-28 01:02:17</th>\n      <td>13</td>\n      <td>-0.488777</td>\n      <td>False</td>\n    </tr>\n    <tr>\n      <th>2023-08-09 16:01:48</th>\n      <td>12</td>\n      <td>-0.089955</td>\n      <td>False</td>\n    </tr>\n    <tr>\n      <th>2023-07-11 07:39:28</th>\n      <td>2</td>\n      <td>0.000000</td>\n      <td>True</td>\n    </tr>\n    <tr>\n      <th>2023-07-13 23:49:10</th>\n      <td>4</td>\n      <td>0.000000</td>\n      <td>True</td>\n    </tr>\n    <tr>\n      <th>2023-07-13 23:49:10</th>\n      <td>5</td>\n      <td>0.000000</td>\n      <td>True</td>\n    </tr>\n    <tr>\n      <th>2023-10-26 16:22:35</th>\n      <td>19</td>\n      <td>0.000000</td>\n      <td>True</td>\n    </tr>\n    <tr>\n      <th>2023-07-13 23:49:10</th>\n      <td>6</td>\n      <td>0.000000</td>\n      <td>True</td>\n    </tr>\n    <tr>\n      <th>2023-07-13 23:49:10</th>\n      <td>7</td>\n      <td>0.000000</td>\n      <td>True</td>\n    </tr>\n    <tr>\n      <th>2023-07-13 23:49:10</th>\n      <td>8</td>\n      <td>0.000000</td>\n      <td>True</td>\n    </tr>\n    <tr>\n      <th>2023-07-11 07:39:28</th>\n      <td>1</td>\n      <td>0.000000</td>\n      <td>True</td>\n    </tr>\n    <tr>\n      <th>2023-07-27 16:03:52</th>\n      <td>9</td>\n      <td>0.030003</td>\n      <td>False</td>\n    </tr>\n    <tr>\n      <th>2023-10-22 16:05:07</th>\n      <td>17</td>\n      <td>0.060015</td>\n      <td>False</td>\n    </tr>\n    <tr>\n      <th>2023-11-05 22:03:06</th>\n      <td>23</td>\n      <td>0.501227</td>\n      <td>False</td>\n    </tr>\n    <tr>\n      <th>2023-11-09 23:06:15</th>\n      <td>26</td>\n      <td>3.416912</td>\n      <td>False</td>\n    </tr>\n    <tr>\n      <th>2023-11-09 15:15:14</th>\n      <td>24</td>\n      <td>5.717179</td>\n      <td>False</td>\n    </tr>\n    <tr>\n      <th>2023-10-25 15:03:53</th>\n      <td>18</td>\n      <td>8.523430</td>\n      <td>False</td>\n    </tr>\n  </tbody>\n</table>\n</div>"
+     },
+     "execution_count": 38,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "from io import StringIO\n",
+    "from typing import Iterable, List\n",
+    "import pandas as pd\n",
+    "\n",
+    "from tradeexecutor.state.position import TradingPosition\n",
+    "from tradeexecutor.state import position\n",
+    "\n",
+    "positions = state.portfolio.closed_positions.values()\n",
+    "\n",
+    "data = [(p.closed_at, p.position_id, p.get_realised_profit_percent() * 100, p.is_repaired()) for p in positions]\n",
+    "\n",
+    "df = pd.DataFrame(data, columns=(\"date\", \"position id\", \"position profit %\", \"failed trades\"))\n",
+    "df = df.set_index(\"date\")\n",
+    "\n",
+    "df = df.sort_values(\"position profit %\", ascending=True)\n",
+    "\n",
+    "pd.set_option('display.max_rows', 100)\n",
+    "\n",
+    "df\n"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "ExecuteTime": {
+     "end_time": "2023-11-20T14:29:50.204001Z",
+     "start_time": "2023-11-20T14:29:50.201654Z"
+    }
+   }
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "## Check prolematic position"
+   ],
+   "metadata": {
+    "collapsed": false
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 40,
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Position <Closed position #22 <Pair WETH-USDC spot_market_hold at 0x45dda9cb7c25131df268515131f647d726f50608 (0.0500% fee) on exchange 0x1f98431c8ad98523631ae4a59f267346ea31f984> $14.087609495767193>\n",
+      "Realised profit -0.6436845170373768\n",
+      "Avg buy 1852.935512317986\n",
+      "Avg sell 1826.4457494181925\n",
+      "Buy value 14.087609495767193\n",
+      "Sell value 5.019633381273124\n",
+      "Balance updates\n",
+      "Funding event #32 redemption -0.004854553252186546 tokens for position #22 at block 49,443,918 from 0x57c111CBc7EEb27497277D165e095E44C5B64076\n"
+     ]
+    }
+   ],
+   "source": [
+    "p: TradingPosition\n",
+    "p = state.portfolio.closed_positions[22]\n",
+    "print(\"Position\", p)\n",
+    "print(\"Realised profit\", p.get_realised_profit_percent())\n",
+    "print(\"Avg buy\", p.get_average_buy())\n",
+    "print(\"Avg sell\", p.get_average_sell())\n",
+    "print(\"Buy value\", p.get_buy_value())\n",
+    "print(\"Sell value\", p.get_sell_value())\n",
+    "print(\"Balance updates\")\n",
+    "for id, bu in p.balance_updates.items():\n",
+    "    print(bu)"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "ExecuteTime": {
+     "end_time": "2023-11-20T14:30:30.440036Z",
+     "start_time": "2023-11-20T14:30:30.422340Z"
+    }
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 39,
+   "outputs": [],
+   "source": [],
+   "metadata": {
+    "collapsed": false,
+    "ExecuteTime": {
+     "end_time": "2023-11-20T14:29:50.223755Z",
+     "start_time": "2023-11-20T14:29:50.207554Z"
+    }
+   }
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 2
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython2",
+   "version": "2.7.6"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 0
+}

--- a/tests/enzyme/test_enzyme_realised_profit.py
+++ b/tests/enzyme/test_enzyme_realised_profit.py
@@ -115,9 +115,11 @@ def test_enzyme_redeemed_position_profit(
 
     - Redeem from one open WETH position
 
-    - Move the price, so that we make losses
+    - Move the price, so that we make losses on the position
 
     - Close the position
+
+    - Chec that realised PnL is correctly calculated for the position with redemptions
     """
 
     reorg_mon = create_reorganisation_monitor(web3)
@@ -221,3 +223,6 @@ def test_enzyme_redeemed_position_profit(
     assert reserve.get_value() == pytest.approx(242.627953)
     assert state.portfolio.get_total_equity() == pytest.approx(242.627953)
 
+    assert position.get_realised_profit_usd() == pytest.approx(-7.372047000000003)
+    # (1359.153875 - 1582.577362) / 1582.577362 ~= -14.1
+    assert position.get_realised_profit_percent() == pytest.approx(-0.14744093999999996)

--- a/tests/enzyme/test_enzyme_realised_profit.py
+++ b/tests/enzyme/test_enzyme_realised_profit.py
@@ -1,0 +1,223 @@
+"""Realised profit w/redemption test."""
+
+import datetime
+import secrets
+from decimal import Decimal
+
+import pytest
+from eth_account import Account
+from hexbytes import HexBytes
+from web3 import Web3
+from web3.contract import Contract
+from eth_typing import HexAddress
+
+from eth_defi.enzyme.vault import Vault
+from eth_defi.hotwallet import HotWallet
+from eth_defi.trace import assert_transaction_success_with_explanation
+from eth_defi.uniswap_v2.deployment import UniswapV2Deployment
+from eth_defi.uniswap_v2.fees import estimate_sell_price
+from eth_defi.uniswap_v2.swap import swap_with_slippage_protection
+from eth_defi.event_reader.reorganisation_monitor import create_reorganisation_monitor
+from tradingstrategy.pair import PandasPairUniverse
+from tradeexecutor.ethereum.uniswap_v2.uniswap_v2_live_pricing import UniswapV2LivePricing
+from tradeexecutor.ethereum.uniswap_v2.uniswap_v2_routing import UniswapV2SimpleRoutingModel
+from tradeexecutor.ethereum.uniswap_v2.uniswap_v2_valuation import UniswapV2PoolRevaluator
+from tradeexecutor.ethereum.enzyme.tx import EnzymeTransactionBuilder
+from tradeexecutor.ethereum.enzyme.vault import EnzymeVaultSyncModel
+from tradeexecutor.state.identifier import AssetIdentifier, TradingPairIdentifier
+from tradeexecutor.state.state import State
+from tradeexecutor.strategy.pandas_trader.position_manager import PositionManager
+from tradeexecutor.strategy.pricing_model import PricingModel
+from tradeexecutor.strategy.trading_strategy_universe import TradingStrategyUniverse
+from tradeexecutor.strategy.valuation import revalue_state, ValuationModel
+from tradeexecutor.testing.ethereumtrader_uniswap_v2 import UniswapV2TestTrader
+
+
+@pytest.fixture
+def hot_wallet(web3, deployer, user_1, usdc: Contract) -> HotWallet:
+    """Create hot wallet for the signing tests.
+
+    Top is up with some gas money and 500 USDC.
+    """
+    private_key = HexBytes(secrets.token_bytes(32))
+    account = Account.from_key(private_key)
+    wallet = HotWallet(account)
+    wallet.sync_nonce(web3)
+    tx_hash = web3.eth.send_transaction({"to": wallet.address, "from": user_1, "value": 15 * 10**18})
+    assert_transaction_success_with_explanation(web3, tx_hash)
+    tx_hash = usdc.functions.transfer(wallet.address, 500 * 10**6).transact({"from": deployer})
+    assert_transaction_success_with_explanation(web3, tx_hash)
+    return wallet
+
+
+@pytest.fixture()
+def routing_model(
+        uniswap_v2,
+        usdc_asset,
+        weth_asset,
+        weth_usdc_trading_pair) -> UniswapV2SimpleRoutingModel:
+
+    # Allowed exchanges as factory -> router pairs
+    factory_router_map = {
+        uniswap_v2.factory.address: (uniswap_v2.router.address, uniswap_v2.init_code_hash),
+    }
+
+    # Three way ETH quoted trades are routed thru WETH/USDC pool
+    allowed_intermediary_pairs = {
+        weth_asset.address: weth_usdc_trading_pair.pool_address
+    }
+
+    return UniswapV2SimpleRoutingModel(
+        factory_router_map,
+        allowed_intermediary_pairs,
+        reserve_token_address=usdc_asset.address,
+    )
+
+
+@pytest.fixture()
+def pricing_model(
+        web3,
+        uniswap_v2,
+        pair_universe: PandasPairUniverse,
+        routing_model) -> UniswapV2LivePricing:
+
+    pricing_model = UniswapV2LivePricing(
+        web3,
+        pair_universe,
+        routing_model,
+    )
+    return pricing_model
+
+
+@pytest.fixture()
+def valuation_model(pricing_model):
+    return UniswapV2PoolRevaluator(pricing_model)
+
+
+def test_enzyme_redeemed_position_profit(
+    web3: Web3,
+    deployer: HexAddress,
+    vault: Vault,
+    usdc: Contract,
+    weth: Contract,
+    usdc_asset: AssetIdentifier,
+    weth_asset: AssetIdentifier,
+    user_1: HexAddress,
+    uniswap_v2: UniswapV2Deployment,
+    weth_usdc_trading_pair: TradingPairIdentifier,
+    pair_universe: PandasPairUniverse,
+    hot_wallet: HotWallet,
+    pricing_model: PricingModel,
+    valuation_model: ValuationModel,
+    single_pair_strategy_universe: TradingStrategyUniverse,
+):
+    """Profit is correctly calculated for a position with redemptions.
+
+    - Redeem from one open WETH position
+
+    - Move the price, so that we make losses
+
+    - Close the position
+    """
+
+    reorg_mon = create_reorganisation_monitor(web3)
+
+    tx_hash = vault.vault.functions.addAssetManagers([hot_wallet.address]).transact({"from": user_1})
+    assert_transaction_success_with_explanation(web3, tx_hash)
+
+    # Starting price for 1 ETH
+    starting_price = estimate_sell_price(uniswap_v2, weth, usdc, 1 * 10**18) / 1e6
+    assert starting_price == pytest.approx(1582.577362)
+
+    sync_model = EnzymeVaultSyncModel(
+        web3,
+        vault.address,
+        reorg_mon,
+    )
+
+    state = State()
+    sync_model.sync_initial(state)
+
+    # Make two deposits from separate parties
+    usdc.functions.transfer(user_1, 500 * 10**6).transact({"from": deployer})
+    usdc.functions.approve(vault.comptroller.address, 500 * 10**6).transact({"from": user_1})
+    tx_hash = vault.comptroller.functions.buyShares(500 * 10**6, 1).transact({"from": user_1})
+    assert_transaction_success_with_explanation(web3, tx_hash)
+
+    # Strategy has its reserve balances updated
+    sync_model.sync_treasury(datetime.datetime.utcnow(), state)
+    assert state.portfolio.get_total_equity() == pytest.approx(500)
+
+    # Create open WETH/USDC position worth of 100
+
+    tx_builder = EnzymeTransactionBuilder(hot_wallet, vault)
+
+    trader = UniswapV2TestTrader(
+        uniswap_v2,
+        state=state,
+        pair_universe=pair_universe,
+        tx_builder=tx_builder,
+    )
+
+    # Open $100 position
+    position, trade = trader.buy(
+        weth_usdc_trading_pair,
+        Decimal(100),
+        execute=True,
+        slippage_tolerance=0.0125,
+    )
+    assert trade.is_success()
+
+    # Redeem 50%
+    # Shares originally = 500
+    # Redeem 250 shares
+    tx_hash = vault.comptroller.functions.redeemSharesInKind(user_1, 250 * 10**18, [], []).transact({"from": user_1})
+    assert_transaction_success_with_explanation(web3, tx_hash)
+
+    # Strategy has its reserve balances updated
+    events = sync_model.sync_treasury(datetime.datetime.utcnow(), state)
+    assert len(events) == 2  # redemption detected for two assts
+
+    assert state.portfolio.open_positions[1].get_unrealised_profit_usd() == 0
+
+    # Move the price
+    # The pool is 1000 ETH / 1.7M USDC.
+    # Deployer dumps 10 ETH to cause a price impact.
+    weth.functions.approve(uniswap_v2.router.address, 1000 * 10**18).transact({"from": deployer})
+    prepared_swap_call = swap_with_slippage_protection(
+        uniswap_v2_deployment=uniswap_v2,
+        recipient_address=deployer,
+        base_token=usdc,
+        quote_token=weth,
+        amount_in=10 * 10**18,
+        max_slippage=10_000,
+    )
+    tx_hash = prepared_swap_call.transact({"from": deployer})
+    assert_transaction_success_with_explanation(web3, tx_hash)
+
+    # Price after movement
+    moved_price = estimate_sell_price(uniswap_v2, weth, usdc, 1 * 10**18) / 1e6
+    assert moved_price == pytest.approx(1359.153875)
+
+    # Revalue positions
+    revalue_state(state, datetime.datetime.utcnow(), valuation_model)
+
+    # Because price went down we have unrealised PnL
+    assert state.portfolio.open_positions[1].get_unrealised_profit_usd() == pytest.approx(-7.372047000000003)
+
+    # Close the position
+    position_manager = PositionManager(datetime.datetime.utcnow(), single_pair_strategy_universe, state, pricing_model)
+    trades = position_manager.close_all()
+    assert len(trades) == 1
+
+    trader.execute_trades_simple(trades)
+
+    # Position has redemptions
+    assert len(position.balance_updates) == 1
+
+    # Portfolio has 250 + losses moved away
+    reserve = state.portfolio.get_default_reserve_position()
+    assert position.get_value() == 0
+    assert reserve.get_value() == pytest.approx(242.627953)
+    assert state.portfolio.get_total_equity() == pytest.approx(242.627953)
+

--- a/tests/enzyme/test_enzyme_redeem.py
+++ b/tests/enzyme/test_enzyme_redeem.py
@@ -8,7 +8,6 @@ import pytest
 from eth_account import Account
 from hexbytes import HexBytes
 
-from eth_defi.enzyme.integration_manager import IntegrationManagerActionId
 from eth_defi.enzyme.vault import Vault
 from eth_defi.hotwallet import HotWallet
 from eth_defi.trace import assert_transaction_success_with_explanation
@@ -16,7 +15,6 @@ from eth_defi.uniswap_v2.deployment import UniswapV2Deployment
 from eth_typing import HexAddress
 
 from tradeexecutor.state.balance_update import BalanceUpdatePositionType, BalanceUpdateCause
-from tradeexecutor.state.blockhain_transaction import BlockchainTransactionType
 from tradingstrategy.pair import PandasPairUniverse
 from web3 import Web3
 from web3.contract import Contract
@@ -46,7 +44,6 @@ def hot_wallet(web3, deployer, user_1, usdc: Contract) -> HotWallet:
     assert_transaction_success_with_explanation(web3, tx_hash)
     tx_hash = usdc.functions.transfer(wallet.address, 500 * 10**6).transact({"from": deployer})
     assert_transaction_success_with_explanation(web3, tx_hash)
-
     return wallet
 
 
@@ -238,3 +235,5 @@ def test_enzyme_redeem_open_position(
     assert position.get_value() == pytest.approx(100)
     assert reserve.get_value() == pytest.approx(200)
     assert state.portfolio.get_total_equity() == pytest.approx(300)
+
+

--- a/tests/strategy_tests/test_long_short_momentum.py
+++ b/tests/strategy_tests/test_long_short_momentum.py
@@ -26,7 +26,7 @@ def logger(request):
 @pytest.fixture()
 def strategy_path() -> Path:
     """Where do we load our strategy file."""
-    return Path(os.path.join(os.path.dirname(__file__), "..", "..", "strategies", "long-short-momentum.py"))
+    return Path(os.path.join(os.path.dirname(__file__), "..", "..", "strategies", "spot-and-short-momentum.py"))
 
 
 def test_long_short_momentum(

--- a/tradeexecutor/state/identifier.py
+++ b/tradeexecutor/state/identifier.py
@@ -372,8 +372,11 @@ class TradingPairIdentifier:
         return f"<Pair {self.base.token_symbol}-{self.quote.token_symbol} {type_name} at {self.pool_address} ({fee * 100:.4f}% fee) on exchange {self.exchange_address}>"
 
     def __hash__(self):
-        assert self.internal_id, "Internal id needed to be hashable"
-        return self.internal_id
+        """Trading pair hash is hash(base, quote, fee).
+
+        This might not hold true for all upcoming markets.
+        """
+        return hash((self.base, self.quote, self.fee))
 
     def __eq__(self, other: "TradingPairIdentifier | None"):
 

--- a/tradeexecutor/state/position.py
+++ b/tradeexecutor/state/position.py
@@ -1097,6 +1097,8 @@ class TradingPosition(GenericPosition):
         - Any avg buy and sell contains all fees we have paid in included in the price,
           so we do not need to add them to profit here
 
+        - See also :py:meth:`get_realised_profit_percent`.
+
         TODO: Handle account corrections
 
         :param include_interest:
@@ -1337,6 +1339,8 @@ class TradingPosition(GenericPosition):
         Calculate how many percent profit this position made,
         relative to all trades taken over the life time of the position.
 
+        See also :py:meth:`get_realised_profit_usd`.
+
         See :ref:`profitability` for more details.
 
         :return:
@@ -1351,6 +1355,15 @@ class TradingPosition(GenericPosition):
         buy_value = self.get_buy_value()
         sell_value = self.get_sell_value()
 
+        # We only need to handle in-kind redemptions,
+        # because deposits are never applied to an open position
+        redemptions = [r for r in self.balance_updates.values() if r.cause == BalanceUpdateCause.redemption]
+        if redemptions:
+            assert self.is_spot(), "Does not know how to handle redemptions for credit positions"
+            redemptions_value = sum(r.usd_value for r in redemptions)
+        else:
+            redemptions_value = 0
+
         if buy_value == 0:
             # Repaired trade
             return 0
@@ -1359,7 +1372,7 @@ class TradingPosition(GenericPosition):
             # Another way of damaged/repaired trade
             return 0
 
-        return sell_value / buy_value - 1
+        return sell_value / (buy_value - redemptions_value) - 1
 
     def get_size_relative_realised_profit_percent(self) -> Percent:
         """Calculated life-time profit over this position.

--- a/tradeexecutor/state/position.py
+++ b/tradeexecutor/state/position.py
@@ -1099,8 +1099,11 @@ class TradingPosition(GenericPosition):
 
         - See also :py:meth:`get_realised_profit_percent`.
 
-        TODO: Handle account corrections
+        .. note ::
 
+            This function does not account for in-kind redemptions or any other account corrections.
+            Please use :py:meth:`get_realised_profit_percent` if possible.
+loca
         :param include_interest:
             Include any accrued interest in PnL.
 

--- a/tradeexecutor/state/state.py
+++ b/tradeexecutor/state/state.py
@@ -842,13 +842,17 @@ class State:
         txt = json.dumps(data, cls=_ExtendedEncoder)
         return txt
 
-    def write_json_file(self, path: Path):
+    def write_json_file(self, path: Path | str):
         """Write JSON to a file.
 
         - Validates state before writing it out
 
         - Work around any serialisation quirks
         """
+
+        if type(path) == str:
+            path = Path(path)
+
         assert isinstance(path, Path)
         txt = self.to_json_safe()
         with path.open("wt") as out:
@@ -869,11 +873,14 @@ class State:
         return start_at, end_at
 
     @staticmethod
-    def read_json_file(path: Path) -> "State":
+    def read_json_file(path: Path | str) -> "State":
         """Read state from the JSON file.
 
         - Deal with all serialisation quirks
         """
+
+        if type(path) == str:
+            path = Path(path)
 
         assert isinstance(path, Path), f"Expected Path, got {path.__class__}"
 


### PR DESCRIPTION
- Fix realised PnL calculation in the case spot positions contain in-kind redemptions
- Allow mixing `str` and `Path` in state serialisation
- Change `hash()` for `TradingPairIdentifier`  to be independent from the internal id. Hash together (base, quote, fee) like Uniswap v3 does.