### PR TITLE
Workaround for Kaleido crash issues

### DIFF
--- a/tests/interest/test_missing_lending_data.py
+++ b/tests/interest/test_missing_lending_data.py
@@ -138,9 +138,18 @@ def decide_trades(
     current_rsi = rsi(close_prices, length=RSI_LENGTH)[-1]
 
     # Calculate Stochastic
-    stoch_series = stoch(
-        candles["high"], candles["low"], candles["close"], k=14, d=3, smooth_k=1
-    )
+    try:
+        stoch_series = stoch(
+            candles["high"], candles["low"], candles["close"], k=14, d=3, smooth_k=1
+        )
+    except Exception as e:
+        # TALib issue
+        # TA_SMA function failed with error code 2: Bad Parameter (TA_BAD_PARAM)
+        # Raises ugly C exception
+        if len(e.args) == 1:
+            msg = e.args[0]
+            if "TA_SMA function failed with error code" in msg:
+                return []
 
     # Calculate MFI (Money Flow Index)
     mfi_series = mfi(

--- a/tradeexecutor/cli/commands/start.py
+++ b/tradeexecutor/cli/commands/start.py
@@ -417,7 +417,7 @@ def start(
 
     # Allow to do Python thread dump using a signal with
     # docker-compose kill command
-    if not execution_context.mode.is_unit_testing():
+    if not unit_testing:
         faulthandler.enable()
 
     loop = ExecutionLoop(

--- a/tradeexecutor/cli/commands/start.py
+++ b/tradeexecutor/cli/commands/start.py
@@ -417,7 +417,8 @@ def start(
 
     # Allow to do Python thread dump using a signal with
     # docker-compose kill command
-    faulthandler.enable()
+    if not execution_context.mode.is_unit_testing():
+        faulthandler.enable()
 
     loop = ExecutionLoop(
         name=name,

--- a/tradeexecutor/strategy/pandas_trader/runner.py
+++ b/tradeexecutor/strategy/pandas_trader/runner.py
@@ -176,6 +176,12 @@ class PandasTraderRunner(StrategyRunner):
             large_image_png,
         )
 
+        # Workaround: Kaleido backend is crashing
+        # https://github.com/tradingstrategy-ai/trade-executor/issues/699
+        import plotly.io as pio
+        scope = pio.kaleido.scope
+        scope._shutdown_kaleido()
+
     def get_small_images(self, small_figure):
         """Gets the png image of the figure and the dark theme png image. Images are 512 x 512."""
         return self.get_image_and_dark_image(small_figure, width=512, height=512)


### PR DESCRIPTION
- Fix hang in Plot's Kaleido chart rendering backend
- Enable Python's `faulthandler` so we should able to use external UNIX signals to get a Python thread dump from inside Docker

Attempt to fix https://github.com/tradingstrategy-ai/trade-executor/issues/699

