### PR TITLE
add backtested state to long short metrics

### DIFF
--- a/tests/ethereum/polygon_forked/generic-router/test_generic_router_live_loop.py
+++ b/tests/ethereum/polygon_forked/generic-router/test_generic_router_live_loop.py
@@ -65,7 +65,7 @@ def decide_trades(
     return trades
 
 
-def test_generic_router_spot_and_shot_strategy(
+def test_generic_router_spot_and_short_strategy(
     logger: Logger,
     web3: Web3,
     hot_wallet: HotWallet,
@@ -122,7 +122,7 @@ def test_generic_router_spot_and_shot_strategy(
         loop.runner.check_accounts(strategy_universe, state)  # Check that on-chain balances reflect what we expect
 
 
-def test_generic_router_spot_and_shot_strategy_manual_tick(
+def test_generic_router_spot_and_short_strategy_manual_tick(
     logger: Logger,
     web3: Web3,
     hot_wallet: HotWallet,
@@ -203,8 +203,11 @@ def test_generic_router_spot_and_shot_strategy_manual_tick(
         ExecutionMode.real_trading
     )
     assert len(portfolio.open_positions) == 1
-    assert position.loan.get_borrow_interest() == pytest.approx(1.4860578061962053)
-    assert position.loan.get_collateral_interest() == pytest.approx(13.711178)
+    
+    tolerance = 1e-5
+    assert position.loan.get_borrow_interest() == pytest.approx(1.4860578061962053, abs=tolerance)
+    tolerance = 1e-4
+    assert position.loan.get_collateral_interest() == pytest.approx(13.711178, abs=tolerance)
 
     loop.runner.check_accounts(strategy_universe, state)  # Check that on-chain balances reflect what we expect
 

--- a/tradeexecutor/cli/commands/perform_test_trade.py
+++ b/tradeexecutor/cli/commands/perform_test_trade.py
@@ -24,6 +24,7 @@ from ...strategy.trading_strategy_universe import TradingStrategyUniverseModel
 from ...strategy.universe_model import UniverseOptions
 from ...utils.timer import timed_task
 from tradeexecutor.cli.commands import shared_options
+from tradeexecutor.statistics.statistics_table import serialise_long_short_stats_as_json_table
 from tradingstrategy.chain import ChainId
 from tradingstrategy.pair import DEXPair
 
@@ -173,6 +174,10 @@ def perform_test_trade(
     runner = run_description.runner
     routing_state, pricing_model, valuation_method = runner.setup_routing(universe)
 
+    long_short_metrics_latest = serialise_long_short_stats_as_json_table(
+        state, None, datetime.timedelta(days=90)
+    )
+    
     if all_pairs:
 
         for pair in universe.data_universe.pairs.iterate_pairs():
@@ -192,6 +197,7 @@ def perform_test_trade(
                 pair=p,
                 buy_only=buy_only,
                 spot_only=spot_only,
+                long_short_metrics_latest=long_short_metrics_latest,
             )
     else:
 
@@ -206,6 +212,7 @@ def perform_test_trade(
             routing_state,
             pair=pair,
             buy_only=buy_only,
+            long_short_metrics_latest=long_short_metrics_latest,
         )
 
     # Store the test trade data in the strategy history

--- a/tradeexecutor/cli/commands/perform_test_trade.py
+++ b/tradeexecutor/cli/commands/perform_test_trade.py
@@ -173,10 +173,6 @@ def perform_test_trade(
 
     runner = run_description.runner
     routing_state, pricing_model, valuation_method = runner.setup_routing(universe)
-
-    long_short_metrics_latest = serialise_long_short_stats_as_json_table(
-        state, None, datetime.timedelta(days=90)
-    )
     
     if all_pairs:
 
@@ -197,7 +193,6 @@ def perform_test_trade(
                 pair=p,
                 buy_only=buy_only,
                 spot_only=spot_only,
-                long_short_metrics_latest=long_short_metrics_latest,
             )
     else:
 
@@ -212,7 +207,6 @@ def perform_test_trade(
             routing_state,
             pair=pair,
             buy_only=buy_only,
-            long_short_metrics_latest=long_short_metrics_latest,
         )
 
     # Store the test trade data in the strategy history

--- a/tradeexecutor/cli/commands/perform_test_trade.py
+++ b/tradeexecutor/cli/commands/perform_test_trade.py
@@ -24,7 +24,6 @@ from ...strategy.trading_strategy_universe import TradingStrategyUniverseModel
 from ...strategy.universe_model import UniverseOptions
 from ...utils.timer import timed_task
 from tradeexecutor.cli.commands import shared_options
-from tradeexecutor.statistics.statistics_table import serialise_long_short_stats_as_json_table
 from tradingstrategy.chain import ChainId
 from tradingstrategy.pair import DEXPair
 
@@ -173,7 +172,7 @@ def perform_test_trade(
 
     runner = run_description.runner
     routing_state, pricing_model, valuation_method = runner.setup_routing(universe)
-    
+
     if all_pairs:
 
         for pair in universe.data_universe.pairs.iterate_pairs():

--- a/tradeexecutor/cli/loop.py
+++ b/tradeexecutor/cli/loop.py
@@ -585,8 +585,8 @@ class ExecutionLoop:
         self.store.sync(state)
 
     def extract_long_short_stats_from_state(self, state):
-        backtested_state = self.metadata.backtested_state
-        backtest_cutoff = self.metadata.key_metrics_backtest_cut_off
+        backtested_state = self.metadata.backtested_state if self.metadata else None
+        backtest_cutoff = self.metadata.key_metrics_backtest_cut_off if self.metadata else datetime.timedelta(days=90)
         long_short_metrics_latest = serialise_long_short_stats_as_json_table(
             state, backtested_state, backtest_cutoff
         )

--- a/tradeexecutor/cli/loop.py
+++ b/tradeexecutor/cli/loop.py
@@ -388,8 +388,10 @@ class ExecutionLoop:
             ts = strategy_cycle_timestamp
         else:
             ts = snap_to_previous_tick(unrounded_timestamp, cycle_duration)
-            
-        long_short_table = serialise_long_short_stats_as_json_table(state, self.metadata.backtested_state, self.metadata.key_metrics_backtest_cut_off)
+        
+        backtested_state = self.metadata.backtested_state if self.metadata else None
+        backtest_cutoff = self.metadata.key_metrics_backtest_cut_off if self.metadata else datetime.timedelta(days=90)
+        long_short_table = serialise_long_short_stats_as_json_table(state, backtested_state, backtest_cutoff)
         state.stats.long_short_metrics_latest = long_short_table
 
         # This Python dict collects internal debugging data through this cycle.

--- a/tradeexecutor/cli/loop.py
+++ b/tradeexecutor/cli/loop.py
@@ -388,12 +388,6 @@ class ExecutionLoop:
             ts = strategy_cycle_timestamp
         else:
             ts = snap_to_previous_tick(unrounded_timestamp, cycle_duration)
-        
-        if self.execution_context.live_trading:
-            backtested_state = self.metadata.backtested_state if self.metadata else None
-            backtest_cutoff = self.metadata.key_metrics_backtest_cut_off if self.metadata else datetime.timedelta(days=90)
-            long_short_table = serialise_long_short_stats_as_json_table(state, backtested_state, backtest_cutoff)
-            state.stats.long_short_metrics_latest = long_short_table
 
         # This Python dict collects internal debugging data through this cycle.
         # Any submodule of strategy execution can add internal information here for
@@ -513,6 +507,10 @@ class ExecutionLoop:
                     )
                 except UnexpectedAccountingCorrectionIssue as e:
                     raise RuntimeError(f"Execution aborted at cycle {ts} #{cycle} because on-chain balances were different what expected after executing the trades") from e
+                
+            backtested_state = self.metadata.backtested_state
+            backtest_cutoff = self.metadata.key_metrics_backtest_cut_off
+            long_short_metrics_latest = serialise_long_short_stats_as_json_table(state, backtested_state, backtest_cutoff)
 
             update_statistics(
                 datetime.datetime.utcnow(),
@@ -520,6 +518,7 @@ class ExecutionLoop:
                 state.portfolio,
                 ExecutionMode.real_trading,
                 strategy_cycle_or_wall_clock=strategy_cycle_timestamp,
+                long_short_metrics_latest=long_short_metrics_latest,
             )
 
         state.uptime.record_cycle_complete(cycle)

--- a/tradeexecutor/cli/loop.py
+++ b/tradeexecutor/cli/loop.py
@@ -389,10 +389,11 @@ class ExecutionLoop:
         else:
             ts = snap_to_previous_tick(unrounded_timestamp, cycle_duration)
         
-        backtested_state = self.metadata.backtested_state if self.metadata else None
-        backtest_cutoff = self.metadata.key_metrics_backtest_cut_off if self.metadata else datetime.timedelta(days=90)
-        long_short_table = serialise_long_short_stats_as_json_table(state, backtested_state, backtest_cutoff)
-        state.stats.long_short_metrics_latest = long_short_table
+        if self.execution_context.live_trading:
+            backtested_state = self.metadata.backtested_state if self.metadata else None
+            backtest_cutoff = self.metadata.key_metrics_backtest_cut_off if self.metadata else datetime.timedelta(days=90)
+            long_short_table = serialise_long_short_stats_as_json_table(state, backtested_state, backtest_cutoff)
+            state.stats.long_short_metrics_latest = long_short_table
 
         # This Python dict collects internal debugging data through this cycle.
         # Any submodule of strategy execution can add internal information here for

--- a/tradeexecutor/cli/loop.py
+++ b/tradeexecutor/cli/loop.py
@@ -26,6 +26,7 @@ from tradeexecutor.ethereum.tx import TransactionBuilder
 from tradeexecutor.ethereum.wallet import perform_gas_level_checks
 from tradeexecutor.state.metadata import Metadata
 from tradeexecutor.statistics.in_memory_statistics import refresh_run_state
+from tradeexecutor.statistics.statistics_table import serialise_long_short_stats_as_json_table
 from tradeexecutor.strategy.account_correction import check_accounts, UnexpectedAccountingCorrectionIssue
 from tradeexecutor.strategy.dummy import DummyExecutionModel
 from tradeexecutor.strategy.generic.generic_pricing_model import GenericPricing
@@ -387,6 +388,9 @@ class ExecutionLoop:
             ts = strategy_cycle_timestamp
         else:
             ts = snap_to_previous_tick(unrounded_timestamp, cycle_duration)
+            
+        long_short_table = serialise_long_short_stats_as_json_table(state, self.metadata.backtested_state, self.metadata.key_metrics_backtest_cut_off)
+        state.stats.long_short_metrics_latest = long_short_table
 
         # This Python dict collects internal debugging data through this cycle.
         # Any submodule of strategy execution can add internal information here for

--- a/tradeexecutor/cli/loop.py
+++ b/tradeexecutor/cli/loop.py
@@ -58,6 +58,7 @@ from tradeexecutor.strategy.sync_model import SyncMethodV0, SyncModel
 from tradeexecutor.state.trade import TradeExecution
 from tradeexecutor.state.validator import validate_state_serialisation
 from tradeexecutor.statistics.core import update_statistics
+from tradeexecutor.statistics.statistics_table import StatisticsTable
 from tradeexecutor.strategy.approval import ApprovalModel
 from tradeexecutor.strategy.description import StrategyExecutionDescription
 from tradeexecutor.strategy.execution_model import ExecutionModel
@@ -584,7 +585,13 @@ class ExecutionLoop:
         # Store the current state to disk
         self.store.sync(state)
 
-    def extract_long_short_stats_from_state(self, state):
+    def extract_long_short_stats_from_state(self, state) -> StatisticsTable:
+        """Extracts the latest long short metrics from the state and execution loop
+        
+        :param state: Current state for the strategy
+        
+        :return: StatisticsTable of the latest long short metrics
+        """
         backtested_state = self.metadata.backtested_state if self.metadata else None
         backtest_cutoff = self.metadata.key_metrics_backtest_cut_off if self.metadata else datetime.timedelta(days=90)
         long_short_metrics_latest = serialise_long_short_stats_as_json_table(

--- a/tradeexecutor/cli/testtrade.py
+++ b/tradeexecutor/cli/testtrade.py
@@ -23,6 +23,7 @@ from tradeexecutor.strategy.pandas_trader.position_manager import PositionManage
 from tradeexecutor.strategy.pricing_model import PricingModel
 from tradeexecutor.strategy.routing import RoutingModel, RoutingState
 from tradeexecutor.strategy.trading_strategy_universe import TradingStrategyUniverse, translate_trading_pair
+from tradeexecutor.statistics.statistics_table import StatisticsTable
 
 logger = logging.getLogger(__name__)
 
@@ -40,6 +41,7 @@ def make_test_trade(
     pair: HumanReadableTradingPairDescription | None = None,
     buy_only: bool = False,
     spot_only: bool = False,
+    long_short_metrics_latest: StatisticsTable = None,
 ):
     """Perform a test trade.
 
@@ -200,7 +202,7 @@ def make_test_trade(
             raise AssertionError("Test buy succeed, but the position was not opened\n"
                                  "Check for dust corrections.")
 
-        update_statistics(datetime.datetime.utcnow(), state.stats, state.portfolio, ExecutionMode.real_trading)
+        update_statistics(datetime.datetime.utcnow(), state.stats, state.portfolio, ExecutionMode.real_trading, long_short_metrics_latest=long_short_metrics_latest)
 
     logger.info("Position %s is open. Now closing the position.", position)
 
@@ -241,7 +243,7 @@ def make_test_trade(
             logger.error("Trade dump:\n%s", sell_trade.get_debug_dump())
             raise AssertionError("Test sell failed")
 
-        update_statistics(datetime.datetime.utcnow(), state.stats, state.portfolio, ExecutionMode.real_trading)
+        update_statistics(datetime.datetime.utcnow(), state.stats, state.portfolio, ExecutionMode.real_trading, long_short_metrics_latest=long_short_metrics_latest)
 
     else:
         sell_trade = None

--- a/tradeexecutor/cli/testtrade.py
+++ b/tradeexecutor/cli/testtrade.py
@@ -9,6 +9,7 @@ from web3 import Web3
 from tradeexecutor.ethereum.enzyme.vault import EnzymeVaultSyncModel
 from tradeexecutor.state.trade import TradeFlag
 from tradeexecutor.statistics.core import update_statistics
+from tradeexecutor.statistics.statistics_table import serialise_long_short_stats_as_json_table
 from tradeexecutor.strategy.execution_context import ExecutionMode
 from tradeexecutor.strategy.sync_model import SyncModel
 from tradeexecutor.utils.accuracy import sum_decimal
@@ -41,7 +42,6 @@ def make_test_trade(
     pair: HumanReadableTradingPairDescription | None = None,
     buy_only: bool = False,
     spot_only: bool = False,
-    long_short_metrics_latest: StatisticsTable = None,
 ):
     """Perform a test trade.
 
@@ -202,6 +202,10 @@ def make_test_trade(
             raise AssertionError("Test buy succeed, but the position was not opened\n"
                                  "Check for dust corrections.")
 
+        long_short_metrics_latest = serialise_long_short_stats_as_json_table(
+            state, None, datetime.timedelta(days=90)
+        )
+        
         update_statistics(datetime.datetime.utcnow(), state.stats, state.portfolio, ExecutionMode.real_trading, long_short_metrics_latest=long_short_metrics_latest)
 
     logger.info("Position %s is open. Now closing the position.", position)
@@ -243,6 +247,10 @@ def make_test_trade(
             logger.error("Trade dump:\n%s", sell_trade.get_debug_dump())
             raise AssertionError("Test sell failed")
 
+        long_short_metrics_latest = serialise_long_short_stats_as_json_table(
+            state, None, datetime.timedelta(days=90)
+        )
+        
         update_statistics(datetime.datetime.utcnow(), state.stats, state.portfolio, ExecutionMode.real_trading, long_short_metrics_latest=long_short_metrics_latest)
 
     else:
@@ -313,7 +321,11 @@ def make_test_trade(
                 raise AssertionError("Test buy succeed, but the position was not opened\n"
                                      "Check for dust corrections.")
 
-            update_statistics(datetime.datetime.utcnow(), state.stats, state.portfolio, ExecutionMode.real_trading)
+            long_short_metrics_latest = serialise_long_short_stats_as_json_table(
+                state, None, datetime.timedelta(days=90)
+            )
+
+            update_statistics(datetime.datetime.utcnow(), state.stats, state.portfolio, ExecutionMode.real_trading, long_short_metrics_latest=long_short_metrics_latest)
 
         # Close the short
 
@@ -372,7 +384,11 @@ def make_test_trade(
             raise AssertionError("Short close succeed, but the position was not opened\n"
                                  "Check for dust corrections.")
 
-        update_statistics(datetime.datetime.utcnow(), state.stats, state.portfolio, ExecutionMode.real_trading)
+        long_short_metrics_latest = serialise_long_short_stats_as_json_table(
+            state, None, datetime.timedelta(days=90)
+        )
+        
+        update_statistics(datetime.datetime.utcnow(), state.stats, state.portfolio, ExecutionMode.real_trading, long_short_metrics_latest=long_short_metrics_latest)
 
     gas_at_end = hot_wallet.get_native_currency_balance(web3)
     reserve_currency_at_end = state.portfolio.get_default_reserve_position().get_value()

--- a/tradeexecutor/statistics/core.py
+++ b/tradeexecutor/statistics/core.py
@@ -195,12 +195,13 @@ def update_statistics(
         strategy_cycle_or_wall_clock
     )
     
-    if execution_mode.is_live_trading():
+    if execution_mode.is_live_trading() and execution_mode != ExecutionMode.unit_testing_trading:
         assert long_short_metrics_latest, "long short metrics should be provided in live trading"
     
     if long_short_metrics_latest:
-        logger.info("Serialising serialise_long_short_stats_as_json_table()")
-        stats.long_short_metrics_latest = long_short_metrics_latest
+        logger.info("Serialising long_short_metrics_latest")
+    
+    stats.long_short_metrics_latest = long_short_metrics_latest
         
     new_stats = calculate_statistics(clock, portfolio, execution_mode)
     stats.portfolio.append(new_stats.portfolio)

--- a/tradeexecutor/statistics/core.py
+++ b/tradeexecutor/statistics/core.py
@@ -6,7 +6,6 @@ from dataclasses import dataclass, field
 from typing import Dict, List
 from tradeexecutor.analysis.trade_analyser import build_trade_analysis
 
-from tradeexecutor.statistics.statistics_table import serialise_long_short_stats_as_json_table
 from tradeexecutor.state.portfolio import Portfolio
 from tradeexecutor.state.position import TradingPosition
 from tradeexecutor.state.statistics import Statistics, PortfolioStatistics, PositionStatistics, FinalPositionStatistics
@@ -194,11 +193,6 @@ def update_statistics(
         strategy_cycle_or_wall_clock
     )
         
-    if execution_mode.is_live_trading():
-        logger.info("Serialising serialise_long_short_stats_as_json_table()")
-        long_short_table = serialise_long_short_stats_as_json_table(portfolio)
-        stats.long_short_metrics_latest = long_short_table
-
     new_stats = calculate_statistics(clock, portfolio, execution_mode)
     stats.portfolio.append(new_stats.portfolio)
     for position_id, position_stats in new_stats.positions.items():

--- a/tradeexecutor/statistics/core.py
+++ b/tradeexecutor/statistics/core.py
@@ -10,6 +10,7 @@ from tradeexecutor.state.portfolio import Portfolio
 from tradeexecutor.state.position import TradingPosition
 from tradeexecutor.state.statistics import Statistics, PortfolioStatistics, PositionStatistics, FinalPositionStatistics
 from tradeexecutor.strategy.execution_context import ExecutionMode
+from tradeexecutor.statistics.statistics_table import StatisticsTable
 
 logger = logging.getLogger(__name__)
 
@@ -156,6 +157,7 @@ def update_statistics(
         portfolio: Portfolio,
         execution_mode: ExecutionMode,
         strategy_cycle_or_wall_clock: datetime.datetime | None = None,
+        long_short_metrics_latest: StatisticsTable | None = None,
 ):
     """Update statistics in a portfolio.
 
@@ -192,6 +194,13 @@ def update_statistics(
         clock,
         strategy_cycle_or_wall_clock
     )
+    
+    if execution_mode.is_live_trading():
+        assert long_short_metrics_latest, "long short metrics should be provided in live trading"
+    
+    if long_short_metrics_latest:
+        logger.info("Serialising serialise_long_short_stats_as_json_table()")
+        stats.long_short_metrics_latest = long_short_metrics_latest
         
     new_stats = calculate_statistics(clock, portfolio, execution_mode)
     stats.portfolio.append(new_stats.portfolio)

--- a/tradeexecutor/strategy/runner.py
+++ b/tradeexecutor/strategy/runner.py
@@ -20,6 +20,7 @@ from tradeexecutor.ethereum.tx import TransactionBuilder
 from tradeexecutor.state.store import StateStore
 from tradeexecutor.state.types import BlockNumber
 from tradeexecutor.statistics.core import update_statistics
+from tradeexecutor.statistics.statistics_table import StatisticsTable
 from tradeexecutor.strategy.account_correction import check_accounts, UnexpectedAccountingCorrectionIssue
 from tradeexecutor.strategy.approval import ApprovalModel
 from tradeexecutor.strategy.cycle import CycleDuration
@@ -168,6 +169,7 @@ class StrategyRunner(abc.ABC):
             state: State,
             debug_details: dict,
             end_block: BlockNumber | NoneType = None,
+            long_short_metrics_latest: StatisticsTable | None = None,
     ):
         """Adjust portfolio balances based on the external events.
 
@@ -246,6 +248,7 @@ class StrategyRunner(abc.ABC):
                     state.portfolio,
                     self.execution_context.mode,
                     strategy_cycle_or_wall_clock=timestamp,
+                    long_short_metrics_latest=long_short_metrics_latest
                 )
 
     def revalue_state(self, ts: datetime.datetime, state: State, valuation_model: ValuationModel):
@@ -589,6 +592,7 @@ class StrategyRunner(abc.ABC):
         cycle_duration: Optional[CycleDuration] = None,
         cycle: Optional[int] = None,
         store: Optional[StateStore] = None,
+        long_short_metrics_latest: StatisticsTable | None = None,
     ) -> dict:
         """Execute the core functions of a strategy.
 

--- a/tradeexecutor/visual/equity_curve.py
+++ b/tradeexecutor/visual/equity_curve.py
@@ -170,6 +170,8 @@ def calculate_aggregate_returns(equity_curve: pd.Series, freq: str | pd.DateOffs
     """
     assert isinstance(equity_curve.index, pd.DatetimeIndex), f"Got {equity_curve.index}"
 
+    equity_curve.sort_index(inplace=True)
+    
     # Each equity curve sample is the last day of the period
     # https://stackoverflow.com/a/14039589/315168
     sampled = equity_curve.asfreq(freq, method='ffill')


### PR DESCRIPTION
### Background

- Currently, long short metrics doesn't use backtested state. This PR aims to fix that
- fixes #757

### Summary

- Adds a new argument to `update_statistics`, `long_short_metrics_latest`. This needs is always provided during live trading