### PR TITLE
Refactor multiple class names to make code more readable

### DIFF
--- a/scripts/manual-test-1delta-short.py
+++ b/scripts/manual-test-1delta-short.py
@@ -32,7 +32,7 @@ from tradeexecutor.strategy.universe_model import default_universe_options
 from tradeexecutor.strategy.trading_strategy_universe import load_partial_data, TradingStrategyUniverse, load_trading_and_lending_data, translate_trading_pair
 from tradeexecutor.strategy.pandas_trader.position_manager import PositionManager
 from tradeexecutor.ethereum.uniswap_v3.uniswap_v3_live_pricing import UniswapV3LivePricing
-from tradeexecutor.ethereum.one_delta.one_delta_routing import OneDeltaSimpleRoutingModel, OneDeltaRoutingState
+from tradeexecutor.ethereum.one_delta.one_delta_routing import OneDeltaRouting, OneDeltaRoutingState
 from tradeexecutor.cli.bootstrap import create_execution_and_sync_model, create_web3_config, create_state_store
 from tradeexecutor.strategy.execution_model import AssetManagementMode
 from tradeexecutor.cli.log import setup_logging
@@ -102,7 +102,7 @@ else:
     state = store.load()
 
 usdc = fetch_erc20_details(sync_model.web3, "0x2791bca1f2de4661ed88a30c99a7a9449aa84174")
