### PR TITLE
Fix live visualisation crashing if the visualisation labels are changed

### DIFF
--- a/tests/backtest/test_backtest_result_visualisation.py
+++ b/tests/backtest/test_backtest_result_visualisation.py
@@ -13,7 +13,7 @@ from tradeexecutor.state.state import State
 from tradeexecutor.state.validator import validate_state_serialisation
 from tradeexecutor.state.visualisation import PlotKind
 from tradeexecutor.statistics.core import calculate_statistics, update_statistics
-from tradeexecutor.strategy.execution_context import ExecutionMode
+from tradeexecutor.strategy.execution_context import ExecutionMode, unit_test_execution_context
 from tradeexecutor.testing.synthetic_price_data import generate_ohlcv_candles
 from tradeexecutor.testing.unit_test_trader import UnitTestTrader
 from tradeexecutor.visual.single_pair import visualise_single_pair, visualise_single_pair_positions_with_duration_and_slippage
@@ -169,7 +169,8 @@ def test_visualise_trades_with_indicator(state_and_candles: tuple[State, pd.Data
     # Now visualise the events
     #
     fig = visualise_single_pair(
-        state, 
+        state,
+        unit_test_execution_context,
         candle_universe,
     )
 
@@ -208,7 +209,8 @@ def test_visualise_trades_with_indicator(state_and_candles: tuple[State, pd.Data
     assert ts == pd.Timestamp("2021-1-1 00:00")
 
     fig2 = visualise_single_pair(
-        state, 
+        state,
+        unit_test_execution_context,
         candle_universe,
         detached_indicators=False
     )
@@ -217,7 +219,8 @@ def test_visualise_trades_with_indicator(state_and_candles: tuple[State, pd.Data
     assert len(fig2._grid_ref) == 1
 
     fig3 = visualise_single_pair(
-        state, 
+        state,
+        unit_test_execution_context,
         candle_universe,
         detached_indicators=False,
         volume_bar_mode=VolumeBarMode.separate,
@@ -228,6 +231,7 @@ def test_visualise_trades_with_indicator(state_and_candles: tuple[State, pd.Data
 
     fig4 = visualise_single_pair(
         state,
+        unit_test_execution_context,
         candle_universe,
         detached_indicators=True,
         technical_indicators=False,
@@ -238,6 +242,7 @@ def test_visualise_trades_with_indicator(state_and_candles: tuple[State, pd.Data
 
     fig5 = visualise_single_pair(
         state,
+        unit_test_execution_context,
         candle_universe,
         detached_indicators=True,
         technical_indicators=False,
@@ -270,7 +275,8 @@ def test_visualise_trades_separate_volume(
     assert len(state.portfolio.closed_positions) == 1
 
     fig = visualise_single_pair(
-        state, 
+        state,
+        unit_test_execution_context,
         candle_universe, 
         volume_bar_mode=VolumeBarMode.separate,
         relative_sizing=[1, 0.2, 0.2, 0.5],
@@ -331,7 +337,8 @@ def test_visualise_trades_with_duration_and_slippage(
     # Now visualise the events
     #
     fig = visualise_single_pair_positions_with_duration_and_slippage(
-        state, 
+        state,
+        unit_test_execution_context,
         candles,
     )
 
@@ -398,7 +405,8 @@ def test_visualise_single_pair_no_error(
     
     # check no error with different arguments
     fig = visualise_single_pair(
-        state, 
+        state,
+        unit_test_execution_context,
         candle_universe,
         relative_sizing=relative_sizing,
         vertical_spacing=vertical_spacing, 
@@ -433,7 +441,8 @@ def test_visualise_single_pair_with_error(
     # check no error with different arguments
     with pytest.raises(AssertionError):
         fig = visualise_single_pair(
-            state, 
+            state,
+            unit_test_execution_context,
             candle_universe,
             relative_sizing=relative_sizing,
             vertical_spacing=vertical_spacing, 
@@ -469,6 +478,7 @@ def test_visualise_single_pair_with_duration_and_slippage_no_error(
     
     fig = visualise_single_pair_positions_with_duration_and_slippage(
         state=state,
+        execution_context=unit_test_execution_context,
         candles=candles,
         relative_sizing=relative_sizing,
         vertical_spacing=vertical_spacing, 
@@ -494,6 +504,7 @@ def test_visualise_single_pair_with_duration_and_slippage_with_error(
     with pytest.raises(AssertionError):
         fig = visualise_single_pair_positions_with_duration_and_slippage(
             state=state,
+            execution_context=unit_test_execution_context,
             candles=candles,
             relative_sizing=relative_sizing,
             vertical_spacing=vertical_spacing, 

--- a/tests/strategy_tests/test_defi_bluechip.py
+++ b/tests/strategy_tests/test_defi_bluechip.py
@@ -18,7 +18,7 @@ from tradeexecutor.backtest.backtest_runner import run_backtest, setup_backtest
 from tradeexecutor.cli.log import setup_pytest_logging
 from tradeexecutor.state.state import State
 from tradeexecutor.statistics.summary import calculate_summary_statistics
-from tradeexecutor.strategy.execution_context import ExecutionMode
+from tradeexecutor.strategy.execution_context import ExecutionMode, unit_test_execution_context
 from tradeexecutor.analysis.trade_analyser import build_trade_analysis
 from tradeexecutor.strategy.trading_strategy_universe import TradingStrategyUniverse
 from tradeexecutor.visual.equity_curve import calculate_compounding_realised_trading_profitability
@@ -135,7 +135,7 @@ def test_alpha_model_timeline(
 
 def test_trade_analysis(
     state,
-        strategy_universe,
+    strategy_universe,
     ):
     """See trade analysis calculations do not crash."""
     analysis = build_trade_analysis(state.portfolio)
@@ -147,6 +147,7 @@ def test_trade_analysis(
 
     fig = visualise_single_pair(
         state,
+        unit_test_execution_context,
         strategy_universe.data_universe.candles,
         pair_id=crv_usd.internal_id,
     )
@@ -155,6 +156,7 @@ def test_trade_analysis(
     candles = strategy_universe.data_universe.candles.get_candles_by_pair(crv_usd.internal_id)
     fig = visualise_single_pair_positions_with_duration_and_slippage(
         state,
+        unit_test_execution_context,
         candles=candles,
         pair_id=crv_usd.internal_id,
     )

--- a/tests/test_strategy_state_visualisation.py
+++ b/tests/test_strategy_state_visualisation.py
@@ -18,6 +18,7 @@ from tradeexecutor.backtest.backtest_runner import run_backtest_inline
 from tradeexecutor.cli.log import setup_pytest_logging
 from tradeexecutor.state.identifier import AssetIdentifier, TradingPairIdentifier
 from tradeexecutor.state.visualisation import PlotKind
+from tradeexecutor.strategy.execution_context import unit_test_execution_context
 from tradeexecutor.strategy.trading_strategy_universe import TradingStrategyUniverse, \
     create_pair_universe_from_code
 from tradeexecutor.testing.synthetic_ethereum_data import generate_random_ethereum_address
@@ -202,7 +203,7 @@ def test_visualise_strategy_state(
         allow_missing_fees=True,
     )
 
-    image = draw_single_pair_strategy_state(state, strategy_universe)
+    image = draw_single_pair_strategy_state(state, unit_test_execution_context, strategy_universe)
 
     assert len(image.data) == 5
     assert len(image._grid_ref) == 1

--- a/tests/test_strategy_state_visualisation_multipair.py
+++ b/tests/test_strategy_state_visualisation_multipair.py
@@ -18,6 +18,7 @@ from tradeexecutor.backtest.backtest_runner import run_backtest_inline
 from tradeexecutor.cli.log import setup_pytest_logging
 from tradeexecutor.state.identifier import AssetIdentifier, TradingPairIdentifier
 from tradeexecutor.state.visualisation import PlotKind
+from tradeexecutor.strategy.execution_context import unit_test_execution_context
 from tradeexecutor.strategy.trading_strategy_universe import TradingStrategyUniverse, \
     create_pair_universe_from_code
 from tradeexecutor.testing.synthetic_ethereum_data import generate_random_ethereum_address
@@ -360,21 +361,21 @@ def test_visualise_strategy_state(
     )
 
     universe = strategy_universe
-    image = draw_multi_pair_strategy_state(state, universe)
+    image = draw_multi_pair_strategy_state(state, unit_test_execution_context, universe)
 
     assert len(image.data) == 27
     assert len(image._grid_ref) == 6
     assert image.data[0]['x'][0] == datetime.datetime(2023,4,3,0,0)
     assert image.data[0]['x'][-1] == datetime.datetime(2023,6,5,0,0)
 
-    image_no_detached = draw_multi_pair_strategy_state(state, universe, detached_indicators=False)
+    image_no_detached = draw_multi_pair_strategy_state(state, unit_test_execution_context, universe, detached_indicators=False)
 
     assert len(image_no_detached.data) == 24
     assert len(image_no_detached._grid_ref) == 3
     assert image_no_detached.data[0]['x'][0] == datetime.datetime(2023,4,3,0,0)
     assert image_no_detached.data[0]['x'][-1] == datetime.datetime(2023,6,5,0,0)
 
-    image_no_indicators = draw_multi_pair_strategy_state(state, universe, technical_indicators=False)
+    image_no_indicators = draw_multi_pair_strategy_state(state, unit_test_execution_context, universe, technical_indicators=False)
 
     assert len(image_no_indicators.data) == 15
     assert len(image_no_indicators._grid_ref) == 3

--- a/tradeexecutor/cli/discord.py
+++ b/tradeexecutor/cli/discord.py
@@ -37,7 +37,7 @@ def post_logging_discord_image(image: bytes):
     If no Discord logger is active do nothing.
     """
 
-    assert isinstance(image, bytes)
+    assert isinstance(image, bytes), f"Expected bytes, got {type(images)}"
 
     handler = get_discord_logging_handler()
     if not handler:

--- a/tradeexecutor/statistics/in_memory_statistics.py
+++ b/tradeexecutor/statistics/in_memory_statistics.py
@@ -67,7 +67,7 @@ def refresh_run_state(
     # Strategy charts
     if visualisation:
         assert universe, "Candle data must be available to update visualisations"
-        redraw_visualisations(run_state, state, universe)
+        redraw_visualisations(run_state, state, universe, execution_context)
 
     # Set gas level warning
     if sync_model is not None:
@@ -85,7 +85,8 @@ def refresh_run_state(
 def redraw_visualisations(
     run_state: RunState | None,
     state: State,
-    universe: TradingStrategyUniverse
+    universe: TradingStrategyUniverse,
+    execution_context: ExecutionContext,
 ):
     """Redraw strategy thinking visualisations."""
 
@@ -113,26 +114,26 @@ def redraw_visualisations(
 
         if pair_count == 1:
 
-            small_figure = draw_single_pair_strategy_state(state, universe, height=512)
+            small_figure = draw_single_pair_strategy_state(state, universe, execution_context, height=512)
             # Draw the inline plot and expose them tot he web server
             # TODO: SVGs here are not very readable, have them as a stop gap solution
-            large_figure = draw_single_pair_strategy_state(state, universe, height=1024)
+            large_figure = draw_single_pair_strategy_state(state, universe, execution_context, height=1024)
 
-            refresh_live_strategy_images(run_state, small_figure, large_figure)
+            refresh_live_strategy_images(run_state, execution_context, small_figure, large_figure)
 
         elif 1 < pair_count <= 3:
 
-            small_figure_combined = draw_multi_pair_strategy_state(state, universe, height=1024)
-            large_figure_combined = draw_multi_pair_strategy_state(state, universe, height=2048)
+            small_figure_combined = draw_multi_pair_strategy_state(state, execution_context, universe, height=1024)
+            large_figure_combined = draw_multi_pair_strategy_state(state, execution_context, universe, height=2048)
 
-            refresh_live_strategy_images(run_state, small_figure_combined, large_figure_combined)
+            refresh_live_strategy_images(run_state, execution_context, small_figure_combined, large_figure_combined)
 
         elif 3 < pair_count <=5:
 
-            small_figure_combined = draw_multi_pair_strategy_state(state, universe, height=2048, detached_indicators = False)
-            large_figure_combined = draw_multi_pair_strategy_state(state, universe, height=3840, width = 2160, detached_indicators = False)
+            small_figure_combined = draw_multi_pair_strategy_state(state, universe, execution_context, height=2048, detached_indicators = False)
+            large_figure_combined = draw_multi_pair_strategy_state(state, universe, execution_context, height=3840, width = 2160, detached_indicators = False)
 
-            refresh_live_strategy_images(run_state, small_figure_combined, large_figure_combined)
+            refresh_live_strategy_images(run_state, execution_context, small_figure_combined, large_figure_combined)
 
         else:
             logger.warning("Charts not yet available for this strategy type. Pair count: %d", pair_count)
@@ -145,6 +146,7 @@ def redraw_visualisations(
 
 def refresh_live_strategy_images(
     run_state: RunState,
+    execution_context: ExecutionContext,
     small_figure,
     large_figure
 ):
@@ -155,6 +157,7 @@ def refresh_live_strategy_images(
     """
 
     assert isinstance(run_state, RunState)
+    assert isinstance(execution_context, ExecutionContext)
 
     small_image, small_image_dark = get_small_images(small_figure)
     large_image, large_image_dark = get_large_images(large_figure)

--- a/tradeexecutor/strategy/pandas_trader/runner.py
+++ b/tradeexecutor/strategy/pandas_trader/runner.py
@@ -150,6 +150,7 @@ class PandasTraderRunner(StrategyRunner):
 
     def refresh_visualisations(self, state: State, universe: TradingStrategyUniverse):
 
+
         if not self.run_state:
             # This strategy is not maintaining a run-state
             # Backtest, simulation, etc.
@@ -163,6 +164,8 @@ class PandasTraderRunner(StrategyRunner):
                     pair_count
                     )
 
+        execution_context = self.execution_context
+
         if universe.is_empty():
             # TODO: Not sure how we end up here
             logger.info("Strategy universe is empty - nothing to report")
@@ -172,24 +175,24 @@ class PandasTraderRunner(StrategyRunner):
 
             if pair_count == 1:
 
-                small_figure = draw_single_pair_strategy_state(state, universe, height=512)
+                small_figure = draw_single_pair_strategy_state(state, universe, execution_context, height=512)
                 # Draw the inline plot and expose them tot he web server
                 # TODO: SVGs here are not very readable, have them as a stop gap solution
-                large_figure = draw_single_pair_strategy_state(state, universe, height=1024)
+                large_figure = draw_single_pair_strategy_state(state, universe, execution_context, height=1024)
 
                 self.update_strategy_thinking_image_data(small_figure, large_figure)
 
             elif 1 < pair_count <= 3:
 
-                small_figure_combined = draw_multi_pair_strategy_state(state, universe, height=1024)
-                large_figure_combined = draw_multi_pair_strategy_state(state, universe, height=2048)
+                small_figure_combined = draw_multi_pair_strategy_state(state, universe, execution_context, height=1024)
+                large_figure_combined = draw_multi_pair_strategy_state(state, universe, execution_context, height=2048)
 
                 self.update_strategy_thinking_image_data(small_figure_combined, large_figure_combined)
 
             elif 3 < pair_count <=5:
 
-                small_figure_combined = draw_multi_pair_strategy_state(state, universe, height=2048, detached_indicators = False)
-                large_figure_combined = draw_multi_pair_strategy_state(state, universe, height=3840, width = 2160, detached_indicators = False)
+                small_figure_combined = draw_multi_pair_strategy_state(state, universe, execution_context, height=2048, detached_indicators = False)
+                large_figure_combined = draw_multi_pair_strategy_state(state, universe, execution_context, height=3840, width = 2160, detached_indicators = False)
 
                 self.update_strategy_thinking_image_data(small_figure_combined, large_figure_combined)
 

--- a/tradeexecutor/strategy/pandas_trader/runner.py
+++ b/tradeexecutor/strategy/pandas_trader/runner.py
@@ -175,24 +175,24 @@ class PandasTraderRunner(StrategyRunner):
 
             if pair_count == 1:
 
-                small_figure = draw_single_pair_strategy_state(state, universe, execution_context, height=512)
+                small_figure = draw_single_pair_strategy_state(state, execution_context, universe, height=512)
                 # Draw the inline plot and expose them tot he web server
                 # TODO: SVGs here are not very readable, have them as a stop gap solution
-                large_figure = draw_single_pair_strategy_state(state, universe, execution_context, height=1024)
+                large_figure = draw_single_pair_strategy_state(state, execution_context, universe, height=1024)
 
                 self.update_strategy_thinking_image_data(small_figure, large_figure)
 
             elif 1 < pair_count <= 3:
 
-                small_figure_combined = draw_multi_pair_strategy_state(state, universe, execution_context, height=1024)
-                large_figure_combined = draw_multi_pair_strategy_state(state, universe, execution_context, height=2048)
+                small_figure_combined = draw_multi_pair_strategy_state(state, execution_context, universe,  height=1024)
+                large_figure_combined = draw_multi_pair_strategy_state(state, execution_context, universe, height=2048)
 
                 self.update_strategy_thinking_image_data(small_figure_combined, large_figure_combined)
 
             elif 3 < pair_count <=5:
 
-                small_figure_combined = draw_multi_pair_strategy_state(state, universe, execution_context, height=2048, detached_indicators = False)
-                large_figure_combined = draw_multi_pair_strategy_state(state, universe, execution_context, height=3840, width = 2160, detached_indicators = False)
+                small_figure_combined = draw_multi_pair_strategy_state(state, execution_context, universe, height=2048, detached_indicators = False)
+                large_figure_combined = draw_multi_pair_strategy_state(state, execution_context, universe, height=3840, width = 2160, detached_indicators = False)
 
                 self.update_strategy_thinking_image_data(small_figure_combined, large_figure_combined)
 
@@ -210,7 +210,8 @@ class PandasTraderRunner(StrategyRunner):
         :param small_image: 512 x 512 image
         :param large_image: 1920 x 1920 image
         """
-        refresh_live_strategy_images(self.run_state, small_figure, large_figure)
+        execution_context = self.execution_context
+        refresh_live_strategy_images(self.run_state, execution_context, small_figure, large_figure)
 
     def report_strategy_thinking(
         self,

--- a/tradeexecutor/visual/multiple_pairs.py
+++ b/tradeexecutor/visual/multiple_pairs.py
@@ -11,6 +11,7 @@ from plotly.subplots import make_subplots
 
 from tradeexecutor.state.state import State
 from tradeexecutor.state.types import PairInternalId
+from tradeexecutor.strategy.execution_context import ExecutionContext
 from tradeexecutor.visual.technical_indicator import overlay_all_technical_indicators
 from tradeexecutor.visual.utils import get_pair_base_quote_names
 
@@ -104,6 +105,7 @@ def get_start_and_end_full(candles: pd.DataFrame | GroupedCandleUniverse, start_
 def visualise_multiple_pairs(
     state: State,
     candle_universe: GroupedCandleUniverse | pd.DataFrame,
+    execution_context: ExecutionContext,
     start_at: Optional[Union[pd.Timestamp, datetime.datetime]] = None,
     end_at: Optional[Union[pd.Timestamp, datetime.datetime]] = None,
     pair_ids: Optional[list[PairInternalId]] = None,
@@ -199,6 +201,8 @@ def visualise_multiple_pairs(
         Plotly figure object
     """
 
+    assert isinstance(execution_context, ExecutionContext)
+
     logger.info("Visualising %s", state)
 
     if not show_trades:
@@ -285,7 +289,7 @@ def visualise_multiple_pairs(
 
         if technical_indicators:
             num_detached_indicators, subplot_names = get_num_detached_and_names(
-                plots, volume_bar_modes[i], volume_text, pair_name, detached_indicators
+                plots, volume_bar_modes[i], volume_text, pair_name, detached_indicators, execution_context,
             )
         else:
             num_detached_indicators, subplot_names = get_num_detached_and_names_no_indicators(volume_bar_modes[i], volume_text, pair_name)

--- a/tradeexecutor/visual/multiple_pairs.py
+++ b/tradeexecutor/visual/multiple_pairs.py
@@ -289,10 +289,10 @@ def visualise_multiple_pairs(
 
         if technical_indicators:
             num_detached_indicators, subplot_names = get_num_detached_and_names(
-                plots, volume_bar_modes[i], volume_text, pair_name, detached_indicators, execution_context,
+                plots, execution_context, volume_bar_modes[i], volume_text, pair_name, detached_indicators,
             )
         else:
-            num_detached_indicators, subplot_names = get_num_detached_and_names_no_indicators(volume_bar_modes[i], volume_text, pair_name)
+            num_detached_indicators, subplot_names = get_num_detached_and_names_no_indicators(execution_context, volume_bar_modes[i], volume_text, pair_name)
 
         if not relative_sizing:
             _relative_sizing = [1] + [0.3] * num_detached_indicators

--- a/tradeexecutor/visual/strategy_state.py
+++ b/tradeexecutor/visual/strategy_state.py
@@ -31,8 +31,8 @@ logger = logging.getLogger(__name__)
 
 def draw_single_pair_strategy_state(
         state: State,
-        universe: TradingStrategyUniverse,
         execution_context: ExecutionContext,
+        universe: TradingStrategyUniverse,
         width=512,
         height=512,
         candle_count=64,

--- a/tradeexecutor/visual/strategy_state.py
+++ b/tradeexecutor/visual/strategy_state.py
@@ -14,7 +14,7 @@ from typing import Optional
 
 from tradeexecutor.state.state import State
 from tradeexecutor.state.types import PairInternalId
-from tradeexecutor.strategy.execution_context import ExecutionContext
+from tradeexecutor.strategy.execution_context import ExecutionContext, unit_test_execution_context
 from tradeexecutor.strategy.trading_strategy_universe import TradingStrategyUniverse
 from tradeexecutor.visual.single_pair import visualise_single_pair
 from tradeexecutor.visual.multiple_pairs import visualise_multiple_pairs
@@ -209,6 +209,7 @@ def visualise_single_pair_strategy_state(
     """
     figure = visualise_single_pair(
         state,
+        unit_test_execution_context,
         target_pair_candles,
         start_at=start_at,
         end_at=end_at,

--- a/tradeexecutor/visual/strategy_state.py
+++ b/tradeexecutor/visual/strategy_state.py
@@ -32,6 +32,7 @@ logger = logging.getLogger(__name__)
 def draw_single_pair_strategy_state(
         state: State,
         universe: TradingStrategyUniverse,
+        execution_context: ExecutionContext,
         width=512,
         height=512,
         candle_count=64,
@@ -60,6 +61,7 @@ def draw_single_pair_strategy_state(
         The strategy state visualisation as Plotly figure
     """
 
+    assert isinstance(execution_context, ExecutionContext)
     assert universe.is_single_pair_universe(), "This visualisation can be done only for single pair trading"
 
     if start_at is None and end_at is None:
@@ -80,17 +82,17 @@ def draw_single_pair_strategy_state(
 
 
 def draw_multi_pair_strategy_state(
-        state: State,
-        universe: TradingStrategyUniverse,
-        execution_context: ExecutionContext,
-        width: Optional[int] =1024,
-        height: Optional[int] = 2048,
-        candle_count: Optional[int] = 64,
-        start_at: Optional[datetime.datetime] = None,
-        end_at: Optional[datetime.datetime] = None,
-        technical_indicators: Optional[bool] = True,
-        pair_ids: Optional[list[PairInternalId]] = None,
-        detached_indicators: Optional[bool] = True,
+    state: State,
+    execution_context: ExecutionContext,
+    universe: TradingStrategyUniverse,
+    width: Optional[int] =1024,
+    height: Optional[int] = 2048,
+    candle_count: Optional[int] = 64,
+    start_at: Optional[datetime.datetime] = None,
+    end_at: Optional[datetime.datetime] = None,
+    technical_indicators: Optional[bool] = True,
+    pair_ids: Optional[list[PairInternalId]] = None,
+    detached_indicators: Optional[bool] = True,
 ) -> list[go.Figure]:
     """Draw mini price chart images for multiple pairs. Returns a single figure with multiple subplots.
 
@@ -134,7 +136,7 @@ def draw_multi_pair_strategy_state(
         The strategy state visualisation as a single Plotly figure with multiple subplots
     """
 
-    assert isinstance(execution_context, ExecutionContext)
+    assert isinstance(execution_context, ExecutionContext), f"Expected ExecutionContext, got {type(execution_context)}"
 
     data = universe.data_universe.candles.df
 

--- a/tradeexecutor/visual/strategy_state.py
+++ b/tradeexecutor/visual/strategy_state.py
@@ -81,6 +81,7 @@ def draw_single_pair_strategy_state(
 def draw_multi_pair_strategy_state(
         state: State,
         universe: TradingStrategyUniverse,
+        execution_context: ExecutionContext,
         width: Optional[int] =1024,
         height: Optional[int] = 2048,
         candle_count: Optional[int] = 64,
@@ -132,6 +133,8 @@ def draw_multi_pair_strategy_state(
         The strategy state visualisation as a single Plotly figure with multiple subplots
     """
 
+    assert isinstance(execution_context, ExecutionContext)
+
     data = universe.data_universe.candles.df
 
     if not pair_ids:
@@ -157,6 +160,7 @@ def draw_multi_pair_strategy_state(
     return visualise_multiple_pairs(
         state,
         data,
+        execution_context,
         start_at,
         end_at,
         pair_ids,

--- a/tradeexecutor/visual/strategy_state.py
+++ b/tradeexecutor/visual/strategy_state.py
@@ -14,6 +14,7 @@ from typing import Optional
 
 from tradeexecutor.state.state import State
 from tradeexecutor.state.types import PairInternalId
+from tradeexecutor.strategy.execution_context import ExecutionContext
 from tradeexecutor.strategy.trading_strategy_universe import TradingStrategyUniverse
 from tradeexecutor.visual.single_pair import visualise_single_pair
 from tradeexecutor.visual.multiple_pairs import visualise_multiple_pairs

--- a/tradeexecutor/visual/utils.py
+++ b/tradeexecutor/visual/utils.py
@@ -490,7 +490,7 @@ def get_num_detached_and_names(
 ):
     """Get num_detached_indicators and subplot_names"""
 
-    assert isinstance(execution_context, ExecutionContext)
+    assert isinstance(execution_context, ExecutionContext), f"Expected ExecutionContext, got {type(execution_context)}"
 
     num_detached_indicators = _get_num_detached_indicators(plots, execution_context, volume_bar_mode, detached_indicators)
     

--- a/tradeexecutor/visual/utils.py
+++ b/tradeexecutor/visual/utils.py
@@ -5,6 +5,8 @@ import logging
 import datetime
 
 import plotly.graph_objects as go
+
+from tradeexecutor.strategy.execution_context import ExecutionContext
 from tradingstrategy.charting.candle_chart import VolumeBarMode
 
 from tradeexecutor.state.portfolio import Portfolio
@@ -374,8 +376,14 @@ def get_all_text(
     return title_text, axes_text, volume_text
 
 
-def _get_num_detached_indicators(plots: list[Plot], volume_bar_mode: VolumeBarMode, detached_indicators: bool):
+def _get_num_detached_indicators(
+        plots: list[Plot],
+        execution_context: ExecutionContext,
+        volume_bar_mode: VolumeBarMode,
+        detached_indicators: bool):
     """Get the number of detached technical indicators"""
+
+    assert isinstance(execution_context, ExecutionContext)
 
     if detached_indicators:
         num_detached_indicators = sum(
@@ -402,12 +410,15 @@ def _get_plot_name_and_separator(plot: Plot) -> str:
 
 def _get_subplot_names(
     plots: list[Plot],
+    execution_context: ExecutionContext,
     volume_bar_mode: VolumeBarMode,
     volume_axis_name: str = "Volume USD",
     pair_name: str = None,
 ):
     """Get subplot names for detached technical indicators.
     Overlaid names are appended to the detached plot name."""
+
+    assert isinstance(execution_context, ExecutionContext)
 
     if volume_bar_mode in {VolumeBarMode.hidden, VolumeBarMode.overlay}:
         subplot_names = []
@@ -443,9 +454,13 @@ def _get_subplot_names(
                 if plot.kind == PlotKind.technical_indicator_detached
             ]
 
-            assert (
-                plot.detached_overlay_name in detached_plots
-            ), f"Overlay name {plot.detached_overlay_name} not in available detached plots {detached_plots}. Make sure there is a matching plot with the same name and kind PlotKind.technical_indicator_detached in the visualisation data."
+            # Don't crash live trading due to visualisation bugs.
+            # This can e.g. happen if the strategy code changes
+            # and the state file contains data for old indicators
+            if not execution_context.mode.is_live_trading():
+                assert (
+                    plot.detached_overlay_name in detached_plots
+                ), f"Overlay name {plot.detached_overlay_name} not in available detached plots {detached_plots}. Make sure there is a matching plot with the same name and kind PlotKind.technical_indicator_detached in the visualisation data."
 
             # check if another overlay exists
             if plot.detached_overlay_name in already_overlaid_names:
@@ -467,17 +482,21 @@ def _get_subplot_names(
 
 def get_num_detached_and_names(
     plots: list[Plot],
+    execution_context: ExecutionContext,
     volume_bar_mode: VolumeBarMode,
     volume_axis_name: str,
     pair_name: str | None = None,
     detached_indicators: bool = True,
 ):
     """Get num_detached_indicators and subplot_names"""
-    num_detached_indicators = _get_num_detached_indicators(plots, volume_bar_mode, detached_indicators)
+
+    assert isinstance(execution_context, ExecutionContext)
+
+    num_detached_indicators = _get_num_detached_indicators(plot, execution_context, volume_bar_mode, detached_indicators)
     
     if detached_indicators:
         subplot_names = _get_subplot_names(
-            plots, volume_bar_mode, volume_axis_name, pair_name
+            plots, execution_context, volume_bar_mode, volume_axis_name, pair_name
         )
     elif volume_bar_mode == VolumeBarMode.separate:
         subplot_names = [pair_name, volume_axis_name]

--- a/tradeexecutor/visual/utils.py
+++ b/tradeexecutor/visual/utils.py
@@ -492,7 +492,7 @@ def get_num_detached_and_names(
 
     assert isinstance(execution_context, ExecutionContext)
 
-    num_detached_indicators = _get_num_detached_indicators(plot, execution_context, volume_bar_mode, detached_indicators)
+    num_detached_indicators = _get_num_detached_indicators(plots, execution_context, volume_bar_mode, detached_indicators)
     
     if detached_indicators:
         subplot_names = _get_subplot_names(
@@ -507,11 +507,15 @@ def get_num_detached_and_names(
 
 
 def get_num_detached_and_names_no_indicators(
+    execution_context: ExecutionContext,
     volume_bar_mode: VolumeBarMode,
     volume_axis_name: str,
     pair_name: str | None = None,
 ):
     """Get num_detached_indicators and subplot_names. Used when technical_indicators == False"""
+
+    assert isinstance(execution_context, ExecutionContext)
+
     if volume_bar_mode == VolumeBarMode.separate:
         num_detached_indicators = 1
     else:


### PR DESCRIPTION
- Having old visualisation data in the state file causes asserts to trigger
- We do not want this in the live trading, instead we want to ignore and continue gracefully
- Pass `ExecutionContext` all the way down to the visualisation code so that this does not cause live execution to crash (backtest still should crash with an assert exception)