### PR TITLE
Add in-memory state copy for web API endpoints

### DIFF
--- a/tests/web/test_webhook_api.py
+++ b/tests/web/test_webhook_api.py
@@ -39,6 +39,7 @@ def server_url(store):
     execution_state.visualisation.large_image_dark = b"4"
     execution_state.version.tag = "v1"
     execution_state.version.commit_message = "Foobar"
+    execution_state.read_only_state_copy = store.load()
 
     queue = Queue()
 

--- a/tradeexecutor/cli/commands/start.py
+++ b/tradeexecutor/cli/commands/start.py
@@ -346,6 +346,10 @@ def start(
         run_state.executor_id = id
         run_state.hot_wallet_gas_warning_level = Decimal(gas_balance_warning_level)
 
+        # Set up read-only state sync
+        run_state.read_only_state_copy = store.load()
+        store.on_save = run_state.on_save_hook
+
         # Create our webhook server
         if http_enabled:
 

--- a/tradeexecutor/cli/commands/start.py
+++ b/tradeexecutor/cli/commands/start.py
@@ -347,7 +347,8 @@ def start(
         run_state.hot_wallet_gas_warning_level = Decimal(gas_balance_warning_level)
 
         # Set up read-only state sync
-        run_state.read_only_state_copy = store.load()
+        if not store.is_pristine():
+            run_state.read_only_state_copy = store.load()
         store.on_save = run_state.on_save_hook
 
         # Create our webhook server

--- a/tradeexecutor/strategy/run_state.py
+++ b/tradeexecutor/strategy/run_state.py
@@ -1,4 +1,5 @@
 """Execution state communicates the current trade execution loop state to the webhook."""
+import copy
 import datetime
 import sys
 from _decimal import Decimal
@@ -11,6 +12,7 @@ from dataclasses_json import dataclass_json
 from tblib import Traceback
 
 from tradeexecutor.cli.version_info import VersionInfo
+from tradeexecutor.state.state import State
 from tradeexecutor.state.types import JSONHexAddress
 from tradeexecutor.strategy.summary import StrategySummaryStatistics
 
@@ -199,6 +201,15 @@ class RunState:
     #:
     version: VersionInfo = field(default_factory=VersionInfo)
 
+    #: A read only copy of the strategy state.
+    #:
+    #: - Used by API end points to display metrics on the state.
+    #: - Created duing sync and start up
+    #: - Static - the live state may be mutated in other threads, so web endpoints
+    #:   cannot read it.
+    #:
+    read_only_state_copy: State | None = None
+
     def __repr__(self):
         return f"<RunState for {self.executor_id}>"
 
@@ -243,3 +254,6 @@ class RunState:
         del data["visualisation"]
         return RunState(**data)
 
+    def on_save_hook(self, state: State):
+        """Called by JSONStateStore.sync()"""
+        self.read_only_state_copy = copy.deepcopy(state)

--- a/tradeexecutor/webhook/api.py
+++ b/tradeexecutor/webhook/api.py
@@ -261,6 +261,7 @@ def web_chart(request: Request):
     if source == WebChartSource.live_trading:
         # Use read-only state copy to calculate charts
         state = run_state.read_only_state_copy
+        assert state is not None, "We asked for teh RunState.read_only_state_copy but it was not set in this point"
     else:
         metadata = cast(Metadata, request.registry["metadata"])
         state = metadata.backtested_state

--- a/tradeexecutor/webhook/api.py
+++ b/tradeexecutor/webhook/api.py
@@ -243,6 +243,8 @@ def web_chart(request: Request):
     Under wrong circumstances
     """
 
+    run_state: RunState = request.registry["run_state"]
+
     type_str = request.params.get("type")
     source_str = request.params.get("source")
 
@@ -257,11 +259,8 @@ def web_chart(request: Request):
         return exception_response(501, detail=f"Not implemented. Unknown source {source_str}")
 
     if source == WebChartSource.live_trading:
-        store: JSONFileStore = request.registry["store"]
-
-        #: We load from the disk to prevent any
-        #: modify in place issues.... slow
-        state = store.load()
+        # Use read-only state copy to calculate charts
+        state = run_state.read_only_state_copy
     else:
         metadata = cast(Metadata, request.registry["metadata"])
         state = metadata.backtested_state


### PR DESCRIPTION
- `web_chart` endpoint is too slow if it needs to deserialise JSON state from the disk to draw charts
   - Fixes production trade-executor overview chart loading too slowly
- Keep in-memory copy of the state produces with `copy.deepcopy`