### PR TITLE
Generic routing spot only e2e

### DIFF
--- a/strategies/test_only/generic_routing_end_to_end_spot.py
+++ b/strategies/test_only/generic_routing_end_to_end_spot.py
@@ -1,0 +1,83 @@
+"""Dummy strategy used in generic routing end-to-end tests.
+
+- Spot only trades with two pairs
+"""
+import datetime
+from typing import List
+
+import pandas as pd
+
+from tradeexecutor.strategy.cycle import CycleDuration
+from tradeexecutor.strategy.execution_context import ExecutionContext
+from tradeexecutor.strategy.pricing_model import PricingModel
+from tradeexecutor.strategy.trading_strategy_universe import TradingStrategyUniverse, load_partial_data
+from tradeexecutor.strategy.universe_model import UniverseOptions
+from tradingstrategy.chain import ChainId
+from tradingstrategy.client import Client, BaseClient
+from tradingstrategy.lending import LendingProtocolType
+
+from tradingstrategy.timebucket import TimeBucket
+
+from tradeexecutor.state.state import State
+from tradeexecutor.state.trade import TradeExecution
+from tradeexecutor.strategy.pandas_trader.position_manager import PositionManager
+
+trading_strategy_engine_version = "0.3"
+trading_strategy_cycle = CycleDuration.cycle_1s
+
+
+def decide_trades(
+    timestamp: pd.Timestamp,
+    strategy_universe: TradingStrategyUniverse,
+    state: State,
+    pricing_model: PricingModel,
+    cycle_debug_data: dict
+) -> List[TradeExecution]:
+
+    trades = []
+    position_manager = PositionManager(timestamp, strategy_universe, state, pricing_model)
+    cycle = cycle_debug_data["cycle"]
+    pairs = strategy_universe.data_universe.pairs
+    spot_eth = pairs.get_pair_by_human_description((ChainId.polygon, "uniswap-v3", "WETH", "USDC", 0.0005))
+    spot_matic = pairs.get_pair_by_human_description((ChainId.polygon, "uniswap-v3", "WMATIC", "USDC", 0.0005))
+
+    if position_manager.is_any_open():
+        trades += position_manager.close_all()
+
+    if cycle % 2 == 0:
+        # Spot day
+        trades += position_manager.open_spot(spot_eth, 100.0)
+    else:
+        # Short day
+        trades += position_manager.open_spot(spot_matic, 150.0)
+
+    return trades
+
+
+def create_trading_universe(
+        ts: datetime.datetime,
+        client: BaseClient,
+        execution_context: ExecutionContext,
+        universe_options: UniverseOptions,
+):
+
+    pairs = [
+        (ChainId.polygon, "uniswap-v3", "WETH", "USDC", 0.0005),
+        (ChainId.polygon, "quickswap", "WMATIC", "USDC", 0.0030),
+    ]
+
+    dataset = load_partial_data(
+        client,
+        execution_context=execution_context,
+        time_bucket=TimeBucket.h1,
+        pairs=pairs,
+        universe_options=universe_options,
+        required_history_period=datetime.timedelta(days=7),
+    )
+
+    strategy_universe = TradingStrategyUniverse.create_from_dataset(
+        dataset,
+        reserve_asset="USDC",
+    )
+
+    return strategy_universe

