### PR TITLE
Long short metrics

### DIFF
--- a/tradeexecutor/analysis/trade_analyser.py
+++ b/tradeexecutor/analysis/trade_analyser.py
@@ -319,6 +319,7 @@ class TradeSummary:
             "Max drawdown": "https://tradingstrategy.ai/glossary/maximum-drawdown",
         }
 
+    @staticmethod
     def format_summary_dataframe(df: pd.DataFrame) -> pd.DataFrame:
         """Format the summary dataframe for display in Jupyter notebook with clickable links.
         

--- a/tradeexecutor/analysis/trade_analyser.py
+++ b/tradeexecutor/analysis/trade_analyser.py
@@ -893,6 +893,7 @@ class TradeAnalysis:
         self,
         time_bucket: Optional[TimeBucket] = None,
         state = None,
+        urls = False,
     ) -> pd.DataFrame:
         """Calculate some statistics how our trades went. This returns a DataFrame with 3 separate columns for overall, long and short.
         
@@ -903,6 +904,9 @@ class TradeAnalysis:
 
         :param state:
             Optional, should be specified if user would like to see advanced statistics such as sharpe ratio, sortino ratio, etc.
+
+        :param urls:
+            Optional, if True, include an extra column for the urls for each row that link to the relevant glorssary documentation.
 
         :return:
             DataFrame with all the stats for overall, long and short.
@@ -942,7 +946,10 @@ class TradeAnalysis:
         all_stats.loc['Annualised return %', 'Long'] = format_value_for_summary_table(as_percent(calculate_annualised_return(profit_long_pct, duration)))
         all_stats.loc['Annualised return %', 'Short'] = format_value_for_summary_table(as_percent(calculate_annualised_return(profit_short_pct, duration)))
 
-        return TradeSummary.format_summary_dataframe(all_stats)
+        if urls:
+            all_stats['help_links'] = [TradeSummary.help_links()[key] for key in all_stats.index]
+
+        return all_stats
 
     def render_summary_statistics_side_by_side(self, time_bucket: Optional[TimeBucket] = None, state = None) -> HTML:
         """Render summary statistics as a JSON table.
@@ -956,10 +963,9 @@ class TradeAnalysis:
         :return:
             Returns a similar table to `calcualate_all_summary_stats_by_side`, but make it makes row headings clickable, directing user to relevant glossary link and, in this case, returns ``HTML`` object instaed of a pandas DataFrame.
         """
-        all_stats = self.calculate_summary_statistics(time_bucket, state)
-        all_stats['help_links'] = [TradeSummary.help_links()[key] for key in all_stats.index]
+        all_stats = self.calculate_all_summary_stats_by_side(time_bucket, state)
 
-        return all_stats
+        return TradeSummary.format_summary_dataframe(all_stats)
 
     @staticmethod
     def get_capital_tied_at_open(position) -> Percent | None:

--- a/tradeexecutor/analysis/trade_analyser.py
+++ b/tradeexecutor/analysis/trade_analyser.py
@@ -249,11 +249,11 @@ class TradeSummary:
                 else formatter(0)
             )
 
-        add_prop(self.average_trade, 'Average position:', as_percent)
-        add_prop(self.median_trade, 'Median position:', as_percent)
+        add_prop(self.average_trade, 'Average position', as_percent)
+        add_prop(self.median_trade, 'Median position', as_percent)
         add_prop(self.max_pos_cons, 'Most consecutive wins', as_integer)
         add_prop(self.max_neg_cons, 'Most consecutive losses', as_integer)
-        add_prop(self.max_realised_loss, 'Biggest realized risk', as_percent)
+        add_prop(self.max_realised_loss, 'Biggest realised risk', as_percent)
         add_prop(self.avg_realised_risk, 'Avg realised risk', as_percent)
         add_prop(self.max_pullback, 'Max pullback of total capital', as_percent)
         add_prop(self.max_loss_risk, 'Max loss risk at opening of position', as_percent)
@@ -269,6 +269,58 @@ class TradeSummary:
         return df
     
     @staticmethod
+    def help_links() -> dict[str, str]:
+        return {
+            "Trading period length": None,
+            "Return %": "https://tradingstrategy.ai/glossary/aggregate-return",
+            "Annualised return %": None,
+            "Cash at start": None,
+            "Value at end": None,
+            "Trade volume": "https://tradingstrategy.ai/glossary/volume",
+            "Position win percent": "https://tradingstrategy.ai/glossary/position",
+            "Total positions": "https://tradingstrategy.ai/glossary/position",
+            "Won positions": "https://tradingstrategy.ai/glossary/position",
+            "Lost positions": "https://tradingstrategy.ai/glossary/position",
+            "Stop losses triggered": "https://tradingstrategy.ai/glossary/stop-loss",
+            "Stop loss % of all": "https://tradingstrategy.ai/glossary/stop-loss",
+            "Stop loss % of lost": "https://tradingstrategy.ai/glossary/stop-loss",
+            "Winning stop losses": "https://tradingstrategy.ai/glossary/stop-loss",
+            "Winning stop losses percent": "https://tradingstrategy.ai/glossary/stop-loss",
+            "Losing stop losses": "https://tradingstrategy.ai/glossary/stop-loss",
+            "Losing stop losses percent": "https://tradingstrategy.ai/glossary/stop-loss",
+            "Take profits triggered": "https://tradingstrategy.ai/glossary/take-profit",
+            "Take profit % of all": "https://tradingstrategy.ai/glossary/take-profit",
+            "Take profit % of won": "https://tradingstrategy.ai/glossary/take-profit",
+            "Zero profit positions": "https://tradingstrategy.ai/glossary/position",
+            "Positions open at the end": "https://tradingstrategy.ai/glossary/open-position",
+            "Realised profit and loss": "https://tradingstrategy.ai/glossary/realised-profit-and-loss",
+            "Unrealised profit and loss": "https://tradingstrategy.ai/glossary/unrealised-profit-and-loss",
+            "Portfolio unrealised value": "https://tradingstrategy.ai/glossary/unrealised-profit-and-loss",
+            "Extra returns on lending pool interest": "https://tradingstrategy.ai/glossary/lending-pool",
+            "Cash left at the end": None,
+            "Average winning position profit %": None,
+            "Average losing position loss %": None,
+            "Biggest winning position %": None,
+            "Biggest losing position %": None,
+            "Average duration of winning positions": None,
+            "Average duration of losing positions": None,
+            "Average bars of winning positions": None,
+            "Average bars of losing positions": None,
+            "LP fees paid": "https://tradingstrategy.ai/glossary/liquidity-provider",
+            "LP fees paid % of volume": "https://tradingstrategy.ai/glossary/liquidity-provider",
+            "Average position": "https://tradingstrategy.ai/glossary/mean",
+            "Median position": "https://tradingstrategy.ai/glossary/median",
+            "Most consecutive wins": None,
+            "Most consecutive losses": None,
+            "Biggest realised risk": "https://tradingstrategy.ai/glossary/realised-risk",
+            "Avg realised risk": "https://tradingstrategy.ai/glossary/realised-risk",
+            "Max pullback of total capital": "https://tradingstrategy.ai/glossary/maximum-pullback",
+            "Max loss risk at opening of position": None,
+            "Max drawdown": "https://tradingstrategy.ai/glossary/maximum-drawdown",
+        }
+
+    
+    @staticmethod
     def format_summary_dataframe(df: pd.DataFrame) -> pd.DataFrame:
         """Format the summary dataframe for display in Jupyter notebook with clickable links.
         
@@ -278,46 +330,7 @@ class TradeSummary:
         :return:
             Formatted dataframe with clickable links.
         """
-        headings = [
-            ("Trading period length", None),
-            ("Return %", "https://tradingstrategy.ai/glossary/aggregate-return"),
-            ("Annualised return %", None),
-            ("Cash at start", None),
-            ("Value at end", None),
-            ("Trade volume", "https://tradingstrategy.ai/glossary/volume"),
-
-            ("Position win percent", "https://tradingstrategy.ai/glossary/position"),
-            ("Total positions", "https://tradingstrategy.ai/glossary/position"),
-            ("Won positions", "https://tradingstrategy.ai/glossary/position"),
-            ("Lost positions", "https://tradingstrategy.ai/glossary/position"),
-
-            ("Stop losses triggered", "https://tradingstrategy.ai/glossary/stop-loss"),
-            ("Stop loss % of all", "https://tradingstrategy.ai/glossary/stop-loss"),
-            ("Stop loss % of lost", "https://tradingstrategy.ai/glossary/stop-loss"),
-            ("Winning stop losses", "https://tradingstrategy.ai/glossary/stop-loss"),
-            ("Winning stop losses percent", "https://tradingstrategy.ai/glossary/stop-loss"),
-            ("Losing stop losses", "https://tradingstrategy.ai/glossary/stop-loss"),
-            ("Losing stop losses percent", "https://tradingstrategy.ai/glossary/stop-loss"),
-
-            ("Take profits triggered", "https://tradingstrategy.ai/glossary/take-profit"),
-            ("Take profit % of all", "https://tradingstrategy.ai/glossary/take-profit"),
-            ("Take profit % of won", "https://tradingstrategy.ai/glossary/take-profit"),
-
-            ("Zero profit positions", "https://tradingstrategy.ai/glossary/position"),
-            ("Positions open at the end", "https://tradingstrategy.ai/glossary/open-position"),
-            ("Realised profit and loss", "https://tradingstrategy.ai/glossary/realised-profit-and-loss"),
-            ("Unrealised profit and loss", "https://tradingstrategy.ai/glossary/unrealised-profit-and-loss"),
-            ("Portfolio unrealised value", "https://tradingstrategy.ai/glossary/unrealised-profit-and-loss"),
-            ("Extra returns on lending pool interest", "https://tradingstrategy.ai/glossary/lending-pool"),
-            ("Cash left at the end", None),
-
-            ("Average winning position profit %", None),
-            ("Average losing position loss %", None),
-            ("Biggest winning position %", None),
-            ("Biggest losing position %", None),
-            ("Average duration of winning positions", None),
-            ("Average duration of losing positions", None),
-        ]
+        
         
         if "Average bars of winning positions" in df.index:
             assert "Average bars of losing positions" in df.index, "Average bars of losing positions not found in dataframe"
