### PR TITLE
Metadata tags

### DIFF
--- a/tests/backtest/test_backtest_inline_synthetic_data.py
+++ b/tests/backtest/test_backtest_inline_synthetic_data.py
@@ -31,7 +31,6 @@ from tradingstrategy.universe import Universe
 from tradingstrategy.chain import ChainId
 from tradingstrategy.timebucket import TimeBucket
 from tradeexecutor.strategy.cycle import CycleDuration
-from tradeexecutor.strategy.strategy_module import pregenerated_create_trading_universe
 from tradeexecutor.strategy.reserve_currency import ReserveCurrency
 from tradeexecutor.strategy.strategy_type import StrategyType
 from tradeexecutor.strategy.default_routing_options import TradeRouting

--- a/tests/backtest/test_backtest_open_position.py
+++ b/tests/backtest/test_backtest_open_position.py
@@ -36,7 +36,6 @@ from tradingstrategy.universe import Universe
 from tradingstrategy.chain import ChainId
 from tradingstrategy.timebucket import TimeBucket
 from tradeexecutor.strategy.cycle import CycleDuration
-from tradeexecutor.strategy.strategy_module import pregenerated_create_trading_universe
 from tradeexecutor.strategy.reserve_currency import ReserveCurrency
 from tradeexecutor.strategy.strategy_type import StrategyType
 from tradeexecutor.strategy.default_routing_options import TradeRouting

--- a/tests/web/test_webhook_api.py
+++ b/tests/web/test_webhook_api.py
@@ -15,7 +15,7 @@ from tradeexecutor.state.state import State
 from tradeexecutor.state.portfolio import Portfolio
 from tradeexecutor.state.store import JSONFileStore
 from tradeexecutor.strategy.run_state import RunState
-from tradeexecutor.strategy.strategy_module import StrategyTag
+from tradeexecutor.strategy.tag import StrategyTag
 from tradeexecutor.webhook.server import create_webhook_server
 
 

--- a/tests/web/test_webhook_api.py
+++ b/tests/web/test_webhook_api.py
@@ -15,6 +15,7 @@ from tradeexecutor.state.state import State
 from tradeexecutor.state.portfolio import Portfolio
 from tradeexecutor.state.store import JSONFileStore
 from tradeexecutor.strategy.run_state import RunState
+from tradeexecutor.strategy.strategy_module import StrategyTag
 from tradeexecutor.webhook.server import create_webhook_server
 
 
@@ -49,6 +50,7 @@ def server_url(store):
         datetime.datetime.utcnow(),
         True,
         badges=Metadata.parse_badges_configuration("polygon, metamask, eth, usdc"),
+        tags={StrategyTag.beta},
     )
 
     # Inject some fake files for the backtest content
@@ -92,6 +94,7 @@ def test_metadata(logger, server_url):
     assert data["executor_running"] == True
     assert data["crashed_at"] is None
     assert data["badges"] == ["polygon", "metamask", "eth", "usdc"]
+    assert data["tags"] == ["beta"]
 
 
 def test_cors(logger, server_url):

--- a/tradeexecutor/cli/bootstrap.py
+++ b/tradeexecutor/cli/bootstrap.py
@@ -41,7 +41,8 @@ from tradeexecutor.strategy.default_routing_options import TradeRouting
 from tradeexecutor.strategy.generic.generic_router import GenericRouting
 from tradeexecutor.strategy.pricing_model import PricingModelFactory
 from tradeexecutor.strategy.routing import RoutingModel
-from tradeexecutor.strategy.strategy_module import StrategyModuleInformation, StrategyTag
+from tradeexecutor.strategy.strategy_module import StrategyModuleInformation
+from tradeexecutor.strategy.tag import StrategyTag
 from tradeexecutor.strategy.sync_model import SyncModel, DummySyncModel
 from tradeexecutor.strategy.valuation import ValuationModelFactory
 from tradeexecutor.testing.dummy_wallet import DummyWalletSyncer

--- a/tradeexecutor/cli/bootstrap.py
+++ b/tradeexecutor/cli/bootstrap.py
@@ -5,7 +5,7 @@ import os
 import shutil
 from decimal import Decimal
 from pathlib import Path
-from typing import Optional, Tuple
+from typing import Optional, Tuple, Set
 
 from eth_defi.enzyme.vault import Vault
 from eth_defi.event_reader.reorganisation_monitor import create_reorganisation_monitor
