### PR TITLE
Quickswap multihops routing

### DIFF
--- a/tests/ethereum/polygon_forked/conftest.py
+++ b/tests/ethereum/polygon_forked/conftest.py
@@ -311,47 +311,50 @@ def one_delta_routing_model(
     )
 
 
-@pytest.fixture()
-def uniswap_v3_routing_model(asset_usdc) -> UniswapV3Routing:
+# @pytest.fixture()
+# def uniswap_v3_routing_model(asset_usdc) -> UniswapV3Routing:
 
-    # for uniswap v3
-    # same addresses for Mainnet, Polygon, Optimism, Arbitrum, Testnets Address
-    # only celo different
-    address_map = {
-        "factory": "0x1F98431c8aD98523631AE4a59f267346ea31F984",
-        "router": "0xE592427A0AEce92De3Edee1F18E0157C05861564",
-        "position_manager": "0xC36442b4a4522E871399CD717aBDD847Ab11FE88",
-        "quoter": "0xb27308f9F90D607463bb33eA1BeBb41C27CE5AB6"
-        # "router02":"0x68b3465833fb72A70ecDF485E0e4C7bD8665Fc45",
-        # "quoterV2":"0x61fFE014bA17989E743c5F6cB21bF9697530B21e"
-    }
+#     # for uniswap v3
+#     # same addresses for Mainnet, Polygon, Optimism, Arbitrum, Testnets Address
+#     # only celo different
+#     address_map = {
+#         "factory": "0x1F98431c8aD98523631AE4a59f267346ea31F984",
+#         "router": "0xE592427A0AEce92De3Edee1F18E0157C05861564",
+#         "position_manager": "0xC36442b4a4522E871399CD717aBDD847Ab11FE88",
+#         "quoter": "0xb27308f9F90D607463bb33eA1BeBb41C27CE5AB6"
+#         # "router02":"0x68b3465833fb72A70ecDF485E0e4C7bD8665Fc45",
+#         # "quoterV2":"0x61fFE014bA17989E743c5F6cB21bF9697530B21e"
+#     }
 
-    allowed_intermediary_pairs = {
-        # Route WMATIC through USDC:WMATIC fee 0.05% pool,
-        # https://tradingstrategy.ai/trading-view/polygon/uniswap-v3/matic-usdc-fee-5
-        "0x0d500b1d8e8ef31e21c99d1db9a6444d3adf1270": "0xa374094527e1673a86de625aa59517c5de346d32",
-        # Route WETH through USDC:WETH fee 0.05% pool,
-        # https://tradingstrategy.ai/trading-view/polygon/uniswap-v3/eth-usdc-fee-5
-        "0x7ceb23fd6bc0add59e62ac25578270cff1b9f619": "0x45dda9cb7c25131df268515131f647d726f50608",
-    }
+#     allowed_intermediary_pairs = {
+#         # Route WMATIC through USDC:WMATIC fee 0.05% pool,
+#         # https://tradingstrategy.ai/trading-view/polygon/uniswap-v3/matic-usdc-fee-5
+#         "0x0d500b1d8e8ef31e21c99d1db9a6444d3adf1270": "0xa374094527e1673a86de625aa59517c5de346d32",
+#         # Route WETH through USDC:WETH fee 0.05% pool,
+#         # https://tradingstrategy.ai/trading-view/polygon/uniswap-v3/eth-usdc-fee-5
+#         "0x7ceb23fd6bc0add59e62ac25578270cff1b9f619": "0x45dda9cb7c25131df268515131f647d726f50608",
+#     }
 
-    return UniswapV3Routing(
-        address_map,
-        allowed_intermediary_pairs,
-        reserve_token_address=asset_usdc.address,
-    )
+#     return UniswapV3Routing(
+#         address_map,
+#         allowed_intermediary_pairs,
+#         reserve_token_address=asset_usdc.address,
+#     )
 
 
-@pytest.fixture()
-def quickswap_routing_model(
-        quickswap_deployment,
-        wmatic_usdc_spot_pair,
-        asset_usdc,
-) -> UniswapV2Routing:
-    # Route WMATIC and USDC quoted pairs on Quickswap
-    uniswap_v2_router = UniswapV2Routing(
-        factory_router_map={quickswap_deployment.factory.address: (quickswap_deployment.router.address, quickswap_deployment.init_code_hash)},
-        allowed_intermediary_pairs={wmatic_usdc_spot_pair.base.address: wmatic_usdc_spot_pair.pool_address},
-        reserve_token_address=asset_usdc.address,
-    )
-    return uniswap_v2_router
+# @pytest.fixture()
+# def quickswap_routing_model(
+#         quickswap_deployment,
+#         wmatic_usdc_spot_pair,
+#         asset_usdc,
+# ) -> UniswapV2Routing:
+#     # Route WMATIC and USDC quoted pairs on Quickswap
+#     uniswap_v2_router = UniswapV2Routing(
+#         factory_router_map={quickswap_deployment.factory.address: (quickswap_deployment.router.address, quickswap_deployment.init_code_hash)},
+#         allowed_intermediary_pairs={
+#             wmatic_usdc_spot_pair.base.address: wmatic_usdc_spot_pair.pool_address,
+#             # "0x7ceb23fd6bc0add59e62ac25578270cff1b9f619": "0x45dda9cb7c25131df268515131f647d726f50608",
+#         },
+#         reserve_token_address=asset_usdc.address,
+#     )
+#     return uniswap_v2_router

