### PR TITLE
Support set visualised pairs in strategy

### DIFF
--- a/tests/test_strategy_state_visualisation_multipair.py
+++ b/tests/test_strategy_state_visualisation_multipair.py
@@ -14,8 +14,13 @@ import pandas as pd
 from pandas_ta import bbands
 from pandas_ta.momentum import rsi
 
+from tradingstrategy.universe import Universe
+from tradingstrategy.chain import ChainId
+from tradingstrategy.timebucket import TimeBucket
+from tradingstrategy.candle import GroupedCandleUniverse
+from tradingstrategy.exchange import ExchangeUniverse
+
 from tradeexecutor.backtest.backtest_runner import run_backtest_inline
-from tradeexecutor.cli.log import setup_pytest_logging
 from tradeexecutor.state.identifier import AssetIdentifier, TradingPairIdentifier
 from tradeexecutor.state.visualisation import PlotKind
 from tradeexecutor.strategy.execution_context import unit_test_execution_context
@@ -24,21 +29,15 @@ from tradeexecutor.strategy.trading_strategy_universe import TradingStrategyUniv
 from tradeexecutor.testing.synthetic_ethereum_data import generate_random_ethereum_address
 from tradeexecutor.testing.synthetic_exchange_data import generate_exchange, generate_simple_routing_model
 from tradeexecutor.testing.synthetic_price_data import generate_ohlcv_candles
-from tradeexecutor.testing.synthetic_pair_data import generate_pair
-from tradingstrategy.candle import GroupedCandleUniverse
 from tradeexecutor.state.trade import TradeExecution
 from tradeexecutor.strategy.pricing_model import PricingModel
 from tradeexecutor.strategy.pandas_trader.position_manager import PositionManager
 from tradeexecutor.state.state import State
-from tradingstrategy.universe import Universe
-from tradingstrategy.chain import ChainId
-from tradingstrategy.timebucket import TimeBucket
 from tradeexecutor.strategy.cycle import CycleDuration
 from tradeexecutor.strategy.reserve_currency import ReserveCurrency
 from tradeexecutor.strategy.default_routing_options import TradeRouting
 from tradeexecutor.visual.strategy_state import draw_multi_pair_strategy_state
 from tradeexecutor.visual.image_output import open_plotly_figure_in_browser
-from tradingstrategy.utils.groupeduniverse import NoDataAvailable
 from tradeexecutor.strategy.trading_strategy_universe import translate_trading_pair
 
 