@@ -41,7 +41,7 @@ from tradeexecutor.strategy.default_routing_options import TradeRouting
 from tradeexecutor.strategy.generic.generic_router import GenericRouting
 from tradeexecutor.strategy.pricing_model import PricingModelFactory
 from tradeexecutor.strategy.routing import RoutingModel
-from tradeexecutor.strategy.strategy_module import StrategyModuleInformation
+from tradeexecutor.strategy.strategy_module import StrategyModuleInformation, StrategyTag
 from tradeexecutor.strategy.sync_model import SyncModel, DummySyncModel
 from tradeexecutor.strategy.valuation import ValuationModelFactory
 from tradeexecutor.testing.dummy_wallet import DummyWalletSyncer
@@ -291,6 +291,7 @@ def create_metadata(
         backtest_html: Optional[Path] = None,
         key_metrics_backtest_cut_off_days: float = 90,
         badges: Optional[str] = None,
+        tags: Optional[Set[StrategyTag]] = None,
 ) -> Metadata:
     """Create metadata object from the configuration variables."""
 
@@ -331,6 +332,7 @@ def create_metadata(
         backtest_html=backtest_html,
         key_metrics_backtest_cut_off=datetime.timedelta(days=key_metrics_backtest_cut_off_days),
         badges=Metadata.parse_badges_configuration(badges),
+        tags=tags or set(),  # Always fill empty set
     )
 
     return metadata

--- a/tradeexecutor/cli/commands/start.py
+++ b/tradeexecutor/cli/commands/start.py
@@ -333,6 +333,7 @@ def start(
             backtest_html=html_report,
             key_metrics_backtest_cut_off_days=key_metrics_backtest_cut_off_days,
             badges=badges,
+            tags=mod.tags,
         )
 
         # Start the queue that relays info from the web server to the strategy executor

--- a/tradeexecutor/state/metadata.py
+++ b/tradeexecutor/state/metadata.py
@@ -10,7 +10,7 @@ from typing import Optional, Dict, TypedDict, List, Set
 
 from dataclasses_json import dataclass_json
 
-from tradeexecutor.strategy.strategy_module import StrategyTag
+from tradeexecutor.strategy.tag import StrategyTag
 from tradingstrategy.chain import ChainId
 
 from tradeexecutor.state.state import State

--- a/tradeexecutor/state/metadata.py
+++ b/tradeexecutor/state/metadata.py
@@ -6,9 +6,11 @@ on the executor start up.
 import datetime
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Optional, Dict, TypedDict, List
+from typing import Optional, Dict, TypedDict, List, Set
 
 from dataclasses_json import dataclass_json
+
+from tradeexecutor.strategy.strategy_module import StrategyTag
 from tradingstrategy.chain import ChainId
 
 from tradeexecutor.state.state import State
@@ -128,7 +130,9 @@ class Metadata:
     #:
     key_metrics_backtest_cut_off: datetime.timedelta = datetime.timedelta(days=90)
 
-    #: List of badges strategy tile can display
+    #: List of badges strategy tile can display.
+    #:
+    #: Used for the user to visualise context information about the strategy.
     #:
     #: E.g. "metamask", "polygon", "eth", "usdc"
     #:
@@ -136,8 +140,17 @@ class Metadata:
     #: - Chain badge e.g. Polygon does not need to be declared as it is part of the strategh
     #: - Vault type. e.g. Enzyme badge is the same
     #: - Can contain badges like USDC
+    #: - Some of badges are automatically derived, some are manually set.
+    #:
+    #: See also :py:attr:`tags`
     #:
     badges: List[str] = field(default_factory=list)
+
+    #: Tags on this strategy
+    #:
+    #: See also :py:attr:`badges`
+    #:
+    tags: Set[StrategyTag] = field(default_factory=set)
 
     @staticmethod
     def create_dummy() -> "Metadata":

--- a/tradeexecutor/strategy/strategy_module.py
+++ b/tradeexecutor/strategy/strategy_module.py
@@ -1,6 +1,5 @@
 """Describe strategy modules and their loading."""
 import datetime
-import enum
 import logging
 import runpy
 from dataclasses import dataclass
@@ -14,6 +13,7 @@ import pandas
 import pandas as pd
 
 from tradeexecutor.strategy.engine_version import SUPPORTED_TRADING_STRATEGY_ENGINE_VERSIONS, TradingStrategyEngineVersion
+from tradeexecutor.strategy.tag import StrategyTag
 from tradingstrategy.chain import ChainId
 from tradeexecutor.state.state import State
 from tradeexecutor.state.trade import TradeExecution