--- a/tests/ethereum/polygon_forked/generic-router/test_generic_router_multihops.py
+++ b/tests/ethereum/polygon_forked/generic-router/test_generic_router_multihops.py
@@ -1,0 +1,166 @@
+"""Test live routing of combined Quickswap spot position, trading through several hops."""
+import datetime
+import os
+import shutil
+from decimal import Decimal
+
+import pytest
+import pandas as pd
+from web3 import Web3
+
+from eth_defi.balances import fetch_erc20_balances_by_token_list
+from eth_defi.token import fetch_erc20_details, TokenDetails
+from eth_defi.hotwallet import HotWallet
+from tradingstrategy.chain import ChainId
+from tradingstrategy.timebucket import TimeBucket
+
+from tradeexecutor.ethereum.execution import EthereumExecution
+from tradeexecutor.strategy.pandas_trader.position_manager import PositionManager
+from tradeexecutor.ethereum.hot_wallet_sync_model import HotWalletSyncModel
+from tradeexecutor.state.identifier import AssetIdentifier, TradingPairIdentifier
+from tradeexecutor.state.state import State
+from tradeexecutor.strategy.generic.generic_router import GenericRouting
+from tradeexecutor.strategy.generic.generic_pricing_model import GenericPricing
+from tradeexecutor.strategy.trading_strategy_universe import TradingStrategyUniverse, load_partial_data
+from tradeexecutor.strategy.execution_context import unit_test_execution_context
+from tradeexecutor.strategy.universe_model import default_universe_options
+
+
+
+pytestmark = pytest.mark.skipif(
+    (os.environ.get("JSON_RPC_POLYGON") is None) or (shutil.which("anvil") is None),
+    reason="Set JSON_RPC_POLYGON env install anvil command to run these tests",
+)
+
+@pytest.fixture
+def wbtc(web3) -> TokenDetails:
+    """Get WBTC on Polygon."""
+    return fetch_erc20_details(web3, "0x1bfd67037b42cf73acf2047067bd4f2c47d9bfd6")
+
+
+@pytest.fixture
+def asset_wbtc(wbtc, chain_id) -> AssetIdentifier:
+    return AssetIdentifier(
+        chain_id,
+        wbtc.contract.address,
+        wbtc.symbol,
+        wbtc.decimals,
+    )
+
+
+@pytest.fixture
+def wbtc_weth_spot_pair(quickswap_deployment, asset_wbtc, asset_weth) -> TradingPairIdentifier:
+    return TradingPairIdentifier(
+        asset_wbtc,
+        asset_weth,
+        "0xdc9232e2df177d7a12fdff6ecbab114e2231198d",
+        quickswap_deployment.factory.address,
+        fee=0.003,
+    )
+
+
+@pytest.fixture()
+def strategy_universe(
+    asset_usdc,
+    persistent_test_client
+) -> TradingStrategyUniverse:
+    """Universe that also contains data about our reserve assets."""
+
+    pairs = [
+        (ChainId.polygon, "quickswap", "WBTC", "WETH", 0.003),
+        (ChainId.polygon, "quickswap", "WETH", "USDC", 0.003),
+    ]
+
+    dataset = load_partial_data(
+        persistent_test_client,
+        execution_context=unit_test_execution_context,
+        time_bucket=TimeBucket.d1,
+        pairs=pairs,
+        universe_options=default_universe_options,
+        start_at=pd.Timestamp("2023-10-01"),
+        end_at=pd.Timestamp("2023-10-30"),
+    )
+
+    # Convert loaded data to a trading pair universe
+    return TradingStrategyUniverse.create_from_dataset(dataset, asset_usdc.address)
+
+
+def test_generic_routing_multihops_trade(
+    web3: Web3,
+    hot_wallet: HotWallet,
+    strategy_universe: TradingStrategyUniverse,
+    generic_routing_model: GenericRouting,
+    generic_pricing_model: GenericPricing,
+    asset_usdc: AssetIdentifier,
+    asset_wbtc: AssetIdentifier,
+    wbtc_weth_spot_pair: TradingPairIdentifier,
+    execution_model: EthereumExecution,
+):
+    """Open Quickswap position using 3-way trade: USDC -> WETH -> WBTC."""
+
+    routing_model = generic_routing_model
+
+    # Check we have data for both DEXes needed
+    exchange_universe = strategy_universe.data_universe.pairs.exchange_universe
+    assert exchange_universe.get_exchange_count() == 1
+    quickswap = exchange_universe.get_by_chain_and_slug(ChainId.polygon, "quickswap")
+    assert quickswap is not None
+    
+    # Check that our preflight checks pass
+    routing_model.perform_preflight_checks_and_logging(strategy_universe.data_universe.pairs)
+
+    sync_model = HotWalletSyncModel(
+        web3,
+        hot_wallet,
+    )
+
+    state = State()
+    sync_model.sync_initial(state)
+
+    # Strategy has its reserve balances updated
+    sync_model.sync_treasury(datetime.datetime.utcnow(), state, supported_reserves=[asset_usdc])
+
+    assert state.portfolio.get_reserve_position(asset_usdc).quantity == Decimal('10_000')
+
+    # Setup routing state for the approvals of this cycle
+    routing_state_details = execution_model.get_routing_state_details()
+    routing_state = routing_model.create_routing_state(strategy_universe, routing_state_details)
+
+    position_manager = PositionManager(
+        datetime.datetime.utcnow(),
+        strategy_universe,
+        state,
+        generic_pricing_model
+    )
+
+    # Trade on Quickswap spot
+    trades = position_manager.open_spot(
+        wbtc_weth_spot_pair,
+        500.0,
+    )
+    execution_model.execute_trades(
+        datetime.datetime.utcnow(),
+        state,
+        trades,
+        routing_model,
+        routing_state,
+        check_balances=True,
+    )
+    assert all([t.is_success() for t in trades])
+
+    assert len(state.portfolio.open_positions) == 1
+
+    # Check our wallet holds all tokens we expect.
+    # Note that these are live prices from mainnet,
+    # so we do a ranged check.
+    balances = fetch_erc20_balances_by_token_list(
+        web3,
+        hot_wallet.address,
+        {
+            asset_usdc.address,
+            asset_wbtc.address,
+        },
+        decimalise=True,
+    )
+    assert 0 < balances[asset_wbtc.address] < 1000, f"Got balance: {balances}"
+    assert balances[asset_usdc.address] == pytest.approx(9_500), f"Got balance: {balances}"

