### PR TITLE
Usdc.e fixes

### DIFF
--- a/strategies/spot-and-short-momentum-4.py
+++ b/strategies/spot-and-short-momentum-4.py
@@ -194,7 +194,7 @@ def create_trading_universe(
         chain_id=ChainId.polygon,
         exchange_slugs={"uniswap-v3"},
         reserve_assets={"USDC"},
-        asset_symbols={"LINK", "WMATIC", "WETH"},
+        asset_ids={"LINK", "WMATIC", "WETH"},
         trading_fee=0.0005,
         time_bucket=TimeBucket.d4,
         stop_loss_time_bucket=TimeBucket.h1,

--- a/strategies/spot-and-short-momentum-4.py
+++ b/strategies/spot-and-short-momentum-4.py
@@ -193,7 +193,7 @@ def create_trading_universe(
         # Ask for all Polygon data
         chain_id=ChainId.polygon,
         exchange_slugs={"uniswap-v3"},
-        reserve_asset_symbols={"USDC"},
+        reserve_assets={"USDC"},
         asset_symbols={"LINK", "WMATIC", "WETH"},
         trading_fee=0.0005,
         time_bucket=TimeBucket.d4,

--- a/strategies/spot-and-short-momentum-grid-3.py
+++ b/strategies/spot-and-short-momentum-grid-3.py
@@ -217,7 +217,7 @@ def create_trading_universe(
         chain_id=ChainId.polygon,
         exchange_slugs={"uniswap-v3"},
         reserve_assets={"USDC"},
-        asset_symbols={"LINK", "WMATIC", "WETH", "BAL"},
+        asset_ids={"LINK", "WMATIC", "WETH", "BAL"},
         trading_fee=0.0005,
         time_bucket=TimeBucket.d1,
         stop_loss_time_bucket=TimeBucket.h4,

--- a/strategies/spot-and-short-momentum-grid-3.py
+++ b/strategies/spot-and-short-momentum-grid-3.py
@@ -216,7 +216,7 @@ def create_trading_universe(
         # Ask for all Polygon data
         chain_id=ChainId.polygon,
         exchange_slugs={"uniswap-v3"},
-        reserve_asset_symbols={"USDC"},
+        reserve_assets={"USDC"},
         asset_symbols={"LINK", "WMATIC", "WETH", "BAL"},
         trading_fee=0.0005,
         time_bucket=TimeBucket.d1,

--- a/strategies/spot-and-short-momentum-grid.py
+++ b/strategies/spot-and-short-momentum-grid.py
@@ -217,7 +217,7 @@ def create_trading_universe(
         chain_id=ChainId.polygon,
         exchange_slugs={"uniswap-v3"},
         reserve_assets={"USDC"},
-        asset_symbols={"LINK", "WMATIC", "WETH", "BAL"},
+        asset_ids={"LINK", "WMATIC", "WETH", "BAL"},
         trading_fee=0.0005,
         time_bucket=TimeBucket.d1,
         stop_loss_time_bucket=TimeBucket.h4,

--- a/strategies/spot-and-short-momentum-grid.py
+++ b/strategies/spot-and-short-momentum-grid.py
@@ -216,7 +216,7 @@ def create_trading_universe(
         # Ask for all Polygon data
         chain_id=ChainId.polygon,
         exchange_slugs={"uniswap-v3"},
-        reserve_asset_symbols={"USDC"},
+        reserve_assets={"USDC"},
         asset_symbols={"LINK", "WMATIC", "WETH", "BAL"},
         trading_fee=0.0005,
         time_bucket=TimeBucket.d1,

--- a/strategies/spot-and-short-momentum-tuned.py
+++ b/strategies/spot-and-short-momentum-tuned.py
@@ -193,7 +193,7 @@ def create_trading_universe(
         chain_id=ChainId.polygon,
         exchange_slugs={"uniswap-v3"},
         reserve_assets={"USDC"},
-        asset_symbols={"LINK", "WMATIC", "WETH", "BAL"},
+        asset_ids={"LINK", "WMATIC", "WETH", "BAL"},
         trading_fee=0.0005,
         time_bucket=TimeBucket.d1,
         stop_loss_time_bucket=TimeBucket.h1,

--- a/strategies/spot-and-short-momentum-tuned.py
+++ b/strategies/spot-and-short-momentum-tuned.py
@@ -192,7 +192,7 @@ def create_trading_universe(
         # Ask for all Polygon data
         chain_id=ChainId.polygon,
         exchange_slugs={"uniswap-v3"},
-        reserve_asset_symbols={"USDC"},
+        reserve_assets={"USDC"},
         asset_symbols={"LINK", "WMATIC", "WETH", "BAL"},
         trading_fee=0.0005,
         time_bucket=TimeBucket.d1,

--- a/strategies/spot-and-short-momentum.py
+++ b/strategies/spot-and-short-momentum.py
@@ -191,7 +191,7 @@ def create_trading_universe(
         # Ask for all Polygon data
         chain_id=ChainId.polygon,
         exchange_slugs={"uniswap-v3"},
-        reserve_assets={"USDC"},
+        reserve_assets={"0x2791Bca1f2de4661ED88A30C99A7a9449Aa84174"},
         asset_ids={"LINK", "WMATIC", "WETH", "BAL"},
         trading_fee=0.0005,
         time_bucket=TimeBucket.d7,

--- a/strategies/spot-and-short-momentum.py
+++ b/strategies/spot-and-short-momentum.py
@@ -192,7 +192,7 @@ def create_trading_universe(
         chain_id=ChainId.polygon,
         exchange_slugs={"uniswap-v3"},
         reserve_assets={"USDC"},
-        asset_symbols={"LINK", "WMATIC", "WETH", "BAL"},
+        asset_ids={"LINK", "WMATIC", "WETH", "BAL"},
         trading_fee=0.0005,
         time_bucket=TimeBucket.d7,
         stop_loss_time_bucket=TimeBucket.h4,

--- a/strategies/spot-and-short-momentum.py
+++ b/strategies/spot-and-short-momentum.py
@@ -191,7 +191,7 @@ def create_trading_universe(
         # Ask for all Polygon data
         chain_id=ChainId.polygon,
         exchange_slugs={"uniswap-v3"},
-        reserve_asset_symbols={"USDC"},
+        reserve_assets={"USDC"},
         asset_symbols={"LINK", "WMATIC", "WETH", "BAL"},
         trading_fee=0.0005,
         time_bucket=TimeBucket.d7,

--- a/strategies/test_only/generic_routing_end_to_end.py
+++ b/strategies/test_only/generic_routing_end_to_end.py
@@ -69,7 +69,7 @@ def create_trading_universe(
 
     reverses = [
         (ChainId.polygon, LendingProtocolType.aave_v3, "WETH"),
-        (ChainId.polygon, LendingProtocolType.aave_v3, "USDC"),
+        (ChainId.polygon, LendingProtocolType.aave_v3, "0x2791Bca1f2de4661ED88A30C99A7a9449Aa84174"),
     ]
 
     dataset = load_partial_data(

--- a/strategies/test_only/polygon-eth-spot-short-bb.py
+++ b/strategies/test_only/polygon-eth-spot-short-bb.py
@@ -53,7 +53,7 @@ TRADING_PAIR = (ChainId.polygon, "uniswap-v3", "WETH", "USDC", 0.0005)
 # NEW
 LENDING_RESERVES = [
     (ChainId.polygon, LendingProtocolType.aave_v3, "WETH"),
-    (ChainId.polygon, LendingProtocolType.aave_v3, "USDC"),
+    (ChainId.polygon, LendingProtocolType.aave_v3, "0x2791Bca1f2de4661ED88A30C99A7a9449Aa84174"),
 ]
 
 # How much % of the cash to put on a single trade

--- a/tests/backtest/test_backtest_credit_supply_mock.py
+++ b/tests/backtest/test_backtest_credit_supply_mock.py
@@ -61,7 +61,7 @@ def create_trading_universe(
     ]
 
     reverses = [
-        (ChainId.polygon, LendingProtocolType.aave_v3, "USDC")
+        (ChainId.polygon, LendingProtocolType.aave_v3, "0x2791Bca1f2de4661ED88A30C99A7a9449Aa84174")
     ]
 
     dataset = load_partial_data(

--- a/tests/backtest/test_backtest_credit_supply_real_data.py
+++ b/tests/backtest/test_backtest_credit_supply_real_data.py
@@ -48,7 +48,7 @@ def create_trading_universe(
     ]
 
     reverses = [
-        (ChainId.polygon, LendingProtocolType.aave_v3, "USDC")
+        (ChainId.polygon, LendingProtocolType.aave_v3, "0x2791Bca1f2de4661ED88A30C99A7a9449Aa84174")
     ]
 
     dataset = load_partial_data(

--- a/tests/backtest/test_backtest_short_real_data.py
+++ b/tests/backtest/test_backtest_short_real_data.py
@@ -49,7 +49,7 @@ def create_trading_universe(
 
     reverses = [
         (ChainId.polygon, LendingProtocolType.aave_v3, "WETH"),
-        (ChainId.polygon, LendingProtocolType.aave_v3, "USDC"),
+        (ChainId.polygon, LendingProtocolType.aave_v3, "0x2791Bca1f2de4661ED88A30C99A7a9449Aa84174"),
     ]
 
     dataset = load_partial_data(

--- a/tests/ethereum/polygon_forked/1delta/test_one_delta_live_short.py
+++ b/tests/ethereum/polygon_forked/1delta/test_one_delta_live_short.py
@@ -77,7 +77,7 @@ def trading_strategy_universe(chain_id, exchange_universe, pair_universe, asset_
 
     reverses = [
         (ChainId.polygon, LendingProtocolType.aave_v3, "WETH"),
-        (ChainId.polygon, LendingProtocolType.aave_v3, "USDC"),
+        (ChainId.polygon, LendingProtocolType.aave_v3, "0x2791Bca1f2de4661ED88A30C99A7a9449Aa84174"),
     ]
 
     dataset = load_partial_data(

--- a/tests/ethereum/polygon_forked/generic-router/conftest.py
+++ b/tests/ethereum/polygon_forked/generic-router/conftest.py
@@ -54,7 +54,7 @@ def strategy_universe(
 
     reverses = [
         (ChainId.polygon, LendingProtocolType.aave_v3, "WETH"),
-        (ChainId.polygon, LendingProtocolType.aave_v3, "USDC"),
+        (ChainId.polygon, LendingProtocolType.aave_v3, "0x2791Bca1f2de4661ED88A30C99A7a9449Aa84174"),
         (ChainId.polygon, LendingProtocolType.aave_v3, "WMATIC"),
     ]
 

--- a/tests/ethereum/polygon_forked/generic-router/test_short_flags.py
+++ b/tests/ethereum/polygon_forked/generic-router/test_short_flags.py
@@ -48,7 +48,7 @@ def strategy_universe(
 
     reverses = [
         (ChainId.polygon, LendingProtocolType.aave_v3, "WETH"),
-        (ChainId.polygon, LendingProtocolType.aave_v3, "USDC"),
+        (ChainId.polygon, LendingProtocolType.aave_v3, "0x2791Bca1f2de4661ED88A30C99A7a9449Aa84174"),
         (ChainId.polygon, LendingProtocolType.aave_v3, "WMATIC"),
     ]
 

--- a/tests/ethereum/test_aave_v3_interest.py
+++ b/tests/ethereum/test_aave_v3_interest.py
@@ -15,7 +15,7 @@ def test_get_aave_v3_candle_for_period(persistent_test_client):
 
     candles = get_aave_v3_candles_for_period(
         client,
-        "USDC",
+        "0x2791Bca1f2de4661ED88A30C99A7a9449Aa84174",
         137,
         datetime.datetime(2023, 1, 1),
         datetime.datetime(2023, 2, 1),
@@ -30,7 +30,7 @@ def test_get_aave_v3_raw_data_for_period(persistent_test_client):
 
     df = get_aave_v3_raw_data_for_period(
         client,
-        "USDC",
+        "0x2791Bca1f2de4661ED88A30C99A7a9449Aa84174",
         137,
         datetime.datetime(2023, 1, 1),
         datetime.datetime(2023, 2, 1),
@@ -43,7 +43,7 @@ def test_get_aave_v3_raw_data_for_period(persistent_test_client):
     "token, chain_id, amount, start_time, end_time",
     (
         (
-            "USDC",
+            "0x2791Bca1f2de4661ED88A30C99A7a9449Aa84174",
             137,
             10000 * 10**6,
             datetime.datetime(2023, 1, 1),
@@ -93,7 +93,6 @@ def test_estimate_loan_interests(persistent_test_client, token, chain_id, amount
     Compare interests calculated from "correct" method and estimation
     """
     client = persistent_test_client
-
 
     decimals = 18
     if token in ("USDC", "USDT"):

--- a/tests/interest/test_lending_dataset.py
+++ b/tests/interest/test_lending_dataset.py
@@ -25,7 +25,7 @@ def test_load_lending_dataset(persistent_test_client: Client):
     ]
 
     reverses = [
-        (ChainId.polygon, LendingProtocolType.aave_v3, "USDC")
+        (ChainId.polygon, LendingProtocolType.aave_v3, "USDC.e")
     ]
 
     dataset = load_partial_data(
@@ -45,7 +45,7 @@ def test_load_lending_dataset(persistent_test_client: Client):
     # Lending reserves ok
     assert dataset.lending_reserves.get_count() == 1
     rates = dataset.lending_candles.supply_apr.get_rates_by_reserve(
-        (ChainId.polygon, LendingProtocolType.aave_v3, "USDC")
+        (ChainId.polygon, LendingProtocolType.aave_v3, "USDC.e")
     )
     assert rates["open"][pd.Timestamp("2023-01-01")] == pytest.approx(0.6998308843795215)
     assert rates["close"][pd.Timestamp("2023-01-01")] == pytest.approx(0.6589076823528996)
@@ -60,7 +60,7 @@ def test_construct_trading_universe_with_lending(persistent_test_client: Client)
     ]
 
     reverses = [
-        (ChainId.polygon, LendingProtocolType.aave_v3, "USDC")
+        (ChainId.polygon, LendingProtocolType.aave_v3, "USDC.e")
     ]
 
     dataset = load_partial_data(
@@ -83,7 +83,7 @@ def test_construct_trading_universe_with_lending(persistent_test_client: Client)
     # Lending reserves ok
     assert data_universe.lending_reserves.get_count() == 1
     rates = data_universe.lending_candles.supply_apr.get_rates_by_reserve(
-        (ChainId.polygon, LendingProtocolType.aave_v3, "USDC")
+        (ChainId.polygon, LendingProtocolType.aave_v3, "USDC.e")
     )
     assert rates["open"][pd.Timestamp("2023-01-01")] == pytest.approx(0.6998308843795215)
     assert rates["close"][pd.Timestamp("2023-01-01")] == pytest.approx(0.6589076823528996)
@@ -102,7 +102,7 @@ def test_get_credit_supply_trading_pair(persistent_test_client: Client):
     ]
 
     reverses = [
-        (ChainId.polygon, LendingProtocolType.aave_v3, "USDC")
+        (ChainId.polygon, LendingProtocolType.aave_v3, "USDC.e")
     ]
 
     dataset = load_partial_data(
@@ -121,7 +121,7 @@ def test_get_credit_supply_trading_pair(persistent_test_client: Client):
     # This trading pair identifies the trades where
     reserve_credit_supply_pair = strategy_universe.get_credit_supply_pair()
     assert reserve_credit_supply_pair.base.token_symbol == "aPolUSDC"
-    assert reserve_credit_supply_pair.quote.token_symbol == "USDC"
+    assert reserve_credit_supply_pair.quote.token_symbol == "USDC.e"
     assert reserve_credit_supply_pair.kind == TradingPairKind.credit_supply
 
     data_universe = strategy_universe.data_universe
@@ -158,7 +158,7 @@ def test_load_trading_and_lending_data_historical(persistent_test_client: Client
     assert data_universe.lending_reserves is not None
 
     # Check one loaded reserve metadata
-    usdc_reserve = data_universe.lending_reserves.get_by_chain_and_symbol(ChainId.polygon, "USDC")
+    usdc_reserve = data_universe.lending_reserves.get_by_chain_and_symbol(ChainId.polygon, "USDC.e")
     assert usdc_reserve.atoken_symbol == "aPolUSDC"
     assert usdc_reserve.vtoken_symbol == "variableDebtPolUSDC"
 
@@ -187,12 +187,13 @@ def test_load_trading_and_lending_data_historical_certain_assets_only(persistent
         exchange_slugs="uniswap-v3",
         asset_symbols={"LINK", "WETH"},
         trading_fee=0.0005,
+        reserve_assets={"0x2791Bca1f2de4661ED88A30C99A7a9449Aa84174"}
     )
 
     strategy_universe = TradingStrategyUniverse.create_from_dataset(dataset)
     data_universe = strategy_universe.data_universe
 
-    usdc_reserve = data_universe.lending_reserves.get_by_chain_and_symbol(ChainId.polygon, "USDC")
+    usdc_reserve = data_universe.lending_reserves.get_by_chain_and_symbol(ChainId.polygon, "USDC.e")
     assert usdc_reserve.atoken_symbol == "aPolUSDC"
     assert usdc_reserve.vtoken_symbol == "variableDebtPolUSDC"
 

--- a/tests/interest/test_lending_dataset.py
+++ b/tests/interest/test_lending_dataset.py
@@ -230,6 +230,7 @@ def test_load_trading_and_lending_data_live(persistent_test_client: Client):
         universe_options=UniverseOptions(history_period=datetime.timedelta(days=7)),
         chain_id=ChainId.polygon,
         exchange_slugs="uniswap-v3",
+        reserve_assets={"0x2791Bca1f2de4661ED88A30C99A7a9449Aa84174"},
     )
 
     assert dataset.history_period == datetime.timedelta(days=7)

--- a/tests/interest/test_lending_dataset.py
+++ b/tests/interest/test_lending_dataset.py
@@ -147,6 +147,7 @@ def test_load_trading_and_lending_data_historical(persistent_test_client: Client
         universe_options=UniverseOptions(start_at=start_at, end_at=end_at),
         chain_id=ChainId.polygon,
         exchange_slugs="uniswap-v3",
+        reserve_assets={"0x2791Bca1f2de4661ED88A30C99A7a9449Aa84174"},
     )
 
     strategy_universe = TradingStrategyUniverse.create_from_dataset(dataset)
@@ -185,7 +186,7 @@ def test_load_trading_and_lending_data_historical_certain_assets_only(persistent
         universe_options=UniverseOptions(start_at=start_at, end_at=end_at),
         chain_id=ChainId.polygon,
         exchange_slugs="uniswap-v3",
-        asset_symbols={"LINK", "WETH"},
+        asset_ids={"LINK", "WETH"},
         trading_fee=0.0005,
         reserve_assets={"0x2791Bca1f2de4661ED88A30C99A7a9449Aa84174"}
     )

--- a/tests/interest/test_missing_lending_data.py
+++ b/tests/interest/test_missing_lending_data.py
@@ -66,7 +66,7 @@ TRADING_PAIR = (ChainId.polygon, "uniswap-v3", "WETH", "USDC", 0.0005)
 
 LENDING_RESERVES = [
     (ChainId.polygon, LendingProtocolType.aave_v3, "WETH"),
-    (ChainId.polygon, LendingProtocolType.aave_v3, "USDC"),
+    (ChainId.polygon, LendingProtocolType.aave_v3, "0x2791Bca1f2de4661ED88A30C99A7a9449Aa84174"),
 ]
 
 STOP_LOSS_TIME_BUCKET = TimeBucket.m15

--- a/tradeexecutor/ethereum/aave_v3/interests.py
+++ b/tradeexecutor/ethereum/aave_v3/interests.py
@@ -9,17 +9,22 @@ from tradingstrategy.chain import ChainId
 from tradingstrategy.lending import LendingReserve, LendingCandleType
 from tradingstrategy.client import Client
 from tradingstrategy.timebucket import TimeBucket
+from tradingstrategy.types import TokenSymbol, NonChecksummedAddress
 
 
 def get_aave_v3_candles_for_period(
     client: Client,
-    token: str,
+    asset_id: TokenSymbol | NonChecksummedAddress,
     chain_id: int,
     start_time: datetime.datetime,
     end_time: datetime.datetime = datetime.datetime.utcnow(),
 ):
     reserve_universe = client.fetch_lending_reserve_universe()
-    reserve: LendingReserve = reserve_universe.get_by_chain_and_symbol(ChainId(chain_id), token)
+
+    if asset_id.startswith("0x"):
+        reserve: LendingReserve = reserve_universe.get_by_chain_and_address(ChainId(chain_id), asset_id)
+    else:
+        reserve: LendingReserve = reserve_universe.get_by_chain_and_symbol(ChainId(chain_id), asset_id)
 
     lending_candles = client.fetch_lending_candles_by_reserve_id(
         reserve.reserve_id,
@@ -34,13 +39,17 @@ def get_aave_v3_candles_for_period(
 
 def get_aave_v3_raw_data_for_period(
     client: Client,
-    token: str,
+    asset_id: TokenSymbol | NonChecksummedAddress,
     chain_id: int,
     start_time: datetime.datetime,
     end_time: datetime.datetime = datetime.datetime.utcnow(),
 ):
     reserve_universe = client.fetch_lending_reserve_universe()
-    reserve: LendingReserve = reserve_universe.get_by_chain_and_symbol(ChainId(chain_id), token)
+
+    if asset_id.startswith("0x"):
+        reserve: LendingReserve = reserve_universe.get_by_chain_and_address(ChainId(chain_id), asset_id)
+    else:
+        reserve: LendingReserve = reserve_universe.get_by_chain_and_symbol(ChainId(chain_id), asset_id)
 
     # NOTE: This is very slow the 1st time
     pq_table = client.fetch_lending_reserves_all_time()

--- a/tradeexecutor/strategy/trading_strategy_universe.py
+++ b/tradeexecutor/strategy/trading_strategy_universe.py
@@ -1045,7 +1045,7 @@ class TradingStrategyUniverse(StrategyExecutionUniverse):
                 borrow_token.address,
             )
         except UnknownLendingReserve as e:
-            raise UnknownLendingReserve(f"Could not resolve {borrow_token}") from e
+            raise UnknownLendingReserve(f"Could not resolve borrowed token {borrow_token}") from e
 
         try:
             collateral_reserve = self.data_universe.lending_reserves.get_by_chain_and_address(
@@ -1053,7 +1053,7 @@ class TradingStrategyUniverse(StrategyExecutionUniverse):
                 collateral_token.address,
             )
         except UnknownLendingReserve as e:
-            raise UnknownLendingReserve(f"Could not resolve {collateral_token}") from e
+            raise UnknownLendingReserve(f"Could not resolve collateral token {collateral_token}") from e
 
         vtoken = translate_token(
             borrow_reserve.get_vtoken(),


### PR DESCRIPTION
- Polygon renamed USDC -> USDC.e
- Native USDC is now USDC on Polygon
- This breaks a lot of assumptions regarding USDC stablecoin as we have now two of them
- This PR will make tests and strategies to address tokens by the USDC address instead of just symbol USDC