-routing_model = OneDeltaSimpleRoutingModel(
+routing_model = OneDeltaRouting(
     address_map={
         "one_delta_broker_proxy": "0x74E95F3Ec71372756a01eB9317864e3fdde1AC53",
         "aave_v3_pool": "0x794a61358D6845594F94dc1DB02A252b5b4814aD",

--- a/strategies/bnb_chain_16h_momentum.py
+++ b/strategies/bnb_chain_16h_momentum.py
@@ -22,7 +22,7 @@ from typing import Dict
 
 import pandas as pd
 
-from tradeexecutor.ethereum.uniswap_v2.uniswap_v2_routing import UniswapV2SimpleRoutingModel
+from tradeexecutor.ethereum.uniswap_v2.uniswap_v2_routing import UniswapV2Routing
 from tradeexecutor.strategy.execution_context import ExecutionMode, ExecutionContext
 from tradingstrategy.client import Client
 from tradingstrategy.candle import GroupedCandleUniverse
@@ -391,7 +391,7 @@ def strategy_factory(
         pricing_model_factory=pricing_model_factory,
         cash_buffer=cash_buffer,
         execution_context=execution_context,
-        routing_model=UniswapV2SimpleRoutingModel(
+        routing_model=UniswapV2Routing(
             factory_router_map,
             allowed_intermediary_pairs,
             reserve_token_address=reserve_token_address,

--- a/strategies/pancake_8h_momentum.py
+++ b/strategies/pancake_8h_momentum.py
@@ -13,7 +13,7 @@ from typing import Dict
 import pandas as pd
 
 from tradeexecutor.ethereum.uniswap_v2.uniswap_v2_execution_v0 import UniswapV2ExecutionModelVersion0
-from tradeexecutor.ethereum.uniswap_v2.uniswap_v2_routing import UniswapV2SimpleRoutingModel
+from tradeexecutor.ethereum.uniswap_v2.uniswap_v2_routing import UniswapV2Routing
 from tradeexecutor.state.state import State
 
 from tradeexecutor.strategy.sync_model import SyncMethodV0
@@ -376,7 +376,7 @@ def strategy_factory(
 
     universe_model = OurUniverseModel(client, timed_task_context_manager)
 
-    routing_model = UniswapV2SimpleRoutingModel(
+    routing_model = UniswapV2Routing(
         factory_router_map,
         allowed_intermediary_pairs,
         reserve_token_address,

--- a/strategies/quickswap-momentum.py
+++ b/strategies/quickswap-momentum.py
@@ -11,7 +11,7 @@ from typing import Dict
 
 import pandas as pd
 
-from tradeexecutor.ethereum.uniswap_v2.uniswap_v2_routing import UniswapV2SimpleRoutingModel
+from tradeexecutor.ethereum.uniswap_v2.uniswap_v2_routing import UniswapV2Routing
 from tradingstrategy.client import Client
 from tradingstrategy.candle import GroupedCandleUniverse
 from tradingstrategy.chain import ChainId
@@ -375,7 +375,7 @@ def strategy_factory(
         sync_model=sync_model,
         pricing_model_factory=pricing_model_factory,
         cash_buffer=cash_buffer,
-        routing_model=UniswapV2SimpleRoutingModel(
+        routing_model=UniswapV2Routing(
             factory_router_map,
             allowed_intermediary_pairs,
             reserve_token_address=reserve_token_address,

--- a/strategies/test_only/frozen_asset.py
+++ b/strategies/test_only/frozen_asset.py
@@ -5,7 +5,7 @@ from typing import Dict, Any
 
 import pandas as pd
 
-from tradeexecutor.ethereum.uniswap_v2.uniswap_v2_routing import UniswapV2SimpleRoutingModel
+from tradeexecutor.ethereum.uniswap_v2.uniswap_v2_routing import UniswapV2Routing
 from tradeexecutor.strategy.execution_context import ExecutionContext, ExecutionMode
 from tradeexecutor.strategy.trading_strategy_universe import translate_trading_pair
 
@@ -112,7 +112,7 @@ def strategy_factory(
         sync_model=sync_model,
         pricing_model_factory=pricing_model_factory,
         cash_buffer=cash_buffer,
-        routing_model=UniswapV2SimpleRoutingModel(
+        routing_model=UniswapV2Routing(
             factory_router_map,
             allowed_intermediary_pairs,
             reserve_token_address,

--- a/strategies/test_only/pancakeswap_v2_main_loop.py
+++ b/strategies/test_only/pancakeswap_v2_main_loop.py
@@ -13,7 +13,7 @@ import pandas as pd
 
 from tradeexecutor.ethereum.uniswap_v2.uniswap_v2_execution import UniswapV2ExecutionModel
 from tradeexecutor.ethereum.uniswap_v2.uniswap_v2_execution_v0 import UniswapV2ExecutionModelVersion0
-from tradeexecutor.ethereum.uniswap_v2.uniswap_v2_routing import UniswapV2SimpleRoutingModel
+from tradeexecutor.ethereum.uniswap_v2.uniswap_v2_routing import UniswapV2Routing
 from tradeexecutor.state.state import State
 from tradeexecutor.strategy.sync_model import SyncMethodV0
 from tradeexecutor.strategy.approval import ApprovalModel
@@ -360,7 +360,7 @@ def strategy_factory(
 
     universe_model = OurUniverseModel(client, timed_task_context_manager)
 
-    routing_model = UniswapV2SimpleRoutingModel(
+    routing_model = UniswapV2Routing(
         factory_router_map,
         allowed_intermediary_pairs,
         reserve_token_address,

--- a/strategies/test_only/pancakeswap_v2_main_loop.py
+++ b/strategies/test_only/pancakeswap_v2_main_loop.py
@@ -11,7 +11,7 @@ from typing import Dict
 
 import pandas as pd
 
-from tradeexecutor.ethereum.uniswap_v2.uniswap_v2_execution import UniswapV2ExecutionModel
+from tradeexecutor.ethereum.uniswap_v2.uniswap_v2_execution import UniswapV2Execution
 from tradeexecutor.ethereum.uniswap_v2.uniswap_v2_execution_v0 import UniswapV2ExecutionModelVersion0
 from tradeexecutor.ethereum.uniswap_v2.uniswap_v2_routing import UniswapV2Routing
 from tradeexecutor.state.state import State
@@ -354,7 +354,7 @@ def strategy_factory(
         # https://www.python.org/dev/peps/pep-3102/
         raise TypeError("Only keyword arguments accepted")
 
-    assert isinstance(execution_model, (UniswapV2ExecutionModel, UniswapV2ExecutionModelVersion0)), f"This strategy is compatible only with UniswapV2ExecutionModel, got {execution_model}"
+    assert isinstance(execution_model, (UniswapV2Execution, UniswapV2ExecutionModelVersion0)), f"This strategy is compatible only with UniswapV2ExecutionModel, got {execution_model}"
 
     assert execution_model.chain_id in (56, 1337), f"This strategy is hardcoded to ganache-cli test chain, got chain {execution_model.chain_id}"
 

--- a/tests/backtest/test_backtest_execution.py
+++ b/tests/backtest/test_backtest_execution.py
@@ -15,8 +15,8 @@ from tradeexecutor.testing.backtest_trader import BacktestTrader
 from tradingstrategy.chain import ChainId
 from tradingstrategy.timebucket import TimeBucket
 
-from tradeexecutor.backtest.backtest_execution import BacktestExecutionModel
-from tradeexecutor.backtest.backtest_pricing import BacktestSimplePricingModel
+from tradeexecutor.backtest.backtest_execution import BacktestExecution
+from tradeexecutor.backtest.backtest_pricing import BacktestPricing
 from tradeexecutor.backtest.backtest_routing import BacktestRoutingModel
 from tradeexecutor.backtest.legacy_backtest_sync import BacktestSyncer
 from tradeexecutor.backtest.backtest_valuation import BacktestValuationModel
@@ -116,8 +116,8 @@ def routing_model() -> BacktestRoutingModel:
 
 
 @pytest.fixture(scope="module")
-def pricing_model(routing_model, strategy_universe) -> BacktestSimplePricingModel:
-    return BacktestSimplePricingModel(strategy_universe, routing_model)
+def pricing_model(routing_model, strategy_universe) -> BacktestPricing:
+    return BacktestPricing(strategy_universe, routing_model)
 
 
 @pytest.fixture(scope="module")
@@ -154,13 +154,13 @@ def test_get_historical_price(
         state: State,
         wallet: SimulatedWallet,
         strategy_universe,
-        pricing_model: BacktestSimplePricingModel,
+        pricing_model: BacktestPricing,
         routing_model: BacktestRoutingModel,
     ):
     """Retrieve historical buy and sell price."""
 
     ts = datetime.datetime(2021, 6, 1)
-    execution_model = BacktestExecutionModel(wallet, max_slippage=0.01)
+    execution_model = BacktestExecution(wallet, max_slippage=0.01)
     trader = BacktestTrader(ts, state, strategy_universe, execution_model, routing_model, pricing_model)
     wbnb_busd = translate_trading_pair(strategy_universe.data_universe.pairs.get_single())
 
@@ -187,7 +187,7 @@ def test_create_and_execute_backtest_trade(
     wallet: SimulatedWallet,
         strategy_universe,
     routing_model: BacktestRoutingModel,
-    pricing_model: BacktestSimplePricingModel,
+    pricing_model: BacktestPricing,
     wbnb: AssetIdentifier,
     busd: AssetIdentifier,
     ):
@@ -196,7 +196,7 @@ def test_create_and_execute_backtest_trade(
     assert wallet.get_balance(busd.address) == 10_000
 
     ts = datetime.datetime(2021, 6, 1)
-    execution_model = BacktestExecutionModel(wallet, max_slippage=0.01)
+    execution_model = BacktestExecution(wallet, max_slippage=0.01)
     trader = BacktestTrader(ts, state, strategy_universe, execution_model, routing_model, pricing_model)
     wbnb_busd = translate_trading_pair(strategy_universe.data_universe.pairs.get_single())
 
@@ -222,14 +222,14 @@ def test_buy_sell_backtest(
     wallet: SimulatedWallet,
         strategy_universe,
     routing_model: BacktestRoutingModel,
-    pricing_model: BacktestSimplePricingModel,
+    pricing_model: BacktestPricing,
     wbnb: AssetIdentifier,
     busd: AssetIdentifier,
     ):
     """Buying and sell using backtest execution."""
 
     ts = datetime.datetime(2021, 6, 1)
-    execution_model = BacktestExecutionModel(wallet, max_slippage=0.01)
+    execution_model = BacktestExecution(wallet, max_slippage=0.01)
     trader = BacktestTrader(ts, state, strategy_universe, execution_model, routing_model, pricing_model)
     wbnb_busd = translate_trading_pair(strategy_universe.data_universe.pairs.get_single())
     wbnb_busd.fee = 0.0025
@@ -262,7 +262,7 @@ def test_buy_with_fee(
     wallet: SimulatedWallet,
         strategy_universe,
     routing_model: BacktestRoutingModel,
-    pricing_model: BacktestSimplePricingModel,
+    pricing_model: BacktestPricing,
     wbnb: AssetIdentifier,
     busd: AssetIdentifier,
     ):
@@ -273,7 +273,7 @@ def test_buy_with_fee(
     """
 
     ts = datetime.datetime(2021, 6, 1)
-    execution_model = BacktestExecutionModel(wallet, max_slippage=0.01)
+    execution_model = BacktestExecution(wallet, max_slippage=0.01)
     trader = BacktestTrader(ts, state, strategy_universe, execution_model, routing_model, pricing_model)
     wbnb_busd = translate_trading_pair(strategy_universe.data_universe.pairs.get_single())
 
@@ -302,14 +302,14 @@ def test_buy_sell_backtest_with_fee(
     wallet: SimulatedWallet,
         strategy_universe,
     routing_model: BacktestRoutingModel,
-    pricing_model: BacktestSimplePricingModel,
+    pricing_model: BacktestPricing,
     wbnb: AssetIdentifier,
     busd: AssetIdentifier,
     ):
     """Buying and sell using backtest execution."""
 
     ts = datetime.datetime(2021, 6, 1)
-    execution_model = BacktestExecutionModel(wallet, max_slippage=0.01)
+    execution_model = BacktestExecution(wallet, max_slippage=0.01)
     trader = BacktestTrader(ts, state, strategy_universe, execution_model, routing_model, pricing_model)
     wbnb_busd = translate_trading_pair(strategy_universe.data_universe.pairs.get_single())
     wbnb_busd.fee = 0.0025

--- a/tests/backtest/test_backtest_execution_three_way.py
+++ b/tests/backtest/test_backtest_execution_three_way.py
@@ -16,8 +16,8 @@ from tradeexecutor.testing.backtest_trader import BacktestTrader
 from tradingstrategy.chain import ChainId
 from tradingstrategy.timebucket import TimeBucket
 
-from tradeexecutor.backtest.backtest_execution import BacktestExecutionModel
-from tradeexecutor.backtest.backtest_pricing import BacktestSimplePricingModel
+from tradeexecutor.backtest.backtest_execution import BacktestExecution
+from tradeexecutor.backtest.backtest_pricing import BacktestPricing
 from tradeexecutor.backtest.backtest_routing import BacktestRoutingModel
 from tradeexecutor.backtest.legacy_backtest_sync import BacktestSyncer
 from tradeexecutor.backtest.backtest_valuation import BacktestValuationModel
@@ -188,8 +188,8 @@ def routing_model() -> BacktestRoutingModel:
 
 
 @pytest.fixture(scope="module")
-def pricing_model(routing_model, strategy_universe) -> BacktestSimplePricingModel:
-    return BacktestSimplePricingModel(strategy_universe, routing_model)
+def pricing_model(routing_model, strategy_universe) -> BacktestPricing:
+    return BacktestPricing(strategy_universe, routing_model)
 
 
 @pytest.fixture(scope="module")
@@ -229,7 +229,7 @@ def test_create_and_execute_backtest_three_way_trade(
         wallet: SimulatedWallet,
         strategy_universe,
         routing_model: BacktestRoutingModel,
-        pricing_model: BacktestSimplePricingModel,
+        pricing_model: BacktestPricing,
         wbnb: AssetIdentifier,
         busd: AssetIdentifier,
         cake: AssetIdentifier,
@@ -239,7 +239,7 @@ def test_create_and_execute_backtest_three_way_trade(
     assert wallet.get_balance(busd.address) == 10_000
 
     ts = datetime.datetime(2021, 6, 1)
-    execution_model = BacktestExecutionModel(wallet, max_slippage=0.01)
+    execution_model = BacktestExecution(wallet, max_slippage=0.01)
     trader = BacktestTrader(ts, state, strategy_universe, execution_model, routing_model, pricing_model)
     cake_wbnb = translate_trading_pair(strategy_universe.data_universe.pairs.get_by_symbols("Cake", "WBNB"))
 
@@ -270,7 +270,7 @@ def test_buy_sell_three_way_backtest(
         wallet: SimulatedWallet,
         strategy_universe,
         routing_model: BacktestRoutingModel,
-        pricing_model: BacktestSimplePricingModel,
+        pricing_model: BacktestPricing,
         wbnb: AssetIdentifier,
         busd: AssetIdentifier,
         cake: AssetIdentifier,
@@ -278,7 +278,7 @@ def test_buy_sell_three_way_backtest(
     """Buying and sell using backtest execution, three way."""
 
     ts = datetime.datetime(2021, 6, 1)
-    execution_model = BacktestExecutionModel(wallet, max_slippage=0.01)
+    execution_model = BacktestExecution(wallet, max_slippage=0.01)
     trader = BacktestTrader(ts, state, strategy_universe, execution_model, routing_model, pricing_model)
     cake_wbnb = translate_trading_pair(strategy_universe.data_universe.pairs.get_by_symbols("Cake", "WBNB"))
     cake_wbnb.fee = 0.0025

--- a/tests/backtest/test_backtest_mixed_positions.py
+++ b/tests/backtest/test_backtest_mixed_positions.py
@@ -17,7 +17,7 @@ from tradingstrategy.timebucket import TimeBucket
 from tradingstrategy.candle import GroupedCandleUniverse
 from tradingstrategy.universe import Universe
 
-from tradeexecutor.backtest.backtest_pricing import BacktestSimplePricingModel
+from tradeexecutor.backtest.backtest_pricing import BacktestPricing
 from tradeexecutor.backtest.backtest_routing import BacktestRoutingModel
 from tradeexecutor.backtest.backtest_runner import run_backtest_inline
 from tradeexecutor.backtest.simulated_wallet import SimulatedWallet

--- a/tests/backtest/test_backtest_short_execution.py
+++ b/tests/backtest/test_backtest_short_execution.py
@@ -8,8 +8,8 @@ from typing import List
 import pytest
 from hexbytes import HexBytes
 
-from tradeexecutor.backtest.backtest_execution import BacktestExecutionModel
-from tradeexecutor.backtest.backtest_pricing import BacktestSimplePricingModel
+from tradeexecutor.backtest.backtest_execution import BacktestExecution
+from tradeexecutor.backtest.backtest_pricing import BacktestPricing
 from tradeexecutor.backtest.backtest_routing import BacktestRoutingModel, BacktestRoutingState
 from tradeexecutor.backtest.backtest_sync import BacktestSyncModel
 from tradeexecutor.backtest.simulated_wallet import SimulatedWallet
@@ -190,8 +190,8 @@ def routing_model(strategy_universe) -> BacktestRoutingModel:
 
 
 @pytest.fixture()
-def pricing_model(routing_model, strategy_universe) -> BacktestSimplePricingModel:
-    return BacktestSimplePricingModel(strategy_universe.data_universe.candles, routing_model)
+def pricing_model(routing_model, strategy_universe) -> BacktestPricing:
+    return BacktestPricing(strategy_universe.data_universe.candles, routing_model)
 
 
 @pytest.fixture()
@@ -203,9 +203,9 @@ def wallet(usdc, weth) -> SimulatedWallet:
 
 
 @pytest.fixture()
-def execution_model(wallet) -> BacktestExecutionModel:
+def execution_model(wallet) -> BacktestExecution:
     """Simulate trades using backtest execution model."""
-    execution_model = BacktestExecutionModel(wallet)
+    execution_model = BacktestExecution(wallet)
     return execution_model
 
 
@@ -250,7 +250,7 @@ def test_open_and_close_one_short(
     weth: AssetIdentifier,
     usdc: AssetIdentifier,
     start_timestamp,
-    execution_model: BacktestExecutionModel,
+    execution_model: BacktestExecution,
     routing_model: BacktestRoutingModel,
     wallet: SimulatedWallet,
 ):
@@ -330,7 +330,7 @@ def test_open_and_close_two_shorts(
     weth: AssetIdentifier,
     aave: AssetIdentifier,
     start_timestamp,
-    execution_model: BacktestExecutionModel,
+    execution_model: BacktestExecution,
     routing_model: BacktestRoutingModel,
     wallet: SimulatedWallet,
 ):
@@ -424,7 +424,7 @@ def test_open_and_close_one_short_with_interest(
     weth: AssetIdentifier,
     usdc: AssetIdentifier,
     start_timestamp,
-    execution_model: BacktestExecutionModel,
+    execution_model: BacktestExecution,
     routing_model: BacktestRoutingModel,
     sync_model: BacktestSyncModel,
     wallet: SimulatedWallet,
@@ -536,7 +536,7 @@ def test_open_and_close_two_shorts_with_interest(
     weth: AssetIdentifier,
     usdc: AssetIdentifier,
     start_timestamp,
-    execution_model: BacktestExecutionModel,
+    execution_model: BacktestExecution,
     routing_model: BacktestRoutingModel,
     sync_model: BacktestSyncModel,
     wallet: SimulatedWallet,
@@ -669,7 +669,7 @@ def test_open_and_reduce_one_short_with_interest(
     weth: AssetIdentifier,
     usdc: AssetIdentifier,
     start_timestamp,
-    execution_model: BacktestExecutionModel,
+    execution_model: BacktestExecution,
     routing_model: BacktestRoutingModel,
     sync_model: BacktestSyncModel,
     wallet: SimulatedWallet,
@@ -790,7 +790,7 @@ def test_open_and_increase_one_short_with_interest(
     weth: AssetIdentifier,
     usdc: AssetIdentifier,
     start_timestamp,
-    execution_model: BacktestExecutionModel,
+    execution_model: BacktestExecution,
     routing_model: BacktestRoutingModel,
     sync_model: BacktestSyncModel,
     wallet: SimulatedWallet,

--- a/tests/backtest/test_backtest_short_synthetic_data.py
+++ b/tests/backtest/test_backtest_short_synthetic_data.py
@@ -19,7 +19,7 @@ from tradingstrategy.timebucket import TimeBucket
 from tradingstrategy.candle import GroupedCandleUniverse
 from tradingstrategy.universe import Universe
 
-from tradeexecutor.backtest.backtest_pricing import BacktestSimplePricingModel
+from tradeexecutor.backtest.backtest_pricing import BacktestPricing
 from tradeexecutor.backtest.backtest_routing import BacktestRoutingModel
 from tradeexecutor.backtest.backtest_runner import run_backtest_inline
 from tradeexecutor.backtest.simulated_wallet import SimulatedWallet
@@ -366,7 +366,7 @@ def test_backtest_short_underlying_price_feed(
         ReserveCurrency.usdc,
     )
 
-    pricing_model = BacktestSimplePricingModel(
+    pricing_model = BacktestPricing(
         strategy_universe.data_universe.candles,
         routing_model,
     )

--- a/tests/enzyme/test_enzyme_correct_accounting.py
+++ b/tests/enzyme/test_enzyme_correct_accounting.py
@@ -17,7 +17,7 @@ from eth_defi.uniswap_v2.deployment import UniswapV2Deployment
 from eth_typing import HexAddress
 
 from tradeexecutor.ethereum.uniswap_v2.uniswap_v2_live_pricing import UniswapV2LivePricing
-from tradeexecutor.ethereum.uniswap_v2.uniswap_v2_routing import UniswapV2SimpleRoutingModel
+from tradeexecutor.ethereum.uniswap_v2.uniswap_v2_routing import UniswapV2Routing
 from tradeexecutor.state.balance_update import BalanceUpdateCause, BalanceUpdatePositionType
 from tradingstrategy.pair import PandasPairUniverse
 from web3 import Web3
@@ -64,7 +64,7 @@ def routing_model(
         uniswap_v2,
         usdc_asset,
         weth_asset,
-        weth_usdc_trading_pair) -> UniswapV2SimpleRoutingModel:
+        weth_usdc_trading_pair) -> UniswapV2Routing:
 
     # Allowed exchanges as factory -> router pairs
     factory_router_map = {
@@ -76,7 +76,7 @@ def routing_model(
         weth_asset.address: weth_usdc_trading_pair.pool_address
     }
 
-    return UniswapV2SimpleRoutingModel(
+    return UniswapV2Routing(
         factory_router_map,
         allowed_intermediary_pairs,
         reserve_token_address=usdc_asset.address,

--- a/tests/enzyme/test_enzyme_realised_profit.py
+++ b/tests/enzyme/test_enzyme_realised_profit.py
@@ -20,7 +20,7 @@ from eth_defi.uniswap_v2.swap import swap_with_slippage_protection
 from eth_defi.event_reader.reorganisation_monitor import create_reorganisation_monitor
 from tradingstrategy.pair import PandasPairUniverse
 from tradeexecutor.ethereum.uniswap_v2.uniswap_v2_live_pricing import UniswapV2LivePricing
-from tradeexecutor.ethereum.uniswap_v2.uniswap_v2_routing import UniswapV2SimpleRoutingModel
+from tradeexecutor.ethereum.uniswap_v2.uniswap_v2_routing import UniswapV2Routing
 from tradeexecutor.ethereum.uniswap_v2.uniswap_v2_valuation import UniswapV2PoolRevaluator
 from tradeexecutor.ethereum.enzyme.tx import EnzymeTransactionBuilder
 from tradeexecutor.ethereum.enzyme.vault import EnzymeVaultSyncModel
@@ -55,7 +55,7 @@ def routing_model(
         uniswap_v2,
         usdc_asset,
         weth_asset,
-        weth_usdc_trading_pair) -> UniswapV2SimpleRoutingModel:
+        weth_usdc_trading_pair) -> UniswapV2Routing:
 
     # Allowed exchanges as factory -> router pairs
     factory_router_map = {
@@ -67,7 +67,7 @@ def routing_model(
         weth_asset.address: weth_usdc_trading_pair.pool_address
     }
 
-    return UniswapV2SimpleRoutingModel(
+    return UniswapV2Routing(
         factory_router_map,
         allowed_intermediary_pairs,
         reserve_token_address=usdc_asset.address,

--- a/tests/enzyme/test_enzyme_trade.py
+++ b/tests/enzyme/test_enzyme_trade.py
@@ -16,7 +16,7 @@ from eth_defi.uniswap_v2.deployment import UniswapV2Deployment
 from eth_typing import HexAddress
 
 from tradeexecutor.ethereum.uniswap_v2.uniswap_v2_live_pricing import UniswapV2LivePricing
-from tradeexecutor.ethereum.uniswap_v2.uniswap_v2_routing import UniswapV2SimpleRoutingModel
+from tradeexecutor.ethereum.uniswap_v2.uniswap_v2_routing import UniswapV2Routing
 from tradeexecutor.state.blockhain_transaction import BlockchainTransactionType
 from tradingstrategy.pair import PandasPairUniverse
 from web3 import Web3
@@ -56,7 +56,7 @@ def routing_model(
         uniswap_v2,
         usdc_asset,
         weth_asset,
-        weth_usdc_trading_pair) -> UniswapV2SimpleRoutingModel:
+        weth_usdc_trading_pair) -> UniswapV2Routing:
 
     # Allowed exchanges as factory -> router pairs
     factory_router_map = {
@@ -68,7 +68,7 @@ def routing_model(
         weth_asset.address: weth_usdc_trading_pair.pool_address
     }
 
-    return UniswapV2SimpleRoutingModel(
+    return UniswapV2Routing(
         factory_router_map,
         allowed_intermediary_pairs,
         reserve_token_address=usdc_asset.address,
@@ -311,7 +311,7 @@ def test_enzyme_lp_fees(
     weth_usdc_trading_pair: TradingPairIdentifier,
     pair_universe: PandasPairUniverse,
     hot_wallet: HotWallet,
-    routing_model: UniswapV2SimpleRoutingModel,
+    routing_model: UniswapV2Routing,
     pricing_model: UniswapV2LivePricing,
 ):
     """See LP fees are correctly estimated and realised."""

--- a/tests/ethereum/polygon_forked/conftest.py
+++ b/tests/ethereum/polygon_forked/conftest.py
@@ -18,11 +18,11 @@ from eth_defi.one_delta.deployment import fetch_deployment as fetch_1delta_deplo
 from eth_defi.provider.multi_provider import create_multi_provider_web3
 from eth_defi.provider.anvil import fork_network_anvil, mine
 from eth_defi.uniswap_v3.price import UniswapV3PriceHelper
-from tradeexecutor.ethereum.one_delta.one_delta_routing import OneDeltaSimpleRoutingModel
+from tradeexecutor.ethereum.one_delta.one_delta_routing import OneDeltaRouting
 from tradeexecutor.ethereum.routing_data import get_quickswap_default_routing_parameters
 from tradeexecutor.ethereum.token import translate_token_details
 from tradeexecutor.ethereum.uniswap_v2.uniswap_v2_routing import UniswapV2Routing
-from tradeexecutor.ethereum.uniswap_v3.uniswap_v3_routing import UniswapV3SimpleRoutingModel
+from tradeexecutor.ethereum.uniswap_v3.uniswap_v3_routing import UniswapV3Routing
 
 from tradeexecutor.state.identifier import AssetIdentifier, TradingPairIdentifier, TradingPairKind, AssetType
 from tradeexecutor.strategy.reserve_currency import ReserveCurrency
@@ -291,8 +291,8 @@ def one_delta_routing_model(
     uniswap_v3_deployment,
     asset_usdc,
     asset_weth,
-) -> OneDeltaSimpleRoutingModel:
-    return OneDeltaSimpleRoutingModel(
+) -> OneDeltaRouting:
+    return OneDeltaRouting(
         address_map={
             "one_delta_broker_proxy": one_delta_deployment.broker_proxy.address,
             "aave_v3_pool": aave_v3_deployment.pool.address,
@@ -309,7 +309,7 @@ def one_delta_routing_model(
 
 
 @pytest.fixture()
-def uniswap_v3_routing_model(asset_usdc) -> UniswapV3SimpleRoutingModel:
+def uniswap_v3_routing_model(asset_usdc) -> UniswapV3Routing:
 
     # for uniswap v3
     # same addresses for Mainnet, Polygon, Optimism, Arbitrum, Testnets Address
@@ -332,7 +332,7 @@ def uniswap_v3_routing_model(asset_usdc) -> UniswapV3SimpleRoutingModel:
         "0x7ceb23fd6bc0add59e62ac25578270cff1b9f619": "0x45dda9cb7c25131df268515131f647d726f50608",
     }
 
-    return UniswapV3SimpleRoutingModel(
+    return UniswapV3Routing(
         address_map,
         allowed_intermediary_pairs,
         reserve_token_address=asset_usdc.address,

--- a/tests/ethereum/polygon_forked/conftest.py
+++ b/tests/ethereum/polygon_forked/conftest.py
@@ -21,7 +21,7 @@ from eth_defi.uniswap_v3.price import UniswapV3PriceHelper
 from tradeexecutor.ethereum.one_delta.one_delta_routing import OneDeltaSimpleRoutingModel
 from tradeexecutor.ethereum.routing_data import get_quickswap_default_routing_parameters
 from tradeexecutor.ethereum.token import translate_token_details
-from tradeexecutor.ethereum.uniswap_v2.uniswap_v2_routing import UniswapV2SimpleRoutingModel
+from tradeexecutor.ethereum.uniswap_v2.uniswap_v2_routing import UniswapV2Routing
 from tradeexecutor.ethereum.uniswap_v3.uniswap_v3_routing import UniswapV3SimpleRoutingModel
 
 from tradeexecutor.state.identifier import AssetIdentifier, TradingPairIdentifier, TradingPairKind, AssetType
@@ -344,9 +344,9 @@ def quickswap_routing_model(
         quickswap_deployment,
         wmatic_usdc_spot_pair,
         asset_usdc,
-) -> UniswapV2SimpleRoutingModel:
+) -> UniswapV2Routing:
     # Route WMATIC and USDC quoted pairs on Quickswap
-    uniswap_v2_router = UniswapV2SimpleRoutingModel(
+    uniswap_v2_router = UniswapV2Routing(
         factory_router_map={quickswap_deployment.factory.address: (quickswap_deployment.router.address, quickswap_deployment.init_code_hash)},
         allowed_intermediary_pairs={wmatic_usdc_spot_pair.base.address: wmatic_usdc_spot_pair.pool_address},
         reserve_token_address=asset_usdc.address,

--- a/tests/ethereum/polygon_forked/test_generic_router.py
+++ b/tests/ethereum/polygon_forked/test_generic_router.py
@@ -7,7 +7,7 @@ from _decimal import Decimal
 import pandas as pd
 import pytest as pytest
 
-from tradeexecutor.ethereum.execution import EthereumExecutionModel
+from tradeexecutor.ethereum.execution import EthereumExecution
 from tradeexecutor.ethereum.tx import HotWalletTransactionBuilder
 from tradingstrategy.chain import ChainId
 from web3 import Web3
@@ -145,9 +145,9 @@ def execution_model(
         hot_wallet: HotWallet,
         exchange_universe: ExchangeUniverse,
         weth_usdc_spot_pair,
-) -> EthereumExecutionModel:
+) -> EthereumExecution:
     """Set EthereumExecutionModel in mainnet fork testing mode."""
-    execution_model = EthereumExecutionModel(
+    execution_model = EthereumExecution(
         HotWalletTransactionBuilder(web3, hot_wallet),
         mainnet_fork=True,
         confirmation_block_count=0,
@@ -165,7 +165,7 @@ def test_generic_routing_open_position_across_markets(
     wmatic_usdc_spot_pair: TradingPairIdentifier,
     weth_usdc_spot_pair: TradingPairIdentifier,
     weth_usdc_shorting_pair: TradingPairIdentifier,
-    execution_model: EthereumExecutionModel,
+    execution_model: EthereumExecution,
 ):
     """Open Uniswap v2, v3 and 1delta position in the same state."""
 

--- a/tests/ethereum/polygon_forked/test_generic_router.py
+++ b/tests/ethereum/polygon_forked/test_generic_router.py
@@ -22,11 +22,11 @@ from tradingstrategy.pair import PandasPairUniverse
 from tradingstrategy.timebucket import TimeBucket
 from tradeexecutor.ethereum.hot_wallet_sync_model import HotWalletSyncModel
 from tradeexecutor.ethereum.one_delta.one_delta_live_pricing import OneDeltaLivePricing
-from tradeexecutor.ethereum.one_delta.one_delta_routing import OneDeltaSimpleRoutingModel
+from tradeexecutor.ethereum.one_delta.one_delta_routing import OneDeltaRouting
 from tradeexecutor.ethereum.uniswap_v2.uniswap_v2_live_pricing import UniswapV2LivePricing
 from tradeexecutor.ethereum.uniswap_v2.uniswap_v2_routing import UniswapV2Routing
 from tradeexecutor.ethereum.uniswap_v3.uniswap_v3_live_pricing import UniswapV3LivePricing
-from tradeexecutor.ethereum.uniswap_v3.uniswap_v3_routing import UniswapV3SimpleRoutingModel
+from tradeexecutor.ethereum.uniswap_v3.uniswap_v3_routing import UniswapV3Routing
 from tradeexecutor.ethereum.universe import create_exchange_universe, create_pair_universe
 from tradeexecutor.state.identifier import AssetIdentifier, TradingPairIdentifier
 from tradeexecutor.state.state import State
@@ -89,8 +89,8 @@ def generic_routing_model(
     quickswap_deployment: UniswapV2Deployment,
     wmatic_usdc_spot_pair: TradingPairIdentifier,
     quickswap_routing_model: UniswapV2Routing,
-    one_delta_routing_model: OneDeltaSimpleRoutingModel,
-    uniswap_v3_routing_model: UniswapV3SimpleRoutingModel,
+    one_delta_routing_model: OneDeltaRouting,
+    uniswap_v3_routing_model: UniswapV3Routing,
     asset_usdc: AssetIdentifier,
     asset_wmatic: AssetIdentifier,
 ) -> GenericRouting:
@@ -114,8 +114,8 @@ def generic_pricing_model(
     web3,
     strategy_universe: TradingStrategyUniverse,
     quickswap_routing_model: UniswapV2Routing,
-    one_delta_routing_model: OneDeltaSimpleRoutingModel,
-    uniswap_v3_routing_model: UniswapV3SimpleRoutingModel,
+    one_delta_routing_model: OneDeltaRouting,
+    uniswap_v3_routing_model: UniswapV3Routing,
 ) -> GenericPricing:
     """Create a routing model that trades Uniswap v2, v3 and 1delta + Aave.
 

--- a/tests/ethereum/polygon_forked/test_generic_router.py
+++ b/tests/ethereum/polygon_forked/test_generic_router.py
@@ -24,7 +24,7 @@ from tradeexecutor.ethereum.hot_wallet_sync_model import HotWalletSyncModel
 from tradeexecutor.ethereum.one_delta.one_delta_live_pricing import OneDeltaLivePricing
 from tradeexecutor.ethereum.one_delta.one_delta_routing import OneDeltaSimpleRoutingModel
 from tradeexecutor.ethereum.uniswap_v2.uniswap_v2_live_pricing import UniswapV2LivePricing
-from tradeexecutor.ethereum.uniswap_v2.uniswap_v2_routing import UniswapV2SimpleRoutingModel
+from tradeexecutor.ethereum.uniswap_v2.uniswap_v2_routing import UniswapV2Routing
 from tradeexecutor.ethereum.uniswap_v3.uniswap_v3_live_pricing import UniswapV3LivePricing
 from tradeexecutor.ethereum.uniswap_v3.uniswap_v3_routing import UniswapV3SimpleRoutingModel
 from tradeexecutor.ethereum.universe import create_exchange_universe, create_pair_universe
@@ -32,7 +32,7 @@ from tradeexecutor.state.identifier import AssetIdentifier, TradingPairIdentifie
 from tradeexecutor.state.state import State
 from tradeexecutor.strategy.execution_context import unit_test_execution_context
 from tradeexecutor.strategy.generic.generic_router import GenericRouting
-from tradeexecutor.strategy.generic.generic_pricing_model import GenericPricingModel
+from tradeexecutor.strategy.generic.generic_pricing_model import GenericPricing
 from tradeexecutor.strategy.trading_strategy_universe import TradingStrategyUniverse, load_partial_data
 from tradeexecutor.strategy.universe_model import default_universe_options
 
@@ -88,7 +88,7 @@ def strategy_universe(chain_id, exchange_universe, pair_universe, asset_usdc, pe
 def generic_routing_model(
     quickswap_deployment: UniswapV2Deployment,
     wmatic_usdc_spot_pair: TradingPairIdentifier,
-    quickswap_routing_model: UniswapV2SimpleRoutingModel,
+    quickswap_routing_model: UniswapV2Routing,
     one_delta_routing_model: OneDeltaSimpleRoutingModel,
     uniswap_v3_routing_model: UniswapV3SimpleRoutingModel,
     asset_usdc: AssetIdentifier,
@@ -113,10 +113,10 @@ def generic_routing_model(
 def generic_pricing_model(
     web3,
     strategy_universe: TradingStrategyUniverse,
-    quickswap_routing_model: UniswapV2SimpleRoutingModel,
+    quickswap_routing_model: UniswapV2Routing,
     one_delta_routing_model: OneDeltaSimpleRoutingModel,
     uniswap_v3_routing_model: UniswapV3SimpleRoutingModel,
-) -> GenericPricingModel:
+) -> GenericPricing:
     """Create a routing model that trades Uniswap v2, v3 and 1delta + Aave.
 
     Live Polygon deployment addresses.
@@ -129,7 +129,7 @@ def generic_pricing_model(
     one_delta_pricing = OneDeltaLivePricing(web3, pair_universe, one_delta_routing_model)
 
     # Uses default router choose function
-    return GenericPricingModel(
+    return GenericPricing(
         pair_universe,
         routes = {
             "quickswap": quickswap_pricing_model,
@@ -160,7 +160,7 @@ def test_generic_routing_open_position_across_markets(
     hot_wallet: HotWallet,
     strategy_universe: TradingStrategyUniverse,
     generic_routing_model: GenericRouting,
-    generic_pricing_model: GenericPricingModel,
+    generic_pricing_model: GenericPricing,
     asset_usdc: AssetIdentifier,
     wmatic_usdc_spot_pair: TradingPairIdentifier,
     weth_usdc_spot_pair: TradingPairIdentifier,

--- a/tests/ethereum/polygon_forked/test_one_delta_live_short.py
+++ b/tests/ethereum/polygon_forked/test_one_delta_live_short.py
@@ -20,7 +20,7 @@ from tradingstrategy.timebucket import TimeBucket
 from tradingstrategy.lending import LendingProtocolType
 
 from tradeexecutor.ethereum.one_delta.one_delta_live_pricing import OneDeltaLivePricing
-from tradeexecutor.ethereum.one_delta.one_delta_routing import OneDeltaSimpleRoutingModel
+from tradeexecutor.ethereum.one_delta.one_delta_routing import OneDeltaRouting
 from tradeexecutor.state.state import State
 from tradeexecutor.state.trade import TradeExecution
 from tradeexecutor.strategy.cycle import snap_to_next_tick
@@ -109,7 +109,7 @@ def test_one_delta_live_strategy_short_open_and_close(
     web3: Web3,
     hot_wallet: HotWallet,
     trading_strategy_universe: TradingStrategyUniverse,
-    one_delta_routing_model: OneDeltaSimpleRoutingModel,
+    one_delta_routing_model: OneDeltaRouting,
     uniswap_v3_deployment: UniswapV3Deployment,
     usdc: Contract,
     weth: Contract,
@@ -248,7 +248,7 @@ def test_one_delta_live_strategy_short_open_accrue_interests(
     hot_wallet: HotWallet,
     trading_strategy_universe: TradingStrategyUniverse,
     uniswap_v3_deployment: UniswapV3Deployment,
-    one_delta_routing_model: OneDeltaSimpleRoutingModel,
+    one_delta_routing_model: OneDeltaRouting,
     usdc: Contract,
     weth: Contract,
     weth_usdc_spot_pair,

--- a/tests/ethereum/test_uniswap_live_pricing.py
+++ b/tests/ethereum/test_uniswap_live_pricing.py
@@ -10,7 +10,7 @@ from web3 import EthereumTesterProvider, Web3
 from web3.contract import Contract
 from eth_defi.token import create_token
 from eth_defi.uniswap_v2.deployment import UniswapV2Deployment, deploy_trading_pair, deploy_uniswap_v2_like
-from tradeexecutor.ethereum.uniswap_v2.uniswap_v2_routing import UniswapV2SimpleRoutingModel
+from tradeexecutor.ethereum.uniswap_v2.uniswap_v2_routing import UniswapV2Routing
 from tradeexecutor.strategy.trading_strategy_universe import translate_trading_pair
 from tradingstrategy.exchange import ExchangeUniverse
 from tradingstrategy.pair import PandasPairUniverse
@@ -180,7 +180,7 @@ def pair_universe(web3, exchange_universe: ExchangeUniverse, weth_usdc_pair, aav
 
 
 @pytest.fixture()
-def routing_model(uniswap_v2, asset_usdc, asset_weth, weth_usdc_pair) -> UniswapV2SimpleRoutingModel:
+def routing_model(uniswap_v2, asset_usdc, asset_weth, weth_usdc_pair) -> UniswapV2Routing:
 
     # Allowed exchanges as factory -> router pairs
     factory_router_map = {
@@ -192,7 +192,7 @@ def routing_model(uniswap_v2, asset_usdc, asset_weth, weth_usdc_pair) -> Uniswap
         asset_weth.address: weth_usdc_pair.pool_address
     }
 
-    return UniswapV2SimpleRoutingModel(
+    return UniswapV2Routing(
         factory_router_map,
         allowed_intermediary_pairs,
         reserve_token_address=asset_usdc.address,
@@ -204,7 +204,7 @@ def test_uniswap_two_leg_buy_price_no_price_impact(
         web3: Web3,
         exchange_universe,
         pair_universe: PandasPairUniverse,
-        routing_model: UniswapV2SimpleRoutingModel,
+        routing_model: UniswapV2Routing,
 ):
     """Two-leg buy trade."""
     pricing_method = UniswapV2LivePricing(web3, pair_universe, routing_model)
@@ -229,7 +229,7 @@ def test_uniswap_two_leg_buy_price_with_price_impact(
         web3: Web3,
         exchange_universe,
         pair_universe: PandasPairUniverse,
-        routing_model: UniswapV2SimpleRoutingModel,
+        routing_model: UniswapV2Routing,
 ):
     """Two-leg buy trade w/signficant price impact."""
     pricing_method = UniswapV2LivePricing(web3, pair_universe, routing_model)
@@ -256,7 +256,7 @@ def test_uniswap_two_leg_sell_price_no_price_impact(
         web3: Web3,
         exchange_universe,
         pair_universe: PandasPairUniverse,
-        routing_model: UniswapV2SimpleRoutingModel,
+        routing_model: UniswapV2Routing,
 ):
     pricing_method = UniswapV2LivePricing(web3, pair_universe, routing_model)
 
@@ -282,7 +282,7 @@ def test_uniswap_two_leg_sell_price_with_price_impact(
         web3: Web3,
         exchange_universe,
         pair_universe: PandasPairUniverse,
-        routing_model: UniswapV2SimpleRoutingModel,
+        routing_model: UniswapV2Routing,
 ):
     """Two-leg buy trade w/signficant price impact."""
     pricing_method = UniswapV2LivePricing(web3, pair_universe, routing_model)
@@ -307,7 +307,7 @@ def test_uniswap_three_leg_buy_price_with_price_impact(
         uniswap_v2,
         exchange_universe,
         pair_universe: PandasPairUniverse,
-        routing_model: UniswapV2SimpleRoutingModel,
+        routing_model: UniswapV2Routing,
 ):
     """Three leg trade w/signficant price impact.
 
@@ -362,7 +362,7 @@ def test_uniswap_three_leg_sell_price_with_price_impact(
         uniswap_v2,
         exchange_universe,
         pair_universe: PandasPairUniverse,
-        routing_model: UniswapV2SimpleRoutingModel,
+        routing_model: UniswapV2Routing,
 ):
     """Three leg sell w/signficant price impact.
 

--- a/tests/ethereum/test_uniswap_live_stop_loss.py
+++ b/tests/ethereum/test_uniswap_live_stop_loss.py
@@ -25,7 +25,7 @@ from eth_defi.token import create_token
 from eth_defi.uniswap_v2.deployment import UniswapV2Deployment, deploy_trading_pair, deploy_uniswap_v2_like
 
 from tradeexecutor.ethereum.uniswap_v2.uniswap_v2_execution import UniswapV2ExecutionModel
-from tradeexecutor.ethereum.uniswap_v2.uniswap_v2_routing import UniswapV2SimpleRoutingModel
+from tradeexecutor.ethereum.uniswap_v2.uniswap_v2_routing import UniswapV2Routing
 from tradeexecutor.state.state import State, UncleanState
 from tradeexecutor.state.trade import TradeExecution
 from tradeexecutor.strategy.cycle import snap_to_previous_tick
@@ -188,7 +188,7 @@ def pair_universe(web3, exchange_universe: ExchangeUniverse, weth_usdc_pair) -> 
 
 
 @pytest.fixture()
-def routing_model(uniswap_v2, asset_usdc, asset_weth, weth_usdc_pair) -> UniswapV2SimpleRoutingModel:
+def routing_model(uniswap_v2, asset_usdc, asset_weth, weth_usdc_pair) -> UniswapV2Routing:
 
     # Allowed exchanges as factory -> router pairs
     factory_router_map = {
@@ -200,7 +200,7 @@ def routing_model(uniswap_v2, asset_usdc, asset_weth, weth_usdc_pair) -> Uniswap
         asset_weth.address: weth_usdc_pair.pool_address
     }
 
-    return UniswapV2SimpleRoutingModel(
+    return UniswapV2Routing(
         factory_router_map,
         allowed_intermediary_pairs,
         reserve_token_address=asset_usdc.address,
@@ -320,7 +320,7 @@ def test_live_stop_loss(
         deployer: HexAddress,
         trader: LocalAccount,
         trading_strategy_universe: TradingStrategyUniverse,
-        routing_model: UniswapV2SimpleRoutingModel,
+        routing_model: UniswapV2Routing,
         uniswap_v2: UniswapV2Deployment,
         usdc_token: Contract,
         weth_token: Contract,
@@ -445,7 +445,7 @@ def test_live_stop_loss_missing(
         deployer: HexAddress,
         trader: LocalAccount,
         trading_strategy_universe: TradingStrategyUniverse,
-        routing_model: UniswapV2SimpleRoutingModel,
+        routing_model: UniswapV2Routing,
         uniswap_v2: UniswapV2Deployment,
         usdc_token: Contract,
         weth_token: Contract,
@@ -509,7 +509,7 @@ def test_broadcast_failed_and_repair_state(
         deployer: HexAddress,
         trader: LocalAccount,
         trading_strategy_universe: TradingStrategyUniverse,
-        routing_model: UniswapV2SimpleRoutingModel,
+        routing_model: UniswapV2Routing,
         uniswap_v2: UniswapV2Deployment,
         usdc_token: Contract,
         weth_token: Contract,

--- a/tests/ethereum/test_uniswap_live_stop_loss.py
+++ b/tests/ethereum/test_uniswap_live_stop_loss.py
@@ -24,7 +24,7 @@ from web3.contract import Contract
 from eth_defi.token import create_token
 from eth_defi.uniswap_v2.deployment import UniswapV2Deployment, deploy_trading_pair, deploy_uniswap_v2_like
 
-from tradeexecutor.ethereum.uniswap_v2.uniswap_v2_execution import UniswapV2ExecutionModel
+from tradeexecutor.ethereum.uniswap_v2.uniswap_v2_execution import UniswapV2Execution
 from tradeexecutor.ethereum.uniswap_v2.uniswap_v2_routing import UniswapV2Routing
 from tradeexecutor.state.state import State, UncleanState
 from tradeexecutor.state.trade import TradeExecution
@@ -536,7 +536,7 @@ def test_broadcast_failed_and_repair_state(
 
     # Make transaction confirmation step to skip,
     execution_model = loop.execution_model
-    assert isinstance(execution_model, UniswapV2ExecutionModel)
+    assert isinstance(execution_model, UniswapV2Execution)
 
     # Set confirmation timeout to negative
     # to signal we are testing broadcast problems

--- a/tests/ethereum/test_uniswap_v3_live_pricing.py
+++ b/tests/ethereum/test_uniswap_v3_live_pricing.py
@@ -18,7 +18,7 @@ from eth_defi.uniswap_v3.deployment import (
 from eth_defi.uniswap_v3.utils import get_default_tick_range
 from eth_defi.uniswap_v3.pool import fetch_pool_details
 
-from tradeexecutor.ethereum.uniswap_v3.uniswap_v3_routing import UniswapV3SimpleRoutingModel
+from tradeexecutor.ethereum.uniswap_v3.uniswap_v3_routing import UniswapV3Routing
 from tradeexecutor.ethereum.uniswap_v3.uniswap_v3_live_pricing import UniswapV3LivePricing
 from tradeexecutor.ethereum.universe import create_exchange_universe, create_pair_universe
 from tradeexecutor.strategy.trading_strategy_universe import translate_trading_pair
@@ -257,7 +257,7 @@ def pair_universe(web3, exchange_universe: ExchangeUniverse, weth_usdc_pair, aav
 
 
 @pytest.fixture()
-def routing_model(uniswap_v3: UniswapV3Deployment, asset_usdc, asset_weth, weth_usdc_pair) -> UniswapV3SimpleRoutingModel:
+def routing_model(uniswap_v3: UniswapV3Deployment, asset_usdc, asset_weth, weth_usdc_pair) -> UniswapV3Routing:
 
     # Allowed exchanges as factory -> router pairs
     address_map = {
@@ -274,7 +274,7 @@ def routing_model(uniswap_v3: UniswapV3Deployment, asset_usdc, asset_weth, weth_
         asset_weth.address: weth_usdc_pair.pool_address
     }
 
-    return UniswapV3SimpleRoutingModel(
+    return UniswapV3Routing(
         address_map,
         allowed_intermediary_pairs,
         reserve_token_address=asset_usdc.address,
@@ -286,7 +286,7 @@ def test_uniswap_v3_two_leg_buy_price_no_price_impact(
         web3: Web3,
         exchange_universe,
         pair_universe: PandasPairUniverse,
-        routing_model: UniswapV3SimpleRoutingModel,
+        routing_model: UniswapV3Routing,
 ):
     """Two-leg buy trade."""
     pricing_method = UniswapV3LivePricing(web3, pair_universe, routing_model)
@@ -310,7 +310,7 @@ def test_uniswap_v3_two_leg_buy_price_with_price_impact(
         web3: Web3,
         exchange_universe,
         pair_universe: PandasPairUniverse,
-        routing_model: UniswapV3SimpleRoutingModel,
+        routing_model: UniswapV3Routing,
 ):
     """Two-leg buy trade w/signficant price impact."""
     pricing_method = UniswapV3LivePricing(web3, pair_universe, routing_model)
@@ -333,7 +333,7 @@ def test_uniswap_v3_two_leg_sell_price_no_price_impact(
         web3: Web3,
         exchange_universe,
         pair_universe: PandasPairUniverse,
-        routing_model: UniswapV3SimpleRoutingModel,
+        routing_model: UniswapV3Routing,
 ):
     pricing_method = UniswapV3LivePricing(web3, pair_universe, routing_model)
 
@@ -356,7 +356,7 @@ def test_uniswap_v3_two_leg_sell_price_with_price_impact(
         web3: Web3,
         exchange_universe,
         pair_universe: PandasPairUniverse,
-        routing_model: UniswapV3SimpleRoutingModel,
+        routing_model: UniswapV3Routing,
 ):
     """Two-leg buy trade w/signficant price impact."""
     pricing_method = UniswapV3LivePricing(web3, pair_universe, routing_model)
@@ -381,7 +381,7 @@ def test_uniswap_v3_three_leg_buy_price_with_price_impact(
         uniswap_v3,
         exchange_universe,
         pair_universe: PandasPairUniverse,
-        routing_model: UniswapV3SimpleRoutingModel,
+        routing_model: UniswapV3Routing,
 ):
     """Three leg trade w/signficant price impact.
 
@@ -445,7 +445,7 @@ def test_uniswap_v3_three_leg_sell_price_with_price_impact(
         uniswap_v3,
         exchange_universe,
         pair_universe: PandasPairUniverse,
-        routing_model: UniswapV3SimpleRoutingModel,
+        routing_model: UniswapV3Routing,
 ):
     """Three leg sell w/signficant price impact.
 

--- a/tests/ethereum/test_uniswap_v3_live_stop_loss.py
+++ b/tests/ethereum/test_uniswap_v3_live_stop_loss.py
@@ -26,7 +26,7 @@ from eth_defi.token import create_token
 from eth_defi.uniswap_v3.deployment import UniswapV3Deployment, deploy_pool, deploy_uniswap_v3, add_liquidity
 from eth_defi.uniswap_v3.utils import get_default_tick_range
 
-from tradeexecutor.ethereum.uniswap_v3.uniswap_v3_execution import UniswapV3ExecutionModel
+from tradeexecutor.ethereum.uniswap_v3.uniswap_v3_execution import UniswapV3Execution
 from tradeexecutor.ethereum.uniswap_v3.uniswap_v3_routing import UniswapV3Routing
 from tradeexecutor.ethereum.uniswap_v3.uniswap_v3_live_pricing import UniswapV3LivePricing
 from tradeexecutor.state.state import State, UncleanState
@@ -572,7 +572,7 @@ def test_broadcast_failed_and_repair_state(
 
     # Make transaction confirmation step to skip,
     execution_model = loop.execution_model
-    assert isinstance(execution_model, UniswapV3ExecutionModel)
+    assert isinstance(execution_model, UniswapV3Execution)
 
     # Set confirmation timeout to negative
     # to signal we are testing broadcast problems
@@ -643,7 +643,7 @@ def test_refresh_visualisations(
 
     # Make transaction confirmation step to skip,
     execution_model = loop.execution_model
-    assert isinstance(execution_model, UniswapV3ExecutionModel)
+    assert isinstance(execution_model, UniswapV3Execution)
 
     # Set confirmation timeout to negative
     # to signal we are testing broadcast problems

--- a/tests/ethereum/test_uniswap_v3_live_stop_loss.py
+++ b/tests/ethereum/test_uniswap_v3_live_stop_loss.py
@@ -27,7 +27,7 @@ from eth_defi.uniswap_v3.deployment import UniswapV3Deployment, deploy_pool, dep
 from eth_defi.uniswap_v3.utils import get_default_tick_range
 
 from tradeexecutor.ethereum.uniswap_v3.uniswap_v3_execution import UniswapV3ExecutionModel
-from tradeexecutor.ethereum.uniswap_v3.uniswap_v3_routing import UniswapV3SimpleRoutingModel
+from tradeexecutor.ethereum.uniswap_v3.uniswap_v3_routing import UniswapV3Routing
 from tradeexecutor.ethereum.uniswap_v3.uniswap_v3_live_pricing import UniswapV3LivePricing
 from tradeexecutor.state.state import State, UncleanState
 from tradeexecutor.state.trade import TradeExecution
@@ -195,7 +195,7 @@ def pair_universe(web3, exchange_universe: ExchangeUniverse, weth_usdc_pair) -> 
 
 
 @pytest.fixture()
-def routing_model(uniswap_v3: UniswapV3Deployment, asset_usdc, asset_weth, weth_usdc_pair) -> UniswapV3SimpleRoutingModel:
+def routing_model(uniswap_v3: UniswapV3Deployment, asset_usdc, asset_weth, weth_usdc_pair) -> UniswapV3Routing:
 
     # Allowed exchanges as factory -> router pairs
     address_map = {
@@ -210,7 +210,7 @@ def routing_model(uniswap_v3: UniswapV3Deployment, asset_usdc, asset_weth, weth_
         asset_weth.address: weth_usdc_pair.pool_address
     }
 
-    return UniswapV3SimpleRoutingModel(
+    return UniswapV3Routing(
         address_map,
         allowed_intermediary_pairs,
         reserve_token_address=asset_usdc.address,
@@ -352,7 +352,7 @@ def test_live_stop_loss(
         deployer: HexAddress,
         trader: LocalAccount,
         trading_strategy_universe: TradingStrategyUniverse,
-        routing_model: UniswapV3SimpleRoutingModel,
+        routing_model: UniswapV3Routing,
         uniswap_v3: UniswapV3Deployment,
         usdc_token: Contract,
         weth_token: Contract,
@@ -479,7 +479,7 @@ def test_live_stop_loss_missing(
         deployer: HexAddress,
         trader: LocalAccount,
         trading_strategy_universe: TradingStrategyUniverse,
-        routing_model: UniswapV3SimpleRoutingModel,
+        routing_model: UniswapV3Routing,
         uniswap_v3: UniswapV3Deployment,
         usdc_token: Contract,
         weth_token: Contract,
@@ -545,7 +545,7 @@ def test_broadcast_failed_and_repair_state(
         deployer: HexAddress,
         trader: LocalAccount,
         trading_strategy_universe: TradingStrategyUniverse,
-        routing_model: UniswapV3SimpleRoutingModel,
+        routing_model: UniswapV3Routing,
         uniswap_v3: UniswapV3Deployment,
         usdc_token: Contract,
         weth_token: Contract,
@@ -619,7 +619,7 @@ def test_refresh_visualisations(
         deployer: HexAddress,
         trader: LocalAccount,
         trading_strategy_universe: TradingStrategyUniverse,
-        routing_model: UniswapV3SimpleRoutingModel,
+        routing_model: UniswapV3Routing,
         uniswap_v3: UniswapV3Deployment,
         usdc_token: Contract,
         weth_token: Contract,

--- a/tests/mainnet_fork/test_uniswap_v2_polygon.py
+++ b/tests/mainnet_fork/test_uniswap_v2_polygon.py
@@ -32,7 +32,7 @@ from tradeexecutor.ethereum.tx import HotWalletTransactionBuilder
 from tradeexecutor.ethereum.uniswap_v2.uniswap_v2_live_pricing import UniswapV2LivePricing
 from tradeexecutor.ethereum.uniswap_v2.uniswap_v2_routing import (
     UniswapV2RoutingState,
-    UniswapV2SimpleRoutingModel,
+    UniswapV2Routing,
 )
 from tradeexecutor.ethereum.uniswap_v2.uniswap_v2_execution import UniswapV2ExecutionModel
 from tradeexecutor.strategy.pandas_trader.position_manager import PositionManager
@@ -207,7 +207,7 @@ def pair_universe(
 
 
 @pytest.fixture()
-def routing_model(usdc_asset) -> UniswapV2SimpleRoutingModel:
+def routing_model(usdc_asset) -> UniswapV2Routing:
 
     # Allowed exchanges as factory -> router pairs
     factory_router_map = {
@@ -224,7 +224,7 @@ def routing_model(usdc_asset) -> UniswapV2SimpleRoutingModel:
         "0x7ceb23fd6bc0add59e62ac25578270cff1b9f619": "0x853ee4b2a13f8a742d64c8f088be7ba2131f670d",
     }
 
-    return UniswapV2SimpleRoutingModel(
+    return UniswapV2Routing(
         factory_router_map,
         allowed_intermediary_pairs,
         reserve_token_address=usdc_asset.address,
@@ -322,7 +322,7 @@ def test_simple_routing_three_leg_live(
     eth_matic_trading_pair: TradingPairIdentifier,
     matic_usdc_trading_pair: TradingPairIdentifier,
     sand_matic_trading_pair: TradingPairIdentifier,
-    routing_model:  UniswapV2SimpleRoutingModel,
+    routing_model:  UniswapV2Routing,
     sand_token: TokenDetails,
     usdc_asset: AssetIdentifier,
     usdc_token: Contract,

--- a/tests/mainnet_fork/test_uniswap_v2_polygon.py
+++ b/tests/mainnet_fork/test_uniswap_v2_polygon.py
@@ -139,7 +139,7 @@ def hot_wallet(
     account = Account.create()
     matic_amount = 15
     web3.eth.send_transaction(
-        {"from": large_usdc_holder, "to": account.address, "value": matic_amount = 15 * 10**18}
+        {"from": large_usdc_holder, "to": account.address, "value": matic_amount * 10**18}
     )
     tx_hash = usdc_token.functions.transfer(account.address, 1_000_000 * 10**6).transact(
         {"from": large_usdc_holder}

--- a/tests/mainnet_fork/test_uniswap_v2_polygon.py
+++ b/tests/mainnet_fork/test_uniswap_v2_polygon.py
@@ -137,8 +137,9 @@ def hot_wallet(
     Start with 10,000 USDC cash and 2 polygon.
     """
     account = Account.create()
+    matic_amount = 15
     web3.eth.send_transaction(
-        {"from": large_usdc_holder, "to": account.address, "value": 2 * 10**18}
+        {"from": large_usdc_holder, "to": account.address, "value": matic_amount = 15 * 10**18}
     )
     tx_hash = usdc_token.functions.transfer(account.address, 1_000_000 * 10**6).transact(
         {"from": large_usdc_holder}

--- a/tests/mainnet_fork/test_uniswap_v2_polygon.py
+++ b/tests/mainnet_fork/test_uniswap_v2_polygon.py
@@ -34,7 +34,7 @@ from tradeexecutor.ethereum.uniswap_v2.uniswap_v2_routing import (
     UniswapV2RoutingState,
     UniswapV2Routing,
 )
-from tradeexecutor.ethereum.uniswap_v2.uniswap_v2_execution import UniswapV2ExecutionModel
+from tradeexecutor.ethereum.uniswap_v2.uniswap_v2_execution import UniswapV2Execution
 from tradeexecutor.strategy.pandas_trader.position_manager import PositionManager
 from tradeexecutor.state.state import State
 from tradeexecutor.state.identifier import TradingPairIdentifier, AssetIdentifier
@@ -274,13 +274,13 @@ def pricing_model(web3, pair_universe, routing_model) -> UniswapV2LivePricing:
 
 
 @pytest.fixture()
-def execution_model(web3, hot_wallet) -> UniswapV2ExecutionModel:
+def execution_model(web3, hot_wallet) -> UniswapV2Execution:
     """Create an execution model that waits zero blocks for confirmation.
 
     Because we are using Anvil mainnet fork, there are not going to be any new blocks.
     """
     tx_builder = HotWalletTransactionBuilder(web3, hot_wallet)
-    return UniswapV2ExecutionModel(
+    return UniswapV2Execution(
         tx_builder,
         confirmation_timeout=datetime.timedelta(seconds=10.00),  # Anvil has total 10 seconds to mine all txs in a batch
         confirmation_block_count=0,
@@ -317,7 +317,7 @@ def test_simple_routing_three_leg_live(
     strategy_universe: TradingStrategyUniverse,
     state: State,
     sync_model: SyncModel,
-    execution_model: UniswapV2ExecutionModel,
+    execution_model: UniswapV2Execution,
     pricing_model: UniswapV2LivePricing,
     eth_matic_trading_pair: TradingPairIdentifier,
     matic_usdc_trading_pair: TradingPairIdentifier,

--- a/tests/mainnet_fork/test_uniswap_v2_routing.py
+++ b/tests/mainnet_fork/test_uniswap_v2_routing.py
@@ -31,7 +31,7 @@ from eth_defi.uniswap_v2.deployment import UniswapV2Deployment, fetch_deployment
 
 from tradeexecutor.ethereum.tx import HotWalletTransactionBuilder
 from tradeexecutor.ethereum.uniswap_v2.uniswap_v2_routing import UniswapV2RoutingState, UniswapV2Routing, OutOfBalance
-from tradeexecutor.ethereum.uniswap_v2.uniswap_v2_execution import UniswapV2ExecutionModel
+from tradeexecutor.ethereum.uniswap_v2.uniswap_v2_execution import UniswapV2Execution
 from tradeexecutor.ethereum.wallet import sync_reserves
 from tradeexecutor.testing.dummy_wallet import apply_sync_events
 from tradeexecutor.state.portfolio import Portfolio
@@ -264,9 +264,9 @@ def routing_model(busd_asset):
 
 
 @pytest.fixture()
-def execution_model(web3, hot_wallet) -> UniswapV2ExecutionModel:
+def execution_model(web3, hot_wallet) -> UniswapV2Execution:
     tx_builder = HotWalletTransactionBuilder(web3, hot_wallet)
-    return UniswapV2ExecutionModel(tx_builder)
+    return UniswapV2Execution(tx_builder)
 
 
 @pytest.fixture
@@ -754,7 +754,7 @@ def test_stateful_routing_three_legstest_stateful_routing_three_legs(
         cake_bnb_trading_pair,
         bnb_busd_trading_pair,
         state: State,
-        execution_model: UniswapV2ExecutionModel
+        execution_model: UniswapV2Execution
 ):
     """Perform 3-leg buy/sell using RoutingModel.execute_trades().
 
@@ -836,7 +836,7 @@ def test_stateful_routing_two_legs(
         routing_model,
         cake_busd_trading_pair,
         state: State,
-        execution_model: UniswapV2ExecutionModel
+        execution_model: UniswapV2Execution
 ):
     """Perform 2-leg buy/sell using RoutingModel.execute_trades().
 
@@ -921,7 +921,7 @@ def test_stateful_routing_out_of_balance(
         routing_model,
         cake_busd_trading_pair,
         state: State,
-        execution_model: UniswapV2ExecutionModel,
+        execution_model: UniswapV2Execution,
         busd_token,
         user_2
 ):
@@ -965,7 +965,7 @@ def test_stateful_routing_adjust_epsilon(
         routing_model,
         cake_busd_trading_pair,
         state: State,
-        execution_model: UniswapV2ExecutionModel,
+        execution_model: UniswapV2Execution,
         busd_token,
         user_2,
 ):
@@ -1022,7 +1022,7 @@ def test_stateful_routing_adjust_epsilon_sell(
         routing_model,
         cake_busd_trading_pair,
         state: State,
-        execution_model: UniswapV2ExecutionModel,
+        execution_model: UniswapV2Execution,
         user_2,
 ):
     """Perform a trade where we have a rounding error in our reserves, sell side.

--- a/tests/mainnet_fork/test_uniswap_v2_routing.py
+++ b/tests/mainnet_fork/test_uniswap_v2_routing.py
@@ -174,8 +174,9 @@ def hot_wallet(web3: Web3, busd_token: Contract, large_busd_holder: HexAddress) 
 
     Start with 10,000 USDC cash and 2 BNB.
     """
+    matic_amount = 15
     account = Account.create()
-    web3.eth.send_transaction({"from": large_busd_holder, "to": account.address, "value": 2 * 10 ** 18})
+    web3.eth.send_transaction({"from": large_busd_holder, "to": account.address, "value": matic_amount * 10 ** 18})
     tx_hash = busd_token.functions.transfer(account.address, 10_000 * 10 ** 18).transact({"from": large_busd_holder})
     wait_transactions_to_complete(web3, [tx_hash])
     wallet = HotWallet(account)

--- a/tests/mainnet_fork/test_uniswap_v2_routing.py
+++ b/tests/mainnet_fork/test_uniswap_v2_routing.py
@@ -30,7 +30,7 @@ from eth_defi.hotwallet import HotWallet
 from eth_defi.uniswap_v2.deployment import UniswapV2Deployment, fetch_deployment
 
 from tradeexecutor.ethereum.tx import HotWalletTransactionBuilder
-from tradeexecutor.ethereum.uniswap_v2.uniswap_v2_routing import UniswapV2RoutingState, UniswapV2SimpleRoutingModel, OutOfBalance
+from tradeexecutor.ethereum.uniswap_v2.uniswap_v2_routing import UniswapV2RoutingState, UniswapV2Routing, OutOfBalance
 from tradeexecutor.ethereum.uniswap_v2.uniswap_v2_execution import UniswapV2ExecutionModel
 from tradeexecutor.ethereum.wallet import sync_reserves
 from tradeexecutor.testing.dummy_wallet import apply_sync_events
@@ -255,7 +255,7 @@ def routing_model(busd_asset):
         "0xbb4cdb9cbd36b01bd1cbaebf2de08d9173bc095c": "0x58f876857a02d6762e0101bb5c46a8c1ed44dc16",
     }
 
-    return UniswapV2SimpleRoutingModel(
+    return UniswapV2Routing(
         factory_router_map,
         allowed_intermediary_pairs,
         reserve_token_address=busd_asset.address,

--- a/tests/mainnet_fork/test_uniswap_v3_routing.py
+++ b/tests/mainnet_fork/test_uniswap_v3_routing.py
@@ -37,7 +37,7 @@ from tradeexecutor.ethereum.uniswap_v3.uniswap_v3_routing import (
     UniswapV3Routing,
     OutOfBalance,
 )
-from tradeexecutor.ethereum.uniswap_v3.uniswap_v3_execution import UniswapV3ExecutionModel
+from tradeexecutor.ethereum.uniswap_v3.uniswap_v3_execution import UniswapV3Execution
 from tradeexecutor.ethereum.wallet import sync_reserves
 from tradeexecutor.testing.dummy_wallet import apply_sync_events
 from tradeexecutor.state.portfolio import Portfolio
@@ -205,9 +205,9 @@ def routing_model(usdc_asset):
 
 
 @pytest.fixture()
-def execution_model(web3, hot_wallet) -> UniswapV3ExecutionModel:
+def execution_model(web3, hot_wallet) -> UniswapV3Execution:
     tx_builder = HotWalletTransactionBuilder(web3, hot_wallet)
-    return UniswapV3ExecutionModel(tx_builder)
+    return UniswapV3Execution(tx_builder)
 
 
 @pytest.fixture
@@ -688,7 +688,7 @@ def test_stateful_routing_three_legs(
     eth_matic_trading_pair,
     matic_usdc_trading_pair,
     state: State,
-    execution_model: UniswapV3ExecutionModel,
+    execution_model: UniswapV3Execution,
 ):
     """Perform 3-leg buy/sell using RoutingModel.execute_trades().
 
@@ -772,7 +772,7 @@ def test_stateful_routing_two_legs(
     routing_model,
     eth_usdc_trading_pair,
     state: State,
-    execution_model: UniswapV3ExecutionModel,
+    execution_model: UniswapV3Execution,
 ):
     """Perform 2-leg buy/sell using RoutingModel.execute_trades().
 
@@ -851,7 +851,7 @@ def test_stateful_routing_two_leg_multi_node_broadcast(
     routing_model,
     eth_usdc_trading_pair,
     state: State,
-    execution_model: UniswapV3ExecutionModel,
+    execution_model: UniswapV3Execution,
     anvil_polygon_chain_fork: str,
 ):
     """Broadcast txs using multi node logic.

--- a/tests/mainnet_fork/test_uniswap_v3_routing.py
+++ b/tests/mainnet_fork/test_uniswap_v3_routing.py
@@ -34,7 +34,7 @@ from eth_defi.uniswap_v3.deployment import (
 from tradeexecutor.ethereum.tx import HotWalletTransactionBuilder
 from tradeexecutor.ethereum.uniswap_v3.uniswap_v3_routing import (
     UniswapV3RoutingState,
-    UniswapV3SimpleRoutingModel,
+    UniswapV3Routing,
     OutOfBalance,
 )
 from tradeexecutor.ethereum.uniswap_v3.uniswap_v3_execution import UniswapV3ExecutionModel
@@ -197,7 +197,7 @@ def routing_model(usdc_asset):
         "0x7ceb23fd6bc0add59e62ac25578270cff1b9f619": "0x45dda9cb7c25131df268515131f647d726f50608",
     }
 
-    return UniswapV3SimpleRoutingModel(
+    return UniswapV3Routing(
         address_map,
         allowed_intermediary_pairs,
         reserve_token_address=usdc_asset.address,
@@ -284,7 +284,7 @@ def test_simple_routing_buy_sell(
     eth_asset,
     eth_token,
     usdc_token,
-    routing_model: UniswapV3SimpleRoutingModel,
+    routing_model: UniswapV3Routing,
     eth_usdc_trading_pair,
     pair_universe,
 ):
@@ -380,7 +380,7 @@ def test_simple_routing_three_leg(
     matic_asset,
     eth_asset,
     eth_token,
-    routing_model: UniswapV3SimpleRoutingModel,
+    routing_model: UniswapV3Routing,
     eth_matic_trading_pair,
     matic_usdc_trading_pair,
     pair_universe,
@@ -431,7 +431,7 @@ def test_three_leg_buy_sell(
     eth_asset,
     eth_token,
     usdc_token,
-    routing_model: UniswapV3SimpleRoutingModel,
+    routing_model: UniswapV3Routing,
     eth_matic_trading_pair,
     matic_usdc_trading_pair,
     pair_universe,

--- a/tests/mainnet_fork/test_uniswap_v3_routing.py
+++ b/tests/mainnet_fork/test_uniswap_v3_routing.py
@@ -107,8 +107,9 @@ def hot_wallet(
     Start with 10,000 USDC cash and 2 polygon.
     """
     account = Account.create()
+    matic_amount = 15
     web3.eth.send_transaction(
-        {"from": large_usdc_holder, "to": account.address, "value": 2 * 10**18}
+        {"from": large_usdc_holder, "to": account.address, "value": matic_amount * 10**18}
     )
     tx_hash = usdc_token.functions.transfer(account.address, 10_000 * 10**6).transact(
         {"from": large_usdc_holder}

--- a/tests/test_approval_in_terminal.py
+++ b/tests/test_approval_in_terminal.py
@@ -25,7 +25,7 @@ from tradeexecutor.ethereum.hot_wallet_sync_model import EthereumHotWalletReserv
 from tradeexecutor.ethereum.uniswap_v2.uniswap_v2_execution_v0 import UniswapV2ExecutionModelVersion0
 from tradeexecutor.ethereum.uniswap_v2.uniswap_v2_live_pricing import uniswap_v2_live_pricing_factory
 from tradeexecutor.ethereum.uniswap_v2.uniswap_v2_valuation import uniswap_v2_sell_valuation_factory
-from tradeexecutor.ethereum.uniswap_v2.uniswap_v2_routing import UniswapV2SimpleRoutingModel
+from tradeexecutor.ethereum.uniswap_v2.uniswap_v2_routing import UniswapV2Routing
 from tradeexecutor.ethereum.universe import create_exchange_universe, create_pair_universe
 from tradeexecutor.state.state import State
 from tradeexecutor.state.portfolio import Portfolio
@@ -236,7 +236,7 @@ def recorded_input() -> bool:
 
 
 @pytest.fixture()
-def routing_model(uniswap_v2, asset_usdc, asset_weth, weth_usdc_pair) -> UniswapV2SimpleRoutingModel:
+def routing_model(uniswap_v2, asset_usdc, asset_weth, weth_usdc_pair) -> UniswapV2Routing:
 
     # Allowed exchanges as factory -> router pairs
     factory_router_map = {
@@ -248,7 +248,7 @@ def routing_model(uniswap_v2, asset_usdc, asset_weth, weth_usdc_pair) -> Uniswap
         asset_weth.address: weth_usdc_pair.pool_address
     }
 
-    return UniswapV2SimpleRoutingModel(
+    return UniswapV2Routing(
         factory_router_map,
         allowed_intermediary_pairs,
         reserve_token_address=asset_usdc.address,

--- a/tests/test_default_routes.py
+++ b/tests/test_default_routes.py
@@ -4,7 +4,7 @@ from tradingstrategy.chain import ChainId
 
 from tradeexecutor.ethereum.routing_data import get_routing_model, MismatchReserveCurrency
 from tradeexecutor.ethereum.uniswap_v2.uniswap_v2_routing import UniswapV2Routing
-from tradeexecutor.ethereum.uniswap_v3.uniswap_v3_routing import UniswapV3SimpleRoutingModel
+from tradeexecutor.ethereum.uniswap_v3.uniswap_v3_routing import UniswapV3Routing
 from tradeexecutor.strategy.default_routing_options import TradeRouting
 from tradeexecutor.strategy.execution_context import ExecutionContext, ExecutionMode
 from tradeexecutor.strategy.reserve_currency import ReserveCurrency
@@ -84,25 +84,25 @@ def test_route_ethereum_dai(execution_context):
 def test_route_uniswap_v3_usdc(execution_context):
     """Test Uniswap v3 USDC routing."""
     routing = get_routing_model(execution_context, TradeRouting.uniswap_v3_usdc, ReserveCurrency.usdc)
-    assert isinstance(routing, UniswapV3SimpleRoutingModel)
+    assert isinstance(routing, UniswapV3Routing)
     assert routing.chain_id == ChainId.ethereum
 
 def test_route_polygon_usdc(execution_context):
     """Test Uniswap v3 Polygon USDC routing."""
     routing = get_routing_model(execution_context, TradeRouting.uniswap_v3_usdc_poly, ReserveCurrency.usdc)
-    assert isinstance(routing, UniswapV3SimpleRoutingModel)
+    assert isinstance(routing, UniswapV3Routing)
     assert routing.chain_id == ChainId.polygon
 
 def test_route_arbitrum_usdc(execution_context):
     """Test Uniswap v3 Arbitrum USDC routing."""
     routing = get_routing_model(execution_context, TradeRouting.uniswap_v3_usdc_arbitrum_native, ReserveCurrency.usdc)
-    assert isinstance(routing, UniswapV3SimpleRoutingModel)
+    assert isinstance(routing, UniswapV3Routing)
     assert routing.chain_id == ChainId.arbitrum
 
 def test_route_arbitrum_usdc(execution_context):
     """Test Uniswap v3 Arbitrum USDC routing."""
     routing = get_routing_model(execution_context, TradeRouting.uniswap_v3_usdc_arbitrum_bridged, ReserveCurrency.usdc_e)
-    assert isinstance(routing, UniswapV3SimpleRoutingModel)
+    assert isinstance(routing, UniswapV3Routing)
     assert routing.chain_id == ChainId.arbitrum
 
 

--- a/tests/test_default_routes.py
+++ b/tests/test_default_routes.py
@@ -3,7 +3,7 @@ import pytest
 from tradingstrategy.chain import ChainId
 
 from tradeexecutor.ethereum.routing_data import get_routing_model, MismatchReserveCurrency
-from tradeexecutor.ethereum.uniswap_v2.uniswap_v2_routing import UniswapV2SimpleRoutingModel
+from tradeexecutor.ethereum.uniswap_v2.uniswap_v2_routing import UniswapV2Routing
 from tradeexecutor.ethereum.uniswap_v3.uniswap_v3_routing import UniswapV3SimpleRoutingModel
 from tradeexecutor.strategy.default_routing_options import TradeRouting
 from tradeexecutor.strategy.execution_context import ExecutionContext, ExecutionMode
@@ -18,67 +18,67 @@ def execution_context() -> ExecutionContext:
 def test_route_pancakeswap_busd(execution_context):
     """Test Pancake BUSD routing."""
     routing = get_routing_model(execution_context, TradeRouting.pancakeswap_busd, ReserveCurrency.busd)
-    assert isinstance(routing, UniswapV2SimpleRoutingModel)
+    assert isinstance(routing, UniswapV2Routing)
     assert routing.chain_id == ChainId.bsc
 
 def test_route_pancakeswap_usdc(execution_context):
     """Test Pancake USDC routing."""
     routing = get_routing_model(execution_context, TradeRouting.pancakeswap_usdc, ReserveCurrency.usdc)
-    assert isinstance(routing, UniswapV2SimpleRoutingModel)
+    assert isinstance(routing, UniswapV2Routing)
     assert routing.chain_id == ChainId.bsc
 
 def test_route_pancakeswap_usdt(execution_context):
     """Test Pancake USDT routing."""
     routing = get_routing_model(execution_context, TradeRouting.pancakeswap_usdt, ReserveCurrency.usdt)
-    assert isinstance(routing, UniswapV2SimpleRoutingModel)
+    assert isinstance(routing, UniswapV2Routing)
     assert routing.chain_id == ChainId.bsc
 
 def test_route_quickswap_usdt(execution_context):
     """Test Quickswap USDC routing."""
     routing = get_routing_model(execution_context, TradeRouting.quickswap_usdc, ReserveCurrency.usdc)
-    assert isinstance(routing, UniswapV2SimpleRoutingModel)
+    assert isinstance(routing, UniswapV2Routing)
     assert routing.chain_id == ChainId.polygon
 
 def test_route_quickswap_usdt(execution_context):
     """Test Quickswap USDT routing."""
     routing = get_routing_model(execution_context, TradeRouting.quickswap_usdt, ReserveCurrency.usdt)
-    assert isinstance(routing, UniswapV2SimpleRoutingModel)
+    assert isinstance(routing, UniswapV2Routing)
     assert routing.chain_id == ChainId.polygon
 
 def test_route_quickswap_dai(execution_context):
     """Test Quickswap DAI routing."""
     routing = get_routing_model(execution_context, TradeRouting.quickswap_dai, ReserveCurrency.dai)
-    assert isinstance(routing, UniswapV2SimpleRoutingModel)
+    assert isinstance(routing, UniswapV2Routing)
     assert routing.chain_id == ChainId.polygon
 
 def test_route_trader_joe_usdc(execution_context):
     """Test Trader Joe USDC routing."""
     routing = get_routing_model(execution_context, TradeRouting.trader_joe_usdc, ReserveCurrency.usdc)
-    assert isinstance(routing, UniswapV2SimpleRoutingModel)
+    assert isinstance(routing, UniswapV2Routing)
     assert routing.chain_id == ChainId.avalanche
 
 def test_route_trader_joe_usdt(execution_context):
     """Test Trader Joe USDT routing."""
     routing = get_routing_model(execution_context, TradeRouting.trader_joe_usdt, ReserveCurrency.usdt)
-    assert isinstance(routing, UniswapV2SimpleRoutingModel)
+    assert isinstance(routing, UniswapV2Routing)
     assert routing.chain_id == ChainId.avalanche
 
 def test_route_ethereum_usdc(execution_context):
     """Test Uniswap v2 USDC routing."""
     routing = get_routing_model(execution_context, TradeRouting.uniswap_v2_usdc, ReserveCurrency.usdc)
-    assert isinstance(routing, UniswapV2SimpleRoutingModel)
+    assert isinstance(routing, UniswapV2Routing)
     assert routing.chain_id == ChainId.ethereum
 
 def test_route_ethereum_usdt(execution_context):
     """Test Uniswap v2 USDT routing."""
     routing = get_routing_model(execution_context, TradeRouting.uniswap_v2_usdt, ReserveCurrency.usdt)
-    assert isinstance(routing, UniswapV2SimpleRoutingModel)
+    assert isinstance(routing, UniswapV2Routing)
     assert routing.chain_id == ChainId.ethereum
 
 def test_route_ethereum_dai(execution_context):
     """Test Uniswap v2 DAI routing."""
     routing = get_routing_model(execution_context, TradeRouting.uniswap_v2_dai, ReserveCurrency.dai)
-    assert isinstance(routing, UniswapV2SimpleRoutingModel)
+    assert isinstance(routing, UniswapV2Routing)
     assert routing.chain_id == ChainId.ethereum
 
 def test_route_uniswap_v3_usdc(execution_context):

--- a/tests/test_position_manager.py
+++ b/tests/test_position_manager.py
@@ -8,7 +8,7 @@ from decimal import Decimal
 
 import pytest
 
-from tradeexecutor.backtest.backtest_pricing import BacktestSimplePricingModel
+from tradeexecutor.backtest.backtest_pricing import BacktestPricing
 from tradeexecutor.backtest.backtest_routing import BacktestRoutingModel
 from tradeexecutor.state.identifier import TradingPairIdentifier, AssetIdentifier
 from tradeexecutor.state.reserve import ReservePosition
@@ -74,7 +74,7 @@ def routing_model(synthetic_universe) -> BacktestRoutingModel:
 
 @pytest.fixture()
 def pricing_model(synthetic_universe, routing_model) -> BacktestRoutingModel:
-    pricing_model = BacktestSimplePricingModel(
+    pricing_model = BacktestPricing(
         synthetic_universe.data_universe.candles,
         routing_model,
         allow_missing_fees=True,
@@ -175,7 +175,7 @@ def test_estimate_fee_from_router(state, synthetic_universe, position_manager):
     """"Estimate the trading fee based on router data."""
 
     routing_model = generate_simple_routing_model(synthetic_universe, trading_fee=0.0025)
-    pricing_model = BacktestSimplePricingModel(
+    pricing_model = BacktestPricing(
         synthetic_universe.data_universe.candles,
         routing_model
     )

--- a/tests/test_rebalance.py
+++ b/tests/test_rebalance.py
@@ -13,8 +13,8 @@ from decimal import Decimal
 import pytest
 from hexbytes import HexBytes
 
-from tradeexecutor.backtest.backtest_execution import BacktestExecutionModel
-from tradeexecutor.backtest.backtest_pricing import BacktestSimplePricingModel
+from tradeexecutor.backtest.backtest_execution import BacktestExecution
+from tradeexecutor.backtest.backtest_pricing import BacktestPricing
 from tradeexecutor.backtest.backtest_routing import BacktestRoutingModel, BacktestRoutingState
 from tradeexecutor.backtest.simulated_wallet import SimulatedWallet
 from tradeexecutor.state.state import State, TradeType
@@ -195,8 +195,8 @@ def routing_model(universe) -> BacktestRoutingModel:
 
 
 @pytest.fixture()
-def pricing_model(routing_model, universe) -> BacktestSimplePricingModel:
-    return BacktestSimplePricingModel(universe.data_universe.candles, routing_model)
+def pricing_model(routing_model, universe) -> BacktestPricing:
+    return BacktestPricing(universe.data_universe.candles, routing_model)
 
 
 @pytest.fixture
@@ -266,9 +266,9 @@ def wallet(usdc, weth) -> SimulatedWallet:
 
 
 @pytest.fixture()
-def execution_model(wallet) -> BacktestExecutionModel:
+def execution_model(wallet) -> BacktestExecution:
     """Simulate trades using backtest execution model."""
-    execution_model = BacktestExecutionModel(wallet)
+    execution_model = BacktestExecution(wallet)
     return execution_model
 
 
@@ -794,7 +794,7 @@ def test_alpha_model_increase_short(
     weth_usdc: TradingPairIdentifier,
     aave_usdc: TradingPairIdentifier,
     start_ts,
-    execution_model: BacktestExecutionModel,
+    execution_model: BacktestExecution,
     routing_model: BacktestRoutingModel,
     wallet: SimulatedWallet,
 ):
@@ -958,7 +958,7 @@ def test_alpha_model_decrease_short(
     weth_usdc: TradingPairIdentifier,
     aave_usdc: TradingPairIdentifier,
     start_ts,
-    execution_model: BacktestExecutionModel,
+    execution_model: BacktestExecution,
     routing_model: BacktestRoutingModel,
     wallet: SimulatedWallet,
 ):

--- a/tests/test_routing_data.py
+++ b/tests/test_routing_data.py
@@ -6,7 +6,7 @@ from tradeexecutor.strategy.reserve_currency import ReserveCurrency
 from tradeexecutor.strategy.execution_context import ExecutionContext, ExecutionMode
 from tradeexecutor.strategy.default_routing_options import TradeRouting
 from tradeexecutor.ethereum.uniswap_v2.uniswap_v2_routing import UniswapV2Routing
-from tradeexecutor.ethereum.uniswap_v3.uniswap_v3_routing import UniswapV3SimpleRoutingModel
+from tradeexecutor.ethereum.uniswap_v3.uniswap_v3_routing import UniswapV3Routing
 from tradeexecutor.ethereum.routing_data import get_routing_model
 
 from tradingstrategy.chain import ChainId
@@ -364,7 +364,7 @@ def test_uniswap_v3_routing_models(
         EXECUTION_CONTEXT, trade_routing, reserve_currency
     )
 
-    expected_model = UniswapV3SimpleRoutingModel(
+    expected_model = UniswapV3Routing(
         UNISWAP_V3_ADDRESS_MAP,
         allowed_intermediary_pairs,
         reserve_token_address,

--- a/tests/test_routing_data.py
+++ b/tests/test_routing_data.py
@@ -5,7 +5,7 @@ import pytest
 from tradeexecutor.strategy.reserve_currency import ReserveCurrency
 from tradeexecutor.strategy.execution_context import ExecutionContext, ExecutionMode
 from tradeexecutor.strategy.default_routing_options import TradeRouting
-from tradeexecutor.ethereum.uniswap_v2.uniswap_v2_routing import UniswapV2SimpleRoutingModel
+from tradeexecutor.ethereum.uniswap_v2.uniswap_v2_routing import UniswapV2Routing
 from tradeexecutor.ethereum.uniswap_v3.uniswap_v3_routing import UniswapV3SimpleRoutingModel
 from tradeexecutor.ethereum.routing_data import get_routing_model
 
@@ -93,7 +93,7 @@ def test_pancake_routing_models(
         EXECUTION_CONTEXT, trade_routing, reserve_currency
     )
 
-    expected_model = UniswapV2SimpleRoutingModel(
+    expected_model = UniswapV2Routing(
         PANCAKE_FACTORY_ROUTER_MAP,
         allowed_intermediary_pairs,
         reserve_token_address,
@@ -147,7 +147,7 @@ def test_quickswap_routing_models(
         EXECUTION_CONTEXT, trade_routing, reserve_currency
     )
 
-    expected_model = UniswapV2SimpleRoutingModel(
+    expected_model = UniswapV2Routing(
         QUICKSWAP_FACTORY_ROUTER_MAP,
         allowed_intermediary_pairs,
         reserve_token_address,
@@ -193,7 +193,7 @@ def test_trader_joe_routing_models(
         EXECUTION_CONTEXT, trade_routing, reserve_currency
     )
 
-    expected_model = UniswapV2SimpleRoutingModel(
+    expected_model = UniswapV2Routing(
         TRADER_JOE_FACTORY_ROUTER_MAP,
         allowed_intermediary_pairs,
         reserve_token_address,
@@ -247,7 +247,7 @@ def test_uniswap_v2_routing_models(
         EXECUTION_CONTEXT, trade_routing, reserve_currency
     )
 
-    expected_model = UniswapV2SimpleRoutingModel(
+    expected_model = UniswapV2Routing(
         UNISWAP_V2_FACTORY_MAP,
         allowed_intermediary_pairs,
         reserve_token_address,

--- a/tradeexecutor/backtest/backtest_execution.py
+++ b/tradeexecutor/backtest/backtest_execution.py
@@ -62,7 +62,7 @@ def fix_sell_token_amount(
     return order_quantity, False
 
 
-class BacktestExecutionModel(ExecutionModel):
+class BacktestExecution(ExecutionModel):
     """Simulate trades against historical data."""
 
     def __init__(self,

--- a/tradeexecutor/backtest/backtest_pricing.py
+++ b/tradeexecutor/backtest/backtest_pricing.py
@@ -9,7 +9,7 @@ import pandas as pd
 
 from tradeexecutor.backtest.backtest_execution import BacktestExecutionModel
 from tradeexecutor.backtest.backtest_routing import BacktestRoutingModel
-from tradeexecutor.ethereum.uniswap_v2.uniswap_v2_routing import UniswapV2SimpleRoutingModel
+from tradeexecutor.ethereum.uniswap_v2.uniswap_v2_routing import UniswapV2Routing
 from tradeexecutor.state.identifier import TradingPairIdentifier
 from tradeexecutor.strategy.execution_model import ExecutionModel
 
@@ -256,11 +256,11 @@ class BacktestSimplePricingModel(PricingModel):
 def backtest_pricing_factory(
         execution_model: ExecutionModel,
         universe: TradingStrategyUniverse,
-        routing_model: UniswapV2SimpleRoutingModel) -> BacktestSimplePricingModel:
+        routing_model: UniswapV2Routing) -> BacktestSimplePricingModel:
 
     assert isinstance(universe, TradingStrategyUniverse)
     assert isinstance(execution_model, BacktestExecutionModel), f"Execution model not compatible with this execution model. Received {execution_model}"
-    assert isinstance(routing_model, (BacktestRoutingModel, UniswapV2SimpleRoutingModel)), f"This pricing method only works with Uniswap routing model, we received {routing_model}"
+    assert isinstance(routing_model, (BacktestRoutingModel, UniswapV2Routing)), f"This pricing method only works with Uniswap routing model, we received {routing_model}"
 
     return BacktestSimplePricingModel(
         universe.data_universe.candles,

--- a/tradeexecutor/backtest/backtest_pricing.py
+++ b/tradeexecutor/backtest/backtest_pricing.py
@@ -7,7 +7,7 @@ from typing import Optional
 
 import pandas as pd
 
-from tradeexecutor.backtest.backtest_execution import BacktestExecutionModel
+from tradeexecutor.backtest.backtest_execution import BacktestExecution
 from tradeexecutor.backtest.backtest_routing import BacktestRoutingModel
 from tradeexecutor.ethereum.uniswap_v2.uniswap_v2_routing import UniswapV2Routing
 from tradeexecutor.state.identifier import TradingPairIdentifier
@@ -24,7 +24,7 @@ from tradingstrategy.timebucket import TimeBucket
 logger = logging.getLogger(__name__)
 
 
-class BacktestSimplePricingModel(PricingModel):
+class BacktestPricing(PricingModel):
     """Look up the historical prices.
 
     - By default, assume we can get buy/sell at
@@ -256,13 +256,13 @@ class BacktestSimplePricingModel(PricingModel):
 def backtest_pricing_factory(
         execution_model: ExecutionModel,
         universe: TradingStrategyUniverse,
-        routing_model: UniswapV2Routing) -> BacktestSimplePricingModel:
+        routing_model: UniswapV2Routing) -> BacktestPricing:
 
     assert isinstance(universe, TradingStrategyUniverse)
-    assert isinstance(execution_model, BacktestExecutionModel), f"Execution model not compatible with this execution model. Received {execution_model}"
+    assert isinstance(execution_model, BacktestExecution), f"Execution model not compatible with this execution model. Received {execution_model}"
     assert isinstance(routing_model, (BacktestRoutingModel, UniswapV2Routing)), f"This pricing method only works with Uniswap routing model, we received {routing_model}"
 
-    return BacktestSimplePricingModel(
+    return BacktestPricing(
         universe.data_universe.candles,
         routing_model)
 

--- a/tradeexecutor/backtest/backtest_valuation.py
+++ b/tradeexecutor/backtest/backtest_valuation.py
@@ -1,7 +1,7 @@
 import datetime
 from typing import Tuple
 
-from tradeexecutor.backtest.backtest_pricing import BacktestSimplePricingModel
+from tradeexecutor.backtest.backtest_pricing import BacktestPricing
 from tradeexecutor.state.position import TradingPosition
 from tradeexecutor.state.types import USDollarAmount
 from tradeexecutor.state.identifier import TradingPairKind
@@ -14,7 +14,7 @@ class BacktestValuationModel(ValuationModel):
     Each asset is valued at its market sell price estimation.
     """
 
-    def __init__(self, pricing_model: BacktestSimplePricingModel):
+    def __init__(self, pricing_model: BacktestPricing):
         assert pricing_model, "pricing_model missing"
         self.pricing_model = pricing_model
 

--- a/tradeexecutor/cli/bootstrap.py
+++ b/tradeexecutor/cli/bootstrap.py
@@ -26,7 +26,7 @@ from tradeexecutor.ethereum.one_delta.one_delta_live_pricing import one_delta_li
 from tradeexecutor.ethereum.one_delta.one_delta_valuation import one_delta_valuation_factory
 from tradeexecutor.ethereum.uniswap_v2.uniswap_v2_execution import UniswapV2ExecutionModel
 from tradeexecutor.ethereum.uniswap_v2.uniswap_v2_live_pricing import uniswap_v2_live_pricing_factory
-from tradeexecutor.ethereum.uniswap_v2.uniswap_v2_routing import UniswapV2SimpleRoutingModel
+from tradeexecutor.ethereum.uniswap_v2.uniswap_v2_routing import UniswapV2Routing
 from tradeexecutor.ethereum.uniswap_v2.uniswap_v2_valuation import uniswap_v2_sell_valuation_factory
 from tradeexecutor.ethereum.uniswap_v3.uniswap_v3_execution import UniswapV3ExecutionModel
 from tradeexecutor.ethereum.uniswap_v3.uniswap_v3_live_pricing import uniswap_v3_live_pricing_factory
@@ -426,7 +426,7 @@ def create_client(
         client.initialise_mock_data()
 
         if mod.trade_routing == TradeRouting.user_supplied_routing_model:
-            routing_model = UniswapV2SimpleRoutingModel(
+            routing_model = UniswapV2Routing(
                 factory_router_map={
                     test_evm_uniswap_v2_factory: (test_evm_uniswap_v2_router, test_evm_uniswap_v2_init_code_hash)},
                 allowed_intermediary_pairs={},

--- a/tradeexecutor/cli/bootstrap.py
+++ b/tradeexecutor/cli/bootstrap.py
@@ -12,7 +12,7 @@ from eth_defi.gas import GasPriceMethod
 from eth_defi.hotwallet import HotWallet
 from web3 import Web3
 
-from tradeexecutor.backtest.backtest_execution import BacktestExecutionModel
+from tradeexecutor.backtest.backtest_execution import BacktestExecution
 from tradeexecutor.backtest.backtest_pricing import backtest_pricing_factory
 from tradeexecutor.backtest.backtest_sync import BacktestSyncModel
 from tradeexecutor.backtest.backtest_valuation import backtest_valuation_factory
@@ -21,14 +21,14 @@ from tradeexecutor.cli.approval import CLIApprovalModel
 from tradeexecutor.ethereum.enzyme.vault import EnzymeVaultSyncModel
 from tradeexecutor.ethereum.hot_wallet_sync_model import HotWalletSyncModel
 from tradeexecutor.ethereum.tx import TransactionBuilder
-from tradeexecutor.ethereum.one_delta.one_delta_execution import OneDeltaExecutionModel
+from tradeexecutor.ethereum.one_delta.one_delta_execution import OneDeltaExecution
 from tradeexecutor.ethereum.one_delta.one_delta_live_pricing import one_delta_live_pricing_factory
 from tradeexecutor.ethereum.one_delta.one_delta_valuation import one_delta_valuation_factory
-from tradeexecutor.ethereum.uniswap_v2.uniswap_v2_execution import UniswapV2ExecutionModel
+from tradeexecutor.ethereum.uniswap_v2.uniswap_v2_execution import UniswapV2Execution
 from tradeexecutor.ethereum.uniswap_v2.uniswap_v2_live_pricing import uniswap_v2_live_pricing_factory
 from tradeexecutor.ethereum.uniswap_v2.uniswap_v2_routing import UniswapV2Routing
 from tradeexecutor.ethereum.uniswap_v2.uniswap_v2_valuation import uniswap_v2_sell_valuation_factory
-from tradeexecutor.ethereum.uniswap_v3.uniswap_v3_execution import UniswapV3ExecutionModel
+from tradeexecutor.ethereum.uniswap_v3.uniswap_v3_execution import UniswapV3Execution
 from tradeexecutor.ethereum.uniswap_v3.uniswap_v3_live_pricing import uniswap_v3_live_pricing_factory
 from tradeexecutor.ethereum.uniswap_v3.uniswap_v3_valuation import uniswap_v3_sell_valuation_factory
 from tradeexecutor.ethereum.web3config import Web3Config
@@ -116,7 +116,7 @@ def create_execution_model(
     # TODO: user_supplied_routing_model can be uni v3 as well
     if routing_hint is None or routing_hint.is_uniswap_v2() or routing_hint == TradeRouting.user_supplied_routing_model:
         logger.info("Uniswap v2 like exchange. Routing hint is %s", routing_hint)
-        execution_model = UniswapV2ExecutionModel(
+        execution_model = UniswapV2Execution(
             tx_builder,
             confirmation_timeout=confirmation_timeout,
             confirmation_block_count=confirmation_block_count,
@@ -128,7 +128,7 @@ def create_execution_model(
         pricing_model_factory = uniswap_v2_live_pricing_factory
     elif routing_hint.is_uniswap_v3():
         logger.info("Uniswap v3 like exchange. Routing hint is %s", routing_hint)
-        execution_model = UniswapV3ExecutionModel(
+        execution_model = UniswapV3Execution(
             tx_builder,
             confirmation_timeout=confirmation_timeout,
             confirmation_block_count=confirmation_block_count,
@@ -140,7 +140,7 @@ def create_execution_model(
         pricing_model_factory = uniswap_v3_live_pricing_factory
     elif routing_hint.is_one_delta():
         logger.info("1delta routing. Routing hint is %s", routing_hint)
-        execution_model = OneDeltaExecutionModel(
+        execution_model = OneDeltaExecution(
             tx_builder,
             confirmation_timeout=confirmation_timeout,
             confirmation_block_count=confirmation_block_count,
@@ -210,7 +210,7 @@ def create_execution_and_sync_model(
     elif asset_management_mode == AssetManagementMode.backtest:
         logger.info("TODO: Command line backtests are always executed with initial deposit of $10,000")
         wallet = SimulatedWallet()
-        execution_model = BacktestExecutionModel(wallet, max_slippage=0.01, stop_loss_data_available=True)
+        execution_model = BacktestExecution(wallet, max_slippage=0.01, stop_loss_data_available=True)
         sync_model = BacktestSyncModel(wallet, Decimal(10_000))
         pricing_model_factory = backtest_pricing_factory
         valuation_model_factory = backtest_valuation_factory

--- a/tradeexecutor/cli/commands/backtest.py
+++ b/tradeexecutor/cli/commands/backtest.py
@@ -34,7 +34,7 @@ from ..watchdog import stop_watchdog
 from ...backtest.backtest_runner import setup_backtest, run_backtest
 from ...backtest.tearsheet import export_backtest_report
 from ...ethereum.enzyme.vault import EnzymeVaultSyncModel
-from ...ethereum.uniswap_v2.uniswap_v2_routing import UniswapV2SimpleRoutingModel
+from ...ethereum.uniswap_v2.uniswap_v2_routing import UniswapV2Routing
 from ...state.state import State
 from ...state.store import NoneStore, JSONFileStore
 from ...strategy.approval import ApprovalType

--- a/tradeexecutor/cli/commands/start.py
+++ b/tradeexecutor/cli/commands/start.py
@@ -32,7 +32,7 @@ from ..result import display_backtesting_results
 from ..version_info import VersionInfo
 from ..watchdog import stop_watchdog
 from ...ethereum.enzyme.vault import EnzymeVaultSyncModel
-from ...ethereum.uniswap_v2.uniswap_v2_routing import UniswapV2SimpleRoutingModel
+from ...ethereum.uniswap_v2.uniswap_v2_routing import UniswapV2Routing
 from ...state.state import State
 from ...state.store import NoneStore, JSONFileStore
 from ...strategy.approval import ApprovalType

--- a/tradeexecutor/cli/loop.py
+++ b/tradeexecutor/cli/loop.py
@@ -46,7 +46,7 @@ except ImportError:
     # but fallback to normal TQDM auto mode
     from tqdm.auto import tqdm
 
-from tradeexecutor.backtest.backtest_pricing import BacktestSimplePricingModel
+from tradeexecutor.backtest.backtest_pricing import BacktestPricing
 from tradeexecutor.state.state import State, BacktestData
 from tradeexecutor.state.store import StateStore
 from tradeexecutor.strategy.sync_model import SyncMethodV0, SyncModel
@@ -669,9 +669,9 @@ class ExecutionLoop:
         routing_state, pricing_model, valuation_model = self.runner.setup_routing(universe)
         assert pricing_model, "Routing did not provide pricing_model"
 
-        assert isinstance(pricing_model, BacktestSimplePricingModel)
+        assert isinstance(pricing_model, BacktestPricing)
 
-        stop_loss_pricing_model = BacktestSimplePricingModel(
+        stop_loss_pricing_model = BacktestPricing(
             universe.backtest_stop_loss_candles,
             self.runner.routing_model,
             time_bucket=universe.backtest_stop_loss_time_bucket,

--- a/tradeexecutor/ethereum/execution.py
+++ b/tradeexecutor/ethereum/execution.py
@@ -47,7 +47,7 @@ logger = logging.getLogger(__name__)
 
 
 # TODO check with tradeexuctor.strategy.execution ExecutionModel
-class EthereumExecutionModel(ExecutionModel):
+class EthereumExecution(ExecutionModel):
     """Run order execution on a single Uniswap v2 style exchanges."""
 
     def __init__(self,

--- a/tradeexecutor/ethereum/execution.py
+++ b/tradeexecutor/ethereum/execution.py
@@ -35,7 +35,7 @@ from tradeexecutor.state.trade import TradeExecution, TradeStatus
 from tradeexecutor.state.blockhain_transaction import BlockchainTransaction
 from tradeexecutor.state.freeze import freeze_position_on_failed_trade
 from tradeexecutor.state.identifier import AssetIdentifier
-from tradeexecutor.ethereum.uniswap_v2.uniswap_v2_routing import UniswapV2SimpleRoutingModel, UniswapV2RoutingState
+from tradeexecutor.ethereum.uniswap_v2.uniswap_v2_routing import UniswapV2Routing, UniswapV2RoutingState
 from tradeexecutor.ethereum.uniswap_v3.uniswap_v3_routing import UniswapV3SimpleRoutingModel, UniswapV3RoutingState
 from tradeexecutor.state.types import BlockNumber
 from tradeexecutor.strategy.execution_model import ExecutionModel, RoutingStateDetails
@@ -115,12 +115,12 @@ class EthereumExecutionModel(ExecutionModel):
     @staticmethod
     def pre_execute_assertions(
         ts: datetime.datetime, 
-        routing_model: UniswapV2SimpleRoutingModel | UniswapV3SimpleRoutingModel,
+        routing_model: UniswapV2Routing | UniswapV3SimpleRoutingModel,
         routing_state: UniswapV2RoutingState | UniswapV3RoutingState
     ):
         assert isinstance(ts, datetime.datetime)
 
-        if isinstance(routing_model, UniswapV2SimpleRoutingModel):
+        if isinstance(routing_model, UniswapV2Routing):
             assert isinstance(routing_state, UniswapV2RoutingState), "Incorrect routing_state specified"
         elif isinstance(routing_model, UniswapV3SimpleRoutingModel):
             assert isinstance(routing_state, UniswapV3RoutingState), "Incorrect routing_state specified"

--- a/tradeexecutor/ethereum/execution.py
+++ b/tradeexecutor/ethereum/execution.py
@@ -36,7 +36,7 @@ from tradeexecutor.state.blockhain_transaction import BlockchainTransaction
 from tradeexecutor.state.freeze import freeze_position_on_failed_trade
 from tradeexecutor.state.identifier import AssetIdentifier
 from tradeexecutor.ethereum.uniswap_v2.uniswap_v2_routing import UniswapV2Routing, UniswapV2RoutingState
-from tradeexecutor.ethereum.uniswap_v3.uniswap_v3_routing import UniswapV3SimpleRoutingModel, UniswapV3RoutingState
+from tradeexecutor.ethereum.uniswap_v3.uniswap_v3_routing import UniswapV3Routing, UniswapV3RoutingState
 from tradeexecutor.state.types import BlockNumber
 from tradeexecutor.strategy.execution_model import ExecutionModel, RoutingStateDetails
 from tradeexecutor.strategy.routing import RoutingModel, RoutingState
@@ -115,14 +115,14 @@ class EthereumExecutionModel(ExecutionModel):
     @staticmethod
     def pre_execute_assertions(
         ts: datetime.datetime, 
-        routing_model: UniswapV2Routing | UniswapV3SimpleRoutingModel,
+        routing_model: UniswapV2Routing | UniswapV3Routing,
         routing_state: UniswapV2RoutingState | UniswapV3RoutingState
     ):
         assert isinstance(ts, datetime.datetime)
 
         if isinstance(routing_model, UniswapV2Routing):
             assert isinstance(routing_state, UniswapV2RoutingState), "Incorrect routing_state specified"
-        elif isinstance(routing_model, UniswapV3SimpleRoutingModel):
+        elif isinstance(routing_model, UniswapV3Routing):
             assert isinstance(routing_state, UniswapV3RoutingState), "Incorrect routing_state specified"
         else:
             raise ValueError("Incorrect routing model specified")

--- a/tradeexecutor/ethereum/one_delta/one_delta_execution.py
+++ b/tradeexecutor/ethereum/one_delta/one_delta_execution.py
@@ -10,13 +10,13 @@ from eth_defi.uniswap_v3.deployment import UniswapV3Deployment
 
 
 from tradeexecutor.ethereum.tx import TransactionBuilder
-from tradeexecutor.ethereum.execution import EthereumExecutionModel
+from tradeexecutor.ethereum.execution import EthereumExecution
 
 
 logger = logging.getLogger(__name__)
 
 
-class OneDeltaExecutionModel(EthereumExecutionModel):
+class OneDeltaExecution(EthereumExecution):
     """Run order execution on 1delta."""
 
     def __init__(

--- a/tradeexecutor/ethereum/one_delta/one_delta_live_pricing.py
+++ b/tradeexecutor/ethereum/one_delta/one_delta_live_pricing.py
@@ -11,7 +11,7 @@ from eth_defi.provider.broken_provider import get_block_tip_latency
 from web3 import Web3
 
 from tradeexecutor.ethereum.one_delta.one_delta_execution import OneDeltaExecutionModel
-from tradeexecutor.ethereum.one_delta.one_delta_routing import OneDeltaSimpleRoutingModel
+from tradeexecutor.ethereum.one_delta.one_delta_routing import OneDeltaRouting
 from tradeexecutor.ethereum.uniswap_v3.uniswap_v3_live_pricing import UniswapV3LivePricing
 from tradeexecutor.ethereum.eth_pricing_model import EthereumPricingModel, LP_FEE_VALIDATION_EPSILON
 from tradeexecutor.state.identifier import TradingPairIdentifier
@@ -34,11 +34,11 @@ class OneDeltaLivePricing(UniswapV3LivePricing):
         self,
         web3: Web3,
         pair_universe: PandasPairUniverse,
-        routing_model: OneDeltaSimpleRoutingModel,
+        routing_model: OneDeltaRouting,
         very_small_amount: float = Decimal("0.10"),
         epsilon: float | None = LP_FEE_VALIDATION_EPSILON,
     ):
-        assert isinstance(routing_model, OneDeltaSimpleRoutingModel)
+        assert isinstance(routing_model, OneDeltaRouting)
 
         super().__init__(
             web3,
@@ -52,11 +52,11 @@ class OneDeltaLivePricing(UniswapV3LivePricing):
 def one_delta_live_pricing_factory(
     execution_model: ExecutionModel,
     universe: TradingStrategyUniverse,
-    routing_model: OneDeltaSimpleRoutingModel,
+    routing_model: OneDeltaRouting,
 ) -> OneDeltaLivePricing:
     assert isinstance(universe, TradingStrategyUniverse)
     assert isinstance(execution_model, OneDeltaExecutionModel), f"Execution model not compatible with this execution model. Received {execution_model}"
-    assert isinstance(routing_model, OneDeltaSimpleRoutingModel), f"This pricing method only works with 1delta routing model, we received {routing_model}"
+    assert isinstance(routing_model, OneDeltaRouting), f"This pricing method only works with 1delta routing model, we received {routing_model}"
 
     return OneDeltaLivePricing(
         execution_model.web3,

--- a/tradeexecutor/ethereum/one_delta/one_delta_live_pricing.py
+++ b/tradeexecutor/ethereum/one_delta/one_delta_live_pricing.py
@@ -10,7 +10,7 @@ from typing import Optional, Dict
 from eth_defi.provider.broken_provider import get_block_tip_latency
 from web3 import Web3
 
-from tradeexecutor.ethereum.one_delta.one_delta_execution import OneDeltaExecutionModel
+from tradeexecutor.ethereum.one_delta.one_delta_execution import OneDeltaExecution
 from tradeexecutor.ethereum.one_delta.one_delta_routing import OneDeltaRouting
 from tradeexecutor.ethereum.uniswap_v3.uniswap_v3_live_pricing import UniswapV3LivePricing
 from tradeexecutor.ethereum.eth_pricing_model import EthereumPricingModel, LP_FEE_VALIDATION_EPSILON
@@ -55,7 +55,7 @@ def one_delta_live_pricing_factory(
     routing_model: OneDeltaRouting,
 ) -> OneDeltaLivePricing:
     assert isinstance(universe, TradingStrategyUniverse)
-    assert isinstance(execution_model, OneDeltaExecutionModel), f"Execution model not compatible with this execution model. Received {execution_model}"
+    assert isinstance(execution_model, OneDeltaExecution), f"Execution model not compatible with this execution model. Received {execution_model}"
     assert isinstance(routing_model, OneDeltaRouting), f"This pricing method only works with 1delta routing model, we received {routing_model}"
 
     return OneDeltaLivePricing(

--- a/tradeexecutor/ethereum/one_delta/one_delta_routing.py
+++ b/tradeexecutor/ethereum/one_delta/one_delta_routing.py
@@ -292,7 +292,7 @@ class OneDeltaRoutingState(EthereumRoutingState):
         return [tx]
 
 
-class OneDeltaSimpleRoutingModel(EthereumRoutingModel):
+class OneDeltaRouting(EthereumRoutingModel):
     """A simple router that does not optimise the trade execution cost.
 
     - Able to trade on multiple exchanges

--- a/tradeexecutor/ethereum/routing_data.py
+++ b/tradeexecutor/ethereum/routing_data.py
@@ -30,7 +30,7 @@ from typing import TypedDict, List
 from tradingstrategy.chain import ChainId
 
 from tradeexecutor.backtest.backtest_routing import BacktestRoutingModel, BacktestRoutingIgnoredModel
-from tradeexecutor.ethereum.uniswap_v2.uniswap_v2_routing import UniswapV2SimpleRoutingModel
+from tradeexecutor.ethereum.uniswap_v2.uniswap_v2_routing import UniswapV2Routing
 from tradeexecutor.ethereum.uniswap_v3.uniswap_v3_routing import UniswapV3SimpleRoutingModel
 from tradeexecutor.strategy.execution_context import ExecutionContext, ExecutionMode
 from tradeexecutor.strategy.reserve_currency import ReserveCurrency
@@ -616,7 +616,7 @@ def get_backtest_routing_model(
 
     real_routing_model = create_compatible_routing(routing_type, reserve_currency)
     
-    if isinstance(real_routing_model, UniswapV2SimpleRoutingModel):
+    if isinstance(real_routing_model, UniswapV2Routing):
         return BacktestRoutingModel(
             real_routing_model.factory_router_map,
             real_routing_model.allowed_intermediary_pairs,
@@ -635,7 +635,7 @@ def get_backtest_routing_model(
 
 def create_uniswap_v2_compatible_routing(
     routing_type: TradeRouting, reserve_currency: ReserveCurrency
-) -> UniswapV2SimpleRoutingModel:
+) -> UniswapV2Routing:
     """Set up Uniswap v2 compatible routing.
     Not recommended to use by itself, because it doesn't validate reserve currency.
     Rather use create_compatible_routing
@@ -676,7 +676,7 @@ def create_uniswap_v2_compatible_routing(
     else:
         raise NotImplementedError()
 
-    routing_model = UniswapV2SimpleRoutingModel(
+    routing_model = UniswapV2Routing(
         params["factory_router_map"],
         params["allowed_intermediary_pairs"],
         params["reserve_token_address"],

--- a/tradeexecutor/ethereum/routing_data.py
+++ b/tradeexecutor/ethereum/routing_data.py
@@ -31,7 +31,7 @@ from tradingstrategy.chain import ChainId
 
 from tradeexecutor.backtest.backtest_routing import BacktestRoutingModel, BacktestRoutingIgnoredModel
 from tradeexecutor.ethereum.uniswap_v2.uniswap_v2_routing import UniswapV2Routing
-from tradeexecutor.ethereum.uniswap_v3.uniswap_v3_routing import UniswapV3SimpleRoutingModel
+from tradeexecutor.ethereum.uniswap_v3.uniswap_v3_routing import UniswapV3Routing
 from tradeexecutor.strategy.execution_context import ExecutionContext, ExecutionMode
 from tradeexecutor.strategy.reserve_currency import ReserveCurrency
 from tradeexecutor.strategy.default_routing_options import TradeRouting
@@ -622,7 +622,7 @@ def get_backtest_routing_model(
             real_routing_model.allowed_intermediary_pairs,
             real_routing_model.reserve_token_address,
         )
-    elif isinstance(real_routing_model, UniswapV3SimpleRoutingModel):
+    elif isinstance(real_routing_model, UniswapV3Routing):
         return BacktestRoutingModel(
             real_routing_model.address_map,
             real_routing_model.allowed_intermediary_pairs,
@@ -689,7 +689,7 @@ def create_uniswap_v2_compatible_routing(
 
 def create_uniswap_v3_compatible_routing(
     routing_type: TradeRouting, reserve_currency: ReserveCurrency
-) -> UniswapV3SimpleRoutingModel:
+) -> UniswapV3Routing:
     """Set up Uniswap v3 compatible routing.
     Not recommended to use by itself, because it doesn't validate reserve currency.
     Rather use create_compatible_routing
@@ -713,7 +713,7 @@ def create_uniswap_v3_compatible_routing(
         raise NotImplementedError()
 
     # Trading fee is derived dynamically for each trading pair
-    routing_model = UniswapV3SimpleRoutingModel(
+    routing_model = UniswapV3Routing(
         params["address_map"],
         params["allowed_intermediary_pairs"],
         params["reserve_token_address"],

--- a/tradeexecutor/ethereum/uniswap_v2/uniswap_v2_execution.py
+++ b/tradeexecutor/ethereum/uniswap_v2/uniswap_v2_execution.py
@@ -13,7 +13,7 @@ from eth_defi.token import fetch_erc20_details
 from eth_defi.trade import TradeSuccess, TradeFail
 
 #from tradeexecutor.strategy.execution_model import ExecutionModel
-from tradeexecutor.ethereum.execution import EthereumExecutionModel
+from tradeexecutor.ethereum.execution import EthereumExecution
 
 
 import logging
@@ -37,7 +37,7 @@ from tradeexecutor.utils.blockchain import get_block_timestamp
 logger = logging.getLogger(__name__)
 
 
-class UniswapV2ExecutionModel(EthereumExecutionModel):
+class UniswapV2Execution(EthereumExecution):
     """Run order execution on a single Uniswap v2 style exchanges."""
 
     def __init__(self,

--- a/tradeexecutor/ethereum/uniswap_v2/uniswap_v2_execution_v0.py
+++ b/tradeexecutor/ethereum/uniswap_v2/uniswap_v2_execution_v0.py
@@ -21,7 +21,7 @@ from eth_defi.trade import TradeSuccess
 from eth_defi.uniswap_v2.deployment import mock_partial_deployment_for_analysis
 from eth_defi.uniswap_v2.analysis import analyse_trade_by_receipt
 from tradeexecutor.ethereum.tx import HotWalletTransactionBuilder
-from tradeexecutor.ethereum.uniswap_v2.uniswap_v2_routing import UniswapV2RoutingState, UniswapV2SimpleRoutingModel
+from tradeexecutor.ethereum.uniswap_v2.uniswap_v2_routing import UniswapV2RoutingState, UniswapV2Routing
 from tradeexecutor.ethereum.execution import broadcast, wait_trades_to_complete, update_confirmation_status
 from tradeexecutor.ethereum.swap import report_failure, get_swap_transactions
 from tradeexecutor.state.freeze import freeze_position_on_failed_trade
@@ -140,7 +140,7 @@ class UniswapV2ExecutionModelVersion0(ExecutionModel):
         """
         assert isinstance(ts, datetime.datetime)
         assert isinstance(state, State), f"Received {state.__class__}"
-        assert isinstance(routing_model, UniswapV2SimpleRoutingModel), f"Received {routing_state.__class__}"
+        assert isinstance(routing_model, UniswapV2Routing), f"Received {routing_state.__class__}"
         assert isinstance(routing_state, UniswapV2RoutingState), f"Received {routing_state.__class__}"
 
         fees = estimate_gas_fees(self.web3)
@@ -153,7 +153,7 @@ class UniswapV2ExecutionModelVersion0(ExecutionModel):
         reserve_asset, rate = state.portfolio.get_default_reserve_asset()
 
         # We know only about one exchange
-        routing_model = UniswapV2SimpleRoutingModel(
+        routing_model = UniswapV2Routing(
             factory_router_map={
                 self.uniswap.factory.address: (self.uniswap.router.address, self.uniswap.init_code_hash),
             },

--- a/tradeexecutor/ethereum/uniswap_v2/uniswap_v2_live_pricing.py
+++ b/tradeexecutor/ethereum/uniswap_v2/uniswap_v2_live_pricing.py
@@ -13,7 +13,7 @@ from web3 import Web3
 from eth_defi.uniswap_v2.deployment import UniswapV2Deployment
 from eth_defi.uniswap_v2.fees import estimate_buy_received_amount_raw, estimate_sell_received_amount_raw
 
-from tradeexecutor.ethereum.uniswap_v2.uniswap_v2_execution import UniswapV2ExecutionModel
+from tradeexecutor.ethereum.uniswap_v2.uniswap_v2_execution import UniswapV2Execution
 from tradeexecutor.ethereum.uniswap_v2.uniswap_v2_execution_v0 import UniswapV2ExecutionModelVersion0
 from tradeexecutor.ethereum.uniswap_v2.uniswap_v2_routing import UniswapV2Routing, route_tokens, get_uniswap_for_pair
 from tradeexecutor.ethereum.eth_pricing_model import EthereumPricingModel, LP_FEE_VALIDATION_EPSILON
@@ -255,7 +255,7 @@ def uniswap_v2_live_pricing_factory(
         routing_model: UniswapV2Routing) -> UniswapV2LivePricing:
 
     assert isinstance(universe, TradingStrategyUniverse)
-    assert isinstance(execution_model, (UniswapV2ExecutionModelVersion0, UniswapV2ExecutionModel, DummyExecutionModel)), f"Execution model not compatible with this execution model. Received {execution_model}"
+    assert isinstance(execution_model, (UniswapV2ExecutionModelVersion0, UniswapV2Execution, DummyExecutionModel)), f"Execution model not compatible with this execution model. Received {execution_model}"
     assert isinstance(routing_model, UniswapV2Routing), f"This pricing method only works with Uniswap routing model, we received {routing_model}"
 
     web3 = execution_model.web3

--- a/tradeexecutor/ethereum/uniswap_v2/uniswap_v2_live_pricing.py
+++ b/tradeexecutor/ethereum/uniswap_v2/uniswap_v2_live_pricing.py
@@ -15,7 +15,7 @@ from eth_defi.uniswap_v2.fees import estimate_buy_received_amount_raw, estimate_
 
 from tradeexecutor.ethereum.uniswap_v2.uniswap_v2_execution import UniswapV2ExecutionModel
 from tradeexecutor.ethereum.uniswap_v2.uniswap_v2_execution_v0 import UniswapV2ExecutionModelVersion0
-from tradeexecutor.ethereum.uniswap_v2.uniswap_v2_routing import UniswapV2SimpleRoutingModel, route_tokens, get_uniswap_for_pair
+from tradeexecutor.ethereum.uniswap_v2.uniswap_v2_routing import UniswapV2Routing, route_tokens, get_uniswap_for_pair
 from tradeexecutor.ethereum.eth_pricing_model import EthereumPricingModel, LP_FEE_VALIDATION_EPSILON
 from tradeexecutor.state.identifier import TradingPairIdentifier
 from tradeexecutor.strategy.dummy import DummyExecutionModel
@@ -56,12 +56,12 @@ class UniswapV2LivePricing(EthereumPricingModel):
     def __init__(self,
                  web3: Web3,
                  pair_universe: PandasPairUniverse,
-                 routing_model: UniswapV2SimpleRoutingModel,
+                 routing_model: UniswapV2Routing,
                  very_small_amount=Decimal("0.10"),
                  epsilon: Optional[float] = LP_FEE_VALIDATION_EPSILON,
                  ):
 
-        assert isinstance(routing_model, UniswapV2SimpleRoutingModel)
+        assert isinstance(routing_model, UniswapV2Routing)
 
         self.uniswap_cache: Dict[TradingPairIdentifier, UniswapV2Deployment] = {}
 
@@ -252,11 +252,11 @@ class UniswapV2LivePricing(EthereumPricingModel):
 def uniswap_v2_live_pricing_factory(
         execution_model: ExecutionModel,
         universe: TradingStrategyUniverse,
-        routing_model: UniswapV2SimpleRoutingModel) -> UniswapV2LivePricing:
+        routing_model: UniswapV2Routing) -> UniswapV2LivePricing:
 
     assert isinstance(universe, TradingStrategyUniverse)
     assert isinstance(execution_model, (UniswapV2ExecutionModelVersion0, UniswapV2ExecutionModel, DummyExecutionModel)), f"Execution model not compatible with this execution model. Received {execution_model}"
-    assert isinstance(routing_model, UniswapV2SimpleRoutingModel), f"This pricing method only works with Uniswap routing model, we received {routing_model}"
+    assert isinstance(routing_model, UniswapV2Routing), f"This pricing method only works with Uniswap routing model, we received {routing_model}"
 
     web3 = execution_model.web3
     return UniswapV2LivePricing(

--- a/tradeexecutor/ethereum/uniswap_v2/uniswap_v2_routing.py
+++ b/tradeexecutor/ethereum/uniswap_v2/uniswap_v2_routing.py
@@ -180,7 +180,7 @@ class UniswapV2RoutingState(EthereumRoutingState):
         return [tx]
 
 
-class UniswapV2SimpleRoutingModel(EthereumRoutingModel):
+class UniswapV2Routing(EthereumRoutingModel):
     """A simple router that does not optimise the trade execution cost.
 
     - Able to trade on multiple exchanges

--- a/tradeexecutor/ethereum/uniswap_v3/uniswap_v3_execution.py
+++ b/tradeexecutor/ethereum/uniswap_v3/uniswap_v3_execution.py
@@ -16,12 +16,12 @@ from tradeexecutor.ethereum.tx import TransactionBuilder
 
 from tradeexecutor.state.identifier import TradingPairIdentifier
 #from tradeexecutor.strategy.execution_model import ExecutionModel
-from tradeexecutor.ethereum.execution import EthereumExecutionModel
+from tradeexecutor.ethereum.execution import EthereumExecution
 
 logger = logging.getLogger(__name__)
 
 
-class UniswapV3ExecutionModel(EthereumExecutionModel):
+class UniswapV3Execution(EthereumExecution):
     """Run order execution on a single Uniswap v3 style exchanges."""
 
     def __init__(self,

--- a/tradeexecutor/ethereum/uniswap_v3/uniswap_v3_live_pricing.py
+++ b/tradeexecutor/ethereum/uniswap_v3/uniswap_v3_live_pricing.py
@@ -12,7 +12,7 @@ from eth_defi.provider.broken_provider import get_block_tip_latency
 from web3 import Web3
 
 from tradeexecutor.ethereum.uniswap_v3.uniswap_v3_execution import UniswapV3ExecutionModel
-from tradeexecutor.ethereum.uniswap_v3.uniswap_v3_routing import UniswapV3SimpleRoutingModel, route_tokens, get_uniswap_for_pair
+from tradeexecutor.ethereum.uniswap_v3.uniswap_v3_routing import UniswapV3Routing, route_tokens, get_uniswap_for_pair
 from tradeexecutor.ethereum.eth_pricing_model import EthereumPricingModel, LP_FEE_VALIDATION_EPSILON
 from tradeexecutor.state.identifier import TradingPairIdentifier
 from tradeexecutor.strategy.execution_model import ExecutionModel
@@ -54,7 +54,7 @@ class UniswapV3LivePricing(EthereumPricingModel):
     def __init__(self,
                  web3: Web3,
                  pair_universe: PandasPairUniverse,
-                 routing_model: UniswapV3SimpleRoutingModel,
+                 routing_model: UniswapV3Routing,
                  very_small_amount=Decimal("0.10"),
                  epsilon: Optional[float] = LP_FEE_VALIDATION_EPSILON,
                  ):
@@ -314,12 +314,12 @@ class UniswapV3LivePricing(EthereumPricingModel):
 def uniswap_v3_live_pricing_factory(
         execution_model: ExecutionModel,
         universe: TradingStrategyUniverse,
-        routing_model: UniswapV3SimpleRoutingModel,
+        routing_model: UniswapV3Routing,
         ) -> UniswapV3LivePricing:
 
     assert isinstance(universe, TradingStrategyUniverse)
     assert isinstance(execution_model, (UniswapV3ExecutionModel)), f"Execution model not compatible with this execution model. Received {execution_model}"
-    assert isinstance(routing_model, UniswapV3SimpleRoutingModel), f"This pricing method only works with Uniswap routing model, we received {routing_model}"
+    assert isinstance(routing_model, UniswapV3Routing), f"This pricing method only works with Uniswap routing model, we received {routing_model}"
     web3 = execution_model.web3
     return UniswapV3LivePricing(
         web3,

--- a/tradeexecutor/ethereum/uniswap_v3/uniswap_v3_live_pricing.py
+++ b/tradeexecutor/ethereum/uniswap_v3/uniswap_v3_live_pricing.py
@@ -11,7 +11,7 @@ from typing import Optional, Dict
 from eth_defi.provider.broken_provider import get_block_tip_latency
 from web3 import Web3
 
-from tradeexecutor.ethereum.uniswap_v3.uniswap_v3_execution import UniswapV3ExecutionModel
+from tradeexecutor.ethereum.uniswap_v3.uniswap_v3_execution import UniswapV3Execution
 from tradeexecutor.ethereum.uniswap_v3.uniswap_v3_routing import UniswapV3Routing, route_tokens, get_uniswap_for_pair
 from tradeexecutor.ethereum.eth_pricing_model import EthereumPricingModel, LP_FEE_VALIDATION_EPSILON
 from tradeexecutor.state.identifier import TradingPairIdentifier
@@ -318,7 +318,7 @@ def uniswap_v3_live_pricing_factory(
         ) -> UniswapV3LivePricing:
 
     assert isinstance(universe, TradingStrategyUniverse)
-    assert isinstance(execution_model, (UniswapV3ExecutionModel)), f"Execution model not compatible with this execution model. Received {execution_model}"
+    assert isinstance(execution_model, (UniswapV3Execution)), f"Execution model not compatible with this execution model. Received {execution_model}"
     assert isinstance(routing_model, UniswapV3Routing), f"This pricing method only works with Uniswap routing model, we received {routing_model}"
     web3 = execution_model.web3
     return UniswapV3LivePricing(

--- a/tradeexecutor/ethereum/uniswap_v3/uniswap_v3_routing.py
+++ b/tradeexecutor/ethereum/uniswap_v3/uniswap_v3_routing.py
@@ -165,7 +165,7 @@ class UniswapV3RoutingState(EthereumRoutingState):
         )
 
 
-class UniswapV3SimpleRoutingModel(EthereumRoutingModel):
+class UniswapV3Routing(EthereumRoutingModel):
     """A simple router that does not optimise the trade execution cost. Designed for uniswap-v2 forks.
 
     - Able to trade on multiple exchanges

--- a/tradeexecutor/strategy/generic/generic_pricing_model.py
+++ b/tradeexecutor/strategy/generic/generic_pricing_model.py
@@ -13,7 +13,7 @@ from tradeexecutor.strategy.pricing_model import PricingModel
 from tradeexecutor.strategy.trade_pricing import TradePricing
 
 
-class GenericPricingModel(PricingModel):
+class GenericPricing(PricingModel):
     """Get a price for the asset from multiple protocols.
 
     - Each protocol has its own pricing model instance,

--- a/tradeexecutor/testing/backtest_trader.py
+++ b/tradeexecutor/testing/backtest_trader.py
@@ -4,8 +4,8 @@ import datetime
 from decimal import Decimal
 from typing import Tuple, Optional
 
-from tradeexecutor.backtest.backtest_execution import BacktestExecutionModel
-from tradeexecutor.backtest.backtest_pricing import BacktestSimplePricingModel
+from tradeexecutor.backtest.backtest_execution import BacktestExecution
+from tradeexecutor.backtest.backtest_pricing import BacktestPricing
 from tradeexecutor.backtest.backtest_routing import BacktestRoutingModel, BacktestRoutingState
 from tradeexecutor.state.state import State, TradeType
 from tradeexecutor.state.position import TradingPosition
@@ -27,9 +27,9 @@ class BacktestTrader:
                  start_ts: datetime.datetime,
                  state: State,
                  universe: TradingStrategyUniverse,
-                 execution_model: BacktestExecutionModel,
+                 execution_model: BacktestExecution,
                  routing_model: BacktestRoutingModel,
-                 pricing_model: BacktestSimplePricingModel,
+                 pricing_model: BacktestPricing,
                  ):
         self.state = state
         self.ts = start_ts

--- a/tradeexecutor/testing/ethereumtrader_one_delta.py
+++ b/tradeexecutor/testing/ethereumtrader_one_delta.py
@@ -16,7 +16,7 @@ from eth_defi.uniswap_v3.price import UniswapV3PriceHelper
 from eth_defi.one_delta.deployment import OneDeltaDeployment
 
 from tradeexecutor.ethereum.tx import HotWalletTransactionBuilder, TransactionBuilder
-from tradeexecutor.ethereum.one_delta.one_delta_routing import OneDeltaSimpleRoutingModel, OneDeltaRoutingState
+from tradeexecutor.ethereum.one_delta.one_delta_routing import OneDeltaRouting, OneDeltaRoutingState
 from tradeexecutor.ethereum.one_delta.one_delta_execution import OneDeltaExecutionModel
 from tradeexecutor.state.freeze import freeze_position_on_failed_trade
 from tradeexecutor.state.state import State, TradeType
@@ -133,7 +133,7 @@ class OneDeltaTestTrader(EthereumTrader):
         aave = self.aave
         reserve_asset, rate = self.state.portfolio.get_default_reserve_asset()
         uniswap = self.uniswap
-        routing_model = OneDeltaSimpleRoutingModel(
+        routing_model = OneDeltaRouting(
             address_map={
                 "one_delta_broker_proxy": one_delta.broker_proxy.address,
                 "aave_v3_pool": aave.pool.address,
@@ -151,7 +151,7 @@ class OneDeltaTestTrader(EthereumTrader):
 
     def execute_trades_simple(
         self,
-        routing_model: OneDeltaSimpleRoutingModel,
+        routing_model: OneDeltaRouting,
         trades: List[TradeExecution],
         max_slippage=0.01, 
         stop_on_execution_failure=True
@@ -167,7 +167,7 @@ class OneDeltaTestTrader(EthereumTrader):
         - Works with single Uniswap test deployment
         """
 
-        assert isinstance(routing_model, OneDeltaSimpleRoutingModel)
+        assert isinstance(routing_model, OneDeltaRouting)
 
         pair_universe = self.pair_universe
         web3 = self.web3

--- a/tradeexecutor/testing/ethereumtrader_one_delta.py
+++ b/tradeexecutor/testing/ethereumtrader_one_delta.py
@@ -17,7 +17,7 @@ from eth_defi.one_delta.deployment import OneDeltaDeployment
 
 from tradeexecutor.ethereum.tx import HotWalletTransactionBuilder, TransactionBuilder
 from tradeexecutor.ethereum.one_delta.one_delta_routing import OneDeltaRouting, OneDeltaRoutingState
-from tradeexecutor.ethereum.one_delta.one_delta_execution import OneDeltaExecutionModel
+from tradeexecutor.ethereum.one_delta.one_delta_execution import OneDeltaExecution
 from tradeexecutor.state.freeze import freeze_position_on_failed_trade
 from tradeexecutor.state.state import State, TradeType
 from tradeexecutor.state.position import TradingPosition
@@ -42,7 +42,7 @@ class OneDeltaTestTrader(EthereumTrader):
         self.one_delta = one_delta
         self.aave = aave
         self.uniswap = uniswap
-        self.execution_model = OneDeltaExecutionModel(tx_builder)
+        self.execution_model = OneDeltaExecution(tx_builder)
         # self.price_helper = UniswapV3PriceHelper(uniswap)
         self.tx_builder = tx_builder
 

--- a/tradeexecutor/testing/ethereumtrader_uniswap_v2.py
+++ b/tradeexecutor/testing/ethereumtrader_uniswap_v2.py
@@ -14,7 +14,7 @@ from eth_defi.uniswap_v2.fees import estimate_buy_quantity, estimate_sell_price
 
 from tradeexecutor.ethereum.uniswap_v2.uniswap_v2_execution import UniswapV2ExecutionModel
 from tradeexecutor.ethereum.tx import HotWalletTransactionBuilder, TransactionBuilder
-from tradeexecutor.ethereum.uniswap_v2.uniswap_v2_routing import UniswapV2SimpleRoutingModel, UniswapV2RoutingState
+from tradeexecutor.ethereum.uniswap_v2.uniswap_v2_routing import UniswapV2Routing, UniswapV2RoutingState
 from tradeexecutor.state.freeze import freeze_position_on_failed_trade
 from tradeexecutor.state.state import State, TradeType
 from tradeexecutor.state.position import TradingPosition
@@ -65,7 +65,7 @@ class UniswapV2TestTrader(EthereumTrader):
         # We know only about one exchange
         uniswap = self.uniswap
         reserve_asset, rate = self.state.portfolio.get_default_reserve_asset()
-        routing_model = UniswapV2SimpleRoutingModel(
+        routing_model = UniswapV2Routing(
             factory_router_map={
                 uniswap.factory.address: (uniswap.router.address, uniswap.init_code_hash),
             },

--- a/tradeexecutor/testing/ethereumtrader_uniswap_v2.py
+++ b/tradeexecutor/testing/ethereumtrader_uniswap_v2.py
@@ -12,7 +12,7 @@ from eth_defi.hotwallet import HotWallet
 from eth_defi.uniswap_v2.deployment import UniswapV2Deployment
 from eth_defi.uniswap_v2.fees import estimate_buy_quantity, estimate_sell_price
 
-from tradeexecutor.ethereum.uniswap_v2.uniswap_v2_execution import UniswapV2ExecutionModel
+from tradeexecutor.ethereum.uniswap_v2.uniswap_v2_execution import UniswapV2Execution
 from tradeexecutor.ethereum.tx import HotWalletTransactionBuilder, TransactionBuilder
 from tradeexecutor.ethereum.uniswap_v2.uniswap_v2_routing import UniswapV2Routing, UniswapV2RoutingState
 from tradeexecutor.state.freeze import freeze_position_on_failed_trade
@@ -58,7 +58,7 @@ class UniswapV2TestTrader(EthereumTrader):
         super().__init__(tx_builder, state, pair_universe)
 
         self.uniswap = uniswap
-        self.execution_model = UniswapV2ExecutionModel(tx_builder)
+        self.execution_model = UniswapV2Execution(tx_builder)
         self.pricing_model = pricing_model
 
     def create_routing_model(self) -> RoutingModel:
@@ -219,7 +219,7 @@ class UniswapV2TestTrader(EthereumTrader):
 
         state = self.state
 
-        execution_model = UniswapV2ExecutionModel(self.tx_builder)
+        execution_model = UniswapV2Execution(self.tx_builder)
         execution_model.broadcast_and_resolve_old(state, trades, routing_model, stop_on_execution_failure=stop_on_execution_failure)
 
         # Clean up failed trades

--- a/tradeexecutor/testing/ethereumtrader_uniswap_v3.py
+++ b/tradeexecutor/testing/ethereumtrader_uniswap_v3.py
@@ -15,7 +15,7 @@ from eth_defi.uniswap_v3.price import UniswapV3PriceHelper
 
 from tradeexecutor.ethereum.tx import HotWalletTransactionBuilder, TransactionBuilder
 from tradeexecutor.ethereum.uniswap_v3.uniswap_v3_routing import UniswapV3Routing, UniswapV3RoutingState
-from tradeexecutor.ethereum.uniswap_v3.uniswap_v3_execution import UniswapV3ExecutionModel
+from tradeexecutor.ethereum.uniswap_v3.uniswap_v3_execution import UniswapV3Execution
 from tradeexecutor.state.freeze import freeze_position_on_failed_trade
 from tradeexecutor.state.state import State, TradeType
 from tradeexecutor.state.position import TradingPosition
@@ -37,7 +37,7 @@ class UniswapV3TestTrader(EthereumTrader):
         super().__init__(tx_builder, state, pair_universe)
         self.uniswap = uniswap
 
-        self.execution_model = UniswapV3ExecutionModel(tx_builder)
+        self.execution_model = UniswapV3Execution(tx_builder)
         self.price_helper = UniswapV3PriceHelper(uniswap)
         self.tx_builder = tx_builder
 
@@ -163,7 +163,7 @@ class UniswapV3TestTrader(EthereumTrader):
         routing_state = UniswapV3RoutingState(pair_universe, tx_builder)
         routing_model.execute_trades_internal(pair_universe, routing_state, trades)
         
-        execution_model = UniswapV3ExecutionModel(self.tx_builder)
+        execution_model = UniswapV3Execution(self.tx_builder)
         execution_model.broadcast_and_resolve_old(state, trades, routing_model, stop_on_execution_failure=stop_on_execution_failure)
 
         # Clean up failed trades

--- a/tradeexecutor/testing/ethereumtrader_uniswap_v3.py
+++ b/tradeexecutor/testing/ethereumtrader_uniswap_v3.py
@@ -14,7 +14,7 @@ from eth_defi.uniswap_v3.deployment import UniswapV3Deployment
 from eth_defi.uniswap_v3.price import UniswapV3PriceHelper
 
 from tradeexecutor.ethereum.tx import HotWalletTransactionBuilder, TransactionBuilder
-from tradeexecutor.ethereum.uniswap_v3.uniswap_v3_routing import UniswapV3SimpleRoutingModel, UniswapV3RoutingState
+from tradeexecutor.ethereum.uniswap_v3.uniswap_v3_routing import UniswapV3Routing, UniswapV3RoutingState
 from tradeexecutor.ethereum.uniswap_v3.uniswap_v3_execution import UniswapV3ExecutionModel
 from tradeexecutor.state.freeze import freeze_position_on_failed_trade
 from tradeexecutor.state.state import State, TradeType
@@ -148,7 +148,7 @@ class UniswapV3TestTrader(EthereumTrader):
         reserve_asset, rate = state.portfolio.get_default_reserve_asset()
 
         # We know only about one exchange
-        routing_model = UniswapV3SimpleRoutingModel(
+        routing_model = UniswapV3Routing(
             address_map={
                 "factory": uniswap.factory.address,
                 "router": uniswap.swap_router.address,

--- a/tradeexecutor/testing/simulated_execution_loop.py
+++ b/tradeexecutor/testing/simulated_execution_loop.py
@@ -29,12 +29,12 @@ from tradeexecutor.ethereum.uniswap_v2.uniswap_v2_valuation import UniswapV2Pool
 
 from tradeexecutor.ethereum.uniswap_v3.uniswap_v3_execution import UniswapV3ExecutionModel
 from tradeexecutor.ethereum.uniswap_v3.uniswap_v3_live_pricing import UniswapV3LivePricing
-from tradeexecutor.ethereum.uniswap_v3.uniswap_v3_routing import UniswapV3SimpleRoutingModel
+from tradeexecutor.ethereum.uniswap_v3.uniswap_v3_routing import UniswapV3Routing
 from tradeexecutor.ethereum.uniswap_v3.uniswap_v3_valuation import UniswapV3PoolRevaluator
 
 from tradeexecutor.ethereum.one_delta.one_delta_execution import OneDeltaExecutionModel
 from tradeexecutor.ethereum.one_delta.one_delta_live_pricing import OneDeltaLivePricing
-from tradeexecutor.ethereum.one_delta.one_delta_routing import OneDeltaSimpleRoutingModel
+from tradeexecutor.ethereum.one_delta.one_delta_routing import OneDeltaRouting
 from tradeexecutor.ethereum.one_delta.one_delta_valuation import OneDeltaPoolRevaluator
 
 
@@ -149,7 +149,7 @@ def set_up_simulated_execution_loop_uniswap_v3(
         web3: Web3,
         decide_trades: DecideTradesProtocol,
         universe: StrategyExecutionUniverse,
-        routing_model: UniswapV3SimpleRoutingModel,
+        routing_model: UniswapV3Routing,
         state: State,
         wallet_account: LocalAccount,
 ) -> ExecutionLoop:
@@ -172,7 +172,7 @@ def set_up_simulated_execution_loop_uniswap_v3(
         raise TypeError("Only keyword arguments accepted")
 
     assert isinstance(wallet_account, LocalAccount)
-    assert isinstance(routing_model, UniswapV3SimpleRoutingModel)
+    assert isinstance(routing_model, UniswapV3Routing)
 
     execution_context = ExecutionContext(
         mode=ExecutionMode.simulated_trading,
@@ -251,7 +251,7 @@ def set_up_simulated_execution_loop_one_delta(
     web3: Web3,
     decide_trades: DecideTradesProtocol,
     universe: StrategyExecutionUniverse,
-    routing_model: OneDeltaSimpleRoutingModel,
+    routing_model: OneDeltaRouting,
     state: State,
     wallet_account = None,
 ) -> ExecutionLoop:
@@ -269,7 +269,7 @@ def set_up_simulated_execution_loop_one_delta(
         block by block.
     """
     # assert isinstance(wallet_account, LocalAccount)
-    assert isinstance(routing_model, OneDeltaSimpleRoutingModel)
+    assert isinstance(routing_model, OneDeltaRouting)
 
     execution_context = ExecutionContext(
         mode=ExecutionMode.simulated_trading,

--- a/tradeexecutor/testing/simulated_execution_loop.py
+++ b/tradeexecutor/testing/simulated_execution_loop.py
@@ -22,17 +22,17 @@ from tradeexecutor.strategy.universe_model import StaticUniverseModel, StrategyE
 from tradeexecutor.strategy.trading_strategy_universe import TradingStrategyUniverse
 from tradeexecutor.utils.timer import timed_task
 
-from tradeexecutor.ethereum.uniswap_v2.uniswap_v2_execution import UniswapV2ExecutionModel
+from tradeexecutor.ethereum.uniswap_v2.uniswap_v2_execution import UniswapV2Execution
 from tradeexecutor.ethereum.uniswap_v2.uniswap_v2_live_pricing import UniswapV2LivePricing
 from tradeexecutor.ethereum.uniswap_v2.uniswap_v2_routing import UniswapV2Routing
 from tradeexecutor.ethereum.uniswap_v2.uniswap_v2_valuation import UniswapV2PoolRevaluator
 
-from tradeexecutor.ethereum.uniswap_v3.uniswap_v3_execution import UniswapV3ExecutionModel
+from tradeexecutor.ethereum.uniswap_v3.uniswap_v3_execution import UniswapV3Execution
 from tradeexecutor.ethereum.uniswap_v3.uniswap_v3_live_pricing import UniswapV3LivePricing
 from tradeexecutor.ethereum.uniswap_v3.uniswap_v3_routing import UniswapV3Routing
 from tradeexecutor.ethereum.uniswap_v3.uniswap_v3_valuation import UniswapV3PoolRevaluator
 
-from tradeexecutor.ethereum.one_delta.one_delta_execution import OneDeltaExecutionModel
+from tradeexecutor.ethereum.one_delta.one_delta_execution import OneDeltaExecution
 from tradeexecutor.ethereum.one_delta.one_delta_live_pricing import OneDeltaLivePricing
 from tradeexecutor.ethereum.one_delta.one_delta_routing import OneDeltaRouting
 from tradeexecutor.ethereum.one_delta.one_delta_valuation import OneDeltaPoolRevaluator
@@ -90,7 +90,7 @@ def set_up_simulated_execution_loop_uniswap_v2(
 
     tx_builder = HotWalletTransactionBuilder(web3, hot_wallet)
 
-    execution_model = UniswapV2ExecutionModel(
+    execution_model = UniswapV2Execution(
         tx_builder,
         max_slippage=1.00,
         confirmation_block_count=0,  # Must be zero for the test chain
@@ -192,7 +192,7 @@ def set_up_simulated_execution_loop_uniswap_v3(
 
     tx_builder = HotWalletTransactionBuilder(web3, hot_wallet)
 
-    execution_model = UniswapV3ExecutionModel(
+    execution_model = UniswapV3Execution(
         tx_builder,
         max_slippage=1.00,
         confirmation_block_count=0,  # Must be zero for the test chain
@@ -292,7 +292,7 @@ def set_up_simulated_execution_loop_one_delta(
 
     tx_builder = HotWalletTransactionBuilder(web3, hot_wallet)
 
-    execution_model = OneDeltaExecutionModel(
+    execution_model = OneDeltaExecution(
         tx_builder,
         max_slippage=1.00,
         mainnet_fork=True,

--- a/tradeexecutor/testing/simulated_execution_loop.py
+++ b/tradeexecutor/testing/simulated_execution_loop.py
@@ -24,7 +24,7 @@ from tradeexecutor.utils.timer import timed_task
 
 from tradeexecutor.ethereum.uniswap_v2.uniswap_v2_execution import UniswapV2ExecutionModel
 from tradeexecutor.ethereum.uniswap_v2.uniswap_v2_live_pricing import UniswapV2LivePricing
-from tradeexecutor.ethereum.uniswap_v2.uniswap_v2_routing import UniswapV2SimpleRoutingModel
+from tradeexecutor.ethereum.uniswap_v2.uniswap_v2_routing import UniswapV2Routing
 from tradeexecutor.ethereum.uniswap_v2.uniswap_v2_valuation import UniswapV2PoolRevaluator
 
 from tradeexecutor.ethereum.uniswap_v3.uniswap_v3_execution import UniswapV3ExecutionModel
@@ -43,7 +43,7 @@ def set_up_simulated_execution_loop_uniswap_v2(
         web3: Web3,
         decide_trades: DecideTradesProtocol,
         universe: StrategyExecutionUniverse,
-        routing_model: UniswapV2SimpleRoutingModel,
+        routing_model: UniswapV2Routing,
         state: State,
         wallet_account: LocalAccount,
 ) -> ExecutionLoop:
@@ -69,7 +69,7 @@ def set_up_simulated_execution_loop_uniswap_v2(
         raise TypeError("Only keyword arguments accepted")
 
     assert isinstance(wallet_account, LocalAccount)
-    assert isinstance(routing_model, UniswapV2SimpleRoutingModel)
+    assert isinstance(routing_model, UniswapV2Routing)
 
     execution_context = ExecutionContext(
         mode=ExecutionMode.simulated_trading,


### PR DESCRIPTION
- `UniswapV2SimpleRoutingModel` -> `UniswapV2Routing`
- `UniswapV3SimpleRoutingModel` -> `UniswapV3Routing`
- `OneDeltaSimpleRoutingModel` -> `OneDeltaRouting`
- `GenericPricingModel` -> `GenericPricing`
- `EthereumExecutionModel` -> `EthereumExecution`
- `BacktestSimplePricingModel` -> `BacktestPricing`
- `BacktestExecutionModel` -> `BacktestExecution`
- Increase MATIC emount available for some Polygon fork tests because Polygon ☠️