### PR TITLE
fix shorting profit percent calculations

### DIFF
--- a/tests/backtest/test_backtest_mixed_positions.py
+++ b/tests/backtest/test_backtest_mixed_positions.py
@@ -235,8 +235,8 @@ def test_backtest_long_short_stats(
     assert long_compounding_profit.iloc[0] == 0
     assert short_compounding_profit.iloc[0] == 0
     
-    assert overall_compounding_profit.iloc[-1] == -0.016521426180387766
+    assert overall_compounding_profit.iloc[-1] == -0.01637882433811455
     assert long_compounding_profit.iloc[-1] == -0.003555468782310056
-    assert short_compounding_profit.iloc[-1] == -0.013012221946998581
+    assert short_compounding_profit.iloc[-1] == -0.01286911127921364
     
     

--- a/tests/backtest/test_backtest_mixed_positions.py
+++ b/tests/backtest/test_backtest_mixed_positions.py
@@ -17,6 +17,7 @@ from tradingstrategy.timebucket import TimeBucket
 from tradingstrategy.candle import GroupedCandleUniverse
 from tradingstrategy.universe import Universe
 
+from tradeexecutor.analysis.trade_analyser import build_trade_analysis
 from tradeexecutor.backtest.backtest_pricing import BacktestPricing
 from tradeexecutor.backtest.backtest_routing import BacktestRoutingModel
 from tradeexecutor.backtest.backtest_runner import run_backtest_inline
@@ -231,12 +232,17 @@ def test_backtest_long_short_stats(
     long_compounding_profit = calculate_long_compounding_realised_trading_profitability(state)
     short_compounding_profit = calculate_short_compounding_realised_trading_profitability(state)
     
+    analysis = build_trade_analysis(state.portfolio)
+    summary = analysis.calculate_summary_statistics(state=state, time_bucket=strategy_universe.data_universe.time_bucket)
+    
+    assert summary.return_percent == pytest.approx(overall_compounding_profit.iloc[-1], abs=1e-3)  # TODO make more precise
+    
     assert overall_compounding_profit.iloc[0] == 0
     assert long_compounding_profit.iloc[0] == 0
     assert short_compounding_profit.iloc[0] == 0
     
-    assert overall_compounding_profit.iloc[-1] == -0.01637882433811455
+    assert overall_compounding_profit.iloc[-1] == -0.018257383118416515
     assert long_compounding_profit.iloc[-1] == -0.003555468782310056
-    assert short_compounding_profit.iloc[-1] == -0.01286911127921364
+    assert short_compounding_profit.iloc[-1] == -0.014754373048884384
     
     

--- a/tests/backtest/test_backtest_short_synthetic_data.py
+++ b/tests/backtest/test_backtest_short_synthetic_data.py
@@ -19,6 +19,7 @@ from tradingstrategy.timebucket import TimeBucket
 from tradingstrategy.candle import GroupedCandleUniverse
 from tradingstrategy.universe import Universe
 
+from tradeexecutor.analysis.trade_analyser import build_trade_analysis
 from tradeexecutor.backtest.backtest_pricing import BacktestPricing
 from tradeexecutor.backtest.backtest_routing import BacktestRoutingModel
 from tradeexecutor.backtest.backtest_runner import run_backtest_inline
@@ -744,7 +745,6 @@ def test_backtest_short_trailing_stop_loss_triggered(persistent_test_client: Cli
 
     assert portfolio.get_cash() == pytest.approx(11952.745496750647)
     
-    from tradeexecutor.analysis.trade_analyser import build_trade_analysis
     analysis = build_trade_analysis(state.portfolio)
     summary = analysis.calculate_summary_statistics(state=state, time_bucket=TimeBucket.d1)
     

--- a/tests/backtest/test_backtest_short_synthetic_data.py
+++ b/tests/backtest/test_backtest_short_synthetic_data.py
@@ -739,5 +739,14 @@ def test_backtest_short_trailing_stop_loss_triggered(persistent_test_client: Cli
 
     assert position.liquidation_price == pytest.approx(Decimal(1912.499999999999950039963892))
     assert position.stop_loss == pytest.approx(1669.082747543819)
+    assert position.get_realised_profit_percent() == pytest.approx(0.06124905034476604)
+    assert position.get_realised_profit_percent() == position.get_total_profit_percent()
 
     assert portfolio.get_cash() == pytest.approx(11952.745496750647)
+    
+    from tradeexecutor.analysis.trade_analyser import build_trade_analysis
+    analysis = build_trade_analysis(state.portfolio)
+    summary = analysis.calculate_summary_statistics(state=state, time_bucket=TimeBucket.d1)
+    
+    assert summary.return_percent == pytest.approx(0.1952745496750649)
+    assert summary.compounding_returns.iloc[-1] == pytest.approx(summary.return_percent, abs=1e-3)  # TODO make match more precisely

--- a/tests/enzyme/test_enzyme_realised_profit.py
+++ b/tests/enzyme/test_enzyme_realised_profit.py
@@ -226,3 +226,4 @@ def test_enzyme_redeemed_position_profit(
     assert position.get_realised_profit_usd() == pytest.approx(-7.372047000000003)
     # (1359.153875 - 1582.577362) / 1582.577362 ~= -14.1
     assert position.get_realised_profit_percent() == pytest.approx(-0.07372047000000002)
+    assert position.get_total_profit_usd() == pytest.approx(-7.372047000000003)

--- a/tests/enzyme/test_enzyme_realised_profit.py
+++ b/tests/enzyme/test_enzyme_realised_profit.py
@@ -226,4 +226,5 @@ def test_enzyme_redeemed_position_profit(
     assert position.get_realised_profit_usd() == pytest.approx(-7.372047000000003)
     # (1359.153875 - 1582.577362) / 1582.577362 ~= -14.1
     assert position.get_realised_profit_percent() == pytest.approx(-0.07372047000000002)
+    assert position.get_total_profit_usd() == position.get_realised_profit_usd()
     assert position.get_total_profit_usd() == pytest.approx(-7.372047000000003)

--- a/tests/enzyme/test_enzyme_realised_profit.py
+++ b/tests/enzyme/test_enzyme_realised_profit.py
@@ -225,4 +225,4 @@ def test_enzyme_redeemed_position_profit(
 
     assert position.get_realised_profit_usd() == pytest.approx(-7.372047000000003)
     # (1359.153875 - 1582.577362) / 1582.577362 ~= -14.1
-    assert position.get_realised_profit_percent() == pytest.approx(-0.14744093999999996)
+    assert position.get_realised_profit_percent() == pytest.approx(-0.07372047000000002)

--- a/tests/test_summary_and_metrics.py
+++ b/tests/test_summary_and_metrics.py
@@ -267,10 +267,12 @@ def test_calculate_all_summary_statistics(state: State):
     #assert datapoints[0] == (datetime.datetime(2021, 10, 2, 0, 0), -0.02687699056973558)
     #assert datapoints[-1] == (datetime.datetime(2021, 12, 31, 0, 0), -0.045838046723895576)
 
-    assert datapoints[0] == (1633132800.0, -0.02687699056973558)
-    assert datapoints[-2] == (1640908800.0, -0.045838046723895576)
-    assert datapoints[-1] == (1640995200.0, -0.045838046723895576)
-
+    assert datapoints[0][0] == pytest.approx(1633132800.0)
+    assert datapoints[0][1] == pytest.approx(-0.02687699056973558)
+    assert datapoints[-2][0] == pytest.approx(1640908800.0)
+    assert datapoints[-2][1] == pytest.approx(-0.045838046723895576)
+    assert datapoints[-1][0] == pytest.approx(1640995200.0)
+    assert datapoints[-1][1] == pytest.approx(-0.045838046723895576)
 
     # Make sure we do not output anything that is not JSON'able
     data = summary.to_dict()

--- a/tradeexecutor/state/position.py
+++ b/tradeexecutor/state/position.py
@@ -1405,9 +1405,15 @@ class TradingPosition(GenericPosition):
             e.g. due to broken trades.
         """
         if self.is_long():
-            return self.get_realised_profit_usd()/(self.get_total_bought_usd())
+            total_bought = self.get_total_bought_usd()
+            if total_bought == 0:
+                return 0
+            return self.get_realised_profit_usd()/total_bought
         else:
-            return self.get_realised_profit_usd()/(self.get_total_sold_usd())
+            total_sold = self.get_total_bought_usd()
+            if total_sold == 0:
+                return 0
+            return self.get_realised_profit_usd()/total_sold
         
         # assert not self.is_open(), "Cannot calculate realised profit for open positions"
 

--- a/tradeexecutor/state/position.py
+++ b/tradeexecutor/state/position.py
@@ -1410,7 +1410,7 @@ class TradingPosition(GenericPosition):
                 return 0
             return self.get_realised_profit_usd()/total_bought
         else:
-            total_sold = self.get_total_bought_usd()
+            total_sold = self.get_total_sold_usd()
             if total_sold == 0:
                 return 0
             return self.get_realised_profit_usd()/total_sold

--- a/tradeexecutor/state/position.py
+++ b/tradeexecutor/state/position.py
@@ -1226,11 +1226,11 @@ class TradingPosition(GenericPosition):
             return profit / bought
         else:
             # TODO: this is not correct yet since it doesn't factor in interest
-            profit = -self.get_total_profit_usd()
-            bought = self.get_total_bought_usd()
-            if bought == 0:
+            profit = self.get_total_profit_usd()
+            sold = self.get_total_sold_usd()
+            if sold == 0:
                 return 0
-            return profit / bought
+            return profit / sold
 
     def get_total_profit_at_timestamp(self, timestamp: datetime.datetime) -> USDollarAmount:
         """Get the profit of the position what it was at a certain point of time.
@@ -1404,30 +1404,34 @@ class TradingPosition(GenericPosition):
             Return ``0`` if the position profitability cannot be calculated,
             e.g. due to broken trades.
         """
-        
-        assert not self.is_open(), "Cannot calculate realised profit for open positions"
-
-        buy_value = self.get_buy_value()
-        sell_value = self.get_sell_value()
-
-        # We only need to handle in-kind redemptions,
-        # because deposits are never applied to an open position
-        redemptions = [r for r in self.balance_updates.values() if r.cause == BalanceUpdateCause.redemption]
-        if redemptions:
-            assert self.is_spot(), "Does not know how to handle redemptions for credit positions"
-            redemptions_value = sum(r.usd_value for r in redemptions)
+        if self.is_long():
+            return self.get_realised_profit_usd()/(self.get_total_bought_usd())
         else:
-            redemptions_value = 0
-
-        if buy_value == 0:
-            # Repaired trade
-            return 0
+            return self.get_realised_profit_usd()/(self.get_total_sold_usd())
         
-        if sell_value == 0:
-            # Another way of damaged/repaired trade
-            return 0
+        # assert not self.is_open(), "Cannot calculate realised profit for open positions"
 
-        return sell_value / (buy_value - redemptions_value) - 1
+        # buy_value = self.get_buy_value()
+        # sell_value = self.get_sell_value()
+
+        # # We only need to handle in-kind redemptions,
+        # # because deposits are never applied to an open position
+        # redemptions = [r for r in self.balance_updates.values() if r.cause == BalanceUpdateCause.redemption]
+        # if redemptions:
+        #     assert self.is_spot(), "Does not know how to handle redemptions for credit positions"
+        #     redemptions_value = sum(r.usd_value for r in redemptions)
+        # else:
+        #     redemptions_value = 0
+
+        # if buy_value == 0:
+        #     # Repaired trade
+        #     return 0
+        
+        # if sell_value == 0:
+        #     # Another way of damaged/repaired trade
+        #     return 0
+
+        # return (sell_value + self.get_claimed_interest() - self.get_repaid_interest()) / (buy_value) - 1
 
     def get_size_relative_realised_profit_percent(self) -> Percent:
         """Calculated life-time profit over this position.


### PR DESCRIPTION
- Unblocks #726
- This PR goes some way to fixing #761 
- With this PR, the shorting profit percentage calculations are correct down to 3 decimal places. This means that they are still not totally correct but much more accurate than before

Here is an `equity curve` plotted against `compounding position returns` before and after:

![newplot_shorting_mismatch](https://github.com/tradingstrategy-ai/trade-executor/assets/74208897/d74cfcc3-7b9b-4249-a556-7e1267983881)
![newplot_short_equity_match](https://github.com/tradingstrategy-ai/trade-executor/assets/74208897/d7f31434-2b09-48b6-9cb0-8fdff27987bf)

Clearly much better now. 