### PR TITLE
align strategy duration

### DIFF
--- a/tests/backtest/test_backtest_inline_synthetic_data.py
+++ b/tests/backtest/test_backtest_inline_synthetic_data.py
@@ -309,7 +309,7 @@ def test_basic_summary_statistics(
     assert summary.undecided == 0
     assert summary.zero_loss == 0
 
-    assert summary.annualised_return_percent == pytest.approx(-0.0095122718274248, rel=APPROX_REL)
+    assert summary.annualised_return_percent == pytest.approx(-0.00808319812565206, rel=APPROX_REL)
     assert summary.realised_profit == pytest.approx(-47.17044385644749, rel=APPROX_REL)
     assert summary.return_percent == pytest.approx(-0.004717044385644658, rel=APPROX_REL)
 

--- a/tests/backtest/test_backtest_inline_synthetic_data.py
+++ b/tests/backtest/test_backtest_inline_synthetic_data.py
@@ -299,7 +299,7 @@ def test_basic_summary_statistics(
     assert summary.end_value == pytest.approx(9952.829556143553, rel=APPROX_REL)
     assert summary.win_percent == pytest.approx(0.36363636363636365, rel=APPROX_REL)
     assert summary.lost_percent == pytest.approx(0.6363636363636364, rel=APPROX_REL)
-    assert summary.duration == datetime.timedelta(days=181)
+    assert summary.duration == datetime.timedelta(days=213)
     assert summary.trade_volume == pytest.approx(21900.29776619458, rel=APPROX_REL)
     assert summary.uninvested_cash == pytest.approx(9952.829556143553, rel=APPROX_REL)
 

--- a/tests/backtest/test_backtest_open_position.py
+++ b/tests/backtest/test_backtest_open_position.py
@@ -247,7 +247,7 @@ def test_basic_summary_statistics(
     assert summary.open_value == pytest.approx(1054.2372274910792, rel=APPROX_REL)
     assert summary.end_value == pytest.approx(10054.23722749108, rel=APPROX_REL)
     assert summary.win_percent is None
-    assert summary.duration == datetime.timedelta(0)
+    assert summary.duration == datetime.timedelta(days=213)
     assert summary.trade_volume == pytest.approx(1000.0, rel=APPROX_REL)
     assert summary.uninvested_cash == pytest.approx(9000.0, rel=APPROX_REL)
 

--- a/tradeexecutor/analysis/trade_analyser.py
+++ b/tradeexecutor/analysis/trade_analyser.py
@@ -728,8 +728,11 @@ class TradeAnalysis:
         average_duration_of_zero_loss_trades = None
         average_duration_of_all_trades = None
 
-        # strategy_duration = self.portfolio.get_trading_history_duration()
-        strategy_duration = state.get_strategy_duration()
+        if state is None:
+            # legacy
+            strategy_duration = self.portfolio.get_trading_history_duration()
+        else:
+            strategy_duration = state.get_strategy_duration()
         
         won = lost = zero_loss = stop_losses = take_profits = undecided = 0
         open_value: USDollarAmount = 0

--- a/tradeexecutor/analysis/trade_analyser.py
+++ b/tradeexecutor/analysis/trade_analyser.py
@@ -728,8 +728,9 @@ class TradeAnalysis:
         average_duration_of_zero_loss_trades = None
         average_duration_of_all_trades = None
 
-        strategy_duration = self.portfolio.get_trading_history_duration()
-
+        # strategy_duration = self.portfolio.get_trading_history_duration()
+        strategy_duration = state.get_strategy_duration()
+        
         won = lost = zero_loss = stop_losses = take_profits = undecided = 0
         open_value: USDollarAmount = 0
         profit: USDollarAmount = 0

--- a/tradeexecutor/state/state.py
+++ b/tradeexecutor/state/state.py
@@ -27,6 +27,7 @@ from .types import USDollarAmount, BPS, USDollarPrice
 from .uptime import Uptime
 from .visualisation import Visualisation
 
+from tradeexecutor.utils.summarydataframe import as_duration, format_value
 from tradeexecutor.strategy.trade_pricing import TradePricing
 from ..strategy.cycle import CycleDuration
 from ..utils.accuracy import ZERO_DECIMAL
@@ -171,6 +172,28 @@ class State:
             return self.backtest_data.start_at, self.backtest_data.end_at
         else:
             return self.created_at, self.last_updated_at
+        
+    def get_strategy_duration(self) -> datetime.timedelta | None:
+        """Get the age of the strategy execution. If backtest, return backtest range, if live, return created - last updated
+        
+        See :py:meth:`get_strategy_time_range` for details.
+        
+        :returns: Age of the strategy execution, or None if the age cannot be calculated.
+        """
+        strategy_start, strategy_end  = self.get_strategy_time_range()
+        if strategy_start and strategy_end:
+            return strategy_end - strategy_start
+        return None
+    
+    def get_formatted_age(self) -> str:
+        """Get the age of the strategy execution in human-readable format.
+        
+        See :py:meth:`get_strategy_duration` for details.
+        
+        :returns: Age of the strategy execution in human-readable format.
+        """
+        age = self.get_strategy_duration()
+        return "Unknown" if age is None else format_value(as_duration(age))
 
     def create_trade(
         self,

--- a/tradeexecutor/state/state.py
+++ b/tradeexecutor/state/state.py
@@ -185,7 +185,7 @@ class State:
             return strategy_end - strategy_start
         return None
     
-    def get_formatted_age(self) -> str:
+    def get_formatted_strategy_duration(self) -> str:
         """Get the age of the strategy execution in human-readable format.
         
         See :py:meth:`get_strategy_duration` for details.

--- a/tradeexecutor/statistics/statistics_table.py
+++ b/tradeexecutor/statistics/statistics_table.py
@@ -137,7 +137,7 @@ def _serialise_long_short_stats_as_json_table(
     compounding_returns = None
     if source == KeyMetricSource.live_trading and source_state:
         compounding_returns = calculate_compounding_realised_trading_profitability(source_state)
-        summary.loc['Trading period length']['All'] = source_state.get_formatted_age()
+        summary.loc['Trading period length']['All'] = source_state.get_formatted_strategy_duration()
     
     if compounding_returns is not None and len(compounding_returns) > 0:
         daily_returns = calculate_non_cumulative_daily_returns(source_state)

--- a/tradeexecutor/statistics/statistics_table.py
+++ b/tradeexecutor/statistics/statistics_table.py
@@ -137,6 +137,7 @@ def _serialise_long_short_stats_as_json_table(
     compounding_returns = None
     if source == KeyMetricSource.live_trading and source_state:
         compounding_returns = calculate_compounding_realised_trading_profitability(source_state)
+        summary.loc['Trading period length']['All'] = source_state.get_formatted_age()
     
     if compounding_returns is not None and len(compounding_returns) > 0:
         daily_returns = calculate_non_cumulative_daily_returns(source_state)

--- a/tradeexecutor/statistics/summary.py
+++ b/tradeexecutor/statistics/summary.py
@@ -77,8 +77,6 @@ def calculate_summary_statistics(
     # We can alway get the current value even if there are no trades
     current_value = portfolio.get_total_equity()
 
-    strategy_start, strategy_end  = state.get_strategy_time_range()
-
     first_trade, last_trade = portfolio.get_first_and_last_executed_trade()
 
     first_trade_at = first_trade.executed_at if first_trade else None
@@ -88,10 +86,7 @@ def calculate_summary_statistics(
         now_ = pd.Timestamp.utcnow().tz_localize(None)
 
     start_at = now_ - time_window
-    if strategy_start and strategy_end:
-        age = strategy_end - strategy_start
-    else:
-        age = None
+    age = state.get_strategy_duration()
 
     stats = state.stats
 


### PR DESCRIPTION
- fixes #787
- Changes `trading period length` to be the entire duration of the backtest/live strategy, not `last.executed_at - first.executed_at`