@@ -266,14 +265,20 @@ def decide_trades(
 
 
 @pytest.fixture(scope="module")
-def strategy_universe() -> TradingStrategyUniverse:
+def mock_exchange():
+    return generate_exchange(
+        exchange_id=random.randint(1, 1000),
+        chain_id=ChainId.ethereum,
+        address=generate_random_ethereum_address(),
+        exchange_slug="uniswap-mock",
+    )
+
+
+@pytest.fixture(scope="module")
+def strategy_universe(mock_exchange) -> TradingStrategyUniverse:
 
     # Set up fake assets
     mock_chain_id = ChainId.ethereum
-    mock_exchange = generate_exchange(
-        exchange_id=random.randint(1, 1000),
-        chain_id=mock_chain_id,
-        address=generate_random_ethereum_address())
     
     usdc = AssetIdentifier(ChainId.ethereum.value, generate_random_ethereum_address(), "USDC", 6, 1)
     
@@ -311,6 +316,7 @@ def strategy_universe() -> TradingStrategyUniverse:
     time_bucket = CANDLE_TIME_BUCKET
 
     pair_universe = create_pair_universe_from_code(mock_chain_id, [weth_usdc, pepe_usdc, bob_usdc])
+    exchange_universe = ExchangeUniverse(exchanges={mock_exchange.exchange_id: mock_exchange})
 
     candles_weth_usdc = generate_ohlcv_candles(time_bucket, START_AT_DATA, END_AT, pair_id=weth_usdc.internal_id, random_seed=1)
     candles_pepe_usdc = generate_ohlcv_candles(time_bucket, START_AT_DATA, END_AT, pair_id=pepe_usdc.internal_id, random_seed = 2)
@@ -322,6 +328,7 @@ def strategy_universe() -> TradingStrategyUniverse:
         time_bucket=time_bucket,
         chains={mock_chain_id},
         exchanges={mock_exchange},
+        exchange_universe=exchange_universe,
         pairs=pair_universe,
         candles=candle_universe,
         liquidity=None
@@ -379,6 +386,63 @@ def test_visualise_strategy_state(
 
     assert len(image_no_indicators.data) == 15
     assert len(image_no_indicators._grid_ref) == 3
+
+    # Test the image on a local screen
+    # using a web brower
+    if os.environ.get("SHOW_IMAGE"):
+        open_plotly_figure_in_browser(image, height=2000, width=1000)
+        open_plotly_figure_in_browser(image_no_detached, height=2000, width=1000)
+        open_plotly_figure_in_browser(image_no_indicators, height=2000, width=1000)
+
+
+def test_visualise_strategy_state_overriden_pairs(
+    logger: logging.Logger,
+    strategy_universe,
+):
+    """Visualise strategy state as a bunch inline images."""
+
+    routing_model = generate_simple_routing_model(strategy_universe)
+
+    # Run the test
+    state, strategy_universe, debug_dump = run_backtest_inline(
+        start_at=START_AT,
+        end_at=END_AT,
+        client=None,  # None of downloads needed, because we are using synthetic data
+        cycle_duration=TRADING_STRATEGY_CYCLE,
+        decide_trades=decide_trades,
+        create_trading_universe=None,
+        universe=strategy_universe,
+        initial_deposit=INITIAL_DEPOSIT,
+        reserve_currency=ReserveCurrency.busd,
+        trade_routing=TradeRouting.user_supplied_routing_model,
+        routing_model=routing_model,
+        log_level=logging.WARNING,
+        allow_missing_fees=True,
+    )
+
+    # visualise only one pair
+    state.visualisation.set_visualised_pairs([
+        strategy_universe.data_universe.pairs.get_pair_by_id(99),
+    ])
+
+    image = draw_multi_pair_strategy_state(state, unit_test_execution_context, strategy_universe)
+
+    assert len(image.data) == 9
+    assert len(image._grid_ref) == 2
+    assert image.data[0]['x'][0] == datetime.datetime(2023,4,3,0,0)
+    assert image.data[0]['x'][-1] == datetime.datetime(2023,6,5,0,0)
+
+    image_no_detached = draw_multi_pair_strategy_state(state, unit_test_execution_context, strategy_universe, detached_indicators=False)
+
+    assert len(image_no_detached.data) == 8
+    assert len(image_no_detached._grid_ref) == 1
+    assert image_no_detached.data[0]['x'][0] == datetime.datetime(2023,4,3,0,0)
+    assert image_no_detached.data[0]['x'][-1] == datetime.datetime(2023,6,5,0,0)
+
+    image_no_indicators = draw_multi_pair_strategy_state(state, unit_test_execution_context, strategy_universe, technical_indicators=False)
+
+    assert len(image_no_indicators.data) == 5
+    assert len(image_no_indicators._grid_ref) == 1
 
     # Test the image on a local screen
     # using a web brower

--- a/tests/test_strategy_state_visualisation_multipair.py
+++ b/tests/test_strategy_state_visualisation_multipair.py
@@ -398,6 +398,7 @@ def test_visualise_strategy_state(
 def test_visualise_strategy_state_overriden_pairs(
     logger: logging.Logger,
     strategy_universe,
+    mock_exchange,
 ):
     """Visualise strategy state as a bunch inline images."""
 
@@ -420,9 +421,9 @@ def test_visualise_strategy_state_overriden_pairs(
         allow_missing_fees=True,
     )
 
-    # visualise only one pair
+    # visualise only one pair WETH/USDC
     state.visualisation.set_visualised_pairs([
-        strategy_universe.data_universe.pairs.get_pair_by_id(99),
+        strategy_universe.get_trading_pair(99),
     ])
 
     image = draw_multi_pair_strategy_state(state, unit_test_execution_context, strategy_universe)
@@ -444,8 +445,7 @@ def test_visualise_strategy_state_overriden_pairs(
     assert len(image_no_indicators.data) == 5
     assert len(image_no_indicators._grid_ref) == 1
 
-    # Test the image on a local screen
-    # using a web brower
+    # Test the image on a local screen using a web brower
     if os.environ.get("SHOW_IMAGE"):
         open_plotly_figure_in_browser(image, height=2000, width=1000)
         open_plotly_figure_in_browser(image_no_detached, height=2000, width=1000)

--- a/tradeexecutor/cli/commands/visualise.py
+++ b/tradeexecutor/cli/commands/visualise.py
@@ -20,7 +20,6 @@ from ..bootstrap import prepare_executor_id
 from ..log import setup_logging
 from tradeexecutor.strategy.execution_context import standalone_backtest_execution_context
 from tradeexecutor.backtest.backtest_module import run_backtest_for_module
-
 from tradeexecutor.visual.strategy_state import draw_single_pair_strategy_state, draw_multi_pair_strategy_state
 from tradeexecutor.statistics.in_memory_statistics import get_image_and_dark_image
 

--- a/tradeexecutor/state/visualisation.py
+++ b/tradeexecutor/state/visualisation.py
@@ -368,7 +368,7 @@ class Visualisation:
         point_count = sum([len(p.points) for p in self.plots.values()])
         return f"<Visualisation with {plot_count} plots and {point_count} data points>"
     
-    def set_visualised_pairs(self, pairs: list[TradingPairIdentifier | DEXPair]) -> None:
+    def set_visualised_pairs(self, pairs: list[TradingPairIdentifier]) -> None:
         """Set the trading pair for this plot.
 
         :param pairs:
@@ -377,12 +377,8 @@ class Visualisation:
         """
         assert isinstance(pairs, list)
         for pair in pairs:
-            if isinstance(pair, DEXPair):
-                self.pair_ids.append(pair.pair_id)
-            elif isinstance(pair, TradingPairIdentifier):
-                self.pair_ids.append(pair.internal_id)
-            else:
-                raise ValueError(f"Unexpected pair type, got {pair} of type {type(pair)}")
+            assert isinstance(pair, TradingPairIdentifier), f"Unexpected pair type, got {pair} of type {type(pair)}"
+            self.pair_ids.append(pair.internal_id)
 
     def add_message(self,
                     timestamp: datetime.datetime,

--- a/tradeexecutor/state/visualisation.py
+++ b/tradeexecutor/state/visualisation.py
@@ -23,6 +23,8 @@ import pandas as pd
 import logging
 
 from dataclasses_json import dataclass_json
+from tradingstrategy.pair import DEXPair
+from tradingstrategy.types import PrimaryKey
 
 from tradeexecutor.utils.timestamp import convert_and_validate_timestamp, convert_and_validate_timestamp_as_int
 from tradeexecutor.state.identifier import TradingPairIdentifier
@@ -321,7 +323,6 @@ class Plot:
         return sorted_entries
 
 
-
 @dataclass_json
 @dataclass
 class Visualisation:
@@ -358,10 +359,30 @@ class Visualisation:
     #:
     plots: Dict[str, Plot] = field(default_factory=dict)
 
+    #: Trading pair IDs to visualise instead of the default trading pairs from 
+    #: strategy universe.
+    pair_ids: list[PrimaryKey] = field(default_factory=list)
+
     def __repr__(self) -> str:
         plot_count = len(self.plots)
         point_count = sum([len(p.points) for p in self.plots.values()])
         return f"<Visualisation with {plot_count} plots and {point_count} data points>"
+    
+    def set_visualised_pairs(self, pairs: list[TradingPairIdentifier | DEXPair]) -> None:
+        """Set the trading pair for this plot.
+
+        :param pairs:
+            Use these trading pairs to plot candle charts instead of the default
+            trading pairs from strategy universe.
+        """
+        assert isinstance(pairs, list)
+        for pair in pairs:
+            if isinstance(pair, DEXPair):
+                self.pair_ids.append(pair.pair_id)
+            elif isinstance(pair, TradingPairIdentifier):
+                self.pair_ids.append(pair.internal_id)
+            else:
+                raise ValueError(f"Unexpected pair type, got {pair} of type {type(pair)}")
 
     def add_message(self,
                     timestamp: datetime.datetime,

--- a/tradeexecutor/visual/strategy_state.py
+++ b/tradeexecutor/visual/strategy_state.py
@@ -141,7 +141,10 @@ def draw_multi_pair_strategy_state(
     data = universe.data_universe.candles.df
 
     if not pair_ids:
-        pair_ids = universe.data_universe.pairs.get_all_pair_ids()
+        if len(state.visualisation.pair_ids) > 0:
+            pair_ids = state.visualisation.pair_ids
+        else:
+            pair_ids = universe.data_universe.pairs.get_all_pair_ids()
 
     if start_at is None and end_at is None:
             # Get


### PR DESCRIPTION
- Add support for `state.visualisation.set_visualised_pairs()` to override default trading pairs which are used for price chart
- Save pair IDs in `state.visualisation.pair_ids`