@@ -438,8 +451,8 @@ class TradeSummary:
         df4 = create_summary_table(data4, ["Stop losses", "Take profits"], "Position Exits")
         
         data5 = {
-            'Biggest realized risk': as_percent(self.max_loss_risk),
-            'Average realized risk': as_percent(self.avg_realised_risk),
+            'Biggest realised risk': as_percent(self.max_loss_risk),
+            'Average realised risk': as_percent(self.avg_realised_risk),
             'Max pullback of capital': as_percent(self.max_pullback),
             'Sharpe Ratio': as_decimal(self.sharpe_ratio),
             'Sortino Ratio': as_decimal(self.sortino_ratio),
@@ -959,6 +972,8 @@ class TradeAnalysis:
 
         if format_headings:
             return TradeSummary.format_summary_dataframe(all_stats)
+
+        all_stats['help_links'] = [TradeSummary.help_links()[key] for key in all_stats.index]
 
         return all_stats
 

--- a/tradeexecutor/statistics/key_metric.py
+++ b/tradeexecutor/statistics/key_metric.py
@@ -298,6 +298,9 @@ def calculate_key_metrics(
         help_link=KeyMetricKind.trades_last_week.get_help_link(),
     )
 
+    long_short_table = calculate_long_short_metrics(source_state, source)
+    yield from (row for row in long_short_table.rows.values())
+
 
 class StatisticsTable:
       
@@ -329,7 +332,8 @@ class StatisticsTable:
 
 
 def calculate_long_short_metrics(
-    source_state: State
+    source_state: State,
+    source: KeyMetricSource,
 ) -> StatisticsTable:
     """Calculate long/short statistics for the summary tile.
 
@@ -338,7 +342,7 @@ def calculate_long_short_metrics(
     :param time_window: How long we look back for the summary statistics
     :param now_: Override current time for unit testing.
     :param legacy_workarounds: Skip some calculations on old data, because data is missing.
-
+    :return: Summary statistics for all, long, and short positions
     """
 
     analysis = build_trade_analysis(source_state.portfolio)
@@ -377,8 +381,6 @@ def calculate_long_short_metrics(
     biggest_losing_position_percent = summary.loc['Biggest losing position %']
     average_duration_of_winning_positions = summary.loc['Average duration of winning positions']
     average_duration_of_losing_positions = summary.loc['Average duration of losing positions']
-    average_bars_of_winning_positions = summary.loc['Average bars of winning positions']
-    average_bars_of_losing_positions = summary.loc['Average bars of losing positions']
     lp_fees_paid = summary.loc['LP fees paid']
     lp_fees_paid_percent_of_volume = summary.loc['LP fees paid % of volume']
     average_position = summary.loc['Average position']
@@ -391,246 +393,296 @@ def calculate_long_short_metrics(
     max_loss_risk_at_opening_of_position = summary.loc['Max loss risk at opening of position']
     max_drawdown = summary.loc['Max drawdown']
 
-    help_links = summary['help_links']
-
     table = StatisticsTable(
         columns=["All", "Long", "Short"],
+        created_at=source_state.created_at,
+        source=source,
         rows={
             KeyMetricKind.trading_period_length: KeyMetric(
                 kind=KeyMetricKind.trading_period_length,
                 value={"All": trading_period_length[0], "Long": trading_period_length[1], "Short": trading_period_length[2]},
                 help_link=trading_period_length[3],
+                source=source_state,
             ),
             KeyMetricKind.return_percent: KeyMetric(
                 kind=KeyMetricKind.return_percent,
                 value={"All": return_percent[0], "Long": return_percent[1], "Short": return_percent[2]},
                 help_link=return_percent[3],
+                source=source_state,
             ),
             KeyMetricKind.annualised_return_percent: KeyMetric(
                 kind=KeyMetricKind.annualised_return_percent,
                 value={"All": annualised_return_percent[0], "Long": annualised_return_percent[1], "Short": annualised_return_percent[2]},
                 help_link=annualised_return_percent[3],
+                source=source_state,
             ),
             KeyMetricKind.cash_at_start: KeyMetric(
                 kind=KeyMetricKind.cash_at_start,
                 value={"All": cash_at_start[0], "Long": cash_at_start[1], "Short": cash_at_start[2]},
                 help_link=cash_at_start[3],
+                source=source_state,
             ),
             KeyMetricKind.value_at_end: KeyMetric(
                 kind=KeyMetricKind.value_at_end,
                 value={"All": value_at_end[0], "Long": value_at_end[1], "Short": value_at_end[2]},
                 help_link=value_at_end[3],
+                source=source_state,
             ),
             KeyMetricKind.trade_volume: KeyMetric(
                 kind=KeyMetricKind.trade_volume,
                 value={"All": trade_volume[0], "Long": trade_volume[1], "Short": trade_volume[2]},
                 help_link=trade_volume[3],
+                source=source_state,
             ),
             KeyMetricKind.position_win_percent: KeyMetric(
                 kind=KeyMetricKind.position_win_percent,
                 value={"All": position_win_percent[0], "Long": position_win_percent[1], "Short": position_win_percent[2]},
                 help_link=position_win_percent[3],
+                source=source_state,
             ),
             KeyMetricKind.total_positions: KeyMetric(
                 kind=KeyMetricKind.total_positions,
                 value={"All": total_positions[0], "Long": total_positions[1], "Short": total_positions[2]},
                 help_link=total_positions[3],
+                source=source_state,
             ),
             KeyMetricKind.won_positions: KeyMetric(
                 kind=KeyMetricKind.won_positions,
                 value={"All": won_positions[0], "Long": won_positions[1], "Short": won_positions[2]},
                 help_link=won_positions[3],
+                source=source_state,
             ),
             KeyMetricKind.lost_positions: KeyMetric(
                 kind=KeyMetricKind.lost_positions,
                 value={"All": lost_positions[0], "Long": lost_positions[1], "Short": lost_positions[2]},
                 help_link=lost_positions[3],
+                source=source_state,
             ),
             KeyMetricKind.stop_losses_triggered: KeyMetric(
                 kind=KeyMetricKind.stop_losses_triggered,
                 value={"All": stop_losses_triggered[0], "Long": stop_losses_triggered[1], "Short": stop_losses_triggered[2]},
                 help_link=stop_losses_triggered[3],
+                source=source_state,
             ),
             KeyMetricKind.stop_loss_percent_of_all: KeyMetric(
                 kind=KeyMetricKind.stop_loss_percent_of_all,
                 value={"All": stop_loss_percent_of_all[0], "Long": stop_loss_percent_of_all[1], "Short": stop_loss_percent_of_all[2]},
                 help_link=stop_loss_percent_of_all[3],
+                source=source_state,
             ),
             KeyMetricKind.stop_loss_percent_of_lost: KeyMetric(
                 kind=KeyMetricKind.stop_loss_percent_of_lost,
                 value={"All": stop_loss_percent_of_lost[0], "Long": stop_loss_percent_of_lost[1], "Short": stop_loss_percent_of_lost[2]},
                 help_link=stop_loss_percent_of_lost[3],
+                source=source_state,
             ),
             KeyMetricKind.winning_stop_losses: KeyMetric(
                 kind=KeyMetricKind.winning_stop_losses,
                 value={"All": winning_stop_losses[0], "Long": winning_stop_losses[1], "Short": winning_stop_losses[2]},
                 help_link=winning_stop_losses[3],
+                source=source_state,
             ),
             KeyMetricKind.winning_stop_losses_percent: KeyMetric(
                 kind=KeyMetricKind.winning_stop_losses_percent,
                 value={"All": winning_stop_losses_percent[0], "Long": winning_stop_losses_percent[1], "Short": winning_stop_losses_percent[2]},
                 help_link=winning_stop_losses_percent[3],
+                source=source_state,
             ),
             KeyMetricKind.losing_stop_losses: KeyMetric(
                 kind=KeyMetricKind.losing_stop_losses,
                 value={"All": losing_stop_losses[0], "Long": losing_stop_losses[1], "Short": losing_stop_losses[2]},
                 help_link=losing_stop_losses[3],
+                source=source_state,
             ),
             KeyMetricKind.losing_stop_losses_percent: KeyMetric(
                 kind=KeyMetricKind.losing_stop_losses_percent,
                 value={"All": losing_stop_losses_percent[0], "Long": losing_stop_losses_percent[1], "Short": losing_stop_losses_percent[2]},
                 help_link=losing_stop_losses_percent[3],
+                source=source_state,
             ),
             KeyMetricKind.take_profits_triggered: KeyMetric(
                 kind=KeyMetricKind.take_profits_triggered,
                 value={"All": take_profits_triggered[0], "Long": take_profits_triggered[1], "Short": take_profits_triggered[2]},
                 help_link=take_profits_triggered[3],
+                source=source_state,
             ),
             KeyMetricKind.take_profit_percent_of_all: KeyMetric(
                 kind=KeyMetricKind.take_profit_percent_of_all,
                 value={"All": take_profit_percent_of_all[0], "Long": take_profit_percent_of_all[1], "Short": take_profit_percent_of_all[2]},
                 help_link=take_profit_percent_of_all[3],
+                source=source_state,
             ),
             KeyMetricKind.take_profit_percent_of_won: KeyMetric(
                 kind=KeyMetricKind.take_profit_percent_of_won,
                 value={"All": take_profit_percent_of_won[0], "Long": take_profit_percent_of_won[1], "Short": take_profit_percent_of_won[2]},
                 help_link=take_profit_percent_of_won[3],
+                source=source_state,
             ),
             KeyMetricKind.zero_profit_positions: KeyMetric(
                 kind=KeyMetricKind.zero_profit_positions,
                 value={"All": zero_profit_positions[0], "Long": zero_profit_positions[1], "Short": zero_profit_positions[2]},
                 help_link=zero_profit_positions[3],
+                source=source_state,
             ),
             KeyMetricKind.positions_open_at_the_end: KeyMetric(
                 kind=KeyMetricKind.positions_open_at_the_end,
                 value={"All": positions_open_at_the_end[0], "Long": positions_open_at_the_end[1], "Short": positions_open_at_the_end[2]},
                 help_link=positions_open_at_the_end[3],
+                source=source_state,
             ),
             KeyMetricKind.realised_profit_and_loss: KeyMetric(
                 kind=KeyMetricKind.realised_profit_and_loss,
                 value={"All": realised_profit_and_loss[0], "Long": realised_profit_and_loss[1], "Short": realised_profit_and_loss[2]},
                 help_link=realised_profit_and_loss[3],
+                source=source_state,
             ),
             KeyMetricKind.unrealised_profit_and_loss: KeyMetric(
                 kind=KeyMetricKind.unrealised_profit_and_loss,
                 value={"All": unrealised_profit_and_loss[0], "Long": unrealised_profit_and_loss[1], "Short": unrealised_profit_and_loss[2]},
                 help_link=unrealised_profit_and_loss[3],
+                source=source_state,
             ),
             KeyMetricKind.portfolio_unrealised_value: KeyMetric(
                 kind=KeyMetricKind.portfolio_unrealised_value,
                 value={"All": portfolio_unrealised_value[0], "Long": portfolio_unrealised_value[1], "Short": portfolio_unrealised_value[2]},
                 help_link=portfolio_unrealised_value[3],
+                source=source_state,
             ),
             KeyMetricKind.extra_returns_on_lending_pool_interest: KeyMetric(
                 kind=KeyMetricKind.extra_returns_on_lending_pool_interest,
                 value={"All": extra_returns_on_lending_pool_interest[0], "Long": extra_returns_on_lending_pool_interest[1], "Short": extra_returns_on_lending_pool_interest[2]},
                 help_link=extra_returns_on_lending_pool_interest[3],
+                source=source_state,
             ),
             KeyMetricKind.cash_left_at_the_end: KeyMetric(
                 kind=KeyMetricKind.cash_left_at_the_end,
                 value={"All": cash_left_at_the_end[0], "Long": cash_left_at_the_end[1], "Short": cash_left_at_the_end[2]},
                 help_link=cash_left_at_the_end[3],
+                source=source_state,
             ),
             KeyMetricKind.average_winning_position_profit_percent: KeyMetric(
                 kind=KeyMetricKind.average_winning_position_profit_percent,
                 value={"All": average_winning_position_profit_percent[0], "Long": average_winning_position_profit_percent[1], "Short": average_winning_position_profit_percent[2]},
                 help_link=average_winning_position_profit_percent[3],
+                source=source_state,
             ),
             KeyMetricKind.average_losing_position_loss_percent: KeyMetric(
                 kind=KeyMetricKind.average_losing_position_loss_percent,
                 value={"All": average_losing_position_loss_percent[0], "Long": average_losing_position_loss_percent[1], "Short": average_losing_position_loss_percent[2]},
                 help_link=average_losing_position_loss_percent[3],
+                source=source_state,
             ),
             KeyMetricKind.biggest_winning_position_percent: KeyMetric(
                 kind=KeyMetricKind.biggest_winning_position_percent,
                 value={"All": biggest_winning_position_percent[0], "Long": biggest_winning_position_percent[1], "Short": biggest_winning_position_percent[2]},
                 help_link=biggest_winning_position_percent[3],
+                source=source_state,
             ),
             KeyMetricKind.biggest_losing_position_percent: KeyMetric(
                 kind=KeyMetricKind.biggest_losing_position_percent,
                 value={"All": biggest_losing_position_percent[0], "Long": biggest_losing_position_percent[1], "Short": biggest_losing_position_percent[2]},
                 help_link=biggest_losing_position_percent[3],
+                source=source_state,
             ),
             KeyMetricKind.average_duration_of_winning_positions: KeyMetric(
                 kind=KeyMetricKind.average_duration_of_winning_positions,
                 value={"All": average_duration_of_winning_positions[0], "Long": average_duration_of_winning_positions[1], "Short": average_duration_of_winning_positions[2]},
                 help_link=average_duration_of_winning_positions[3],
+                source=source_state,
             ),
             KeyMetricKind.average_duration_of_losing_positions: KeyMetric(
                 kind=KeyMetricKind.average_duration_of_losing_positions,
                 value={"All": average_duration_of_losing_positions[0], "Long": average_duration_of_losing_positions[1], "Short": average_duration_of_losing_positions[2]},
                 help_link=average_duration_of_losing_positions[3],
-            ),
-            KeyMetricKind.average_bars_of_winning_positions: KeyMetric(
-                kind=KeyMetricKind.average_bars_of_winning_positions,
-                value={"All": average_bars_of_winning_positions[0], "Long": average_bars_of_winning_positions[1], "Short": average_bars_of_winning_positions[2]},
-                help_link=average_bars_of_winning_positions[3],
-            ),
-            KeyMetricKind.average_bars_of_losing_positions: KeyMetric(
-                kind=KeyMetricKind.average_bars_of_losing_positions,
-                value={"All": average_bars_of_losing_positions[0], "Long": average_bars_of_losing_positions[1], "Short": average_bars_of_losing_positions[2]},
-                help_link=average_bars_of_losing_positions[3],
+                source=source_state,
             ),
             KeyMetricKind.lp_fees_paid: KeyMetric(
                 kind=KeyMetricKind.lp_fees_paid,
                 value={"All": lp_fees_paid[0], "Long": lp_fees_paid[1], "Short": lp_fees_paid[2]},
                 help_link=lp_fees_paid[3],
+                source=source_state,
             ),
             KeyMetricKind.lp_fees_paid_percent_of_volume: KeyMetric(
                 kind=KeyMetricKind.lp_fees_paid_percent_of_volume,
                 value={"All": lp_fees_paid_percent_of_volume[0], "Long": lp_fees_paid_percent_of_volume[1], "Short": lp_fees_paid_percent_of_volume[2]},
                 help_link=lp_fees_paid_percent_of_volume[3],
+                source=source_state,
             ),
             KeyMetricKind.average_position: KeyMetric(
                 kind=KeyMetricKind.average_position,
                 value={"All": average_position[0], "Long": average_position[1], "Short": average_position[2]},
                 help_link=average_position[3],
+                source=source_state,
             ),
             KeyMetricKind.median_position: KeyMetric(
                 kind=KeyMetricKind.median_position,
                 value={"All": median_position[0], "Long": median_position[1], "Short": median_position[2]},
                 help_link=median_position[3],
+                source=source_state,
             ),
             KeyMetricKind.most_consecutive_wins: KeyMetric(
                 kind=KeyMetricKind.most_consecutive_wins,
                 value={"All": most_consecutive_wins[0], "Long": most_consecutive_wins[1], "Short": most_consecutive_wins[2]},
                 help_link=most_consecutive_wins[3],
+                source=source_state,
             ),
             KeyMetricKind.most_consecutive_losses: KeyMetric(
                 kind=KeyMetricKind.most_consecutive_losses,
                 value={"All": most_consecutive_losses[0], "Long": most_consecutive_losses[1], "Short": most_consecutive_losses[2]},
                 help_link=most_consecutive_losses[3],
+                source=source_state,
             ),
             KeyMetricKind.biggest_realised_risk: KeyMetric(
                 kind=KeyMetricKind.biggest_realised_risk,
                 value={"All": biggest_realised_risk[0], "Long": biggest_realised_risk[1], "Short": biggest_realised_risk[2]},
                 help_link=biggest_realised_risk[3],
+                source=source_state,
             ),
             KeyMetricKind.avg_realised_risk: KeyMetric(
                 kind=KeyMetricKind.avg_realised_risk,
                 value={"All": avg_realised_risk[0], "Long": avg_realised_risk[1], "Short": avg_realised_risk[2]},
                 help_link=avg_realised_risk[3],
+                source=source_state,
             ),
             KeyMetricKind.max_pullback_of_total_capital: KeyMetric(
                 kind=KeyMetricKind.max_pullback_of_total_capital,
                 value={"All": max_pullback_of_total_capital[0], "Long": max_pullback_of_total_capital[1], "Short": max_pullback_of_total_capital[2]},
                 help_link=max_pullback_of_total_capital[3],
+                source=source_state,
             ),
             KeyMetricKind.max_loss_risk_at_opening_of_position: KeyMetric(
                 kind=KeyMetricKind.max_loss_risk_at_opening_of_position,
                 value={"All": max_loss_risk_at_opening_of_position[0], "Long": max_loss_risk_at_opening_of_position[1], "Short": max_loss_risk_at_opening_of_position[2]},
                 help_link=max_loss_risk_at_opening_of_position[3],
+                source=source_state,
             ),
             KeyMetricKind.max_drawdown: KeyMetric(
                 kind=KeyMetricKind.max_drawdown,
                 value={"All": max_drawdown[0], "Long": max_drawdown[1], "Short": max_drawdown[2]},
                 help_link=max_drawdown[3],
+                source=source_state,
             ),
         }
     )
 
-    # add state to each row
+    if 'Average bars of winning positions' in summary.index:
+        average_bars_of_winning_positions = summary.loc['Average bars of winning positions']
+        average_bars_of_losing_positions = summary.loc['Average bars of losing positions']
+
+        table.rows[KeyMetricKind.average_bars_of_winning_positions] = KeyMetric(
+            kind=KeyMetricKind.average_bars_of_winning_positions,
+            value={"All": average_bars_of_winning_positions[0], "Long": average_bars_of_winning_positions[1], "Short": average_bars_of_winning_positions[2]},
+            help_link=average_bars_of_winning_positions[3],
+        )
+        table.rows[KeyMetricKind.average_bars_of_losing_positions] = KeyMetric(
+            kind=KeyMetricKind.average_bars_of_losing_positions,
+            value={"All": average_bars_of_losing_positions[0], "Long": average_bars_of_losing_positions[1], "Short": average_bars_of_losing_positions[2]},
+            help_link=average_bars_of_losing_positions[3],
+        )
+
     for row in table.rows:
         row.source = source_state
         row.calculation_window_start_at = source_state.created_at
         row.calculation_window_end_at = datetime.datetime.utcnow()
+
+    return table

--- a/tradeexecutor/statistics/key_metric.py
+++ b/tradeexecutor/statistics/key_metric.py
@@ -13,7 +13,7 @@ from tradeexecutor.state.state import State
 from tradeexecutor.state.types import Percent
 from tradeexecutor.strategy.summary import KeyMetric, KeyMetricKind, KeyMetricSource, KeyMetricCalculationMethod
 from tradeexecutor.visual.equity_curve import calculate_size_relative_realised_trading_returns
-from tradeexecutor.analysis.trade_analyser import build_trade_analysis, TradeSummary
+from tradeexecutor.statistics.statistics_table import get_data_source_and_calculation_window
 
 
 def calculate_sharpe(returns: pd.Series, periods=365) -> float:
@@ -187,26 +187,8 @@ def calculate_key_metrics(
 
     assert isinstance(live_state, State)
 
-    source_state = None
-    source = None
-    calculation_window_start_at = None
-    calculation_window_end_at = None
 
-    # Live history is calculated from the
-    live_history = live_state.portfolio.get_trading_history_duration()
-    if live_history is not None and live_history >= required_history:
-        source_state = live_state
-        source = KeyMetricSource.live_trading
-        calculation_window_start_at = source_state.created_at
-        calculation_window_end_at = datetime.datetime.utcnow()
-    else:
-        if backtested_state:
-            if backtested_state.portfolio.get_trading_history_duration():
-                source_state = backtested_state
-                source = KeyMetricSource.backtesting
-                first_trade, last_trade = source_state.portfolio.get_first_and_last_executed_trade()
-                calculation_window_start_at = first_trade.executed_at
-                calculation_window_end_at = last_trade.executed_at
+    source_state, source, calculation_window_start_at, calculation_window_end_at = get_data_source_and_calculation_window(live_state, backtested_state, required_history)
 
     if source_state:
 
@@ -297,138 +279,3 @@ def calculate_key_metrics(
         calculation_method=KeyMetricCalculationMethod.latest_value,
         help_link=KeyMetricKind.trades_last_week.get_help_link(),
     )
-
-    long_short_table = serialise_summary_statistics_as_json_table(source_state, source)
-    yield from (row for row in long_short_table.rows.values())
-
-
-class StatisticsTable:
-      
-
-    def __init__(
-        self,
-        columns: list[str],
-        rows: dict[KeyMetricKind, KeyMetric], 
-        created_at: datetime.datetime, 
-        source: KeyMetricSource, 
-        calculation_window_start_at: datetime.datetime | None = None, 
-        calculation_window_end_at: datetime.timedelta | None = None
-    ):
-        """Create a new statistics table.
-        
-        :param columns: The columns of the table.
-        :param rows: The rows of the table.
-        :param created_at: The time at which the table was created.
-        :param source: The source of the table. Can either be live trading or backtesting.
-        :param calculation_window_start_at: The start of the calculation window.
-        :param calculation_window_end_at: The end of the calculation window.
-        """
-        self.columns = columns
-        self.rows = rows
-        self.created_at = created_at
-        self.source = source
-        self.calculation_window_start_at = calculation_window_start_at
-        self.calculation_window_end_at = calculation_window_end_at        
-
-
-def serialise_summary_statistics_as_json_table(
-    source_state: State,
-    source: KeyMetricSource,
-) -> StatisticsTable:
-    """Calculate long/short statistics for the summary tile.
-
-    :param state: Strategy state from which we calculate the summary
-    :param execution_mode: If we need to skip calculations during backtesting.
-    :param time_window: How long we look back for the summary statistics
-    :param now_: Override current time for unit testing.
-    :param legacy_workarounds: Skip some calculations on old data, because data is missing.
-    :return: Summary statistics for all, long, and short positions
-    """
-
-    analysis = build_trade_analysis(source_state.portfolio)
-    summary = analysis.calculate_all_summary_stats_by_side(state=source_state, urls=True)  # TODO timebucket
-
-    key_metrics_map = {
-        KeyMetricKind.trading_period_length: 'Trading period length',
-        KeyMetricKind.return_percent: 'Return %',
-        KeyMetricKind.annualised_return_percent: 'Annualised return %',
-        KeyMetricKind.cash_at_start: 'Cash at start',
-        KeyMetricKind.value_at_end: 'Value at end',
-        KeyMetricKind.trade_volume: 'Trade volume',
-        KeyMetricKind.position_win_percent: 'Position win percent',
-        KeyMetricKind.total_positions: 'Total positions',
-        KeyMetricKind.won_positions: 'Won positions',
-        KeyMetricKind.lost_positions: 'Lost positions',
-        KeyMetricKind.stop_losses_triggered: 'Stop losses triggered',
-        KeyMetricKind.stop_loss_percent_of_all: 'Stop loss % of all',
-        KeyMetricKind.stop_loss_percent_of_lost: 'Stop loss % of lost',
-        KeyMetricKind.winning_stop_losses: 'Winning stop losses',
-        KeyMetricKind.winning_stop_losses_percent: 'Winning stop losses percent',
-        KeyMetricKind.losing_stop_losses: 'Losing stop losses',
-        KeyMetricKind.losing_stop_losses_percent: 'Losing stop losses percent',
-        KeyMetricKind.take_profits_triggered: 'Take profits triggered',
-        KeyMetricKind.take_profit_percent_of_all: 'Take profit % of all',
-        KeyMetricKind.take_profit_percent_of_won: 'Take profit % of won',
-        KeyMetricKind.zero_profit_positions: 'Zero profit positions',
-        KeyMetricKind.positions_open_at_the_end: 'Positions open at the end',
-        KeyMetricKind.realised_profit_and_loss: 'Realised profit and loss',
-        KeyMetricKind.unrealised_profit_and_loss: 'Unrealised profit and loss',
-        KeyMetricKind.portfolio_unrealised_value: 'Portfolio unrealised value',
-        KeyMetricKind.extra_returns_on_lending_pool_interest: 'Extra returns on lending pool interest',
-        KeyMetricKind.cash_left_at_the_end: 'Cash left at the end',
-        KeyMetricKind.average_winning_position_profit_percent: 'Average winning position profit %',
-        KeyMetricKind.average_losing_position_loss_percent: 'Average losing position loss %',
-        KeyMetricKind.biggest_winning_position_percent: 'Biggest winning position %',
-        KeyMetricKind.biggest_losing_position_percent: 'Biggest losing position %',
-        KeyMetricKind.average_duration_of_winning_positions: 'Average duration of winning positions',
-        KeyMetricKind.average_duration_of_losing_positions: 'Average duration of losing positions',
-        KeyMetricKind.lp_fees_paid: 'LP fees paid',
-        KeyMetricKind.lp_fees_paid_percent_of_volume: 'LP fees paid % of volume',
-        KeyMetricKind.average_position: 'Average position',
-        KeyMetricKind.median_position: 'Median position',
-        KeyMetricKind.most_consecutive_wins: 'Most consecutive wins',
-        KeyMetricKind.most_consecutive_losses: 'Most consecutive losses',
-        KeyMetricKind.biggest_realised_risk: 'Biggest realised risk',
-        KeyMetricKind.avg_realised_risk: 'Avg realised risk',
-        KeyMetricKind.max_pullback_of_total_capital: 'Max pullback of total capital',
-        KeyMetricKind.max_loss_risk_at_opening_of_position: 'Max loss risk at opening of position',
-        KeyMetricKind.max_drawdown: 'Max drawdown',
-    }
-
-    rows = {}
-    for key_metric_kind, summary_index in key_metrics_map.items():
-        if summary_index in summary.index:
-            metric_data = summary.loc[summary_index]
-
-            rows[key_metric_kind] = KeyMetric(
-                kind=key_metric_kind,
-                value={"All": metric_data[0], "Long": metric_data[1], "Short": metric_data[2]},
-                help_link=metric_data[3],
-                source=source_state,
-                calculation_window_start_at = source_state.created_at,
-                calculation_window_end_at = datetime.datetime.utcnow(),
-            )
-
-    if 'Average bars of winning positions' in summary.index:
-        average_bars_of_winning_positions = summary.loc['Average bars of winning positions']
-        average_bars_of_losing_positions = summary.loc['Average bars of losing positions']
-
-        rows[KeyMetricKind.average_bars_of_winning_positions] = KeyMetric(
-            kind=KeyMetricKind.average_bars_of_winning_positions,
-            value={"All": average_bars_of_winning_positions[0], "Long": average_bars_of_winning_positions[1], "Short": average_bars_of_winning_positions[2]},
-            help_link=average_bars_of_winning_positions[3],
-        )
-        rows[KeyMetricKind.average_bars_of_losing_positions] = KeyMetric(
-            kind=KeyMetricKind.average_bars_of_losing_positions,
-            value={"All": average_bars_of_losing_positions[0], "Long": average_bars_of_losing_positions[1], "Short": average_bars_of_losing_positions[2]},
-            help_link=average_bars_of_losing_positions[3],
-        )
-
-    table = StatisticsTable(
-        columns=["All", "Long", "Short"],
-        created_at=source_state.created_at,
-        source=source,
-        rows=rows,
-    )
-
-    return table

--- a/tradeexecutor/statistics/key_metric.py
+++ b/tradeexecutor/statistics/key_metric.py
@@ -13,6 +13,7 @@ from tradeexecutor.state.state import State
 from tradeexecutor.state.types import Percent
 from tradeexecutor.strategy.summary import KeyMetric, KeyMetricKind, KeyMetricSource, KeyMetricCalculationMethod
 from tradeexecutor.visual.equity_curve import calculate_size_relative_realised_trading_returns
+from tradeexecutor.analysis.trade_analyser import build_trade_analysis
 
 
 def calculate_sharpe(returns: pd.Series, periods=365) -> float:
@@ -297,3 +298,339 @@ def calculate_key_metrics(
         help_link=KeyMetricKind.trades_last_week.get_help_link(),
     )
 
+
+class StatisticsTable:
+      
+
+    def __init__(
+        self,
+        columns: list[str],
+        rows: dict[KeyMetricKind, KeyMetric], 
+        created_at: datetime.datetime, 
+        source: KeyMetricSource, 
+        calculation_window_start_at: datetime.datetime | None = None, 
+        calculation_window_end_at: datetime.timedelta | None = None
+    ):
+        """Create a new statistics table.
+        
+        :param columns: The columns of the table.
+        :param rows: The rows of the table.
+        :param created_at: The time at which the table was created.
+        :param source: The source of the table. Can either be live trading or backtesting.
+        :param calculation_window_start_at: The start of the calculation window.
+        :param calculation_window_end_at: The end of the calculation window.
+        """
+        self.columns = columns
+        self.rows = rows
+        self.created_at = created_at
+        self.source = source
+        self.calculation_window_start_at = calculation_window_start_at
+        self.calculation_window_end_at = calculation_window_end_at        
+
+
+def calculate_long_short_metrics(
+    source_state: State
+) -> StatisticsTable:
+    """Calculate long/short statistics for the summary tile.
+
+    :param state: Strategy state from which we calculate the summary
+    :param execution_mode: If we need to skip calculations during backtesting.
+    :param time_window: How long we look back for the summary statistics
+    :param now_: Override current time for unit testing.
+    :param legacy_workarounds: Skip some calculations on old data, because data is missing.
+
+    """
+
+    analysis = build_trade_analysis(source_state.portfolio)
+    summary = analysis.calculate_all_summary_stats_by_side(state=source_state, format_headings=False)  # TODO timebucket
+
+    trading_period_length = summary.loc['Trading period length']
+    return_percent = summary.loc['Return %']
+    annualised_return_percent = summary.loc['Annualised return %']
+    cash_at_start = summary.loc['Cash at start']
+    value_at_end = summary.loc['Value at end']
+    trade_volume = summary.loc['Trade volume']
+    position_win_percent = summary.loc['Position win percent']
+    total_positions = summary.loc['Total positions']
+    won_positions = summary.loc['Won positions']
+    lost_positions = summary.loc['Lost positions']
+    stop_losses_triggered = summary.loc['Stop losses triggered']
+    stop_loss_percent_of_all = summary.loc['Stop loss % of all']
+    stop_loss_percent_of_lost = summary.loc['Stop loss % of lost']
+    winning_stop_losses = summary.loc['Winning stop losses']
+    winning_stop_losses_percent = summary.loc['Winning stop losses percent']
+    losing_stop_losses = summary.loc['Losing stop losses']
+    losing_stop_losses_percent = summary.loc['Losing stop losses percent']
+    take_profits_triggered = summary.loc['Take profits triggered']
+    take_profit_percent_of_all = summary.loc['Take profit % of all']
+    take_profit_percent_of_won = summary.loc['Take profit % of won']
+    zero_profit_positions = summary.loc['Zero profit positions']
+    positions_open_at_the_end = summary.loc['Positions open at the end']
+    realised_profit_and_loss = summary.loc['Realised profit and loss']
+    unrealised_profit_and_loss = summary.loc['Unrealised profit and loss']
+    portfolio_unrealised_value = summary.loc['Portfolio unrealised value']
+    extra_returns_on_lending_pool_interest = summary.loc['Extra returns on lending pool interest']
+    cash_left_at_the_end = summary.loc['Cash left at the end']
+    average_winning_position_profit_percent = summary.loc['Average winning position profit %']
+    average_losing_position_loss_percent = summary.loc['Average losing position loss %']
+    biggest_winning_position_percent = summary.loc['Biggest winning position %']
+    biggest_losing_position_percent = summary.loc['Biggest losing position %']
+    average_duration_of_winning_positions = summary.loc['Average duration of winning positions']
+    average_duration_of_losing_positions = summary.loc['Average duration of losing positions']
+    average_bars_of_winning_positions = summary.loc['Average bars of winning positions']
+    average_bars_of_losing_positions = summary.loc['Average bars of losing positions']
+    lp_fees_paid = summary.loc['LP fees paid']
+    lp_fees_paid_percent_of_volume = summary.loc['LP fees paid % of volume']
+    average_position = summary.loc['Average position']
+    median_position = summary.loc['Median position']
+    most_consecutive_wins = summary.loc['Most consecutive wins']
+    most_consecutive_losses = summary.loc['Most consecutive losses']
+    biggest_realised_risk = summary.loc['Biggest realised risk']
+    avg_realised_risk = summary.loc['Avg realised risk']
+    max_pullback_of_total_capital = summary.loc['Max pullback of total capital']
+    max_loss_risk_at_opening_of_position = summary.loc['Max loss risk at opening of position']
+    max_drawdown = summary.loc['Max drawdown']
+
+    help_links = summary['help_links']
+
+    table = StatisticsTable(
+        columns=["All", "Long", "Short"],
+        rows={
+            KeyMetricKind.trading_period_length: KeyMetric(
+                kind=KeyMetricKind.trading_period_length,
+                value={"All": trading_period_length[0], "Long": trading_period_length[1], "Short": trading_period_length[2]},
+                help_link=trading_period_length[3],
+            ),
+            KeyMetricKind.return_percent: KeyMetric(
+                kind=KeyMetricKind.return_percent,
+                value={"All": return_percent[0], "Long": return_percent[1], "Short": return_percent[2]},
+                help_link=return_percent[3],
+            ),
+            KeyMetricKind.annualised_return_percent: KeyMetric(
+                kind=KeyMetricKind.annualised_return_percent,
+                value={"All": annualised_return_percent[0], "Long": annualised_return_percent[1], "Short": annualised_return_percent[2]},
+                help_link=annualised_return_percent[3],
+            ),
+            KeyMetricKind.cash_at_start: KeyMetric(
+                kind=KeyMetricKind.cash_at_start,
+                value={"All": cash_at_start[0], "Long": cash_at_start[1], "Short": cash_at_start[2]},
+                help_link=cash_at_start[3],
+            ),
+            KeyMetricKind.value_at_end: KeyMetric(
+                kind=KeyMetricKind.value_at_end,
+                value={"All": value_at_end[0], "Long": value_at_end[1], "Short": value_at_end[2]},
+                help_link=value_at_end[3],
+            ),
+            KeyMetricKind.trade_volume: KeyMetric(
+                kind=KeyMetricKind.trade_volume,
+                value={"All": trade_volume[0], "Long": trade_volume[1], "Short": trade_volume[2]},
+                help_link=trade_volume[3],
+            ),
+            KeyMetricKind.position_win_percent: KeyMetric(
+                kind=KeyMetricKind.position_win_percent,
+                value={"All": position_win_percent[0], "Long": position_win_percent[1], "Short": position_win_percent[2]},
+                help_link=position_win_percent[3],
+            ),
+            KeyMetricKind.total_positions: KeyMetric(
+                kind=KeyMetricKind.total_positions,
+                value={"All": total_positions[0], "Long": total_positions[1], "Short": total_positions[2]},
+                help_link=total_positions[3],
+            ),
+            KeyMetricKind.won_positions: KeyMetric(
+                kind=KeyMetricKind.won_positions,
+                value={"All": won_positions[0], "Long": won_positions[1], "Short": won_positions[2]},
+                help_link=won_positions[3],
+            ),
+            KeyMetricKind.lost_positions: KeyMetric(
+                kind=KeyMetricKind.lost_positions,
+                value={"All": lost_positions[0], "Long": lost_positions[1], "Short": lost_positions[2]},
+                help_link=lost_positions[3],
+            ),
+            KeyMetricKind.stop_losses_triggered: KeyMetric(
+                kind=KeyMetricKind.stop_losses_triggered,
+                value={"All": stop_losses_triggered[0], "Long": stop_losses_triggered[1], "Short": stop_losses_triggered[2]},
+                help_link=stop_losses_triggered[3],
+            ),
+            KeyMetricKind.stop_loss_percent_of_all: KeyMetric(
+                kind=KeyMetricKind.stop_loss_percent_of_all,
+                value={"All": stop_loss_percent_of_all[0], "Long": stop_loss_percent_of_all[1], "Short": stop_loss_percent_of_all[2]},
+                help_link=stop_loss_percent_of_all[3],
+            ),
+            KeyMetricKind.stop_loss_percent_of_lost: KeyMetric(
+                kind=KeyMetricKind.stop_loss_percent_of_lost,
+                value={"All": stop_loss_percent_of_lost[0], "Long": stop_loss_percent_of_lost[1], "Short": stop_loss_percent_of_lost[2]},
+                help_link=stop_loss_percent_of_lost[3],
+            ),
+            KeyMetricKind.winning_stop_losses: KeyMetric(
+                kind=KeyMetricKind.winning_stop_losses,
+                value={"All": winning_stop_losses[0], "Long": winning_stop_losses[1], "Short": winning_stop_losses[2]},
+                help_link=winning_stop_losses[3],
+            ),
+            KeyMetricKind.winning_stop_losses_percent: KeyMetric(
+                kind=KeyMetricKind.winning_stop_losses_percent,
+                value={"All": winning_stop_losses_percent[0], "Long": winning_stop_losses_percent[1], "Short": winning_stop_losses_percent[2]},
+                help_link=winning_stop_losses_percent[3],
+            ),
+            KeyMetricKind.losing_stop_losses: KeyMetric(
+                kind=KeyMetricKind.losing_stop_losses,
+                value={"All": losing_stop_losses[0], "Long": losing_stop_losses[1], "Short": losing_stop_losses[2]},
+                help_link=losing_stop_losses[3],
+            ),
+            KeyMetricKind.losing_stop_losses_percent: KeyMetric(
+                kind=KeyMetricKind.losing_stop_losses_percent,
+                value={"All": losing_stop_losses_percent[0], "Long": losing_stop_losses_percent[1], "Short": losing_stop_losses_percent[2]},
+                help_link=losing_stop_losses_percent[3],
+            ),
+            KeyMetricKind.take_profits_triggered: KeyMetric(
+                kind=KeyMetricKind.take_profits_triggered,
+                value={"All": take_profits_triggered[0], "Long": take_profits_triggered[1], "Short": take_profits_triggered[2]},
+                help_link=take_profits_triggered[3],
+            ),
+            KeyMetricKind.take_profit_percent_of_all: KeyMetric(
+                kind=KeyMetricKind.take_profit_percent_of_all,
+                value={"All": take_profit_percent_of_all[0], "Long": take_profit_percent_of_all[1], "Short": take_profit_percent_of_all[2]},
+                help_link=take_profit_percent_of_all[3],
+            ),
+            KeyMetricKind.take_profit_percent_of_won: KeyMetric(
+                kind=KeyMetricKind.take_profit_percent_of_won,
+                value={"All": take_profit_percent_of_won[0], "Long": take_profit_percent_of_won[1], "Short": take_profit_percent_of_won[2]},
+                help_link=take_profit_percent_of_won[3],
+            ),
+            KeyMetricKind.zero_profit_positions: KeyMetric(
+                kind=KeyMetricKind.zero_profit_positions,
+                value={"All": zero_profit_positions[0], "Long": zero_profit_positions[1], "Short": zero_profit_positions[2]},
+                help_link=zero_profit_positions[3],
+            ),
+            KeyMetricKind.positions_open_at_the_end: KeyMetric(
+                kind=KeyMetricKind.positions_open_at_the_end,
+                value={"All": positions_open_at_the_end[0], "Long": positions_open_at_the_end[1], "Short": positions_open_at_the_end[2]},
+                help_link=positions_open_at_the_end[3],
+            ),
+            KeyMetricKind.realised_profit_and_loss: KeyMetric(
+                kind=KeyMetricKind.realised_profit_and_loss,
+                value={"All": realised_profit_and_loss[0], "Long": realised_profit_and_loss[1], "Short": realised_profit_and_loss[2]},
+                help_link=realised_profit_and_loss[3],
+            ),
+            KeyMetricKind.unrealised_profit_and_loss: KeyMetric(
+                kind=KeyMetricKind.unrealised_profit_and_loss,
+                value={"All": unrealised_profit_and_loss[0], "Long": unrealised_profit_and_loss[1], "Short": unrealised_profit_and_loss[2]},
+                help_link=unrealised_profit_and_loss[3],
+            ),
+            KeyMetricKind.portfolio_unrealised_value: KeyMetric(
+                kind=KeyMetricKind.portfolio_unrealised_value,
+                value={"All": portfolio_unrealised_value[0], "Long": portfolio_unrealised_value[1], "Short": portfolio_unrealised_value[2]},
+                help_link=portfolio_unrealised_value[3],
+            ),
+            KeyMetricKind.extra_returns_on_lending_pool_interest: KeyMetric(
+                kind=KeyMetricKind.extra_returns_on_lending_pool_interest,
+                value={"All": extra_returns_on_lending_pool_interest[0], "Long": extra_returns_on_lending_pool_interest[1], "Short": extra_returns_on_lending_pool_interest[2]},
+                help_link=extra_returns_on_lending_pool_interest[3],
+            ),
+            KeyMetricKind.cash_left_at_the_end: KeyMetric(
+                kind=KeyMetricKind.cash_left_at_the_end,
+                value={"All": cash_left_at_the_end[0], "Long": cash_left_at_the_end[1], "Short": cash_left_at_the_end[2]},
+                help_link=cash_left_at_the_end[3],
+            ),
+            KeyMetricKind.average_winning_position_profit_percent: KeyMetric(
+                kind=KeyMetricKind.average_winning_position_profit_percent,
+                value={"All": average_winning_position_profit_percent[0], "Long": average_winning_position_profit_percent[1], "Short": average_winning_position_profit_percent[2]},
+                help_link=average_winning_position_profit_percent[3],
+            ),
+            KeyMetricKind.average_losing_position_loss_percent: KeyMetric(
+                kind=KeyMetricKind.average_losing_position_loss_percent,
+                value={"All": average_losing_position_loss_percent[0], "Long": average_losing_position_loss_percent[1], "Short": average_losing_position_loss_percent[2]},
+                help_link=average_losing_position_loss_percent[3],
+            ),
+            KeyMetricKind.biggest_winning_position_percent: KeyMetric(
+                kind=KeyMetricKind.biggest_winning_position_percent,
+                value={"All": biggest_winning_position_percent[0], "Long": biggest_winning_position_percent[1], "Short": biggest_winning_position_percent[2]},
+                help_link=biggest_winning_position_percent[3],
+            ),
+            KeyMetricKind.biggest_losing_position_percent: KeyMetric(
+                kind=KeyMetricKind.biggest_losing_position_percent,
+                value={"All": biggest_losing_position_percent[0], "Long": biggest_losing_position_percent[1], "Short": biggest_losing_position_percent[2]},
+                help_link=biggest_losing_position_percent[3],
+            ),
+            KeyMetricKind.average_duration_of_winning_positions: KeyMetric(
+                kind=KeyMetricKind.average_duration_of_winning_positions,
+                value={"All": average_duration_of_winning_positions[0], "Long": average_duration_of_winning_positions[1], "Short": average_duration_of_winning_positions[2]},
+                help_link=average_duration_of_winning_positions[3],
+            ),
+            KeyMetricKind.average_duration_of_losing_positions: KeyMetric(
+                kind=KeyMetricKind.average_duration_of_losing_positions,
+                value={"All": average_duration_of_losing_positions[0], "Long": average_duration_of_losing_positions[1], "Short": average_duration_of_losing_positions[2]},
+                help_link=average_duration_of_losing_positions[3],
+            ),
+            KeyMetricKind.average_bars_of_winning_positions: KeyMetric(
+                kind=KeyMetricKind.average_bars_of_winning_positions,
+                value={"All": average_bars_of_winning_positions[0], "Long": average_bars_of_winning_positions[1], "Short": average_bars_of_winning_positions[2]},
+                help_link=average_bars_of_winning_positions[3],
+            ),
+            KeyMetricKind.average_bars_of_losing_positions: KeyMetric(
+                kind=KeyMetricKind.average_bars_of_losing_positions,
+                value={"All": average_bars_of_losing_positions[0], "Long": average_bars_of_losing_positions[1], "Short": average_bars_of_losing_positions[2]},
+                help_link=average_bars_of_losing_positions[3],
+            ),
+            KeyMetricKind.lp_fees_paid: KeyMetric(
+                kind=KeyMetricKind.lp_fees_paid,
+                value={"All": lp_fees_paid[0], "Long": lp_fees_paid[1], "Short": lp_fees_paid[2]},
+                help_link=lp_fees_paid[3],
+            ),
+            KeyMetricKind.lp_fees_paid_percent_of_volume: KeyMetric(
+                kind=KeyMetricKind.lp_fees_paid_percent_of_volume,
+                value={"All": lp_fees_paid_percent_of_volume[0], "Long": lp_fees_paid_percent_of_volume[1], "Short": lp_fees_paid_percent_of_volume[2]},
+                help_link=lp_fees_paid_percent_of_volume[3],
+            ),
+            KeyMetricKind.average_position: KeyMetric(
+                kind=KeyMetricKind.average_position,
+                value={"All": average_position[0], "Long": average_position[1], "Short": average_position[2]},
+                help_link=average_position[3],
+            ),
+            KeyMetricKind.median_position: KeyMetric(
+                kind=KeyMetricKind.median_position,
+                value={"All": median_position[0], "Long": median_position[1], "Short": median_position[2]},
+                help_link=median_position[3],
+            ),
+            KeyMetricKind.most_consecutive_wins: KeyMetric(
+                kind=KeyMetricKind.most_consecutive_wins,
+                value={"All": most_consecutive_wins[0], "Long": most_consecutive_wins[1], "Short": most_consecutive_wins[2]},
+                help_link=most_consecutive_wins[3],
+            ),
+            KeyMetricKind.most_consecutive_losses: KeyMetric(
+                kind=KeyMetricKind.most_consecutive_losses,
+                value={"All": most_consecutive_losses[0], "Long": most_consecutive_losses[1], "Short": most_consecutive_losses[2]},
+                help_link=most_consecutive_losses[3],
+            ),
+            KeyMetricKind.biggest_realised_risk: KeyMetric(
+                kind=KeyMetricKind.biggest_realised_risk,
+                value={"All": biggest_realised_risk[0], "Long": biggest_realised_risk[1], "Short": biggest_realised_risk[2]},
+                help_link=biggest_realised_risk[3],
+            ),
+            KeyMetricKind.avg_realised_risk: KeyMetric(
+                kind=KeyMetricKind.avg_realised_risk,
+                value={"All": avg_realised_risk[0], "Long": avg_realised_risk[1], "Short": avg_realised_risk[2]},
+                help_link=avg_realised_risk[3],
+            ),
+            KeyMetricKind.max_pullback_of_total_capital: KeyMetric(
+                kind=KeyMetricKind.max_pullback_of_total_capital,
+                value={"All": max_pullback_of_total_capital[0], "Long": max_pullback_of_total_capital[1], "Short": max_pullback_of_total_capital[2]},
+                help_link=max_pullback_of_total_capital[3],
+            ),
+            KeyMetricKind.max_loss_risk_at_opening_of_position: KeyMetric(
+                kind=KeyMetricKind.max_loss_risk_at_opening_of_position,
+                value={"All": max_loss_risk_at_opening_of_position[0], "Long": max_loss_risk_at_opening_of_position[1], "Short": max_loss_risk_at_opening_of_position[2]},
+                help_link=max_loss_risk_at_opening_of_position[3],
+            ),
+            KeyMetricKind.max_drawdown: KeyMetric(
+                kind=KeyMetricKind.max_drawdown,
+                value={"All": max_drawdown[0], "Long": max_drawdown[1], "Short": max_drawdown[2]},
+                help_link=max_drawdown[3],
+            ),
+        }
+    )
+
+    # add state to each row
+    for row in table.rows:
+        row.source = source_state
+        row.calculation_window_start_at = source_state.created_at
+        row.calculation_window_end_at = datetime.datetime.utcnow()

--- a/tradeexecutor/statistics/key_metric.py
+++ b/tradeexecutor/statistics/key_metric.py
@@ -411,7 +411,7 @@ def calculate_long_short_metrics(
     if 'Average bars of winning positions' in summary.index:
         average_bars_of_winning_positions = summary.loc['Average bars of winning positions']
         average_bars_of_losing_positions = summary.loc['Average bars of losing positions']
-        
+
         rows[KeyMetricKind.average_bars_of_winning_positions] = KeyMetric(
             kind=KeyMetricKind.average_bars_of_winning_positions,
             value={"All": average_bars_of_winning_positions[0], "Long": average_bars_of_winning_positions[1], "Short": average_bars_of_winning_positions[2]},
@@ -429,7 +429,5 @@ def calculate_long_short_metrics(
         source=source,
         rows=rows,
     )
-
-    
 
     return table

--- a/tradeexecutor/statistics/key_metric.py
+++ b/tradeexecutor/statistics/key_metric.py
@@ -348,341 +348,88 @@ def calculate_long_short_metrics(
     analysis = build_trade_analysis(source_state.portfolio)
     summary = analysis.calculate_all_summary_stats_by_side(state=source_state, format_headings=False)  # TODO timebucket
 
-    trading_period_length = summary.loc['Trading period length']
-    return_percent = summary.loc['Return %']
-    annualised_return_percent = summary.loc['Annualised return %']
-    cash_at_start = summary.loc['Cash at start']
-    value_at_end = summary.loc['Value at end']
-    trade_volume = summary.loc['Trade volume']
-    position_win_percent = summary.loc['Position win percent']
-    total_positions = summary.loc['Total positions']
-    won_positions = summary.loc['Won positions']
-    lost_positions = summary.loc['Lost positions']
-    stop_losses_triggered = summary.loc['Stop losses triggered']
-    stop_loss_percent_of_all = summary.loc['Stop loss % of all']
-    stop_loss_percent_of_lost = summary.loc['Stop loss % of lost']
-    winning_stop_losses = summary.loc['Winning stop losses']
-    winning_stop_losses_percent = summary.loc['Winning stop losses percent']
-    losing_stop_losses = summary.loc['Losing stop losses']
-    losing_stop_losses_percent = summary.loc['Losing stop losses percent']
-    take_profits_triggered = summary.loc['Take profits triggered']
-    take_profit_percent_of_all = summary.loc['Take profit % of all']
-    take_profit_percent_of_won = summary.loc['Take profit % of won']
-    zero_profit_positions = summary.loc['Zero profit positions']
-    positions_open_at_the_end = summary.loc['Positions open at the end']
-    realised_profit_and_loss = summary.loc['Realised profit and loss']
-    unrealised_profit_and_loss = summary.loc['Unrealised profit and loss']
-    portfolio_unrealised_value = summary.loc['Portfolio unrealised value']
-    extra_returns_on_lending_pool_interest = summary.loc['Extra returns on lending pool interest']
-    cash_left_at_the_end = summary.loc['Cash left at the end']
-    average_winning_position_profit_percent = summary.loc['Average winning position profit %']
-    average_losing_position_loss_percent = summary.loc['Average losing position loss %']
-    biggest_winning_position_percent = summary.loc['Biggest winning position %']
-    biggest_losing_position_percent = summary.loc['Biggest losing position %']
-    average_duration_of_winning_positions = summary.loc['Average duration of winning positions']
-    average_duration_of_losing_positions = summary.loc['Average duration of losing positions']
-    lp_fees_paid = summary.loc['LP fees paid']
-    lp_fees_paid_percent_of_volume = summary.loc['LP fees paid % of volume']
-    average_position = summary.loc['Average position']
-    median_position = summary.loc['Median position']
-    most_consecutive_wins = summary.loc['Most consecutive wins']
-    most_consecutive_losses = summary.loc['Most consecutive losses']
-    biggest_realised_risk = summary.loc['Biggest realised risk']
-    avg_realised_risk = summary.loc['Avg realised risk']
-    max_pullback_of_total_capital = summary.loc['Max pullback of total capital']
-    max_loss_risk_at_opening_of_position = summary.loc['Max loss risk at opening of position']
-    max_drawdown = summary.loc['Max drawdown']
+    key_metrics_map = {
+        KeyMetricKind.trading_period_length: 'Trading period length',
+        KeyMetricKind.return_percent: 'Return %',
+        KeyMetricKind.annualised_return_percent: 'Annualised return %',
+        KeyMetricKind.cash_at_start: 'Cash at start',
+        KeyMetricKind.value_at_end: 'Value at end',
+        KeyMetricKind.trade_volume: 'Trade volume',
+        KeyMetricKind.position_win_percent: 'Position win percent',
+        KeyMetricKind.total_positions: 'Total positions',
+        KeyMetricKind.won_positions: 'Won positions',
+        KeyMetricKind.lost_positions: 'Lost positions',
+        KeyMetricKind.stop_losses_triggered: 'Stop losses triggered',
+        KeyMetricKind.stop_loss_percent_of_all: 'Stop loss % of all',
+        KeyMetricKind.stop_loss_percent_of_lost: 'Stop loss % of lost',
+        KeyMetricKind.winning_stop_losses: 'Winning stop losses',
+        KeyMetricKind.winning_stop_losses_percent: 'Winning stop losses percent',
+        KeyMetricKind.losing_stop_losses: 'Losing stop losses',
+        KeyMetricKind.losing_stop_losses_percent: 'Losing stop losses percent',
+        KeyMetricKind.take_profits_triggered: 'Take profits triggered',
+        KeyMetricKind.take_profit_percent_of_all: 'Take profit % of all',
+        KeyMetricKind.take_profit_percent_of_won: 'Take profit % of won',
+        KeyMetricKind.zero_profit_positions: 'Zero profit positions',
+        KeyMetricKind.positions_open_at_the_end: 'Positions open at the end',
+        KeyMetricKind.realised_profit_and_loss: 'Realised profit and loss',
+        KeyMetricKind.unrealised_profit_and_loss: 'Unrealised profit and loss',
+        KeyMetricKind.portfolio_unrealised_value: 'Portfolio unrealised value',
+        KeyMetricKind.extra_returns_on_lending_pool_interest: 'Extra returns on lending pool interest',
+        KeyMetricKind.cash_left_at_the_end: 'Cash left at the end',
+        KeyMetricKind.average_winning_position_profit_percent: 'Average winning position profit %',
+        KeyMetricKind.average_losing_position_loss_percent: 'Average losing position loss %',
+        KeyMetricKind.biggest_winning_position_percent: 'Biggest winning position %',
+        KeyMetricKind.biggest_losing_position_percent: 'Biggest losing position %',
+        KeyMetricKind.average_duration_of_winning_positions: 'Average duration of winning positions',
+        KeyMetricKind.average_duration_of_losing_positions: 'Average duration of losing positions',
+        KeyMetricKind.lp_fees_paid: 'LP fees paid',
+        KeyMetricKind.lp_fees_paid_percent_of_volume: 'LP fees paid % of volume',
+        KeyMetricKind.average_position: 'Average position',
+        KeyMetricKind.median_position: 'Median position',
+        KeyMetricKind.most_consecutive_wins: 'Most consecutive wins',
+        KeyMetricKind.most_consecutive_losses: 'Most consecutive losses',
+        KeyMetricKind.biggest_realised_risk: 'Biggest realised risk',
+        KeyMetricKind.avg_realised_risk: 'Avg realised risk',
+        KeyMetricKind.max_pullback_of_total_capital: 'Max pullback of total capital',
+        KeyMetricKind.max_loss_risk_at_opening_of_position: 'Max loss risk at opening of position',
+        KeyMetricKind.max_drawdown: 'Max drawdown',
+    }
 
-    table = StatisticsTable(
-        columns=["All", "Long", "Short"],
-        created_at=source_state.created_at,
-        source=source,
-        rows={
-            KeyMetricKind.trading_period_length: KeyMetric(
-                kind=KeyMetricKind.trading_period_length,
-                value={"All": trading_period_length[0], "Long": trading_period_length[1], "Short": trading_period_length[2]},
-                help_link=trading_period_length[3],
+    rows = {}
+    for key_metric_kind, summary_index in key_metrics_map.items():
+        if summary_index in summary.index:
+            metric_data = summary.loc[summary_index]
+            rows[key_metric_kind] = KeyMetric(
+                kind=key_metric_kind,
+                value={"All": metric_data[0], "Long": metric_data[1], "Short": metric_data[2]},
+                help_link=metric_data[3],
                 source=source_state,
-            ),
-            KeyMetricKind.return_percent: KeyMetric(
-                kind=KeyMetricKind.return_percent,
-                value={"All": return_percent[0], "Long": return_percent[1], "Short": return_percent[2]},
-                help_link=return_percent[3],
-                source=source_state,
-            ),
-            KeyMetricKind.annualised_return_percent: KeyMetric(
-                kind=KeyMetricKind.annualised_return_percent,
-                value={"All": annualised_return_percent[0], "Long": annualised_return_percent[1], "Short": annualised_return_percent[2]},
-                help_link=annualised_return_percent[3],
-                source=source_state,
-            ),
-            KeyMetricKind.cash_at_start: KeyMetric(
-                kind=KeyMetricKind.cash_at_start,
-                value={"All": cash_at_start[0], "Long": cash_at_start[1], "Short": cash_at_start[2]},
-                help_link=cash_at_start[3],
-                source=source_state,
-            ),
-            KeyMetricKind.value_at_end: KeyMetric(
-                kind=KeyMetricKind.value_at_end,
-                value={"All": value_at_end[0], "Long": value_at_end[1], "Short": value_at_end[2]},
-                help_link=value_at_end[3],
-                source=source_state,
-            ),
-            KeyMetricKind.trade_volume: KeyMetric(
-                kind=KeyMetricKind.trade_volume,
-                value={"All": trade_volume[0], "Long": trade_volume[1], "Short": trade_volume[2]},
-                help_link=trade_volume[3],
-                source=source_state,
-            ),
-            KeyMetricKind.position_win_percent: KeyMetric(
-                kind=KeyMetricKind.position_win_percent,
-                value={"All": position_win_percent[0], "Long": position_win_percent[1], "Short": position_win_percent[2]},
-                help_link=position_win_percent[3],
-                source=source_state,
-            ),
-            KeyMetricKind.total_positions: KeyMetric(
-                kind=KeyMetricKind.total_positions,
-                value={"All": total_positions[0], "Long": total_positions[1], "Short": total_positions[2]},
-                help_link=total_positions[3],
-                source=source_state,
-            ),
-            KeyMetricKind.won_positions: KeyMetric(
-                kind=KeyMetricKind.won_positions,
-                value={"All": won_positions[0], "Long": won_positions[1], "Short": won_positions[2]},
-                help_link=won_positions[3],
-                source=source_state,
-            ),
-            KeyMetricKind.lost_positions: KeyMetric(
-                kind=KeyMetricKind.lost_positions,
-                value={"All": lost_positions[0], "Long": lost_positions[1], "Short": lost_positions[2]},
-                help_link=lost_positions[3],
-                source=source_state,
-            ),
-            KeyMetricKind.stop_losses_triggered: KeyMetric(
-                kind=KeyMetricKind.stop_losses_triggered,
-                value={"All": stop_losses_triggered[0], "Long": stop_losses_triggered[1], "Short": stop_losses_triggered[2]},
-                help_link=stop_losses_triggered[3],
-                source=source_state,
-            ),
-            KeyMetricKind.stop_loss_percent_of_all: KeyMetric(
-                kind=KeyMetricKind.stop_loss_percent_of_all,
-                value={"All": stop_loss_percent_of_all[0], "Long": stop_loss_percent_of_all[1], "Short": stop_loss_percent_of_all[2]},
-                help_link=stop_loss_percent_of_all[3],
-                source=source_state,
-            ),
-            KeyMetricKind.stop_loss_percent_of_lost: KeyMetric(
-                kind=KeyMetricKind.stop_loss_percent_of_lost,
-                value={"All": stop_loss_percent_of_lost[0], "Long": stop_loss_percent_of_lost[1], "Short": stop_loss_percent_of_lost[2]},
-                help_link=stop_loss_percent_of_lost[3],
-                source=source_state,
-            ),
-            KeyMetricKind.winning_stop_losses: KeyMetric(
-                kind=KeyMetricKind.winning_stop_losses,
-                value={"All": winning_stop_losses[0], "Long": winning_stop_losses[1], "Short": winning_stop_losses[2]},
-                help_link=winning_stop_losses[3],
-                source=source_state,
-            ),
-            KeyMetricKind.winning_stop_losses_percent: KeyMetric(
-                kind=KeyMetricKind.winning_stop_losses_percent,
-                value={"All": winning_stop_losses_percent[0], "Long": winning_stop_losses_percent[1], "Short": winning_stop_losses_percent[2]},
-                help_link=winning_stop_losses_percent[3],
-                source=source_state,
-            ),
-            KeyMetricKind.losing_stop_losses: KeyMetric(
-                kind=KeyMetricKind.losing_stop_losses,
-                value={"All": losing_stop_losses[0], "Long": losing_stop_losses[1], "Short": losing_stop_losses[2]},
-                help_link=losing_stop_losses[3],
-                source=source_state,
-            ),
-            KeyMetricKind.losing_stop_losses_percent: KeyMetric(
-                kind=KeyMetricKind.losing_stop_losses_percent,
-                value={"All": losing_stop_losses_percent[0], "Long": losing_stop_losses_percent[1], "Short": losing_stop_losses_percent[2]},
-                help_link=losing_stop_losses_percent[3],
-                source=source_state,
-            ),
-            KeyMetricKind.take_profits_triggered: KeyMetric(
-                kind=KeyMetricKind.take_profits_triggered,
-                value={"All": take_profits_triggered[0], "Long": take_profits_triggered[1], "Short": take_profits_triggered[2]},
-                help_link=take_profits_triggered[3],
-                source=source_state,
-            ),
-            KeyMetricKind.take_profit_percent_of_all: KeyMetric(
-                kind=KeyMetricKind.take_profit_percent_of_all,
-                value={"All": take_profit_percent_of_all[0], "Long": take_profit_percent_of_all[1], "Short": take_profit_percent_of_all[2]},
-                help_link=take_profit_percent_of_all[3],
-                source=source_state,
-            ),
-            KeyMetricKind.take_profit_percent_of_won: KeyMetric(
-                kind=KeyMetricKind.take_profit_percent_of_won,
-                value={"All": take_profit_percent_of_won[0], "Long": take_profit_percent_of_won[1], "Short": take_profit_percent_of_won[2]},
-                help_link=take_profit_percent_of_won[3],
-                source=source_state,
-            ),
-            KeyMetricKind.zero_profit_positions: KeyMetric(
-                kind=KeyMetricKind.zero_profit_positions,
-                value={"All": zero_profit_positions[0], "Long": zero_profit_positions[1], "Short": zero_profit_positions[2]},
-                help_link=zero_profit_positions[3],
-                source=source_state,
-            ),
-            KeyMetricKind.positions_open_at_the_end: KeyMetric(
-                kind=KeyMetricKind.positions_open_at_the_end,
-                value={"All": positions_open_at_the_end[0], "Long": positions_open_at_the_end[1], "Short": positions_open_at_the_end[2]},
-                help_link=positions_open_at_the_end[3],
-                source=source_state,
-            ),
-            KeyMetricKind.realised_profit_and_loss: KeyMetric(
-                kind=KeyMetricKind.realised_profit_and_loss,
-                value={"All": realised_profit_and_loss[0], "Long": realised_profit_and_loss[1], "Short": realised_profit_and_loss[2]},
-                help_link=realised_profit_and_loss[3],
-                source=source_state,
-            ),
-            KeyMetricKind.unrealised_profit_and_loss: KeyMetric(
-                kind=KeyMetricKind.unrealised_profit_and_loss,
-                value={"All": unrealised_profit_and_loss[0], "Long": unrealised_profit_and_loss[1], "Short": unrealised_profit_and_loss[2]},
-                help_link=unrealised_profit_and_loss[3],
-                source=source_state,
-            ),
-            KeyMetricKind.portfolio_unrealised_value: KeyMetric(
-                kind=KeyMetricKind.portfolio_unrealised_value,
-                value={"All": portfolio_unrealised_value[0], "Long": portfolio_unrealised_value[1], "Short": portfolio_unrealised_value[2]},
-                help_link=portfolio_unrealised_value[3],
-                source=source_state,
-            ),
-            KeyMetricKind.extra_returns_on_lending_pool_interest: KeyMetric(
-                kind=KeyMetricKind.extra_returns_on_lending_pool_interest,
-                value={"All": extra_returns_on_lending_pool_interest[0], "Long": extra_returns_on_lending_pool_interest[1], "Short": extra_returns_on_lending_pool_interest[2]},
-                help_link=extra_returns_on_lending_pool_interest[3],
-                source=source_state,
-            ),
-            KeyMetricKind.cash_left_at_the_end: KeyMetric(
-                kind=KeyMetricKind.cash_left_at_the_end,
-                value={"All": cash_left_at_the_end[0], "Long": cash_left_at_the_end[1], "Short": cash_left_at_the_end[2]},
-                help_link=cash_left_at_the_end[3],
-                source=source_state,
-            ),
-            KeyMetricKind.average_winning_position_profit_percent: KeyMetric(
-                kind=KeyMetricKind.average_winning_position_profit_percent,
-                value={"All": average_winning_position_profit_percent[0], "Long": average_winning_position_profit_percent[1], "Short": average_winning_position_profit_percent[2]},
-                help_link=average_winning_position_profit_percent[3],
-                source=source_state,
-            ),
-            KeyMetricKind.average_losing_position_loss_percent: KeyMetric(
-                kind=KeyMetricKind.average_losing_position_loss_percent,
-                value={"All": average_losing_position_loss_percent[0], "Long": average_losing_position_loss_percent[1], "Short": average_losing_position_loss_percent[2]},
-                help_link=average_losing_position_loss_percent[3],
-                source=source_state,
-            ),
-            KeyMetricKind.biggest_winning_position_percent: KeyMetric(
-                kind=KeyMetricKind.biggest_winning_position_percent,
-                value={"All": biggest_winning_position_percent[0], "Long": biggest_winning_position_percent[1], "Short": biggest_winning_position_percent[2]},
-                help_link=biggest_winning_position_percent[3],
-                source=source_state,
-            ),
-            KeyMetricKind.biggest_losing_position_percent: KeyMetric(
-                kind=KeyMetricKind.biggest_losing_position_percent,
-                value={"All": biggest_losing_position_percent[0], "Long": biggest_losing_position_percent[1], "Short": biggest_losing_position_percent[2]},
-                help_link=biggest_losing_position_percent[3],
-                source=source_state,
-            ),
-            KeyMetricKind.average_duration_of_winning_positions: KeyMetric(
-                kind=KeyMetricKind.average_duration_of_winning_positions,
-                value={"All": average_duration_of_winning_positions[0], "Long": average_duration_of_winning_positions[1], "Short": average_duration_of_winning_positions[2]},
-                help_link=average_duration_of_winning_positions[3],
-                source=source_state,
-            ),
-            KeyMetricKind.average_duration_of_losing_positions: KeyMetric(
-                kind=KeyMetricKind.average_duration_of_losing_positions,
-                value={"All": average_duration_of_losing_positions[0], "Long": average_duration_of_losing_positions[1], "Short": average_duration_of_losing_positions[2]},
-                help_link=average_duration_of_losing_positions[3],
-                source=source_state,
-            ),
-            KeyMetricKind.lp_fees_paid: KeyMetric(
-                kind=KeyMetricKind.lp_fees_paid,
-                value={"All": lp_fees_paid[0], "Long": lp_fees_paid[1], "Short": lp_fees_paid[2]},
-                help_link=lp_fees_paid[3],
-                source=source_state,
-            ),
-            KeyMetricKind.lp_fees_paid_percent_of_volume: KeyMetric(
-                kind=KeyMetricKind.lp_fees_paid_percent_of_volume,
-                value={"All": lp_fees_paid_percent_of_volume[0], "Long": lp_fees_paid_percent_of_volume[1], "Short": lp_fees_paid_percent_of_volume[2]},
-                help_link=lp_fees_paid_percent_of_volume[3],
-                source=source_state,
-            ),
-            KeyMetricKind.average_position: KeyMetric(
-                kind=KeyMetricKind.average_position,
-                value={"All": average_position[0], "Long": average_position[1], "Short": average_position[2]},
-                help_link=average_position[3],
-                source=source_state,
-            ),
-            KeyMetricKind.median_position: KeyMetric(
-                kind=KeyMetricKind.median_position,
-                value={"All": median_position[0], "Long": median_position[1], "Short": median_position[2]},
-                help_link=median_position[3],
-                source=source_state,
-            ),
-            KeyMetricKind.most_consecutive_wins: KeyMetric(
-                kind=KeyMetricKind.most_consecutive_wins,
-                value={"All": most_consecutive_wins[0], "Long": most_consecutive_wins[1], "Short": most_consecutive_wins[2]},
-                help_link=most_consecutive_wins[3],
-                source=source_state,
-            ),
-            KeyMetricKind.most_consecutive_losses: KeyMetric(
-                kind=KeyMetricKind.most_consecutive_losses,
-                value={"All": most_consecutive_losses[0], "Long": most_consecutive_losses[1], "Short": most_consecutive_losses[2]},
-                help_link=most_consecutive_losses[3],
-                source=source_state,
-            ),
-            KeyMetricKind.biggest_realised_risk: KeyMetric(
-                kind=KeyMetricKind.biggest_realised_risk,
-                value={"All": biggest_realised_risk[0], "Long": biggest_realised_risk[1], "Short": biggest_realised_risk[2]},
-                help_link=biggest_realised_risk[3],
-                source=source_state,
-            ),
-            KeyMetricKind.avg_realised_risk: KeyMetric(
-                kind=KeyMetricKind.avg_realised_risk,
-                value={"All": avg_realised_risk[0], "Long": avg_realised_risk[1], "Short": avg_realised_risk[2]},
-                help_link=avg_realised_risk[3],
-                source=source_state,
-            ),
-            KeyMetricKind.max_pullback_of_total_capital: KeyMetric(
-                kind=KeyMetricKind.max_pullback_of_total_capital,
-                value={"All": max_pullback_of_total_capital[0], "Long": max_pullback_of_total_capital[1], "Short": max_pullback_of_total_capital[2]},
-                help_link=max_pullback_of_total_capital[3],
-                source=source_state,
-            ),
-            KeyMetricKind.max_loss_risk_at_opening_of_position: KeyMetric(
-                kind=KeyMetricKind.max_loss_risk_at_opening_of_position,
-                value={"All": max_loss_risk_at_opening_of_position[0], "Long": max_loss_risk_at_opening_of_position[1], "Short": max_loss_risk_at_opening_of_position[2]},
-                help_link=max_loss_risk_at_opening_of_position[3],
-                source=source_state,
-            ),
-            KeyMetricKind.max_drawdown: KeyMetric(
-                kind=KeyMetricKind.max_drawdown,
-                value={"All": max_drawdown[0], "Long": max_drawdown[1], "Short": max_drawdown[2]},
-                help_link=max_drawdown[3],
-                source=source_state,
-            ),
-        }
-    )
+                calculation_window_start_at = source_state.created_at,
+                calculation_window_end_at = datetime.datetime.utcnow(),
+            )
 
     if 'Average bars of winning positions' in summary.index:
         average_bars_of_winning_positions = summary.loc['Average bars of winning positions']
         average_bars_of_losing_positions = summary.loc['Average bars of losing positions']
-
-        table.rows[KeyMetricKind.average_bars_of_winning_positions] = KeyMetric(
+        
+        rows[KeyMetricKind.average_bars_of_winning_positions] = KeyMetric(
             kind=KeyMetricKind.average_bars_of_winning_positions,
             value={"All": average_bars_of_winning_positions[0], "Long": average_bars_of_winning_positions[1], "Short": average_bars_of_winning_positions[2]},
             help_link=average_bars_of_winning_positions[3],
         )
-        table.rows[KeyMetricKind.average_bars_of_losing_positions] = KeyMetric(
+        rows[KeyMetricKind.average_bars_of_losing_positions] = KeyMetric(
             kind=KeyMetricKind.average_bars_of_losing_positions,
             value={"All": average_bars_of_losing_positions[0], "Long": average_bars_of_losing_positions[1], "Short": average_bars_of_losing_positions[2]},
             help_link=average_bars_of_losing_positions[3],
         )
 
-    for row in table.rows:
-        row.source = source_state
-        row.calculation_window_start_at = source_state.created_at
-        row.calculation_window_end_at = datetime.datetime.utcnow()
+    table = StatisticsTable(
+        columns=["All", "Long", "Short"],
+        created_at=source_state.created_at,
+        source=source,
+        rows=rows,
+    )
+
+    
 
     return table

--- a/tradeexecutor/statistics/statistics_table.py
+++ b/tradeexecutor/statistics/statistics_table.py
@@ -1,0 +1,186 @@
+"""Module for statistics table. 
+
+This table can work with any table data that can be represented as a dictionary of key metrics. 
+It is also used to help display statistics in the web frontend.
+"""
+from dataclasses import dataclass
+from dataclasses_json import dataclass_json
+import datetime
+from typing import Literal
+
+from tradeexecutor.analysis.trade_analyser import build_trade_analysis
+from tradeexecutor.strategy.summary import KeyMetricKind, KeyMetricSource, KeyMetric
+from tradeexecutor.state.state import State
+
+
+@dataclass_json
+@dataclass
+class StatisticsTable:
+    """
+    - A table of statistics. 
+    - This table can work with any table data that can be represented as a dictionary of key metrics. 
+    - It is also used to help display statistics in the web frontend.
+    """
+
+    #: The columns of the table.
+    columns: list[str]
+
+    #: The rows of the table.
+    rows: dict[KeyMetricKind, KeyMetric]
+    
+    #: The time at which the table was created.
+    created_at: datetime.datetime
+
+    #: The source of the table. Can either be live trading or backtesting.
+    source: KeyMetricSource
+
+    #: The start of the calculation window.
+    calculation_window_start_at: datetime.datetime | None = None
+    
+    #: The end of the calculation window.
+    calculation_window_end_at: datetime.timedelta | None = None
+
+
+def serialise_long_short_stats_as_json_table(
+    live_state: State,
+    backtested_state: State | None,
+    required_history: datetime.timedelta,
+) -> StatisticsTable:
+    """Calculate long/short statistics for the summary tile.
+
+    :param state: Strategy state from which we calculate the summary
+    :param execution_mode: If we need to skip calculations during backtesting.
+    :param time_window: How long we look back for the summary statistics
+    :param now_: Override current time for unit testing.
+    :param legacy_workarounds: Skip some calculations on old data, because data is missing.
+    :return: Summary statistics for all, long, and short positions
+    """
+
+    source_state, source, calculation_window_start_at, calculation_window_end_at = get_data_source_and_calculation_window(live_state, backtested_state, required_history)
+
+    if source_state is None:
+        return StatisticsTable(
+            columns=["All", "Long", "Short"],
+            created_at=datetime.datetime.utcnow(),
+            source=source,
+            rows={},
+        )
+
+    analysis = build_trade_analysis(source_state.portfolio)
+    summary = analysis.calculate_all_summary_stats_by_side(state=source_state, urls=True)  # TODO timebucket
+
+    key_metrics_map = {
+        KeyMetricKind.trading_period_length: 'Trading period length',
+        KeyMetricKind.return_percent: 'Return %',
+        KeyMetricKind.annualised_return_percent: 'Annualised return %',
+        KeyMetricKind.cash_at_start: 'Cash at start',
+        KeyMetricKind.value_at_end: 'Value at end',
+        KeyMetricKind.trade_volume: 'Trade volume',
+        KeyMetricKind.position_win_percent: 'Position win percent',
+        KeyMetricKind.total_positions: 'Total positions',
+        KeyMetricKind.won_positions: 'Won positions',
+        KeyMetricKind.lost_positions: 'Lost positions',
+        KeyMetricKind.stop_losses_triggered: 'Stop losses triggered',
+        KeyMetricKind.stop_loss_percent_of_all: 'Stop loss % of all',
+        KeyMetricKind.stop_loss_percent_of_lost: 'Stop loss % of lost',
+        KeyMetricKind.winning_stop_losses: 'Winning stop losses',
+        KeyMetricKind.winning_stop_losses_percent: 'Winning stop losses percent',
+        KeyMetricKind.losing_stop_losses: 'Losing stop losses',
+        KeyMetricKind.losing_stop_losses_percent: 'Losing stop losses percent',
+        KeyMetricKind.take_profits_triggered: 'Take profits triggered',
+        KeyMetricKind.take_profit_percent_of_all: 'Take profit % of all',
+        KeyMetricKind.take_profit_percent_of_won: 'Take profit % of won',
+        KeyMetricKind.zero_profit_positions: 'Zero profit positions',
+        KeyMetricKind.positions_open_at_the_end: 'Positions open at the end',
+        KeyMetricKind.realised_profit_and_loss: 'Realised profit and loss',
+        KeyMetricKind.unrealised_profit_and_loss: 'Unrealised profit and loss',
+        KeyMetricKind.portfolio_unrealised_value: 'Portfolio unrealised value',
+        KeyMetricKind.extra_returns_on_lending_pool_interest: 'Extra returns on lending pool interest',
+        KeyMetricKind.cash_left_at_the_end: 'Cash left at the end',
+        KeyMetricKind.average_winning_position_profit_percent: 'Average winning position profit %',
+        KeyMetricKind.average_losing_position_loss_percent: 'Average losing position loss %',
+        KeyMetricKind.biggest_winning_position_percent: 'Biggest winning position %',
+        KeyMetricKind.biggest_losing_position_percent: 'Biggest losing position %',
+        KeyMetricKind.average_duration_of_winning_positions: 'Average duration of winning positions',
+        KeyMetricKind.average_duration_of_losing_positions: 'Average duration of losing positions',
+        KeyMetricKind.lp_fees_paid: 'LP fees paid',
+        KeyMetricKind.lp_fees_paid_percent_of_volume: 'LP fees paid % of volume',
+        KeyMetricKind.average_position: 'Average position',
+        KeyMetricKind.median_position: 'Median position',
+        KeyMetricKind.most_consecutive_wins: 'Most consecutive wins',
+        KeyMetricKind.most_consecutive_losses: 'Most consecutive losses',
+        KeyMetricKind.biggest_realised_risk: 'Biggest realised risk',
+        KeyMetricKind.avg_realised_risk: 'Avg realised risk',
+        KeyMetricKind.max_pullback_of_total_capital: 'Max pullback of total capital',
+        KeyMetricKind.max_loss_risk_at_opening_of_position: 'Max loss risk at opening of position',
+        KeyMetricKind.max_drawdown: 'Max drawdown',
+    }
+
+    rows = {}
+    for key_metric_kind, summary_index in key_metrics_map.items():
+        if summary_index in summary.index:
+            metric_data = summary.loc[summary_index]
+
+            rows[key_metric_kind] = KeyMetric(
+                kind=key_metric_kind,
+                value={"All": metric_data[0], "Long": metric_data[1], "Short": metric_data[2]},
+                help_link=metric_data[3],
+                source=source_state,
+                calculation_window_start_at = calculation_window_start_at,
+                calculation_window_end_at = calculation_window_end_at,
+                name = metric_data.name,
+            )
+
+    if 'Average bars of winning positions' in summary.index:
+        average_bars_of_winning_positions = summary.loc['Average bars of winning positions']
+        average_bars_of_losing_positions = summary.loc['Average bars of losing positions']
+
+        rows[KeyMetricKind.average_bars_of_winning_positions] = KeyMetric(
+            kind=KeyMetricKind.average_bars_of_winning_positions,
+            value={"All": average_bars_of_winning_positions[0], "Long": average_bars_of_winning_positions[1], "Short": average_bars_of_winning_positions[2]},
+            help_link=average_bars_of_winning_positions[3],
+        )
+        rows[KeyMetricKind.average_bars_of_losing_positions] = KeyMetric(
+            kind=KeyMetricKind.average_bars_of_losing_positions,
+            value={"All": average_bars_of_losing_positions[0], "Long": average_bars_of_losing_positions[1], "Short": average_bars_of_losing_positions[2]},
+            help_link=average_bars_of_losing_positions[3],
+        )
+
+    table = StatisticsTable(
+        columns=["All", "Long", "Short"],
+        created_at=source_state.created_at,
+        source=source,
+        rows=rows,
+    )
+
+    return table
+
+
+def get_data_source_and_calculation_window(
+    live_state: State, 
+    backtested_state: State | None, 
+    required_history: datetime.timedelta,
+)-> tuple[State | None, Literal[KeyMetricSource.live_trading, KeyMetricSource.backtesting] | None, datetime.datetime | None, datetime.datetime | None]:
+    """Get the data source and calculation window for the key metrics.
+    
+    :param live_state: The current live execution state
+    :param backtested_state: The backtested state
+    :param required_history: How long history we need before using live execution as the basis for the key metric calculations
+    :return: The data source and calculation window for the key metrics.
+    """
+    source_state, source, calculation_window_start_at, calculation_window_end_at = None, None, None, None
+    live_history = live_state.portfolio.get_trading_history_duration()
+
+    if live_history is not None and live_history >= required_history:
+        source_state = live_state
+        source = KeyMetricSource.live_trading
+        calculation_window_start_at = source_state.created_at
+        calculation_window_end_at = datetime.datetime.utcnow()
+    elif backtested_state and backtested_state.portfolio.get_trading_history_duration():
+        source_state = backtested_state
+        source = KeyMetricSource.backtesting
+        first_trade, last_trade = source_state.portfolio.get_first_and_last_executed_trade()
+        calculation_window_start_at = first_trade.executed_at
+        calculation_window_end_at = last_trade.executed_at
+
+    return source_state, source, calculation_window_start_at, calculation_window_end_at

--- a/tradeexecutor/statistics/summary.py
+++ b/tradeexecutor/statistics/summary.py
@@ -8,6 +8,7 @@ import pandas as pd
 
 from tradeexecutor.state.state import State
 from tradeexecutor.statistics.key_metric import calculate_key_metrics
+from tradeexecutor.statistics.statistics_table import serialise_long_short_stats_as_json_table
 from tradeexecutor.strategy.execution_context import ExecutionMode
 from tradeexecutor.strategy.summary import StrategySummaryStatistics
 from tradeexecutor.visual.equity_curve import calculate_compounding_realised_trading_profitability
@@ -120,6 +121,8 @@ def calculate_summary_statistics(
 
     key_metrics = {m.kind.value: m for m in calculate_key_metrics(state, backtested_state, required_history=key_metrics_backtest_cut_off)}
 
+    long_short_table = serialise_long_short_stats_as_json_table(state, backtested_state, key_metrics_backtest_cut_off)
+
     logger.info("calculate_summary_statistics() finished, took %s seconds", perf_counter() - func_started_at)
 
     return StrategySummaryStatistics(
@@ -134,4 +137,5 @@ def calculate_summary_statistics(
         backtest_metrics_cut_off_period=key_metrics_backtest_cut_off,
         return_all_time=returns_all_time,
         return_annualised=returns_annualised,
+        long_short_table=long_short_table,
     )

--- a/tradeexecutor/strategy/summary.py
+++ b/tradeexecutor/strategy/summary.py
@@ -41,6 +41,141 @@ class KeyMetricKind(enum.Enum):
     #: Trades last week
     trades_last_week = "trades_last_week"
 
+    #: Duration of the trading period
+    trading_period_length = "trading_period_length"
+
+    #: Percentage return over the trading period
+    return_percent = "return_percent"
+
+    #: Annualized percentage return, adjusted for the length of the trading period
+    annualised_return_percent = "annualised_return_percent"
+
+    #: Initial cash amount at the start of the trading period
+    cash_at_start = "cash_at_start"
+
+    #: Portfolio value at the end of the trading period
+    value_at_end = "value_at_end"
+
+    #: Total value of all trades conducted
+    trade_volume = "trade_volume"
+
+    #: Percentage of positions that were profitable
+    position_win_percent = "position_win_percent"
+
+    #: Total number of trading positions taken
+    total_positions = "total_positions"
+
+    #: Number of positions that resulted in a profit
+    won_positions = "won_positions"
+
+    #: Number of positions that resulted in a loss
+    lost_positions = "lost_positions"
+
+    #: Number of times stop losses were triggered
+    stop_losses_triggered = "stop_losses_triggered"
+
+    #: Percentage of all positions where stop losses were triggered
+    stop_loss_percent_of_all = "stop_loss_percent_of_all"
+
+    #: Percentage of losing positions where stop losses were triggered
+    stop_loss_percent_of_lost = "stop_loss_percent_of_lost"
+
+    #: Number of winning positions where stop losses were set
+    winning_stop_losses = "winning_stop_losses"
+
+    #: Percentage of winning positions where stop losses were set
+    winning_stop_losses_percent = "winning_stop_losses_percent"
+
+    #: Number of losing positions where stop losses were triggered
+    losing_stop_losses = "losing_stop_losses"
+
+    #: Percentage of losing positions where stop losses were triggered
+    losing_stop_losses_percent = "losing_stop_losses_percent"
+
+    #: Number of times take profits were triggered
+    take_profits_triggered = "take_profits_triggered"
+
+    #: Percentage of all positions where take profits were triggered
+    take_profit_percent_of_all = "take_profit_percent_of_all"
+
+    #: Percentage of winning positions where take profits were triggered
+    take_profit_percent_of_won = "take_profit_percent_of_won"
+
+    #: Number of positions closed with zero profit or loss
+    zero_profit_positions = "zero_profit_positions"
+
+    #: Number of positions still open at the end of the trading period
+    positions_open_at_the_end = "positions_open_at_the_end"
+
+    #: Total realized profit and loss from all closed positions
+    realised_profit_and_loss = "realised_profit_and_loss"
+
+    #: Unrealized profit and loss from positions still open
+    unrealised_profit_and_loss = "unrealised_profit_and_loss"
+
+    #: Unrealized value of the portfolio
+    portfolio_unrealised_value = "portfolio_unrealised_value"
+
+    #: Extra returns earned from lending pool interest
+    extra_returns_on_lending_pool_interest = "extra_returns_on_lending_pool_interest"
+
+    #: Cash amount remaining at the end of the trading period
+    cash_left_at_the_end = "cash_left_at_the_end"
+
+    #: Average profit percentage for winning positions
+    average_winning_position_profit_percent = "average_winning_position_profit_percent"
+
+    #: Average loss percentage for losing positions
+    average_losing_position_loss_percent = "average_losing_position_loss_percent"
+
+    #: Largest percentage profit for a single position
+    biggest_winning_position_percent = "biggest_winning_position_percent"
+
+    #: Largest percentage loss for a single position
+    biggest_losing_position_percent = "biggest_losing_position_percent"
+
+    #: Average duration for positions that ended in profit
+    average_duration_of_winning_positions = "average_duration_of_winning_positions"
+
+    #: Average duration for positions that ended in loss
+    average_duration_of_losing_positions = "average_duration_of_losing_positions"
+
+    #: Average number of price bars for winning positions
+    average_bars_of_winning_positions = "average_bars_of_winning_positions"
+
+    #: Average number of price bars for losing positions
+    average_bars_of_losing_positions = "average_bars_of_losing_positions"
+
+    #: Total liquidity provider fees paid
+    lp_fees_paid = "lp_fees_paid"
+
+    #: Percentage of trade volume spent on liquidity provider fees
+    lp_fees_paid_percent_of_volume = "lp_fees_paid_percent_of_volume"
+
+    #: Average profit or loss for all positions
+    average_position = "average_position"
+
+    #: Median profit or loss for all positions
+    median_position = "median_position"
+
+    #: Highest number of consecutive winning trades
+    most_consecutive_wins = "most_consecutive_wins"
+
+    #: Highest number of consecutive losing trades
+    most_consecutive_losses = "most_consecutive_losses"
+
+    #: Largest risk realized in a single trade
+    biggest_realised_risk = "biggest_realised_risk"
+
+    #: Average risk realized across all trades
+    avg_realised_risk = "avg_realised_risk"
+
+    #: Maximum percentage pullback from peak capital
+    max_pullback_of_total_capital = "max_pullback_of_total_capital"
+
+    #: Maximum loss risked at the opening of a position
+    max_loss_risk_at_opening_of_position = "max_loss_risk_at_opening_of_position"
+
     def get_help_link(self) -> Optional[str]:
         return _KEY_METRIC_HELP[self]
 

--- a/tradeexecutor/strategy/summary.py
+++ b/tradeexecutor/strategy/summary.py
@@ -250,6 +250,11 @@ class KeyMetric:
     #:
     help_link: str | None = None
 
+    #: Name of the metric
+    #: 
+    #: Should be in human readable format
+    name: str | None = None
+
     @staticmethod
     def create_na(kind: KeyMetricKind, reason: str) -> "KeyMetric":
         """Create missing value placeholder."""
@@ -363,6 +368,12 @@ class StrategySummaryStatistics:
     #: This mostly affects strategy summary tiles.
     #:
     backtest_metrics_cut_off_period: Optional[datetime.timedelta] = None
+
+    #: Long/short statistics for the summary tile.
+    #:
+    #: It should have 3 columns: all, long, short.
+    #:
+    long_short_table: Optional['StatisticsTable'] = None
 
 
 @dataclass_json


### PR DESCRIPTION
### Summary

- Adds support for separate key metrics for longing and shorting in `calculate_summary_statistics`
- This is so that these statistics can be displayed on the TradingStrategy frontend
- Adds support for a new class `StatisticsTable`, that can be used to store any table data where the data points can be represented as `KeyMetrics`
- Fixes #706 

CC @kenkunz 