### PR TITLE
Create sensible unrealised PnL for positions

### DIFF
--- a/tests/enzyme/test_enzyme_realised_profit.py
+++ b/tests/enzyme/test_enzyme_realised_profit.py
@@ -225,6 +225,6 @@ def test_enzyme_redeemed_position_profit(
 
     assert position.get_realised_profit_usd() == pytest.approx(-7.372047000000003)
     # (1359.153875 - 1582.577362) / 1582.577362 ~= -14.1
-    assert position.get_realised_profit_percent() == pytest.approx(-0.07372047000000002)
+    assert position.get_realised_profit_percent() == pytest.approx(-0.14744093999999996)
     assert position.get_total_profit_usd() == position.get_realised_profit_usd()
     assert position.get_total_profit_usd() == pytest.approx(-7.372047000000003)

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -675,6 +675,16 @@ def test_realised_partial_profit_calculation(usdc, weth_usdc, start_ts: datetime
 
     # TODO: Should we express this differently?
     assert position.get_realised_profit_usd() == pytest.approx(62.5)
+    assert position.get_realised_profit_percent() == pytest.approx(0.023584905660377336)
+    assert position.get_unrealised_profit_usd() == pytest.approx(-50)
+    assert position.get_unrealised_and_realised_profit_percent() == pytest.approx(0.004716981132075429)
+
+    # Realise the remaining 50% of position profit
+    position, trade = trader.sell(weth_usdc, Decimal("0.75"), 1850.0)
+    assert position.get_realised_profit_usd() == pytest.approx(124.99999999999989)
+    assert position.get_realised_profit_percent() == pytest.approx(0.04716981132075467)
+    assert position.get_unrealised_profit_usd() == pytest.approx(0)
+    assert position.get_unrealised_and_realised_profit_percent() == pytest.approx(0.04716981132075467)
 
 
 def test_unrealised_profit_calculation(usdc, weth_usdc, start_ts: datetime.datetime):
@@ -714,6 +724,7 @@ def test_unrealised_profit_calculation(usdc, weth_usdc, start_ts: datetime.datet
     assert position.get_realised_profit_usd() is None
     assert position.get_unrealised_profit_usd() == pytest.approx(-400)
     assert position.get_total_profit_percent() == pytest.approx(-0.15094339622641514)
+    assert position.get_unrealised_and_realised_profit_percent() == pytest.approx(-0.15094339622641514)
 
     # Revalue ETH to 2000 USD, we are on green
     revalue_state(state, start_ts, EthValuator(2000))

--- a/tradeexecutor/state/position.py
+++ b/tradeexecutor/state/position.py
@@ -1458,9 +1458,14 @@ class TradingPosition(GenericPosition):
     def get_unrealised_and_realised_profit_percent(self) -> Percent:
         """Calculated unrealised PnL for this position.
 
+        This is an estimation of the profit % assuming the position would be completely closed
+        with the current price.
+
         See also
 
         - :py:meth:`get_realised_profit_percent`
+
+        - :py:meth:`get_total_profit_percent` (don't use, legacy)
 
         :return:
             The profitability of this position currently.

--- a/tradeexecutor/state/position.py
+++ b/tradeexecutor/state/position.py
@@ -1222,10 +1222,13 @@ class TradingPosition(GenericPosition):
         total_profit = realised_profit + unrealised_profit
         return total_profit
 
-    def get_total_profit_percent(self) -> float:
+    def get_total_profit_percent(self) -> Percent:
         """How much % we have made profit so far.
 
-        :return: 0 if profit calculation cannot be made yet
+        TODO: Legacy method. Use :py:meth:`get_unrealised_and_realised_profit_percent` instead.
+
+        :return:
+            0 if profit calculation cannot be made yet
         """
         if self.is_long():
             profit = self.get_total_profit_usd()
@@ -1451,6 +1454,31 @@ class TradingPosition(GenericPosition):
         #     return 0
 
         # return (sell_value + self.get_claimed_interest() - self.get_repaid_interest()) / (buy_value) - 1
+
+    def get_unrealised_and_realised_profit_percent(self) -> Percent:
+        """Calculated unrealised PnL for this position.
+
+        See also
+
+        - :py:meth:`get_realised_profit_percent`
+
+        :return:
+            The profitability of this position currently.
+
+        """
+        if self.is_long():
+            total_bought = self.get_total_bought_usd()
+            if total_bought == 0:
+                return 0
+            return (self.get_realised_profit_usd() + self.get_unrealised_profit_usd()) / total_bought
+        elif self.is_short():
+            total_sold = self.get_total_sold_usd()
+
+            if total_sold == 0:
+                return 0
+            return (self.get_realised_profit_usd() + self.get_unrealised_profit_usd()) / total_sold
+        else:
+            raise NotImplementedError(f"get_unrealised_profit_percent() supports only long and short positions")
 
     def get_size_relative_realised_profit_percent(self) -> Percent:
         """Calculated life-time profit over this position.

--- a/tradeexecutor/state/position.py
+++ b/tradeexecutor/state/position.py
@@ -1554,8 +1554,9 @@ class TradingPosition(GenericPosition):
             adjusted_buy_volume = buy_volume + (average_buy * float(redemptions))
             adjusted_sell_volume = sell_volume
 
-            assert adjusted_buy_volume <= buy_volume
-            assert adjusted_sell_volume <= sell_volume
+            if redemptions < 0:  # Some broken data might break redemptions amount, in legacy tests
+                assert adjusted_buy_volume <= buy_volume, f"Adjusted buy volume: {adjusted_buy_volume}, buy volume: {buy_volume}"
+                assert adjusted_sell_volume <= sell_volume
 
             # How much have we closed this position
             if not include_unrealised:

--- a/tradeexecutor/state/position.py
+++ b/tradeexecutor/state/position.py
@@ -521,6 +521,19 @@ class TradingPosition(GenericPosition):
         # Always convert zero to decimal
         return Decimal(s)
 
+    def get_redeemed(self) -> Decimal:
+        """Get amount of position reduced via in-kind redemptions.
+
+        - Also include any other account corrections
+
+        Alias for :py:meth:`get_base_token_balance_update_quantity`
+
+        :return:
+            A negative number, the amount of quantiy redeemed from this position
+        """
+        assert self.is_spot()
+        return self.get_base_token_balance_update_quantity()
+
     def get_available_trading_quantity(self) -> Decimal:
         """Get token quantity still availble for the trades in this strategy cycle.
 
@@ -1194,12 +1207,18 @@ class TradingPosition(GenericPosition):
 
         return trade_profit
 
-    def get_unrealised_profit_usd(self, include_interest=True) -> USDollarAmount:
+    def get_unrealised_profit_usd(self, include_interest=True, account_redemptions=True) -> USDollarAmount:
         """Calculate the position unrealised profit.
 
         Calculates the profit & loss (P&L) that has yet to be 'realised'
         in the remaining non-zero quantity of assets, due to the current
         market price.
+
+        :param include_interest:
+            The interest accrued on this position is includedin the result
+
+        :param account_redemptions:
+            Any in-kind redemptions are reduced from the net euqantity.
 
         :return:
             profit in dollar
@@ -1208,7 +1227,15 @@ class TradingPosition(GenericPosition):
         if avg_price is None:
             return 0
 
-        unrealised_equity = (self.get_current_price() - avg_price) * float(self.get_net_quantity())
+        # get_quantity() accounts for redemptions
+        net_quantity = self.get_quantity()
+
+        if account_redemptions:
+            # Simple accounting model where open positions cannot be touched by redemptions
+            unrealised_equity = (self.get_current_price() - avg_price) * float(net_quantity)
+        else:
+            # Simple accounting model where open positions cannot be touched by redemptions
+            unrealised_equity = (self.get_current_price() - avg_price) * float(net_quantity)
 
         if include_interest:
             return unrealised_equity + self.get_accrued_interest()
@@ -1412,6 +1439,8 @@ class TradingPosition(GenericPosition):
 
         - :py:meth:`get_unrealised_profit_usd`
 
+        - TODO: Does not include interest calculations
+
         See :ref:`profitability` for more details.
 
         :return:
@@ -1421,10 +1450,12 @@ class TradingPosition(GenericPosition):
             e.g. due to broken trades.
         """
         if self.is_long():
-            total_bought = self.get_total_bought_usd()
-            if total_bought == 0:
-                return 0
-            return self.get_realised_profit_usd()/total_bought
+            # New path
+            return self.get_unrealised_and_realised_profit_percent(include_unrealised=False)
+            #total_bought = self.get_total_bought_usd()
+            #if total_bought == 0:
+            #    return 0
+            #return self.get_realised_profit_usd()/total_bought
         else:
             total_sold = self.get_total_sold_usd()
             if total_sold == 0:
@@ -1455,11 +1486,19 @@ class TradingPosition(GenericPosition):
 
         # return (sell_value + self.get_claimed_interest() - self.get_repaid_interest()) / (buy_value) - 1
 
-    def get_unrealised_and_realised_profit_percent(self) -> Percent:
+    def get_unrealised_and_realised_profit_percent(
+        self,
+        valuation_price=None,
+        include_unrealised=True,
+    ) -> Percent:
         """Calculated unrealised PnL for this position.
 
         This is an estimation of the profit % assuming the position would be completely closed
         with the current price.
+
+        - This function accounts for in-kind redemptions affecting the position
+
+        - Currently only long positions supportd
 
         See also
 
@@ -1467,23 +1506,64 @@ class TradingPosition(GenericPosition):
 
         - :py:meth:`get_total_profit_percent` (don't use, legacy)
 
+        :param valuation_price:
+            Valuate the unrealised portion of tokens at this price
+
+        :param include_unrealised:
+            Include the unrealised PnL as the part of the result
+
         :return:
             The profitability of this position currently.
 
+            Return 0.05 for a position that is 5% in profit.
         """
+
         if self.is_long():
+            redemptions = self.get_redeemed()  # Negative
             total_bought = self.get_total_bought_usd()
             if total_bought == 0:
                 return 0
-            return (self.get_realised_profit_usd() + self.get_unrealised_profit_usd()) / total_bought
-        elif self.is_short():
-            total_sold = self.get_total_sold_usd()
 
-            if total_sold == 0:
-                return 0
-            return (self.get_realised_profit_usd() + self.get_unrealised_profit_usd()) / total_sold
+            unrealised_equity = 0
+            if include_unrealised:
+                quantity_left_sell = self.get_quantity()
+                if quantity_left_sell:
+                    assert valuation_price, "Cannot value unrealised PnL without an explicit valuation price for the unsold portion"
+                    unrealised_equity = valuation_price * float(quantity_left_sell)
+
+            avg_price = self.get_average_price()
+            # redemption_adjustment = avg_price * float(redemptions)
+            profit = ((self.get_realised_profit_usd() or 0) + (self.get_unrealised_profit_usd() or 0))
+
+            buy_quantity = self.get_buy_quantity()
+
+            sell_quantity = self.get_sell_quantity()
+            redeem_adjusted_buy_quantity = buy_quantity + redemptions
+            buy_volume = sum([t.get_value() for t in self.trades.values() if t.is_buy()])
+            sell_volume = sum([t.get_value() for t in self.trades.values() if t.is_sell()])
+            average_buy = buy_volume / float(buy_quantity)
+            average_sell = (sell_volume / float(sell_quantity)) if sell_quantity else 0
+
+            # Predent redemptions where there not in the first palce
+            adjusted_buy_volume = buy_volume + (average_buy * float(redemptions))
+            adjusted_sell_volume = sell_volume
+
+            assert adjusted_buy_volume <= buy_volume
+            assert adjusted_sell_volume <= sell_volume
+
+            adjusted_avg_buy = adjusted_buy_volume / float(redeem_adjusted_buy_quantity)
+            adjusted_profit_pct = (adjusted_sell_volume + unrealised_equity - adjusted_buy_volume) / (adjusted_buy_volume)
+
+            # average_sell = self.get_total_sold_usd() / float(sell_quantity)
+            # unadjusted_profit_usd = (average_sell - average_buy) / float(buy_quantity)
+            # buy_volume = self.get_average_buy() * float(redeem_adjusted_buy_quantity)
+            import ipdb ; ipdb.set_trace()
+            return adjusted_profit_pct
+            #else:
+            #    # No in-kind redemptions, the simple accounting path
+            #    return ((self.get_realised_profit_usd() or 0) + (self.get_unrealised_profit_usd() or 0)) / total_bought
         else:
-            raise NotImplementedError(f"get_unrealised_profit_percent() supports only long and short positions")
+            raise NotImplementedError(f"get_unrealised_and_realised_profit_percent() supports only long positions ATM")
 
     def get_size_relative_realised_profit_percent(self) -> Percent:
         """Calculated life-time profit over this position.

--- a/tradeexecutor/state/position.py
+++ b/tradeexecutor/state/position.py
@@ -1560,7 +1560,12 @@ class TradingPosition(GenericPosition):
             # How much have we closed this position
             if not include_unrealised:
 
-                pct_closed = float(sell_quantity / (buy_quantity + redemptions))
+                # Position has account corrections
+                divider = (buy_quantity + redemptions)
+                if divider == 0:
+                    return 0
+
+                pct_closed = float(sell_quantity / divider)
                 if pct_closed == 0:
                     return 0
 


### PR DESCRIPTION
- Add `get_unrealised_and_realised_profit_percent` that should give you what the final realised profit is if the position would be immediately closed
- In-kind redemptions make this very complex
- Fixes to unrealised and realised PnL calculations with in-kind redemptions reducing the position