--- a/strategies/test_only/generic_routing_end_to_end_spot.py
+++ b/strategies/test_only/generic_routing_end_to_end_spot.py
@@ -63,7 +63,7 @@ def create_trading_universe(
 
     pairs = [
         (ChainId.polygon, "uniswap-v3", "WETH", "USDC", 0.0005),
-        (ChainId.polygon, "quickswap", "WMATIC", "USDC", 0.0030),
+        (ChainId.polygon, "uniswap-v3", "WMATIC", "USDC", 0.0005),
     ]
 
     dataset = load_partial_data(

--- a/tests/ethereum/polygon_forked/generic-router/test_generic_router_end_to_end.py
+++ b/tests/ethereum/polygon_forked/generic-router/test_generic_router_end_to_end.py
@@ -251,6 +251,6 @@ def test_generic_routing_live_trading_start_spot_only(
     # Check that trades completed
     with state_file.open("rt") as inp:
         state = State.from_json(inp.read())
-        assert len(state.portfolio.closed_positions) == 1
-        assert len(state.portfolio.open_pos**18 * 0.03112978758721282)
+        assert len(state.portfolio.closed_positions) == 8
+
 

--- a/tradeexecutor/cli/commands/perform_test_trade.py
+++ b/tradeexecutor/cli/commands/perform_test_trade.py
@@ -90,7 +90,8 @@ def perform_test_trade(
 
     execution_context = ExecutionContext(
         mode=ExecutionMode.preflight_check,
-        timed_task_context_manager=timed_task
+        timed_task_context_manager=timed_task,
+        engine_version=mod.trading_strategy_engine_version,
     )
 
     web3config = create_web3_config(

--- a/tradeexecutor/state/identifier.py
+++ b/tradeexecutor/state/identifier.py
@@ -32,9 +32,7 @@ from tradingstrategy.types import PrimaryKey
 AssetFriendlyId: TypeAlias = str
 
 
-@dataclass_json
-@dataclass
-class AssetType:
+class AssetType(enum.Enum):
     """What kind of asset is this.
 
     We mark special tokens that are dynamically created
@@ -111,7 +109,7 @@ class AssetIdentifier:
     #:
     #: Legacy data will default to ``None``.
     #:
-    type: AssetType | None = None
+    type: Optional[AssetType] = None
 
     #: Aave liquidation threhold for this asset
     #:
@@ -135,12 +133,16 @@ class AssetIdentifier:
         return self.chain_id == other.chain_id and self.address == other.address
 
     def __post_init__(self):
+        """Validate asset description initialisation."""
         assert type(self.address) == str, f"Got address {self.address} as {type(self.address)}"
         assert self.address.startswith("0x")
         self.address= self.address.lower()
         assert type(self.chain_id) == int
         assert type(self.decimals) == int, f"Bad decimals {self.decimals}"
         assert self.decimals >= 0
+
+        if self.type:
+            assert isinstance(self.type, AssetType), f"Got {self.type.__class__}: {self.type}"
 
     def get_identifier(self) -> AssetFriendlyId:
         """Assets are identified by their smart contract address.

--- a/tradeexecutor/strategy/lending_protocol_leverage.py
+++ b/tradeexecutor/strategy/lending_protocol_leverage.py
@@ -121,8 +121,8 @@ def create_short_loan(
     assert pair.base.underlying, "Base token lacks underlying asset"
     assert pair.quote.underlying, "Quote token lacks underlying asset"
 
-    assert pair.base.type == AssetType.borrowed, f"Trading pair base asset is not borrowed: {pair.base}"
-    assert pair.quote.type == AssetType.collateral, f"Trading pair quote asset is not collateral: {pair.quote}"
+    assert pair.base.type == AssetType.borrowed, f"Trading pair base asset is not borrowed: {pair.base}, {pair.base.type}"
+    assert pair.quote.type == AssetType.collateral, f"Trading pair quote asset is not collateral: {pair.quote}, {pair.quote.type}"
 
     assert pair.quote.underlying.is_stablecoin(), f"Only stablecoin collateral supported for shorts: {pair.quote}"
 

--- a/tradeexecutor/strategy/trading_strategy_universe.py
+++ b/tradeexecutor/strategy/trading_strategy_universe.py
@@ -1362,7 +1362,7 @@ def translate_token(
         token.symbol,
         token.decimals,
         underlying=underlying,
-        type=type,
+        type=AssetType.token,
         liquidation_threshold=liquidation_threshold,
     )
 

--- a/tradeexecutor/strategy/trading_strategy_universe.py
+++ b/tradeexecutor/strategy/trading_strategy_universe.py
@@ -885,7 +885,7 @@ class TradingStrategyUniverse(StrategyExecutionUniverse):
             liquidity=dataset.liquidity,
             resampled_liquidity=dataset,
             exchange_universe=dataset.exchanges,
-            exchanges={e for e in dataset.exchanges.exchanges},
+            exchanges={e for e in dataset.exchanges.exchanges.values()},
             lending_candles=dataset.lending_candles,
         )
 

--- a/tradeexecutor/strategy/trading_strategy_universe.py
+++ b/tradeexecutor/strategy/trading_strategy_universe.py
@@ -1362,7 +1362,7 @@ def translate_token(
         token.symbol,
         token.decimals,
         underlying=underlying,
-        type=AssetType.token,
+        type=type,
         liquidation_threshold=liquidation_threshold,
     )
 


### PR DESCRIPTION
- Add `test_generic_routing_live_trading_start_spot_only` and `test_generic_routing_test_trade_spot_only`
- Fix `AssetType` not being enum, causing serialisation failures
- Fix problems with passing exchanges to `Universe` construction