### PR TITLE
Fix long short table serialisation

### DIFF
--- a/tradeexecutor/statistics/statistics_table.py
+++ b/tradeexecutor/statistics/statistics_table.py
@@ -32,7 +32,7 @@ class StatisticsTable:
     created_at: datetime.datetime
 
     #: The source of the table. Can either be live trading or backtesting.
-    source: KeyMetricSource
+    source: KeyMetricSource | None = None
 
     #: The start of the calculation window.
     calculation_window_start_at: datetime.datetime | None = None
@@ -41,7 +41,8 @@ class StatisticsTable:
     calculation_window_end_at: datetime.timedelta | None = None
 
     def __post_init__(self):
-        assert isinstance(self.source, KeyMetricSource)
+        if self.source is not None:
+            assert isinstance(self.source, KeyMetricSource), f"Got {self.source}"
         assert type(self.columns) == list
 
 

--- a/tradeexecutor/statistics/statistics_table.py
+++ b/tradeexecutor/statistics/statistics_table.py
@@ -26,7 +26,7 @@ class StatisticsTable:
     columns: list[str]
 
     #: The rows of the table.
-    rows: dict[KeyMetricKind, KeyMetric]
+    rows: dict[str, KeyMetric]
     
     #: The time at which the table was created.
     created_at: datetime.datetime
@@ -39,6 +39,10 @@ class StatisticsTable:
     
     #: The end of the calculation window.
     calculation_window_end_at: datetime.timedelta | None = None
+
+    def __post_init__(self):
+        assert isinstance(self.source, KeyMetricSource)
+        assert type(self.columns) == list
 
 
 def serialise_long_short_stats_as_json_table(
@@ -125,7 +129,7 @@ def serialise_long_short_stats_as_json_table(
                 kind=key_metric_kind,
                 value={"All": metric_data[0], "Long": metric_data[1], "Short": metric_data[2]},
                 help_link=metric_data[3],
-                source=source_state,
+                source=source,
                 calculation_window_start_at = calculation_window_start_at,
                 calculation_window_end_at = calculation_window_end_at,
                 name = metric_data.name,

--- a/tradeexecutor/strategy/summary.py
+++ b/tradeexecutor/strategy/summary.py
@@ -256,6 +256,10 @@ class KeyMetric:
     #: Should be in human readable format
     name: str | None = None
 
+    def __post_init__(self):
+        assert isinstance(self.source, KeyMetricSource)
+        assert isinstance(self.kind, KeyMetricKind)
+
     @staticmethod
     def create_na(kind: KeyMetricKind, reason: str) -> "KeyMetric":
         """Create missing value placeholder."""


### PR DESCRIPTION
- Fix the new summary metrics table in RunState causing excessive serialisation and then crash by hanging