--- a/tests/test_routing_data.py
+++ b/tests/test_routing_data.py
@@ -119,6 +119,7 @@ def test_pancake_routing_models(
             ReserveCurrency.usdc,
             {
                 "0x0d500b1d8e8ef31e21c99d1db9a6444d3adf1270": "0x6e7a5fafcec6bb1e78bae2a1f0b612012bf14827",
+                "0x7ceb23fd6bc0add59e62ac25578270cff1b9f619": "0x853ee4b2a13f8a742d64c8f088be7ba2131f670d",
             },
             "0x2791Bca1f2de4661ED88A30C99A7a9449Aa84174".lower(),
         ),

--- a/tradeexecutor/ethereum/routing_data.py
+++ b/tradeexecutor/ethereum/routing_data.py
@@ -178,6 +178,10 @@ def get_quickswap_default_routing_parameters(
             # Route WMATIC through USDC:WMATIC pool,
             # https://tradingstrategy.ai/trading-view/polygon/quickswap/matic-usdc
             "0x0d500b1d8e8ef31e21c99d1db9a6444d3adf1270": "0x6e7a5fafcec6bb1e78bae2a1f0b612012bf14827",
+
+            # Route WETH through WETH/USDC pool,
+            # https://tradingstrategy.ai/trading-view/polygon/quickswap/eth-usdc
+            "0x7ceb23fd6bc0add59e62ac25578270cff1b9f619": "0x853ee4b2a13f8a742d64c8f088be7ba2131f670d",
         }
     elif reserve_currency == ReserveCurrency.usdt:
         # https://tradingstrategy.ai/trading-view/polygon/tokens/0xc2132d05d31c914a87c6611c10748aeb04b58e8f


### PR DESCRIPTION
- Add WETH to be allowed intermediate token in Quickswap routing
- Add mainnet fork test to make sure 3-way trade works

Fix #849 