@@ -26,7 +26,6 @@ from tradeexecutor.strategy.reserve_currency import ReserveCurrency
 from tradeexecutor.strategy.strategy_type import StrategyType
 from tradeexecutor.strategy.trading_strategy_universe import TradingStrategyUniverse
 from tradingstrategy.client import Client
-from tradingstrategy.timebucket import TimeBucket
 from tradingstrategy.universe import Universe
 
 from tradeexecutor.strategy.universe_model import UniverseOptions
@@ -272,32 +271,6 @@ class CreateTradingUniverseProtocol(Protocol):
             The trading universe also contains information about the reserve asset,
             usually stablecoin, we use for the strategy.
             """
-
-class StrategyTag(enum.Enum):
-    """Tags we can for a strategy.
-
-    - Tags give the context of the strategy and its life cycle for the users
-      and the development team
-
-    - Tags are shown in the strategy explorer and are a sorting criteria
-      for displaying strategies to the user: live > beta > alpha > prototype
-
-    - Some strategy functionality e.g. displaying the risk metrics
-      and additional disclaimer depends on the tags
-    """
-
-    #: Testing strategy in forward-testing
-    alpha = "alpha"
-
-    #: Users can deposit
-    beta = "beta"
-
-    #: The strategy is expected to make profit and has enough history to show this
-    live = "live"
-
-    #: The strategy is not expected to make profit, but is only running as an infrastructure test
-    internal_testing = "internal_testing"
-
 
 
 @dataclass

--- a/tradeexecutor/strategy/summary.py
+++ b/tradeexecutor/strategy/summary.py
@@ -2,12 +2,13 @@
 import datetime
 import enum
 from dataclasses import dataclass, field
-from typing import Optional, List, Tuple, Dict, Any
+from typing import Optional, List, Tuple, Dict, Any, Set
 
 from dataclasses_json import dataclass_json
 
 from tradeexecutor.state.metadata import OnChainData
 from tradeexecutor.state.types import USDollarAmount, UnixTimestamp, Percent
+from tradeexecutor.strategy.strategy_module import StrategyTag
 
 
 class KeyMetricKind(enum.Enum):
@@ -301,6 +302,12 @@ class StrategySummary:
     #: See `Metadata.badges` for description.
     #:
     badges: List[str] = field(default_factory=list)
+
+    #: List of strategy tile badges
+    #:
+    #: See `Metadata.tags` for description.
+    #:
+    tags: Set[StrategyTag] = field(default_factory=set)
 
 
 #: Help links for different metrics

--- a/tradeexecutor/strategy/summary.py
+++ b/tradeexecutor/strategy/summary.py
@@ -8,7 +8,7 @@ from dataclasses_json import dataclass_json
 
 from tradeexecutor.state.metadata import OnChainData
 from tradeexecutor.state.types import USDollarAmount, UnixTimestamp, Percent
-from tradeexecutor.strategy.strategy_module import StrategyTag
+from tradeexecutor.strategy.tag import StrategyTag
 
 
 class KeyMetricKind(enum.Enum):

--- a/tradeexecutor/strategy/tag.py
+++ b/tradeexecutor/strategy/tag.py
@@ -1,0 +1,29 @@
+"""Tagging live strategies."""
+
+import enum
+
+
+class StrategyTag(enum.Enum):
+    """Tags we can for a strategy.
+
+    - Tags give the context of the strategy and its life cycle for the users
+      and the development team
+
+    - Tags are shown in the strategy explorer and are a sorting criteria
+      for displaying strategies to the user: live > beta > alpha > prototype
+
+    - Some strategy functionality e.g. displaying the risk metrics
+      and additional disclaimer depends on the tags
+    """
+
+    #: Testing strategy in forward-testing
+    alpha = "alpha"
+
+    #: Users can deposit
+    beta = "beta"
+
+    #: The strategy is expected to make profit and has enough history to show this
+    live = "live"
+
+    #: The strategy is not expected to make profit, but is only running as an infrastructure test
+    internal_testing = "internal_testing"

--- a/tradeexecutor/webhook/api.py
+++ b/tradeexecutor/webhook/api.py
@@ -72,6 +72,7 @@ def web_metadata(request: Request):
         backtest_available=metadata.has_backtest_data(),
         crashed_at=run_state.crashed_at,
         badges=metadata.badges,
+        tags=metadata.tags,
     )
 
     # Catch NaN's and other data JavaScript cannot eat


### PR DESCRIPTION
- Add `StrategyTag` to describe what kind of tags strategy module can have and what's the purpose of the tags
- Expose tags all the way to the metadata endpoint