### PR TITLE
Enable aUSDC check in the tests

### DIFF
--- a/tests/ethereum/polygon_forked/generic-router/test_generic_router.py
+++ b/tests/ethereum/polygon_forked/generic-router/test_generic_router.py
@@ -269,7 +269,6 @@ def test_generic_routing_close_position_across_markets(
     assert balances[asset_usdc.address] == pytest.approx(Decimal(9992.900326), rel=Decimal(0.03)), f"Got balance: {balances}"
 
 
-@pytest.mark.skip(reason="This test has still calculation errors")
 def test_generic_routing_check_accounts(
     web3: Web3,
     hot_wallet: HotWallet,

--- a/tests/ethereum/polygon_forked/generic-router/test_generic_router.py
+++ b/tests/ethereum/polygon_forked/generic-router/test_generic_router.py
@@ -352,11 +352,11 @@ def test_generic_routing_check_accounts(
     # USDC 9600
     # WMATIC 174.375401861648687986
     # variableDebtPolWETH 0.6022047928580665889345412089
-    # aPolUSDC 898.1999999999999999625299729
+    # aPolUSDC 898.085644
     assert asset_to_position_mapping[asset_usdc].quantity == Decimal("9600")
     assert asset_to_position_mapping[asset_wmatic].quantity == pytest.approx(Decimal(174.375401861648687986))
     assert asset_to_position_mapping[weth_usdc_shorting_pair.base].quantity == pytest.approx(Decimal(0.3678414988406300651822788816))
-    assert asset_to_position_mapping[weth_usdc_shorting_pair.quote].quantity == pytest.approx(Decimal(898.1999999999999999625299729))
+    assert asset_to_position_mapping[weth_usdc_shorting_pair.quote].quantity == pytest.approx(Decimal(898.085644))
     assert len(asset_to_position_mapping) == 4
 
     # Check that our internal balance matches on-chain balance after execution

--- a/tests/ethereum/polygon_forked/generic-router/test_generic_router_live_loop.py
+++ b/tests/ethereum/polygon_forked/generic-router/test_generic_router_live_loop.py
@@ -204,7 +204,7 @@ def test_generic_router_spot_and_shot_strategy_manual_tick(
     )
     assert len(portfolio.open_positions) == 1
     assert position.loan.get_borrow_interest() == pytest.approx(1.695878549577238)
-    assert position.loan.get_collateral_interest() == pytest.approx(4.301575)
+    assert position.loan.get_collateral_interest() == pytest.approx(4.313776)
 
     loop.runner.check_accounts(strategy_universe, state)  # Check that on-chain balances reflect what we expect
 

--- a/tradeexecutor/ethereum/one_delta/one_delta_routing.py
+++ b/tradeexecutor/ethereum/one_delta/one_delta_routing.py
@@ -475,11 +475,19 @@ class OneDeltaRouting(EthereumRoutingModel):
             assert (executed_collateral_consumption > 0) and (executed_amount != 0) and (price > 0), f"Executed amount {executed_amount}, executed collateral consumption: {executed_collateral_consumption},  executed_reserve: {executed_reserve}, price: {price}, tx info {trade.tx_info}"
 
             # update the executed loan
-            trade.executed_loan_update = trade.planned_loan_update
-            trade.executed_loan_update.collateral.quantity = executed_collateral_consumption + executed_collateral_allocation + executed_reserve
+            loan = trade.planned_loan_update.clone()
 
-            trade.executed_loan_update.borrowed.quantity = -executed_amount
-            trade.executed_loan_update.borrowed.last_usd_price = float(price)
+            # TODO: hack the loan number directly here, refactor
+            collateral_quantity = executed_collateral_consumption + executed_collateral_allocation + executed_reserve
+            borrowed_quantity = -executed_amount
+
+            loan.collateral.quantity = collateral_quantity
+            loan.collateral_interest.last_token_amount = collateral_quantity
+            loan.borrowed.quantity = borrowed_quantity
+            loan.borrowed_interest.last_token_amount = borrowed_quantity
+            loan.borrowed.last_usd_price = float(price)
+
+            trade.executed_loan_update = loan
 
             # Mark as success
             state.mark_trade_success(


### PR DESCRIPTION
- Enable `test_generic_routing_check_accounts`

Currently failing bit still thinks there is a minor tweak needed for aUSDC:

```

    # for a in asset_to_position_mapping.values(): print(a.asset.token_symbol, a.quantity)
    # USDC 9600
    # WMATIC 174.375401861648687986
    # variableDebtPolWETH 0.3678414988406300651822788816
    # aPolUSDC 898.1999999999999999625299729
    assert asset_to_position_mapping[asset_usdc].quantity == Decimal("9600")
    assert asset_to_position_mapping[asset_wmatic].quantity == pytest.approx(Decimal(174.375401861648687986))
    assert asset_to_position_mapping[weth_usdc_shorting_pair.base].quantity == pytest.approx(Decimal(0.3678414988406300651822788816))
    assert asset_to_position_mapping[weth_usdc_shorting_pair.quote].quantity == pytest.approx(Decimal(898.1999999999999999625299729))
    assert len(asset_to_position_mapping) == 4

    # Check that our internal balance matches on-chain balance after execution
    corrections = calculate_account_corrections(
        pair_universe=strategy_universe.data_universe.pairs,
        reserve_assets=state.portfolio.get_reserve_assets(),
        state=state,
        sync_model=sync_model,
        all_balances=False,
    )
    corrections = list(corrections)
    assert len(corrections) == 0, f"Got corrections: {corrections}"

```

`calculate_account_corrections` gives us

```
Accounting correction type unknown_cause for Trading position #2 for variableDebtPolWETH-aPolUSDC asset aPolUSDC, expected 898.1999999999999999625299729, actual 898.085645 at 2023-10-22 00:13:17>
```

Because the difference is ranges of few BPS, could it be swap fees?