### PR TITLE
Generic routing spot and short tests

### DIFF
--- a/tests/ethereum/polygon_forked/generic-router/test_generic_router_end_to_end.py
+++ b/tests/ethereum/polygon_forked/generic-router/test_generic_router_end_to_end.py
@@ -194,7 +194,7 @@ def test_generic_routing_test_trade_spot_and_short(
 
     with patch.dict(os.environ, environment, clear=True):
         with pytest.raises(SystemExit) as e:
-            cli.main(args=["perform-test-trade", "--all-pairs"])
+            cli.main(args=["perform-test-trade", "--all-pairs", "--spot-only"])
         assert e.value.code == 0
 
     # Check the resulting state and see we made some trade for trading fee losses
@@ -257,7 +257,7 @@ def test_generic_routing_test_trade_spot_only(
 
     with patch.dict(os.environ, environment, clear=True):
         with pytest.raises(SystemExit) as e:
-            cli.main(args=["perform-test-trade", "--all-pairs"])
+            cli.main(args=["perform-test-trade", "--all-pairs", "--spot-only"])
         assert e.value.code == 0
 
     # Check the resulting state and see we made some trade for trading fee losses

--- a/tests/ethereum/polygon_forked/generic-router/test_generic_router_end_to_end.py
+++ b/tests/ethereum/polygon_forked/generic-router/test_generic_router_end_to_end.py
@@ -142,7 +142,6 @@ def test_generic_routing_live_trading_init(
         assert state.sync.deployment.block_number > 1
 
 
-@pytest.mark.skip(reason="This test is not yet finished")
 def test_generic_routing_live_trading_start(
     environment: dict,
     state_file: Path,

--- a/tests/ethereum/polygon_forked/generic-router/test_generic_router_end_to_end.py
+++ b/tests/ethereum/polygon_forked/generic-router/test_generic_router_end_to_end.py
@@ -194,7 +194,7 @@ def test_generic_routing_test_trade_spot_and_short(
 
     with patch.dict(os.environ, environment, clear=True):
         with pytest.raises(SystemExit) as e:
-            cli.main(args=["perform-test-trade", "--all-pairs", "--spot-only"])
+            cli.main(args=["perform-test-trade", "--all-pairs"])
         assert e.value.code == 0
 
     # Check the resulting state and see we made some trade for trading fee losses

--- a/tradeexecutor/cli/commands/perform_test_trade.py
+++ b/tradeexecutor/cli/commands/perform_test_trade.py
@@ -66,7 +66,8 @@ def perform_test_trade(
     pair: Optional[str] = shared_options.pair,
     all_pairs: bool = shared_options.all_pairs,
 
-    buy_only: bool = Option(None, "--buy-only", envvar="BUY_ONLY", help="Only perform the buy side of the test trade - leave position open.")
+    buy_only: bool = Option(None, "--buy-only", envvar="BUY_ONLY", help="Only perform the buy side of the test trade - leave position open."),
+    spot_only: bool = Option(None, "--spot-only", envvar="SPOT_ONLY", help="Perform spot trades only."),
 ):
     """Perform a small test swap.
 
@@ -190,6 +191,7 @@ def perform_test_trade(
                 routing_state,
                 pair=p,
                 buy_only=buy_only,
+                spot_only=spot_only,
             )
     else:
 

--- a/tradeexecutor/cli/commands/start.py
+++ b/tradeexecutor/cli/commands/start.py
@@ -93,6 +93,7 @@ def start(
     confirmation_block_count: int = shared_options.confirmation_block_count,
     private_key: Optional[str] = shared_options.private_key,
     min_gas_balance: Optional[float] = shared_options.min_gas_balance,
+    gas_balance_warning_level: Optional[float] = typer.Option(25.0, envvar="GAS_BALANCE_WARNING_LEVEL", help="If hot wallet gas level falls below this amount of tokens, issue a low gas warning."),
 
     # Logging
     discord_webhook_url: Optional[str] = typer.Option(None, envvar="DISCORD_WEBHOOK_URL", help="Discord webhook URL for notifications"),
@@ -341,8 +342,7 @@ def start(
         run_state.version = VersionInfo.read_docker_version()
         run_state.executor_id = id
 
-        # TODO: Gas warning level hard coded now
-        run_state.hot_wallet_gas_warning_level = 25
+        run_state.hot_wallet_gas_warning_level = Decimal(gas_balance_warning_level)
 
         # Create our webhook server
         if http_enabled:

--- a/tradeexecutor/cli/loop.py
+++ b/tradeexecutor/cli/loop.py
@@ -27,6 +27,7 @@ from tradeexecutor.ethereum.wallet import perform_gas_level_checks
 from tradeexecutor.state.metadata import Metadata
 from tradeexecutor.statistics.summary import calculate_summary_statistics
 from tradeexecutor.strategy.account_correction import check_accounts, UnexpectedAccountingCorrectionIssue
+from tradeexecutor.strategy.dummy import DummyExecutionModel
 from tradeexecutor.strategy.generic.generic_pricing_model import GenericPricing
 from tradeexecutor.strategy.pandas_trader.decision_trigger import wait_for_universe_data_availability_jsonl
 from tradeexecutor.strategy.routing import RoutingModel
@@ -1040,7 +1041,8 @@ class ExecutionLoop:
                     universe = None
 
                 # Shortcut universe downlado in forked mainnet test strategies
-                if self.execution_context.mode == ExecutionMode.unit_testing_trading:
+                if self.execution_context.mode == ExecutionMode.unit_testing_trading and not isinstance(self.execution_model, DummyExecutionModel):
+                    # Dummy execution marks special test_trading_data_availability_based_strategy_cycle_trigger
                     universe = self.unit_testing_universe
 
                 # Run the main strategy logic

--- a/tradeexecutor/cli/testtrade.py
+++ b/tradeexecutor/cli/testtrade.py
@@ -38,6 +38,7 @@ def make_test_trade(
     amount=Decimal("1.0"),
     pair: HumanReadableTradingPairDescription | None = None,
     buy_only: bool = False,
+    spot_only: bool = False,
 ):
     """Perform a test trade.
 
@@ -237,10 +238,7 @@ def make_test_trade(
     else:
         sell_trade = None
 
-    if universe.can_open_short(
-        datetime.datetime.utcnow(),
-        pair,
-    ):
+    if universe.has_any_lending_data() and universe.can_open_short(datetime.datetime.utcnow(), pair) and not spot_only:
         short_pair = universe.get_shorting_pair(pair)
         position = state.portfolio.get_position_by_trading_pair(short_pair)
 

--- a/tradeexecutor/state/position.py
+++ b/tradeexecutor/state/position.py
@@ -1129,11 +1129,13 @@ class TradingPosition(GenericPosition):
 
         - See also :py:meth:`get_realised_profit_percent`.
 
+        - Always returns zero for frozen positions
+
         .. note ::
 
             This function does not account for in-kind redemptions or any other account corrections.
             Please use :py:meth:`get_realised_profit_percent` if possible.
-loca
+
         :param include_interest:
             Include any accrued interest in PnL.
 
@@ -1142,6 +1144,9 @@ loca
 
             `None` if the position lacks any realised profit (contains only unrealised).
         """
+
+        if self.is_frozen():
+            return 0
 
         if not self.is_reduced():
             return None
@@ -1158,6 +1163,10 @@ loca
                     # realised profit is zero
                     trade_profit = 0
             else:
+
+                # Need to fix for frozen positions
+                #  trade_profit = (self.get_average_sell() - self.get_average_buy()) * float(self.get_buy_quantity())
+                # TypeError: unsupported operand type(s) for -: 'float' and 'NoneType'
                 trade_profit = (self.get_average_sell() - self.get_average_buy()) * float(self.get_buy_quantity())
         else:
             # No closes yet, only unrealised PnL

--- a/tradeexecutor/strategy/execution_context.py
+++ b/tradeexecutor/strategy/execution_context.py
@@ -85,8 +85,12 @@ class ExecutionMode(enum.Enum):
     one_off = "one_off"
 
     def is_live_trading(self) -> bool:
-        """Are we trading  real time?"""
-        return self in (self.real_trading, self.paper_trading, self.unit_testing_trading, self.simulated_trading)
+        """Are we trading real time?
+
+        - Preflight check is considered live trading, because strategy modules
+          are not in backtesting when doing preflight checks
+        """
+        return self in (self.real_trading, self.paper_trading, self.unit_testing_trading, self.simulated_trading, self.preflight_check)
 
     def is_fresh_data_always_needed(self):
         """Should we purge caches for each trade cycle.

--- a/tradeexecutor/strategy/interest.py
+++ b/tradeexecutor/strategy/interest.py
@@ -16,7 +16,7 @@ from tradeexecutor.state.position import TradingPosition
 from tradeexecutor.state.state import State
 from tradeexecutor.state.types import USDollarPrice, Percent, BlockNumber
 from tradeexecutor.strategy.pricing_model import PricingModel
-from tradeexecutor.utils.accuracy import QUANTITY_EPSILON
+from tradeexecutor.utils.accuracy import QUANTITY_EPSILON, INTEREST_EPSILON
 from tradingstrategy.utils.time import ZERO_TIMEDELTA
 
 logger = logging.getLogger(__name__)
@@ -367,9 +367,9 @@ def distribute_interest_for_assets(
     # We also may encounter negative updates < epsilon due to the rounding
     # errors.
     interest_accrued = new_amount - asset_total
-    if abs(interest_accrued) >= QUANTITY_EPSILON:
+    if abs(interest_accrued) >= INTEREST_EPSILON:
 
-        assert interest_accrued >= 0, f"Interest cannot go negative: {interest_accrued}, our epsilon is {QUANTITY_EPSILON}"
+        assert interest_accrued >= 0, f"Interest cannot go negative: {interest_accrued}, our epsilon is {INTEREST_EPSILON}"
         interest_accrued_relative = interest_accrued / asset_total
 
         assert interest_accrued_relative <= max_interest_gain, \

--- a/tradeexecutor/strategy/pandas_trader/position_manager.py
+++ b/tradeexecutor/strategy/pandas_trader/position_manager.py
@@ -1155,6 +1155,8 @@ class PositionManager:
 
         assert executor_pair.is_spot(), f"Give a spot pair as input and we will figure out shorting pair for you. Got {executor_pair}"
 
+        assert self.strategy_universe is not None, f"PositionManager.strategy_universe not set, data_universe is {self.data_universe}"
+
         shorting_pair = self.strategy_universe.get_shorting_pair(executor_pair)
 
         # Check that pair data looks good

--- a/tradeexecutor/strategy/trading_strategy_universe.py
+++ b/tradeexecutor/strategy/trading_strategy_universe.py
@@ -239,6 +239,10 @@ class TradingStrategyUniverse(StrategyExecutionUniverse):
         """
         raise NotImplementedError("This function is still TBD")
 
+    def has_any_lending_data(self) -> bool:
+        """Does this trading universe has any lending data loaded"""
+        return self.data_universe.lending_reserves is not None
+
     def has_lending_market_available(
         self,
         timestamp: pd.Timestamp | datetime.datetime,

--- a/tradeexecutor/utils/accuracy.py
+++ b/tradeexecutor/utils/accuracy.py
@@ -42,6 +42,16 @@ COLLATERAL_EPSILON = Decimal(10**-5)
 CLOSE_POSITION_COLLATERAL_EPSILON = Decimal(0.02)
 
 
+
+#: What is the lower threshold check for zero interest
+#:
+#: Spotted from test_generic_routing_live_trading_start
+#: that does mainnet fork trading.
+#:
+INTEREST_EPSILON = Decimal(0.000002)
+
+
+
 def setup_decimal_accuracy():
     """Make sure we can handle Decimals up to 18 digits.
 


### PR DESCRIPTION
- End-to-end start spot and short strategy run test with 10 cycles
- End-to-end perform test trade test: open and close short for pairs that do support shorting
- Uses forked Polygon mainnet