### PR TITLE
add more stats to frontend

### DIFF
--- a/tests/backtest/test_backtest_inline_synthetic_data.py
+++ b/tests/backtest/test_backtest_inline_synthetic_data.py
@@ -346,7 +346,7 @@ def test_basic_summary_statistics(
     assert summary.sharpe_ratio == pytest.approx(-0.16440603545590504, rel=APPROX_REL)
     assert summary.sortino_ratio == pytest.approx(-0.23988078508533023, rel=APPROX_REL)
     assert summary.profit_factor == pytest.approx(0.9754583954173234, rel=APPROX_REL)
-    assert summary.average_duration_between_positions == pd.Timedelta('17 days 09:36:00')
+    assert summary.average_duration_between_position_openings == pd.Timedelta('17 days 09:36:00')
     assert summary.average_position_frequency == pytest.approx(0.051643192488262914)
     assert summary.average_interest_paid_usd == pytest.approx(0.0, rel=APPROX_REL)
     assert summary.max_interest_paid_usd == pytest.approx(0.0, rel=APPROX_REL)

--- a/tradeexecutor/analysis/trade_analyser.py
+++ b/tradeexecutor/analysis/trade_analyser.py
@@ -283,7 +283,7 @@ class TradeSummary:
             })
 
         human_data.update({
-            "Average duration between position openings": self.format_duration(self.average_duration_between_positions),
+            "Average duration between position openings": self.format_duration(self.average_duration_between_position_openings),
             "Average positions per day": as_decimal(self.average_position_frequency),
             "Average interest paid": as_dollar(self.average_interest_paid_usd),
             "Median interest paid": as_dollar(self.median_interest_paid_usd),

--- a/tradeexecutor/analysis/trade_analyser.py
+++ b/tradeexecutor/analysis/trade_analyser.py
@@ -183,7 +183,7 @@ class TradeSummary:
     max_interest_paid_usd: Optional[USDollarPrice] = None
     min_interest_paid_usd: Optional[USDollarPrice] = None
 
-    average_duration_between_positions: Optional[datetime.timedelta] = None
+    average_duration_between_position_openings: Optional[datetime.timedelta] = None
     average_position_frequency: Optional[datetime.timedelta] = None
 
     def __post_init__(self):
@@ -269,7 +269,7 @@ class TradeSummary:
             "Biggest losing position %": as_percent(self.biggest_losing_trade_pc),
             "Average duration of winning positions": self.format_duration(self.average_duration_of_winning_trades),
             "Average duration of losing positions": self.format_duration(self.average_duration_of_losing_trades),
-            "Average duration between position openings": self.format_duration(self.average_duration_between_positions),
+            "Average duration between position openings": self.format_duration(self.average_duration_between_position_openings),
             "Average positions per day": as_decimal(self.average_position_frequency),
             "Average interest paid": as_dollar(self.average_interest_paid_usd),
             "Median interest paid": as_dollar(self.median_interest_paid_usd),
@@ -911,7 +911,7 @@ class TradeAnalysis:
         median_interest_paid_usd = func_check(interest_paid_usd, median)
         max_interest_paid_usd = func_check(interest_paid_usd, max)
         min_interest_paid_usd = func_check(interest_paid_usd, min)
-        average_duration_between_positions = pd.to_timedelta(durations_between_positions).mean() if len(durations_between_positions) > 0 else datetime.timedelta(0)
+        average_duration_between_position_openings = pd.to_timedelta(durations_between_positions).mean() if len(durations_between_positions) > 0 else datetime.timedelta(0)
 
         biggest_winning_trade_pc = func_check(winning_trades, max)
         biggest_losing_trade_pc = func_check(losing_trades, min)
@@ -951,7 +951,7 @@ class TradeAnalysis:
             average_duration_of_losing_trades=average_duration_of_losing_trades,
             average_duration_of_zero_loss_trades=average_duration_of_zero_loss_trades,
             average_duration_of_all_trades=average_duration_of_all_trades,
-            average_duration_between_positions=average_duration_between_positions,
+            average_duration_between_position_openings=average_duration_between_position_openings,
             average_trade=average_trade,
             average_interest_paid_usd=average_interest_paid_usd,
             median_interest_paid_usd=median_interest_paid_usd,

--- a/tradeexecutor/statistics/statistics_table.py
+++ b/tradeexecutor/statistics/statistics_table.py
@@ -194,6 +194,13 @@ def _serialise_long_short_stats_as_json_table(
         KeyMetricKind.max_pullback_of_total_capital: 'Max pullback of total capital',
         KeyMetricKind.max_loss_risk_at_opening_of_position: 'Max loss risk at opening of position',
         KeyMetricKind.max_drawdown: 'Max drawdown',
+        KeyMetricKind.average_interest_paid_usd: 'average_interest_paid_usd',
+        KeyMetricKind.median_interest_paid_usd: 'median_interest_paid_usd',
+        KeyMetricKind.max_interest_paid_usd: 'max_interest_paid_usd',
+        KeyMetricKind.min_interest_paid_usd: 'min_interest_paid_usd',
+        KeyMetricKind.total_interest_paid_usd: 'total_interest_paid_usd',
+        KeyMetricKind.average_duration_between_position_openings: 'average_duration_between_position_openings',
+        KeyMetricKind.average_position_frequency: 'average_position_frequency',
     }
 
     rows = {}

--- a/tradeexecutor/strategy/summary.py
+++ b/tradeexecutor/strategy/summary.py
@@ -177,6 +177,20 @@ class KeyMetricKind(enum.Enum):
     #: Maximum loss risked at the opening of a position
     max_loss_risk_at_opening_of_position = "max_loss_risk_at_opening_of_position"
 
+    average_interest_paid_usd = "average_interest_paid_usd"
+
+    median_interest_paid_usd = "median_interest_paid_usd"
+
+    max_interest_paid_usd = "max_interest_paid_usd"
+
+    min_interest_paid_usd = "min_interest_paid_usd"
+    
+    total_interest_paid_usd = "total_interest_paid_usd"
+
+    average_duration_between_position_openings = "average_duration_between_position_openings"
+
+    average_position_frequency = "average_position_frequency"
+
     def get_help_link(self) -> Optional[str]:
         return _KEY_METRIC_HELP[self]
 


### PR DESCRIPTION
- renames `average_duration_between_positions` to `average_duration_between_position_openings`
- adds average_interest_paid_usd, median_interest_paid_usd, max_interest_paid_usd, min_interest_paid_usd, total_interest_paid_usd, average_duration_between_position_openings, average_position_frequency to frontend stats