### PR TITLE
Pass grid search parameter correctly around

### DIFF
--- a/tradeexecutor/backtest/backtest_runner.py
+++ b/tradeexecutor/backtest/backtest_runner.py
@@ -688,6 +688,7 @@ def run_backtest_inline(
     parameters: Type | StrategyParameters | None = None,
     mode: ExecutionMode = ExecutionMode.backtesting,
     max_workers=8,
+    grid_search=False,
 ) -> Tuple[State, TradingStrategyUniverse, dict]:
     """Run backtests for given decide_trades and create_trading_universe functions.
 
@@ -930,6 +931,7 @@ def run_backtest_inline(
         parameters=parameters,
         mode=mode,
         max_workers=max_workers,
+        grid_search=grid_search,
     )
 
     state, universe, debug_dump = run_backtest(backtest_setup, client, allow_missing_fees=True)

--- a/tradeexecutor/backtest/backtest_runner.py
+++ b/tradeexecutor/backtest/backtest_runner.py
@@ -115,7 +115,7 @@ class BacktestSetup:
 
     #: Is this backtest part a grid saerch
     #:
-    grid_search = False
+    grid_search: bool = False
 
     #: What's the execution mode of this backtest run
     #:

--- a/tradeexecutor/backtest/grid_search.py
+++ b/tradeexecutor/backtest/grid_search.py
@@ -952,6 +952,7 @@ def run_grid_search_backtest(
             engine_version=trading_strategy_engine_version,
             parameters=parameters,
             indicator_storage=indicator_storage,
+            grid_search=True,
         )
     except Exception as e:
         # Report to the notebook which of the grid search combinations is a problematic one


### PR DESCRIPTION
- `BacktestSetup.grid_search` was not correctly being set