### PR TITLE
Fix all key metrics

### DIFF
--- a/tests/backtest/test_backtest_profit_calculation.py
+++ b/tests/backtest/test_backtest_profit_calculation.py
@@ -297,7 +297,9 @@ def test_profitabilities_are_same(backtest_result_hourly: State):
     """
     summary_stats = calculate_summary_statistics(backtest_result_hourly, time_window=datetime.timedelta(days=2000), key_metrics_backtest_cut_off=datetime.timedelta(days=0))
     
-    assert summary_stats.key_metrics['profitability'].value == summary_stats.return_all_time
+    assert summary_stats.return_all_time == -0.1937959274935105
+    
+    assert summary_stats.key_metrics['profitability'].value == pytest.approx(summary_stats.return_all_time, abs=1e-14)
     
 
 def test_calculate_realised_trading_profitability_no_trades():

--- a/tests/backtest/test_backtest_profit_calculation.py
+++ b/tests/backtest/test_backtest_profit_calculation.py
@@ -309,8 +309,8 @@ def test_key_metrics(backtest_result_hourly: State):
     # correct since standard dev = 0
     assert summary_stats.key_metrics['sharpe'].value == float('-inf')
     assert summary_stats.key_metrics['sortino'].value == pytest.approx(-19.104973174542796)
-    assert summary_stats.key_metrics['max_drawdown'] == pytest.approx(0.18798605414266745)
-    assert summary_stats.key_metrics['profitability'] == pytest.approx(-0.1937959274935087)
+    assert summary_stats.key_metrics['max_drawdown'].value == pytest.approx(0.18798605414266745)
+    assert summary_stats.key_metrics['profitability'].value == pytest.approx(-0.1937959274935087)
 
 
 def test_calculate_realised_trading_profitability_no_trades():

--- a/tests/backtest/test_backtest_profit_calculation.py
+++ b/tests/backtest/test_backtest_profit_calculation.py
@@ -302,6 +302,17 @@ def test_profitabilities_are_same(backtest_result_hourly: State):
     assert summary_stats.key_metrics['profitability'].value == pytest.approx(summary_stats.return_all_time, abs=1e-14)
     
 
+def test_key_metrics(backtest_result_hourly: State):
+    """Check that the all key metrics are correct"""
+    summary_stats = calculate_summary_statistics(backtest_result_hourly, time_window=datetime.timedelta(days=2000), key_metrics_backtest_cut_off=datetime.timedelta(days=0))
+    
+    # correct since standard dev = 0
+    assert summary_stats.key_metrics['sharpe'].value == float('-inf')
+    assert summary_stats.key_metrics['sortino'].value == pytest.approx(-19.104973174542796)
+    assert summary_stats.key_metrics['max_drawdown'] == pytest.approx(0.18798605414266745)
+    assert summary_stats.key_metrics['profitability'] == pytest.approx(-0.1937959274935087)
+
+
 def test_calculate_realised_trading_profitability_no_trades():
     """Do not crash when calculating realised trading profitability if there are no trades."""
     state = State()

--- a/tradeexecutor/statistics/key_metric.py
+++ b/tradeexecutor/statistics/key_metric.py
@@ -199,7 +199,7 @@ def calculate_key_metrics(
         
         # use this method to avoid losing data points when resampling
         # gives compounded returns for each day
-        daily_returns = returns.add(1).resample('D').prod().sub(1)
+        daily_returns = returns.add(1).resample(freq_base).prod().sub(1)
         
         # alternate method
         # use log returns to avoid losing any data points when resampling

--- a/tradeexecutor/statistics/key_metric.py
+++ b/tradeexecutor/statistics/key_metric.py
@@ -199,7 +199,7 @@ def calculate_key_metrics(
         
         # use this method to avoid losing data points when resampling
         # gives compounded returns for each day
-        daily_returns = returns.add(1).resample(freq_base).prod().sub(1)
+        daily_returns = returns.add(1).resample(freq_base).prod().sub(1).fillna(0)
         
         # alternate method
         # use log returns to avoid losing any data points when resampling

--- a/tradeexecutor/statistics/key_metric.py
+++ b/tradeexecutor/statistics/key_metric.py
@@ -197,10 +197,14 @@ def calculate_key_metrics(
         # sharpe/sortino/etc. stays compatible regardless of deposit flow
         returns = calculate_size_relative_realised_trading_returns(source_state)
         
+        # use this method to avoid losing data points when resampling
+        daily_returns = returns.add(1).resample('D').prod().sub(1)
+        
+        # alternate method
         # use log returns to avoid losing any data points when resampling
-        log_returns = np.log(returns.add(1))
-        daily_log_sum_returns = log_returns.resample('D').sum().fillna(0)
-        daily_returns = np.exp(daily_log_sum_returns) - 1
+        # log_returns = np.log(returns.add(1))
+        # daily_log_sum_returns = log_returns.resample('D').sum().fillna(0)
+        # daily_returns = np.exp(daily_log_sum_returns) - 1
         
         periods = pd.Timedelta(days=365) / freq_base
 

--- a/tradeexecutor/statistics/key_metric.py
+++ b/tradeexecutor/statistics/key_metric.py
@@ -202,7 +202,6 @@ def calculate_key_metrics(
         daily_returns = returns.add(1).resample(freq_base).prod().sub(1).fillna(0)
         
         # alternate method
-        # use log returns to avoid losing any data points when resampling
         # log_returns = np.log(returns.add(1))
         # daily_log_sum_returns = log_returns.resample('D').sum().fillna(0)
         # daily_returns = np.exp(daily_log_sum_returns) - 1

--- a/tradeexecutor/statistics/key_metric.py
+++ b/tradeexecutor/statistics/key_metric.py
@@ -198,6 +198,7 @@ def calculate_key_metrics(
         returns = calculate_size_relative_realised_trading_returns(source_state)
         
         # use this method to avoid losing data points when resampling
+        # gives compounded returns for each day
         daily_returns = returns.add(1).resample('D').prod().sub(1)
         
         # alternate method


### PR DESCRIPTION
### Background

- Some stats were incorrect (see #747 and #749) due to resampling. The resampling caused data points to be lost.
- PR #748 already fixed the profit calculation by not using resampled data. However, there were other stats such as Sortino, Sharpe, etc. that used the incorrect resampled data
- This PR fixes the root cause of the issue by correcting the resampling not to lose any data points

### Tasks

- fixes #747
- fixes #749