### PR TITLE
Add CAGR, make the default backtest cut off to 2 years

### DIFF
--- a/tests/test_summary_and_metrics.py
+++ b/tests/test_summary_and_metrics.py
@@ -315,7 +315,7 @@ def test_calculate_key_metrics_live(state: State):
     # returns = calculate_compounding_realised_profitability(state)
 
     metrics = {m.kind.value: m for m in calculate_key_metrics(state)}
-    assert len(metrics) == 8
+    assert len(metrics) == 9
     assert metrics["sharpe"].value == pytest.approx(-2.1464509890620724)
     assert metrics["sortino"].value == pytest.approx(-2.720957242817309)
     assert metrics["profitability"].value == pytest.approx(-0.045838046723895576)
@@ -323,6 +323,7 @@ def test_calculate_key_metrics_live(state: State):
     assert metrics["max_drawdown"].value == pytest.approx(0.04780138378916754)
     assert metrics["max_drawdown"].source == KeyMetricSource.live_trading
     assert metrics["max_drawdown"].help_link == "https://tradingstrategy.ai/glossary/maximum-drawdown"
+    assert metrics["cagr"].value == pytest.approx(-0.07760827122577163)
 
     assert metrics["trades_last_week"].value == 0
     assert metrics["last_trade"].value == datetime.datetime(2021, 12, 31, 0, 0)

--- a/tradeexecutor/state/metadata.py
+++ b/tradeexecutor/state/metadata.py
@@ -146,7 +146,9 @@ class Metadata:
 
     #: How many days live data is collected until key metrics are switched from backtest to live trading based
     #:
-    key_metrics_backtest_cut_off: datetime.timedelta = datetime.timedelta(days=90)
+    #: Two years: by default we do not show live trading metrics until the strategy has been running for long.
+    #:
+    key_metrics_backtest_cut_off: datetime.timedelta = datetime.timedelta(days=365*2)
 
     #: List of badges strategy tile can display.
     #:

--- a/tradeexecutor/statistics/key_metric.py
+++ b/tradeexecutor/statistics/key_metric.py
@@ -160,7 +160,10 @@ def calculate_cagr(returns: pd.Series) -> Percent:
     if len(returns) == 0:
         return 0
 
-    return cagr(returns)
+    try:
+        return cagr(returns)
+    except ZeroDivisionError:
+        return 0
 
 
 def calculate_trades_last_week(portfolio: Portfolio, cut_off_date=None) -> int:

--- a/tradeexecutor/statistics/key_metric.py
+++ b/tradeexecutor/statistics/key_metric.py
@@ -8,6 +8,7 @@ from typing import List, Iterable, Literal
 
 import pandas as pd
 import numpy as np
+from quantstats.stats import cagr
 
 from tradeexecutor.state.portfolio import Portfolio
 from tradeexecutor.state.state import State
@@ -142,6 +143,17 @@ def calculate_profitability(returns: pd.Series) -> Percent:
     return compounded[-1]
 
 
+def calculate_cagr(returns: pd.Series) -> Percent:
+    """Calculate CAGR.
+
+    See :term:`CAGR`.
+
+    :param returns:
+        Returns series
+    """
+    return cagr(returns)
+
+
 def calculate_trades_last_week(portfolio: Portfolio, cut_off_date=None) -> int:
     """How many trades were executed last week.
 
@@ -158,10 +170,10 @@ def calculate_trades_last_week(portfolio: Portfolio, cut_off_date=None) -> int:
 
 
 def calculate_key_metrics(
-        live_state: State,
-        backtested_state: State | None = None,
-        required_history = datetime.timedelta(days=90),
-        freq_base: pd.DateOffset = pd.offsets.Day(),
+    live_state: State,
+    backtested_state: State | None = None,
+    required_history = datetime.timedelta(days=90),
+    freq_base: pd.DateOffset = pd.offsets.Day(),
 ) -> Iterable[KeyMetric]:
     """Calculate summary metrics to be displayed on the web frontend.
 
@@ -225,6 +237,9 @@ def calculate_key_metrics(
         profitability = calculate_profitability(daily_returns)
         yield KeyMetric.create_metric(KeyMetricKind.profitability, source, profitability, calculation_window_start_at, calculation_window_end_at, KeyMetricCalculationMethod.historical_data)
 
+        cagr = calculate_cagr(daily_returns)
+        yield KeyMetric.create_metric(KeyMetricKind.cagr, source, cagr, calculation_window_start_at, calculation_window_end_at, KeyMetricCalculationMethod.historical_data)
+
         if live_state:
             total_equity = live_state.portfolio.get_total_equity()
 
@@ -246,6 +261,7 @@ def calculate_key_metrics(
         calculation_window_start_at = None
         calculation_window_end_at = None
 
+        yield KeyMetric.create_na(KeyMetricKind.cagr, reason)
         yield KeyMetric.create_na(KeyMetricKind.sharpe, reason)
         yield KeyMetric.create_na(KeyMetricKind.sortino, reason)
         yield KeyMetric.create_na(KeyMetricKind.max_drawdown, reason)

--- a/tradeexecutor/statistics/key_metric.py
+++ b/tradeexecutor/statistics/key_metric.py
@@ -150,7 +150,16 @@ def calculate_cagr(returns: pd.Series) -> Percent:
 
     :param returns:
         Returns series
+
+    :return:
+        Compounded returns,
+
+        0 if cannot calculate.
     """
+
+    if len(returns) == 0:
+        return 0
+
     return cagr(returns)
 
 

--- a/tradeexecutor/statistics/key_metric.py
+++ b/tradeexecutor/statistics/key_metric.py
@@ -8,7 +8,6 @@ from typing import List, Iterable, Literal
 
 import pandas as pd
 import numpy as np
-from quantstats.stats import cagr
 
 from tradeexecutor.state.portfolio import Portfolio
 from tradeexecutor.state.state import State
@@ -154,8 +153,14 @@ def calculate_cagr(returns: pd.Series) -> Percent:
     :return:
         Compounded returns,
 
-        0 if cannot calculate.
+        0 if cannot calculate, or QuantStats unimportable.
     """
+
+    try:
+        # Does not work in pyodide
+        from quantstats.stats import cagr
+    except ImportError:
+        return 0
 
     if len(returns) == 0:
         return 0

--- a/tradeexecutor/strategy/summary.py
+++ b/tradeexecutor/strategy/summary.py
@@ -30,7 +30,12 @@ class KeyMetricKind(enum.Enum):
     #: UNIX timestamp when the first trade was executd
     started_at = "started_at"
 
-    #: Annualised profitability
+    #: CAGR
+    #:
+    #: See :term:`CAGR`
+    cagr = "cagr"
+
+    #: All-time profitability
     profitability = "profitability"
 
     #: Total equity
@@ -470,6 +475,7 @@ class StrategySummary:
 
 #: Help links for different metrics
 _KEY_METRIC_HELP = {
+   KeyMetricKind.cagr: "https://tradingstrategy.ai/glossary/compound-annual-growth-rate-cagr",
    KeyMetricKind.sharpe: "https://tradingstrategy.ai/glossary/sharpe",
    KeyMetricKind.sortino: "https://tradingstrategy.ai/glossary/sortino",
    KeyMetricKind.max_drawdown: "https://tradingstrategy.ai/glossary/maximum-drawdown",


### PR DESCRIPTION
- Export CAGR metric as the key metrics to the frontend
- Set the live/backtest switch cut off date 90 days -> 2 years
   - 90 days is not statistically meaningful time frame for any of the current strategies