### PR TITLE
Fix performance chart 90 days

### DIFF
--- a/tests/backtest/test_backtest_profit_calculation.py
+++ b/tests/backtest/test_backtest_profit_calculation.py
@@ -297,11 +297,22 @@ def test_daily_returns(backtest_result_hourly: State):
     """
     cum_profit = calculate_cumulative_daily_returns(backtest_result_hourly)
     assert isinstance(cum_profit, pd.Series)
+    
+    # remove last entry, since it was added to fill the gap
+    cum_profit = cum_profit[:-1]
 
     non_cum_profit = calculate_non_cumulative_daily_returns(backtest_result_hourly)
     assert isinstance(non_cum_profit, pd.Series)
 
-    non_cum_profit.add(1).cumprod().sub(1).iloc[-1] == pytest.approx(cum_profit.iloc[-1], abs=1e-10)
+    cum_profit_2 = non_cum_profit.add(1).cumprod().sub(1)
+    
+    assert cum_profit.index.equals(cum_profit_2.index)
+    
+    assert all(cum_profit - cum_profit_2 < 1e-10)
+    
+    assert cum_profit_2.iloc[-3] == pytest.approx(cum_profit.iloc[-3], abs=1e-10)
+    assert cum_profit_2.iloc[-2] == pytest.approx(cum_profit.iloc[-2], abs=1e-10)
+    assert cum_profit_2.iloc[-1] == pytest.approx(cum_profit.iloc[-1], abs=1e-10)
     
 
 def test_profitabilities_are_same(backtest_result_hourly: State):

--- a/tradeexecutor/visual/equity_curve.py
+++ b/tradeexecutor/visual/equity_curve.py
@@ -561,5 +561,5 @@ def calculate_cumulative_daily_returns(state: State, freq_base: pd.offsets.DateO
     """
     returns = calculate_compounding_realised_trading_profitability(state)
     _returns = returns.copy()
-    cumulative_daily_returns = _returns.add(1).resample(freq_base).prod(min_count=1).sub(1).ffill()
+    cumulative_daily_returns = _returns.resample(freq_base).last().ffill()
     return cumulative_daily_returns


### PR DESCRIPTION
- This PR fixes and tests a test for `calculate_cumulative_daily_returns`
- Fixes #805

Before After:
![equity_curve](https://github.com/tradingstrategy-ai/trade-executor/assets/74208897/57f0c8ed-7a25-4309-98a7-8061e23e2fef)
![equity_curve_2](https://github.com/tradingstrategy-ai/trade-executor/assets/74208897/f1677323-4f47-4e90-88ce-f482c3fe8583)

