### PR TITLE
Adding strategy sort priority as the part of the UI

### DIFF
--- a/notebooks/breakout-bollinger-bands-new/matic/v02-matic-breakout-single.ipynb
+++ b/notebooks/breakout-bollinger-bands-new/matic/v02-matic-breakout-single.ipynb
@@ -24,7 +24,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 61,
    "outputs": [
     {
      "name": "stdout",
@@ -57,8 +57,8 @@
    "metadata": {
     "collapsed": false,
     "ExecuteTime": {
-     "end_time": "2024-04-18T08:43:04.404429Z",
-     "start_time": "2024-04-18T08:43:04.323102Z"
+     "end_time": "2024-04-18T11:15:51.805498Z",
+     "start_time": "2024-04-18T11:15:51.671097Z"
     }
    }
   },
@@ -75,7 +75,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 62,
    "outputs": [],
    "source": [
     "from tradingstrategy.chain import ChainId\n",
@@ -139,8 +139,8 @@
    "metadata": {
     "collapsed": false,
     "ExecuteTime": {
-     "end_time": "2024-04-18T08:43:04.404939Z",
-     "start_time": "2024-04-18T08:43:04.403501Z"
+     "end_time": "2024-04-18T11:15:51.805701Z",
+     "start_time": "2024-04-18T11:15:51.736625Z"
     }
    }
   },
@@ -159,7 +159,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 63,
    "outputs": [
     {
      "data": {
@@ -167,7 +167,7 @@
       "application/vnd.jupyter.widget-view+json": {
        "version_major": 2,
        "version_minor": 0,
-       "model_id": "2b87d293ff2d4b0c95469251553a0a0e"
+       "model_id": "417685c4a3564d14bb88ae4bc334b8ad"
       }
      },
      "metadata": {},
@@ -260,8 +260,8 @@
    "metadata": {
     "collapsed": false,
     "ExecuteTime": {
-     "end_time": "2024-04-18T08:43:47.706793Z",
-     "start_time": "2024-04-18T08:43:04.403614Z"
+     "end_time": "2024-04-18T11:15:51.896899Z",
+     "start_time": "2024-04-18T11:15:51.736726Z"
     }
    }
   },
@@ -278,7 +278,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 64,
    "outputs": [],
    "source": [
     "import pandas_ta\n",
@@ -313,8 +313,8 @@
    "metadata": {
     "collapsed": false,
     "ExecuteTime": {
-     "end_time": "2024-04-18T08:43:47.710749Z",
-     "start_time": "2024-04-18T08:43:47.708987Z"
+     "end_time": "2024-04-18T11:15:51.899218Z",
+     "start_time": "2024-04-18T11:15:51.897086Z"
     }
    }
   },
@@ -331,7 +331,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 65,
    "outputs": [],
    "source": [
     "from tradeexecutor.state.visualisation import PlotKind\n",
@@ -350,6 +350,7 @@
     "    state = input.state\n",
     "    timestamp = input.timestamp\n",
     "    indicators = input.indicators\n",
+    "    strategy_universe = input.strategy_universe\n",
     "\n",
     "    position_manager.log(\"decide_trades() start\")\n",
     "\n",
@@ -424,8 +425,8 @@
    "metadata": {
     "collapsed": false,
     "ExecuteTime": {
-     "end_time": "2024-04-18T08:43:47.716876Z",
-     "start_time": "2024-04-18T08:43:47.711077Z"
+     "end_time": "2024-04-18T11:15:51.899505Z",
+     "start_time": "2024-04-18T11:15:51.897280Z"
     }
    }
   },
@@ -442,8 +443,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 66,
    "outputs": [
+    {
+     "data": {
+      "text/plain": "Reading cached indicators rsi, bbands for 1 pairs, using 8 threads:   0%|          | 0/2 [00:00<?, ?it/s]",
+      "application/vnd.jupyter.widget-view+json": {
+       "version_major": 2,
+       "version_minor": 0,
+       "model_id": "03639746de384b80926cff515b16574b"
+      }
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
     {
      "name": "stdout",
      "output_type": "stream",
@@ -453,23 +466,11 @@
     },
     {
      "data": {
-      "text/plain": "Calculating indicators rsi, bbands using 8 processes:   0%|          | 0/2 [00:00<?, ?it/s]",
-      "application/vnd.jupyter.widget-view+json": {
-       "version_major": 2,
-       "version_minor": 0,
-       "model_id": "e36a5c49a7754de5b7c55714815173fb"
-      }
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
       "text/plain": "  0%|          | 0/82684800 [00:00<?, ?it/s]",
       "application/vnd.jupyter.widget-view+json": {
        "version_major": 2,
        "version_minor": 0,
-       "model_id": "caba33f91d5f4e4bb67c54bf10c52866"
+       "model_id": "b2fc51c4e82f4a7d81ebb593c72217ee"
       }
      },
      "metadata": {},
@@ -504,8 +505,8 @@
    "metadata": {
     "collapsed": false,
     "ExecuteTime": {
-     "end_time": "2024-04-18T08:44:12.233406Z",
-     "start_time": "2024-04-18T08:43:47.719214Z"
+     "end_time": "2024-04-18T11:16:13.200621Z",
+     "start_time": "2024-04-18T11:15:51.899688Z"
     }
    }
   },
@@ -520,7 +521,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 67,
    "outputs": [
     {
      "name": "stderr",
@@ -566,8 +567,8 @@
    "metadata": {
     "collapsed": false,
     "ExecuteTime": {
-     "end_time": "2024-04-18T08:44:12.813790Z",
-     "start_time": "2024-04-18T08:44:12.302420Z"
+     "end_time": "2024-04-18T11:16:13.769255Z",
+     "start_time": "2024-04-18T11:16:13.270559Z"
     }
    }
   },
@@ -582,12 +583,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 68,
    "outputs": [
     {
      "data": {
-      "text/plain": "                             Strategy Buy and hold MATIC\nStart Period               2021-09-01         2021-09-01\nEnd Period                 2024-04-14         2024-04-14\nRisk-Free Rate                   0.0%               0.0%\nTime in Market                   9.0%               5.0%\nCumulative Return              98.11%            -51.63%\nCAGR﹪                          29.82%            -24.22%\nSharpe                           0.23               0.04\nProb. Sharpe Ratio             96.69%             63.99%\nSmart Sharpe                     0.22               0.04\nSortino                          0.37               0.07\nSmart Sortino                    0.36               0.07\nSortino/√2                       0.26               0.05\nSmart Sortino/√2                 0.26               0.05\nOmega                            1.14               1.14\nMax Drawdown                  -29.98%            -87.95%\nLongest DD Days                   366                838\nVolatility (ann.)               5.47%              20.6%\nR^2                               0.0                0.0\nInformation Ratio                 0.0                0.0\nCalmar                           0.99              -0.28\nSkew                             4.63               4.13\nKurtosis                       153.91             180.03\nExpected Daily                   0.0%              -0.0%\nExpected Monthly                2.16%             -2.24%\nExpected Yearly                18.64%            -16.61%\nKelly Criterion                15.27%             43.91%\nRisk of Ruin                     0.0%               0.0%\nDaily Value-at-Risk            -0.47%             -1.77%\nExpected Shortfall (cVaR)      -0.47%             -1.77%\nMax Consecutive Wins                7                  1\nMax Consecutive Losses              7                  1\nGain/Pain Ratio                  0.41               0.03\nGain/Pain (1M)                   1.12               0.18\nPayoff Ratio                     1.77              12.17\nProfit Factor                    1.14               1.03\nCommon Sense Ratio                  -                  -\nCPC Index                        0.92               6.06\nTail Ratio                          -                  -\nOutlier Win Ratio               56.54              21.03\nOutlier Loss Ratio               3.24               0.51\nMTD                              0.0%            -34.78%\n3M                             12.36%            -26.74%\n6M                              4.74%             23.48%\nYTD                            12.36%            -33.42%\n1Y                            -18.66%            -44.64%\n3Y (ann.)                      29.82%            -24.22%\n5Y (ann.)                      29.82%            -24.22%\n10Y (ann.)                     29.82%            -24.22%\nAll-time (ann.)                29.82%            -24.22%\nBest Day                        8.16%             33.28%\nWorst Day                      -5.31%            -21.82%\nBest Month                     21.81%             96.29%\nWorst Month                   -11.61%            -43.28%\nBest Year                      52.87%             92.21%\nWorst Year                     -1.22%            -70.08%\nAvg. Drawdown                  -4.07%            -28.23%\nAvg. Drawdown Days                 23                134\nRecovery Factor                  3.27              -0.59\nUlcer Index                      0.14               0.63\nSerenity Index                   0.07              -0.01\nAvg. Up Month                   8.65%             37.89%\nAvg. Down Month                -7.16%            -13.47%\nWin Days                       45.83%             48.17%\nWin Month                      63.33%              37.5%\nWin Quarter                    63.64%             41.67%\nWin Year                        75.0%              50.0%\nBeta                             0.01                  -\nAlpha                            0.01                  -\nCorrelation                     2.29%                  -\nTreynor Ratio               16111.92%                  -",
-      "text/html": "<div>\n<style scoped>\n    .dataframe tbody tr th:only-of-type {\n        vertical-align: middle;\n    }\n\n    .dataframe tbody tr th {\n        vertical-align: top;\n    }\n\n    .dataframe thead th {\n        text-align: right;\n    }\n</style>\n<table border=\"1\" class=\"dataframe\">\n  <thead>\n    <tr style=\"text-align: right;\">\n      <th></th>\n      <th>Strategy</th>\n      <th>Buy and hold MATIC</th>\n    </tr>\n  </thead>\n  <tbody>\n    <tr>\n      <th>Start Period</th>\n      <td>2021-09-01</td>\n      <td>2021-09-01</td>\n    </tr>\n    <tr>\n      <th>End Period</th>\n      <td>2024-04-14</td>\n      <td>2024-04-14</td>\n    </tr>\n    <tr>\n      <th>Risk-Free Rate</th>\n      <td>0.0%</td>\n      <td>0.0%</td>\n    </tr>\n    <tr>\n      <th>Time in Market</th>\n      <td>9.0%</td>\n      <td>5.0%</td>\n    </tr>\n    <tr>\n      <th>Cumulative Return</th>\n      <td>98.11%</td>\n      <td>-51.63%</td>\n    </tr>\n    <tr>\n      <th>CAGR﹪</th>\n      <td>29.82%</td>\n      <td>-24.22%</td>\n    </tr>\n    <tr>\n      <th>Sharpe</th>\n      <td>0.23</td>\n      <td>0.04</td>\n    </tr>\n    <tr>\n      <th>Prob. Sharpe Ratio</th>\n      <td>96.69%</td>\n      <td>63.99%</td>\n    </tr>\n    <tr>\n      <th>Smart Sharpe</th>\n      <td>0.22</td>\n      <td>0.04</td>\n    </tr>\n    <tr>\n      <th>Sortino</th>\n      <td>0.37</td>\n      <td>0.07</td>\n    </tr>\n    <tr>\n      <th>Smart Sortino</th>\n      <td>0.36</td>\n      <td>0.07</td>\n    </tr>\n    <tr>\n      <th>Sortino/√2</th>\n      <td>0.26</td>\n      <td>0.05</td>\n    </tr>\n    <tr>\n      <th>Smart Sortino/√2</th>\n      <td>0.26</td>\n      <td>0.05</td>\n    </tr>\n    <tr>\n      <th>Omega</th>\n      <td>1.14</td>\n      <td>1.14</td>\n    </tr>\n    <tr>\n      <th>Max Drawdown</th>\n      <td>-29.98%</td>\n      <td>-87.95%</td>\n    </tr>\n    <tr>\n      <th>Longest DD Days</th>\n      <td>366</td>\n      <td>838</td>\n    </tr>\n    <tr>\n      <th>Volatility (ann.)</th>\n      <td>5.47%</td>\n      <td>20.6%</td>\n    </tr>\n    <tr>\n      <th>R^2</th>\n      <td>0.0</td>\n      <td>0.0</td>\n    </tr>\n    <tr>\n      <th>Information Ratio</th>\n      <td>0.0</td>\n      <td>0.0</td>\n    </tr>\n    <tr>\n      <th>Calmar</th>\n      <td>0.99</td>\n      <td>-0.28</td>\n    </tr>\n    <tr>\n      <th>Skew</th>\n      <td>4.63</td>\n      <td>4.13</td>\n    </tr>\n    <tr>\n      <th>Kurtosis</th>\n      <td>153.91</td>\n      <td>180.03</td>\n    </tr>\n    <tr>\n      <th>Expected Daily</th>\n      <td>0.0%</td>\n      <td>-0.0%</td>\n    </tr>\n    <tr>\n      <th>Expected Monthly</th>\n      <td>2.16%</td>\n      <td>-2.24%</td>\n    </tr>\n    <tr>\n      <th>Expected Yearly</th>\n      <td>18.64%</td>\n      <td>-16.61%</td>\n    </tr>\n    <tr>\n      <th>Kelly Criterion</th>\n      <td>15.27%</td>\n      <td>43.91%</td>\n    </tr>\n    <tr>\n      <th>Risk of Ruin</th>\n      <td>0.0%</td>\n      <td>0.0%</td>\n    </tr>\n    <tr>\n      <th>Daily Value-at-Risk</th>\n      <td>-0.47%</td>\n      <td>-1.77%</td>\n    </tr>\n    <tr>\n      <th>Expected Shortfall (cVaR)</th>\n      <td>-0.47%</td>\n      <td>-1.77%</td>\n    </tr>\n    <tr>\n      <th>Max Consecutive Wins</th>\n      <td>7</td>\n      <td>1</td>\n    </tr>\n    <tr>\n      <th>Max Consecutive Losses</th>\n      <td>7</td>\n      <td>1</td>\n    </tr>\n    <tr>\n      <th>Gain/Pain Ratio</th>\n      <td>0.41</td>\n      <td>0.03</td>\n    </tr>\n    <tr>\n      <th>Gain/Pain (1M)</th>\n      <td>1.12</td>\n      <td>0.18</td>\n    </tr>\n    <tr>\n      <th>Payoff Ratio</th>\n      <td>1.77</td>\n      <td>12.17</td>\n    </tr>\n    <tr>\n      <th>Profit Factor</th>\n      <td>1.14</td>\n      <td>1.03</td>\n    </tr>\n    <tr>\n      <th>Common Sense Ratio</th>\n      <td>-</td>\n      <td>-</td>\n    </tr>\n    <tr>\n      <th>CPC Index</th>\n      <td>0.92</td>\n      <td>6.06</td>\n    </tr>\n    <tr>\n      <th>Tail Ratio</th>\n      <td>-</td>\n      <td>-</td>\n    </tr>\n    <tr>\n      <th>Outlier Win Ratio</th>\n      <td>56.54</td>\n      <td>21.03</td>\n    </tr>\n    <tr>\n      <th>Outlier Loss Ratio</th>\n      <td>3.24</td>\n      <td>0.51</td>\n    </tr>\n    <tr>\n      <th>MTD</th>\n      <td>0.0%</td>\n      <td>-34.78%</td>\n    </tr>\n    <tr>\n      <th>3M</th>\n      <td>12.36%</td>\n      <td>-26.74%</td>\n    </tr>\n    <tr>\n      <th>6M</th>\n      <td>4.74%</td>\n      <td>23.48%</td>\n    </tr>\n    <tr>\n      <th>YTD</th>\n      <td>12.36%</td>\n      <td>-33.42%</td>\n    </tr>\n    <tr>\n      <th>1Y</th>\n      <td>-18.66%</td>\n      <td>-44.64%</td>\n    </tr>\n    <tr>\n      <th>3Y (ann.)</th>\n      <td>29.82%</td>\n      <td>-24.22%</td>\n    </tr>\n    <tr>\n      <th>5Y (ann.)</th>\n      <td>29.82%</td>\n      <td>-24.22%</td>\n    </tr>\n    <tr>\n      <th>10Y (ann.)</th>\n      <td>29.82%</td>\n      <td>-24.22%</td>\n    </tr>\n    <tr>\n      <th>All-time (ann.)</th>\n      <td>29.82%</td>\n      <td>-24.22%</td>\n    </tr>\n    <tr>\n      <th>Best Day</th>\n      <td>8.16%</td>\n      <td>33.28%</td>\n    </tr>\n    <tr>\n      <th>Worst Day</th>\n      <td>-5.31%</td>\n      <td>-21.82%</td>\n    </tr>\n    <tr>\n      <th>Best Month</th>\n      <td>21.81%</td>\n      <td>96.29%</td>\n    </tr>\n    <tr>\n      <th>Worst Month</th>\n      <td>-11.61%</td>\n      <td>-43.28%</td>\n    </tr>\n    <tr>\n      <th>Best Year</th>\n      <td>52.87%</td>\n      <td>92.21%</td>\n    </tr>\n    <tr>\n      <th>Worst Year</th>\n      <td>-1.22%</td>\n      <td>-70.08%</td>\n    </tr>\n    <tr>\n      <th>Avg. Drawdown</th>\n      <td>-4.07%</td>\n      <td>-28.23%</td>\n    </tr>\n    <tr>\n      <th>Avg. Drawdown Days</th>\n      <td>23</td>\n      <td>134</td>\n    </tr>\n    <tr>\n      <th>Recovery Factor</th>\n      <td>3.27</td>\n      <td>-0.59</td>\n    </tr>\n    <tr>\n      <th>Ulcer Index</th>\n      <td>0.14</td>\n      <td>0.63</td>\n    </tr>\n    <tr>\n      <th>Serenity Index</th>\n      <td>0.07</td>\n      <td>-0.01</td>\n    </tr>\n    <tr>\n      <th>Avg. Up Month</th>\n      <td>8.65%</td>\n      <td>37.89%</td>\n    </tr>\n    <tr>\n      <th>Avg. Down Month</th>\n      <td>-7.16%</td>\n      <td>-13.47%</td>\n    </tr>\n    <tr>\n      <th>Win Days</th>\n      <td>45.83%</td>\n      <td>48.17%</td>\n    </tr>\n    <tr>\n      <th>Win Month</th>\n      <td>63.33%</td>\n      <td>37.5%</td>\n    </tr>\n    <tr>\n      <th>Win Quarter</th>\n      <td>63.64%</td>\n      <td>41.67%</td>\n    </tr>\n    <tr>\n      <th>Win Year</th>\n      <td>75.0%</td>\n      <td>50.0%</td>\n    </tr>\n    <tr>\n      <th>Beta</th>\n      <td>0.01</td>\n      <td>-</td>\n    </tr>\n    <tr>\n      <th>Alpha</th>\n      <td>0.01</td>\n      <td>-</td>\n    </tr>\n    <tr>\n      <th>Correlation</th>\n      <td>2.29%</td>\n      <td>-</td>\n    </tr>\n    <tr>\n      <th>Treynor Ratio</th>\n      <td>16111.92%</td>\n      <td>-</td>\n    </tr>\n  </tbody>\n</table>\n</div>"
+      "text/plain": "                             Strategy Buy and hold MATIC\nStart Period               2021-09-01         2021-09-01\nEnd Period                 2024-04-14         2024-04-14\nRisk-Free Rate                   0.0%               0.0%\nTime in Market                  22.0%               6.0%\nCumulative Return              98.11%            -100.0%\nCAGR﹪                          29.82%            -100.0%\nSharpe                           1.06              -1.58\nProb. Sharpe Ratio             97.24%               0.0%\nSmart Sharpe                     1.05              -1.56\nSortino                          2.38              -1.65\nSmart Sortino                    2.35              -1.63\nSortino/√2                       1.68              -1.16\nSmart Sortino/√2                 1.66              -1.15\nOmega                            1.41               1.41\nMax Drawdown                  -28.07%           -3245.1%\nLongest DD Days                   363                898\nVolatility (ann.)              28.15%           2224.91%\nR^2                               0.0                0.0\nInformation Ratio                0.08               0.08\nCalmar                           1.06              -0.03\nSkew                             3.83             -13.53\nKurtosis                        23.52             267.47\nExpected Daily                  0.07%            -100.0%\nExpected Monthly                2.16%            -100.0%\nExpected Yearly                18.64%            -100.0%\nKelly Criterion                31.68%              6.85%\nRisk of Ruin                     0.0%               0.0%\nDaily Value-at-Risk            -2.34%           -201.18%\nExpected Shortfall (cVaR)      -2.34%           -201.18%\nMax Consecutive Wins                3                  2\nMax Consecutive Losses              4                  5\nGain/Pain Ratio                  0.41              -0.79\nGain/Pain (1M)                   1.13               -1.0\nPayoff Ratio                      5.6                4.8\nProfit Factor                    1.41               0.21\nCommon Sense Ratio               1.04                  -\nCPC Index                        3.32               0.23\nTail Ratio                       0.74                  -\nOutlier Win Ratio               13.14               1.59\nOutlier Loss Ratio              95.37               0.48\nMTD                              0.0%               0.0%\n3M                             12.36%               0.0%\n6M                              5.26%               0.0%\nYTD                            12.36%               0.0%\n1Y                             -16.9%               0.0%\n3Y (ann.)                      29.82%            -100.0%\n5Y (ann.)                      29.82%            -100.0%\n10Y (ann.)                     29.82%            -100.0%\nAll-time (ann.)                29.82%            -100.0%\nBest Day                       12.61%            698.59%\nWorst Day                      -4.82%          -2560.67%\nBest Month                     21.81%               0.0%\nWorst Month                   -11.61%         -11980.48%\nBest Year                      52.87%               0.0%\nWorst Year                     -1.22%            -100.0%\nAvg. Drawdown                   -5.6%           -855.18%\nAvg. Drawdown Days                 40                158\nRecovery Factor                   3.5              -0.03\nUlcer Index                      0.13               1.87\nSerenity Index                   0.44              -0.17\nAvg. Up Month                       -                  -\nAvg. Down Month                     -                  -\nWin Days                       42.03%             22.92%\nWin Month                      63.33%               0.0%\nWin Quarter                    63.64%               0.0%\nWin Year                        75.0%               0.0%\nBeta                              0.0                  -\nAlpha                            0.32                  -\nCorrelation                     5.49%                  -\nTreynor Ratio               141299.7%                  -",
+      "text/html": "<div>\n<style scoped>\n    .dataframe tbody tr th:only-of-type {\n        vertical-align: middle;\n    }\n\n    .dataframe tbody tr th {\n        vertical-align: top;\n    }\n\n    .dataframe thead th {\n        text-align: right;\n    }\n</style>\n<table border=\"1\" class=\"dataframe\">\n  <thead>\n    <tr style=\"text-align: right;\">\n      <th></th>\n      <th>Strategy</th>\n      <th>Buy and hold MATIC</th>\n    </tr>\n  </thead>\n  <tbody>\n    <tr>\n      <th>Start Period</th>\n      <td>2021-09-01</td>\n      <td>2021-09-01</td>\n    </tr>\n    <tr>\n      <th>End Period</th>\n      <td>2024-04-14</td>\n      <td>2024-04-14</td>\n    </tr>\n    <tr>\n      <th>Risk-Free Rate</th>\n      <td>0.0%</td>\n      <td>0.0%</td>\n    </tr>\n    <tr>\n      <th>Time in Market</th>\n      <td>22.0%</td>\n      <td>6.0%</td>\n    </tr>\n    <tr>\n      <th>Cumulative Return</th>\n      <td>98.11%</td>\n      <td>-100.0%</td>\n    </tr>\n    <tr>\n      <th>CAGR﹪</th>\n      <td>29.82%</td>\n      <td>-100.0%</td>\n    </tr>\n    <tr>\n      <th>Sharpe</th>\n      <td>1.06</td>\n      <td>-1.58</td>\n    </tr>\n    <tr>\n      <th>Prob. Sharpe Ratio</th>\n      <td>97.24%</td>\n      <td>0.0%</td>\n    </tr>\n    <tr>\n      <th>Smart Sharpe</th>\n      <td>1.05</td>\n      <td>-1.56</td>\n    </tr>\n    <tr>\n      <th>Sortino</th>\n      <td>2.38</td>\n      <td>-1.65</td>\n    </tr>\n    <tr>\n      <th>Smart Sortino</th>\n      <td>2.35</td>\n      <td>-1.63</td>\n    </tr>\n    <tr>\n      <th>Sortino/√2</th>\n      <td>1.68</td>\n      <td>-1.16</td>\n    </tr>\n    <tr>\n      <th>Smart Sortino/√2</th>\n      <td>1.66</td>\n      <td>-1.15</td>\n    </tr>\n    <tr>\n      <th>Omega</th>\n      <td>1.41</td>\n      <td>1.41</td>\n    </tr>\n    <tr>\n      <th>Max Drawdown</th>\n      <td>-28.07%</td>\n      <td>-3245.1%</td>\n    </tr>\n    <tr>\n      <th>Longest DD Days</th>\n      <td>363</td>\n      <td>898</td>\n    </tr>\n    <tr>\n      <th>Volatility (ann.)</th>\n      <td>28.15%</td>\n      <td>2224.91%</td>\n    </tr>\n    <tr>\n      <th>R^2</th>\n      <td>0.0</td>\n      <td>0.0</td>\n    </tr>\n    <tr>\n      <th>Information Ratio</th>\n      <td>0.08</td>\n      <td>0.08</td>\n    </tr>\n    <tr>\n      <th>Calmar</th>\n      <td>1.06</td>\n      <td>-0.03</td>\n    </tr>\n    <tr>\n      <th>Skew</th>\n      <td>3.83</td>\n      <td>-13.53</td>\n    </tr>\n    <tr>\n      <th>Kurtosis</th>\n      <td>23.52</td>\n      <td>267.47</td>\n    </tr>\n    <tr>\n      <th>Expected Daily</th>\n      <td>0.07%</td>\n      <td>-100.0%</td>\n    </tr>\n    <tr>\n      <th>Expected Monthly</th>\n      <td>2.16%</td>\n      <td>-100.0%</td>\n    </tr>\n    <tr>\n      <th>Expected Yearly</th>\n      <td>18.64%</td>\n      <td>-100.0%</td>\n    </tr>\n    <tr>\n      <th>Kelly Criterion</th>\n      <td>31.68%</td>\n      <td>6.85%</td>\n    </tr>\n    <tr>\n      <th>Risk of Ruin</th>\n      <td>0.0%</td>\n      <td>0.0%</td>\n    </tr>\n    <tr>\n      <th>Daily Value-at-Risk</th>\n      <td>-2.34%</td>\n      <td>-201.18%</td>\n    </tr>\n    <tr>\n      <th>Expected Shortfall (cVaR)</th>\n      <td>-2.34%</td>\n      <td>-201.18%</td>\n    </tr>\n    <tr>\n      <th>Max Consecutive Wins</th>\n      <td>3</td>\n      <td>2</td>\n    </tr>\n    <tr>\n      <th>Max Consecutive Losses</th>\n      <td>4</td>\n      <td>5</td>\n    </tr>\n    <tr>\n      <th>Gain/Pain Ratio</th>\n      <td>0.41</td>\n      <td>-0.79</td>\n    </tr>\n    <tr>\n      <th>Gain/Pain (1M)</th>\n      <td>1.13</td>\n      <td>-1.0</td>\n    </tr>\n    <tr>\n      <th>Payoff Ratio</th>\n      <td>5.6</td>\n      <td>4.8</td>\n    </tr>\n    <tr>\n      <th>Profit Factor</th>\n      <td>1.41</td>\n      <td>0.21</td>\n    </tr>\n    <tr>\n      <th>Common Sense Ratio</th>\n      <td>1.04</td>\n      <td>-</td>\n    </tr>\n    <tr>\n      <th>CPC Index</th>\n      <td>3.32</td>\n      <td>0.23</td>\n    </tr>\n    <tr>\n      <th>Tail Ratio</th>\n      <td>0.74</td>\n      <td>-</td>\n    </tr>\n    <tr>\n      <th>Outlier Win Ratio</th>\n      <td>13.14</td>\n      <td>1.59</td>\n    </tr>\n    <tr>\n      <th>Outlier Loss Ratio</th>\n      <td>95.37</td>\n      <td>0.48</td>\n    </tr>\n    <tr>\n      <th>MTD</th>\n      <td>0.0%</td>\n      <td>0.0%</td>\n    </tr>\n    <tr>\n      <th>3M</th>\n      <td>12.36%</td>\n      <td>0.0%</td>\n    </tr>\n    <tr>\n      <th>6M</th>\n      <td>5.26%</td>\n      <td>0.0%</td>\n    </tr>\n    <tr>\n      <th>YTD</th>\n      <td>12.36%</td>\n      <td>0.0%</td>\n    </tr>\n    <tr>\n      <th>1Y</th>\n      <td>-16.9%</td>\n      <td>0.0%</td>\n    </tr>\n    <tr>\n      <th>3Y (ann.)</th>\n      <td>29.82%</td>\n      <td>-100.0%</td>\n    </tr>\n    <tr>\n      <th>5Y (ann.)</th>\n      <td>29.82%</td>\n      <td>-100.0%</td>\n    </tr>\n    <tr>\n      <th>10Y (ann.)</th>\n      <td>29.82%</td>\n      <td>-100.0%</td>\n    </tr>\n    <tr>\n      <th>All-time (ann.)</th>\n      <td>29.82%</td>\n      <td>-100.0%</td>\n    </tr>\n    <tr>\n      <th>Best Day</th>\n      <td>12.61%</td>\n      <td>698.59%</td>\n    </tr>\n    <tr>\n      <th>Worst Day</th>\n      <td>-4.82%</td>\n      <td>-2560.67%</td>\n    </tr>\n    <tr>\n      <th>Best Month</th>\n      <td>21.81%</td>\n      <td>0.0%</td>\n    </tr>\n    <tr>\n      <th>Worst Month</th>\n      <td>-11.61%</td>\n      <td>-11980.48%</td>\n    </tr>\n    <tr>\n      <th>Best Year</th>\n      <td>52.87%</td>\n      <td>0.0%</td>\n    </tr>\n    <tr>\n      <th>Worst Year</th>\n      <td>-1.22%</td>\n      <td>-100.0%</td>\n    </tr>\n    <tr>\n      <th>Avg. Drawdown</th>\n      <td>-5.6%</td>\n      <td>-855.18%</td>\n    </tr>\n    <tr>\n      <th>Avg. Drawdown Days</th>\n      <td>40</td>\n      <td>158</td>\n    </tr>\n    <tr>\n      <th>Recovery Factor</th>\n      <td>3.5</td>\n      <td>-0.03</td>\n    </tr>\n    <tr>\n      <th>Ulcer Index</th>\n      <td>0.13</td>\n      <td>1.87</td>\n    </tr>\n    <tr>\n      <th>Serenity Index</th>\n      <td>0.44</td>\n      <td>-0.17</td>\n    </tr>\n    <tr>\n      <th>Avg. Up Month</th>\n      <td>-</td>\n      <td>-</td>\n    </tr>\n    <tr>\n      <th>Avg. Down Month</th>\n      <td>-</td>\n      <td>-</td>\n    </tr>\n    <tr>\n      <th>Win Days</th>\n      <td>42.03%</td>\n      <td>22.92%</td>\n    </tr>\n    <tr>\n      <th>Win Month</th>\n      <td>63.33%</td>\n      <td>0.0%</td>\n    </tr>\n    <tr>\n      <th>Win Quarter</th>\n      <td>63.64%</td>\n      <td>0.0%</td>\n    </tr>\n    <tr>\n      <th>Win Year</th>\n      <td>75.0%</td>\n      <td>0.0%</td>\n    </tr>\n    <tr>\n      <th>Beta</th>\n      <td>0.0</td>\n      <td>-</td>\n    </tr>\n    <tr>\n      <th>Alpha</th>\n      <td>0.32</td>\n      <td>-</td>\n    </tr>\n    <tr>\n      <th>Correlation</th>\n      <td>5.49%</td>\n      <td>-</td>\n    </tr>\n    <tr>\n      <th>Treynor Ratio</th>\n      <td>141299.7%</td>\n      <td>-</td>\n    </tr>\n  </tbody>\n</table>\n</div>"
      },
      "metadata": {},
      "output_type": "display_data"
@@ -605,6 +606,7 @@
     "    returns,\n",
     "    mode=AdvancedMetricsMode.full,\n",
     "    benchmark=benchmark_returns,\n",
+    "    convert_to_daily=True,\n",
     ")\n",
     "\n",
     "display(metrics)"
@@ -612,8 +614,8 @@
    "metadata": {
     "collapsed": false,
     "ExecuteTime": {
-     "end_time": "2024-04-18T08:44:13.563445Z",
-     "start_time": "2024-04-18T08:44:12.813584Z"
+     "end_time": "2024-04-18T11:16:14.227272Z",
+     "start_time": "2024-04-18T11:16:13.773571Z"
     }
    }
   },
@@ -628,7 +630,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": 69,
    "outputs": [
     {
      "data": {
@@ -649,8 +651,8 @@
    "metadata": {
     "collapsed": false,
     "ExecuteTime": {
-     "end_time": "2024-04-18T08:44:13.580583Z",
-     "start_time": "2024-04-18T08:44:13.577766Z"
+     "end_time": "2024-04-18T11:16:14.245635Z",
+     "start_time": "2024-04-18T11:16:14.242486Z"
     }
    }
   },
@@ -665,7 +667,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": 70,
    "outputs": [
     {
      "data": {
@@ -695,8 +697,8 @@
    "metadata": {
     "collapsed": false,
     "ExecuteTime": {
-     "end_time": "2024-04-18T08:44:13.917548Z",
-     "start_time": "2024-04-18T08:44:13.583112Z"
+     "end_time": "2024-04-18T11:16:14.472818Z",
+     "start_time": "2024-04-18T11:16:14.247919Z"
     }
    }
   }

--- a/notebooks/breakout-bollinger-bands-new/matic/v03-matic-breakout-regime-filter.ipynb
+++ b/notebooks/breakout-bollinger-bands-new/matic/v03-matic-breakout-regime-filter.ipynb
@@ -107,7 +107,7 @@
     "\n",
     "    rsi_bars = [6, 10, 14, 16, 21]  # Number of bars to calculate RSI for each trading bar\n",
     "    bollinger_bands_ma_length = [10, 17, 19, 21, 25]\n",
-    "    std_dev = [2, 2.5, 2.8, 3.0]\n",
+    "    std_dev = [2.5, 2.8, 3.0]\n",
     "\n",
     "    regime_filter_ma_days = [30, 90, 180]  # Bull/bear MA begime filter in days\n",
     "\n",

--- a/strategies/matic-breakout.py
+++ b/strategies/matic-breakout.py
@@ -406,7 +406,7 @@ def create_trading_universe(
 
 tags = {StrategyTag.beta, StrategyTag.live}
 
-sort_priorty = 99
+sort_priority = 99
 
 name = "ETH-BTC-USDC momentum"
 

--- a/strategies/matic-breakout.py
+++ b/strategies/matic-breakout.py
@@ -1,0 +1,488 @@
+"""MATIC breakout strategy.
+
+- See https://github.com/tradingstrategy-ai/tradingview-defi-strategy for the strategy development information
+
+To backtest this strategy module locally:
+
+.. code-block:: console
+
+    trade-executor \
+        backtest \
+        --strategy-file=strategies/matic-breakout.py \
+        --trading-strategy-api-key=$TRADING_STRATEGY_API_KEY
+
+To see the backtest for longer history, refer to the notebook doing backtest with Binance data.
+"""
+import datetime
+
+import pandas_ta
+import pandas as pd
+
+from tradeexecutor.state.trade import TradeExecution
+from tradeexecutor.state.visualisation import PlotKind, PlotLabel, PlotShape
+from tradeexecutor.strategy.alpha_model import AlphaModel
+from tradeexecutor.strategy.cycle import CycleDuration
+from tradeexecutor.strategy.default_routing_options import TradeRouting
+from tradeexecutor.strategy.execution_context import ExecutionContext, ExecutionMode
+from tradeexecutor.strategy.pandas_trader.indicator import IndicatorSet, IndicatorSource
+from tradeexecutor.strategy.pandas_trader.strategy_input import StrategyInput
+from tradeexecutor.strategy.parameters import StrategyParameters
+from tradeexecutor.strategy.tag import StrategyTag
+from tradeexecutor.strategy.trading_strategy_universe import TradingStrategyUniverse, load_partial_data
+from tradeexecutor.strategy.universe_model import UniverseOptions
+from tradeexecutor.strategy.weighting import weight_passthrouh
+from tradeexecutor.utils.binance import create_binance_universe
+from tradingstrategy.chain import ChainId
+from tradingstrategy.client import Client
+from tradingstrategy.pair import HumanReadableTradingPairDescription
+from tradingstrategy.timebucket import TimeBucket
+from tradingstrategy.utils.groupeduniverse import resample_price_series
+
+trading_strategy_engine_version = "0.5"
+
+
+def get_strategy_trading_pairs(execution_mode: ExecutionMode) -> list[HumanReadableTradingPairDescription]:
+    """Switch between backtest and live trading pairs.
+
+    Because the live trading DEX venues do not have enough history (< 2 years)
+    for meaningful backtesting, we test with Binance CEX data.
+    """
+    if execution_mode.is_live_trading():
+        # Live trade
+        return [
+            (ChainId.polygon, "uniswap-v3", "WMATIC", "USDC", 0.0005),
+        ]
+    else:
+        # Backtest - Binance fee matched to DEXes with Parameters.backtest_trading_fee
+        return [
+            (ChainId.centralised_exchange, "binance", "WMATIC", "USDC"),
+        ]
+
+
+
+class Parameters:
+    """Parameteres for this strategy.
+
+    - Collect parameters used for this strategy here
+
+    - Both live trading and backtesting parameters
+    """
+
+    id = "v02-matic-breakout-single" # Used in cache paths
+
+    cycle_duration = CycleDuration.cycle_1h  # Run decide_trades() every 8h
+    source_time_bucket = TimeBucket.h1  # Use 1h candles as the raw data
+    target_time_bucket = TimeBucket.h1  # Create synthetic 8h candles
+    clock_shift_bars = 0  # Do not do shifted candles
+
+    allocation = 0.98   # Cash allocation per open position
+
+    rsi_bars = 14  # Number of bars to calculate RSI for each trading bar
+    bollinger_bands_ma_length = 19
+    std_dev = 2.8
+
+    # regime_filter_ma_length = 200  # Bull/bear MA begime filter in days
+    # regime_filter_only_btc = 1   # Use BTC or per-pair regime filter
+
+    rsi_entry = 50
+    trailing_stop_loss = 0.98  # Trailing stop loss as 1 - x
+    trailing_stop_loss_activation_level = 1.05  # How much above opening price we must be before starting to use trailing stop loss
+    stop_loss = 0.98  # Hard stop loss when opening a new position
+
+    #
+    # Live trading only
+    #
+    chain_id = ChainId.polygon
+    routing = TradeRouting.default  # Pick default routes for trade execution
+    required_history_period = datetime.timedelta(hours=25) * 2  # Based on max MA length 2x extra history just in case
+
+    #
+    # Backtesting only
+    #
+    # backtest_start = datetime.datetime(2019, 9, 1) #  Include early abnormal MATIC pump
+    backtest_start = datetime.datetime(2021, 9, 1)
+    backtest_end = datetime.datetime(2024, 4, 15)
+    stop_loss_time_bucket = TimeBucket.m15  # use 1h close as the stop loss signal
+    backtest_trading_fee = 0.0005  # Switch to QuickSwap 30 BPS free from the default Binance 5 BPS fee
+    initial_cash = 10_000
+
+
+def create_indicators(
+    timestamp: datetime.datetime | None,
+    parameters: StrategyParameters,
+    strategy_universe: TradingStrategyUniverse,
+    execution_context: ExecutionContext
+):
+    indicators = IndicatorSet()
+
+    indicators.add(
+        "rsi",
+        pandas_ta.rsi,
+        {"length": parameters.rsi_bars}
+    )
+
+    indicators.add(
+        "bbands",
+        pandas_ta.bbands,
+        {"length": parameters.bollinger_bands_ma_length, "std": parameters.std_dev},
+    )
+    return indicators
+
+
+def decide_trades(
+    input: StrategyInput,
+) -> list[TradeExecution]:
+    """Trade logic."""
+
+    # Resolve some variables we are going to use to here
+    parameters = input.parameters
+    position_manager = input.get_position_manager()
+    state = input.state
+    timestamp = input.timestamp
+    indicators = input.indicators
+    shift = parameters.clock_shift_bars
+    clock_shift = pd.Timedelta(hours=1) * shift
+    upsample = parameters.target_time_bucket
+    mode = input.execution_context.mode
+    our_pairs = get_strategy_trading_pairs(mode)
+
+    # Execute the daily trade cycle when the clock hour 0..24 is correct for our hourly shift
+    assert upsample.to_timedelta() >= parameters.cycle_duration.to_timedelta(), "Upsample period must be longer than cycle period"
+    assert shift <= 0  # Shift -1 = do action 1 hour later
+
+    # Override the trading fee to simulate worse DEX fees and price impact vs. Binance
+    if mode.is_backtesting():
+        if parameters.backtest_trading_fee:
+            input.pricing_model.set_trading_fee_override(parameters.backtest_trading_fee)
+
+    # Do the clock shift trick
+    if parameters.cycle_duration.to_timedelta() != upsample.to_timedelta():
+        if (input.cycle - 1 + shift) % int(upsample.to_hours()) != 0:
+            return []
+
+    alpha_model = AlphaModel(input.timestamp)
+    btc_pair = position_manager.get_trading_pair(our_pairs[0])
+    eth_pair = position_manager.get_trading_pair(our_pairs[1])
+    position_manager.log("decide_trades() start")
+
+    #
+    # Indicators
+    #
+    # Calculate indicators for each pair.
+    #
+
+    # Per-trading pair calcualted data
+    current_rsi_values = {}  # RSI yesterday
+    previous_rsi_values = {}  # RSI day before yesterday
+    current_price = {}  # Close price yesterday
+    momentum = {btc_pair: 0, eth_pair: 0}
+
+    for pair in [btc_pair, eth_pair]:
+        current_price[pair] = indicators.get_price(pair)
+        current_rsi_values[pair] = indicators.get_indicator_value("rsi", index=-1, pair=pair, clock_shift=clock_shift)
+        previous_rsi_values[pair] = indicators.get_indicator_value("rsi", index=-2, pair=pair, clock_shift=clock_shift)
+
+    eth_btc_yesterday = indicators.get_indicator_value("eth_btc", clock_shift=clock_shift)
+    eth_btc_rsi_yesterday = indicators.get_indicator_value("eth_btc_rsi", clock_shift=clock_shift)
+    if eth_btc_rsi_yesterday is not None:
+        eth_momentum = (eth_btc_rsi_yesterday / 100) + 0.5
+        btc_momentum = (1 - (eth_btc_rsi_yesterday / 100)) + 0.5
+        momentum[eth_pair] = eth_momentum ** parameters.momentum_exponent
+        momentum[btc_pair] = btc_momentum ** parameters.momentum_exponent
+
+    #
+    # Trading logic
+    #
+
+    for pair in [btc_pair, eth_pair]:
+
+        #
+        # Regime filter
+        #
+        # If no indicator data yet, or regime filter disabled,
+        # be always bullish
+        bullish = True
+        if parameters.regime_filter_ma_length:  # Regime filter is not disabled
+            regime_filter_pair = btc_pair if parameters.regime_filter_only_btc else pair  # Each pair has its own bullish/bearish regime?
+            regime_filter_price = current_price[regime_filter_pair]
+            sma = indicators.get_indicator_value("sma", index=-1, pair=regime_filter_pair, clock_shift=clock_shift)
+            if sma:
+                # We are bearish if close price is beloe SMA
+                bullish = regime_filter_price > sma
+
+        if bullish:
+            rsi_entry = parameters.bullish_rsi_entry
+            rsi_exit = parameters.bullish_rsi_exit
+        else:
+            rsi_entry = parameters.bearish_rsi_entry
+            rsi_exit = parameters.bearish_rsi_exit
+
+        existing_position = position_manager.get_current_position_for_pair(pair)
+        pair_open = existing_position is not None
+        pair_momentum = momentum.get(pair, 0)
+        signal_strength = max(pair_momentum, 0.1)  # Singal strength must be positive, as we do long-only
+        if pd.isna(signal_strength):
+            signal_strength = 0
+        alpha_model.set_signal(pair, 0)
+
+        if pair_open:
+            # We have existing open position for this pair,
+            # keep it open by default unless we get a trigger condition below
+            position_manager.log(f"Pair {pair} already open")
+            alpha_model.set_signal(pair, signal_strength, stop_loss=parameters.stop_loss)
+
+        if current_rsi_values[pair] and previous_rsi_values[pair]:
+
+            # Check for RSI crossing our threshold values in this cycle, compared to the previous cycle
+            if rsi_entry:
+                rsi_cross_above = current_rsi_values[pair] >= rsi_entry and previous_rsi_values[pair] < rsi_entry
+            else:
+                # bearish_rsi_entry = None -> don't trade in bear market
+                rsi_cross_above = False
+
+            rsi_cross_below = current_rsi_values[pair] < rsi_exit and previous_rsi_values[pair] > rsi_exit
+
+            if not pair_open:
+                # Check for opening a position if no position is open
+                if rsi_cross_above:
+                    position_manager.log(f"Pair {pair} crossed above")
+                    alpha_model.set_signal(pair, signal_strength, stop_loss=parameters.stop_loss)
+            else:
+                # We have open position, check for the close condition
+                if rsi_cross_below:
+                    position_manager.log(f"Pair {pair} crossed below")
+                    alpha_model.set_signal(pair, 0)
+
+    # Enable trailing stop loss if we have reached the activation level
+    if parameters.trailing_stop_loss_activation_level is not None and parameters.trailing_stop_loss is not None:
+       for p in state.portfolio.open_positions.values():
+           if p.trailing_stop_loss_pct is None:
+               if current_price[p.pair] >= p.get_opening_price() * parameters.trailing_stop_loss_activation_level:
+                   p.trailing_stop_loss_pct = parameters.trailing_stop_loss
+
+    # Use alpha model and construct a portfolio of two assets
+    alpha_model.select_top_signals(2)
+    alpha_model.assign_weights(weight_passthrouh)
+    alpha_model.normalise_weights()
+    alpha_model.update_old_weights(state.portfolio)
+    portfolio = position_manager.get_current_portfolio()
+    portfolio_target_value = portfolio.get_total_equity() * parameters.allocation
+    alpha_model.calculate_target_positions(position_manager, portfolio_target_value)
+    trades = alpha_model.generate_rebalance_trades_and_triggers(
+        position_manager,
+        min_trade_threshold=parameters.rebalance_threshold * portfolio.get_total_equity(),
+    )
+
+    #
+    # Visualisations
+    #
+
+    if input.is_visualisation_enabled():
+
+        visualisation = state.visualisation  # Helper class to visualise strategy output
+
+        # BTC RSI daily
+        if current_rsi_values[btc_pair]:
+            visualisation.plot_indicator(
+                timestamp,
+                f"RSI BTC",
+                PlotKind.technical_indicator_detached,
+                current_rsi_values[btc_pair],
+                colour="orange",
+            )
+
+            # RSI exit value
+            visualisation.plot_indicator(
+                timestamp,
+                f"RSI exit trigger",
+                PlotKind.technical_indicator_overlay_on_detached,
+                rsi_exit,
+                detached_overlay_name=f"RSI BTC",
+                colour="red",
+                label=PlotLabel.hidden,
+            )
+
+            # RSI entry value
+            visualisation.plot_indicator(
+                timestamp,
+                f"RSI entry trigger",
+                PlotKind.technical_indicator_overlay_on_detached,
+                rsi_entry,
+                detached_overlay_name=f"RSI BTC",
+                colour="red",
+                label=PlotLabel.hidden,
+            )
+
+        # ETH RSI daily
+        if current_rsi_values[eth_pair]:
+            visualisation.plot_indicator(
+                timestamp,
+                f"RSI ETH",
+                PlotKind.technical_indicator_overlay_on_detached,
+                current_rsi_values[eth_pair],
+                colour="blue",
+                label=PlotLabel.hidden,
+                detached_overlay_name=f"RSI BTC",
+            )
+
+        if eth_btc_yesterday is not None:
+            visualisation.plot_indicator(
+                timestamp,
+                f"ETH/BTC",
+                PlotKind.technical_indicator_detached,
+                eth_btc_yesterday,
+                colour="grey",
+            )
+
+        if eth_btc_rsi_yesterday is not None:
+            visualisation.plot_indicator(
+                timestamp,
+                f"ETH/BTC RSI",
+                PlotKind.technical_indicator_detached,
+                eth_btc_rsi_yesterday,
+                colour="grey",
+            )
+
+        state.visualisation.add_calculations(timestamp, alpha_model.to_dict())  # Record alpha model thinking
+
+    position_manager.log(
+        f"BTC RSI: {current_rsi_values[btc_pair]}, BTC RSI yesterday: {previous_rsi_values[btc_pair]}",
+    )
+
+    return trades
+
+
+def create_trading_universe(
+    timestamp: datetime.datetime,
+    client: Client,
+    execution_context: ExecutionContext,
+    universe_options: UniverseOptions,
+) -> TradingStrategyUniverse:
+    """Create the trading universe.
+
+    - For live trading, we load DEX data
+
+    - We backtest with Binance data, as it has more history
+    """
+
+    pair_ids = get_strategy_trading_pairs(execution_context.mode)
+
+    if execution_context.mode.is_backtesting():
+        # Backtesting - load Binance data
+        strategy_universe = create_binance_universe(
+            [f"{p[2]}{p[3]}" for p in pair_ids],
+            candle_time_bucket=Parameters.source_time_bucket,
+            stop_loss_time_bucket=Parameters.stop_loss_time_bucket,
+            start_at=universe_options.start_at,
+            end_at=universe_options.end_at,
+            trading_fee_override=Parameters.backtest_trading_fee,
+        )
+    else:
+
+        dataset = load_partial_data(
+            client=client,
+            time_bucket=Parameters.source_time_bucket,
+            pairs=pair_ids,
+            execution_context=execution_context,
+            universe_options=universe_options,
+            liquidity=False,
+            stop_loss_time_bucket=Parameters.stop_loss_time_bucket,
+        )
+        # Construct a trading universe from the loaded data,
+        # and apply any data preprocessing needed before giving it
+        # to the strategy and indicators
+        strategy_universe = TradingStrategyUniverse.create_from_dataset(
+            dataset,
+            reserve_asset="USDC",
+            forward_fill=True,
+        )
+
+    return strategy_universe
+#
+# Strategy metadata.
+#
+# Displayed in the user interface.
+#
+
+tags = {StrategyTag.beta, StrategyTag.live}
+
+sort_priorty = 99
+
+name = "ETH-BTC-USDC momentum"
+
+short_description = "A momentum strategy for ETH-USDC and BTC-USDC pairs based on RSI indicators"
+
+icon = "https://tradingstrategy.ai/avatars/polygon-eth-spot-short.webp"
+
+long_description = """
+# Strategy description
+
+This strategy is a momentum and breakout strategy.
+
+- Based on [RSI technical indicator](https://tradingstrategy.ai/glossary/relative-strength-index-rsi), the strategy is buying when others are buying, and the strategy is selling when others are selling
+- The strategy has [a regime filter](https://tradingstrategy.ai/glossary/regime-filter) to reduce trading in a [bear market](https://tradingstrategy.ai/glossary/bear-market) 
+
+**Past Performance Is Not Indicative Of Future Results**.
+
+## Assets and trading venues
+
+- The strategy trades only spot market
+- We trade two trading asset: ETH and BTC
+- The strategy keeps reserves in USDC stablecoin
+- The trading happens on QuickSwap and Uniswap on Polygon blockchain
+- The strategy decision cycle is daily rebalance
+
+## Backtesting
+
+The backtesting was performed with Binance ETH-USDT and BTC-USDT data of 2019-2024.
+[Read more about what is backtesting](https://tradingstrategy.ai/glossary/backtest).
+
+The backtesting trading venue (Binance) is different from the live trading venue (Quickswap, Uniswap), because DEX markets
+do not have long enough history to result to a meaningful backtest.
+
+The backtesting period saw one bull market rally that is unlikely to repeat in the same magnitude 
+for the assets we trade.
+
+Past peformance is no guarantee of future results. Like with manual trading, automated trading is unlikely to be perfect.
+There will be variance in the range of 30% - 50% in the results.
+
+## Profit
+
+The backtested results indicate *80%* yearly profit ([CAGR](https://tradingstrategy.ai/glossary/compound-annual-growth-rate-cagr)). 
+
+## Risk
+
+This is medium risk strategy with *-50%* backtested [maximum drawdown](https://tradingstrategy.ai/glossary/maximum-drawdown).
+The backtested [Sharpe ratio](https://tradingstrategy.ai/glossary/sharpe) is is *1.00*.
+
+For understanding the risk assessment
+
+- The strategy does not use any leverage
+- The strategy has high maximum drawdown, comparable to buying and holding cryptocurrency  
+- The strategy trades only highly liquid trading pairs which are unlikely to go to zero
+
+## Benchmark
+
+For the same backtesting period, here are some benchmark of performance of different assets and indices:
+
+- Buy and hold BTC:
+- Buy and hold ETH:
+- SP500 stock index:
+- US treasury notes: 
+
+## Trading frequency
+
+This strategy is estimated to enter a position every *20 days*. 
+
+## Robustness
+
+The strategy wins 50% of its trading positions.
+The strategy is not very accurate. The profits 
+come for long running bull market positions.
+
+## Further information
+
+- [Any questions are welcome in the Discord community chat](https://tradingstrategy.ai/community)
+- [See the blog post how the strategy is constructed](https://tradingstrategy.ai/blog/outperfoming-eth) on how this strategy is constructed
+ 
+"""

--- a/strategies/matic-breakout.py
+++ b/strategies/matic-breakout.py
@@ -41,6 +41,50 @@ from tradingstrategy.utils.groupeduniverse import resample_price_series
 trading_strategy_engine_version = "0.5"
 
 
+class Parameters:
+    """Parameteres for this strategy.
+
+    - Collect parameters used for this strategy here
+
+    - Both live trading and backtesting parameters
+    """
+
+    id = "matic-breakout" # Used in cache paths
+
+    cycle_duration = CycleDuration.cycle_1h  # Run decide_trades() every 8h
+    source_time_bucket = TimeBucket.h1  # Use 1h candles as the raw data
+    target_time_bucket = TimeBucket.h1  # Create synthetic 8h candles
+    clock_shift_bars = 0  # Do not do shifted candles
+
+    allocation = 0.98   # Cash allocation per open position
+
+    rsi_bars = 14  # Number of bars to calculate RSI for each trading bar
+    bollinger_bands_ma_length = 19
+    std_dev = 2.8
+
+    rsi_entry = 50
+    trailing_stop_loss = 0.98  # Trailing stop loss as 1 - x
+    trailing_stop_loss_activation_level = 1.05  # How much above opening price we must be before starting to use trailing stop loss
+    stop_loss = 0.98  # Hard stop loss when opening a new position
+
+    #
+    # Live trading only
+    #
+    chain_id = ChainId.polygon
+    routing = TradeRouting.default  # Pick default routes for trade execution
+    required_history_period = datetime.timedelta(hours=bollinger_bands_ma_length) * 2
+
+    #
+    # Backtesting only
+    #
+    # backtest_start = datetime.datetime(2019, 9, 1) #  Include early abnormal MATIC pump
+    backtest_start = datetime.datetime(2021, 9, 1)
+    backtest_end = datetime.datetime(2024, 4, 15)
+    stop_loss_time_bucket = TimeBucket.m15  # use 1h close as the stop loss signal
+    backtest_trading_fee = 0.0005  # Switch to QuickSwap 30 BPS free from the default Binance 5 BPS fee
+    initial_cash = 10_000
+
+
 def get_strategy_trading_pairs(execution_mode: ExecutionMode) -> list[HumanReadableTradingPairDescription]:
     """Switch between backtest and live trading pairs.
 
@@ -55,56 +99,8 @@ def get_strategy_trading_pairs(execution_mode: ExecutionMode) -> list[HumanReada
     else:
         # Backtest - Binance fee matched to DEXes with Parameters.backtest_trading_fee
         return [
-            (ChainId.centralised_exchange, "binance", "WMATIC", "USDC"),
+            (ChainId.centralised_exchange, "binance", "MATIC", "USDT"),
         ]
-
-
-
-class Parameters:
-    """Parameteres for this strategy.
-
-    - Collect parameters used for this strategy here
-
-    - Both live trading and backtesting parameters
-    """
-
-    id = "v02-matic-breakout-single" # Used in cache paths
-
-    cycle_duration = CycleDuration.cycle_1h  # Run decide_trades() every 8h
-    source_time_bucket = TimeBucket.h1  # Use 1h candles as the raw data
-    target_time_bucket = TimeBucket.h1  # Create synthetic 8h candles
-    clock_shift_bars = 0  # Do not do shifted candles
-
-    allocation = 0.98   # Cash allocation per open position
-
-    rsi_bars = 14  # Number of bars to calculate RSI for each trading bar
-    bollinger_bands_ma_length = 19
-    std_dev = 2.8
-
-    # regime_filter_ma_length = 200  # Bull/bear MA begime filter in days
-    # regime_filter_only_btc = 1   # Use BTC or per-pair regime filter
-
-    rsi_entry = 50
-    trailing_stop_loss = 0.98  # Trailing stop loss as 1 - x
-    trailing_stop_loss_activation_level = 1.05  # How much above opening price we must be before starting to use trailing stop loss
-    stop_loss = 0.98  # Hard stop loss when opening a new position
-
-    #
-    # Live trading only
-    #
-    chain_id = ChainId.polygon
-    routing = TradeRouting.default  # Pick default routes for trade execution
-    required_history_period = datetime.timedelta(hours=25) * 2  # Based on max MA length 2x extra history just in case
-
-    #
-    # Backtesting only
-    #
-    # backtest_start = datetime.datetime(2019, 9, 1) #  Include early abnormal MATIC pump
-    backtest_start = datetime.datetime(2021, 9, 1)
-    backtest_end = datetime.datetime(2024, 4, 15)
-    stop_loss_time_bucket = TimeBucket.m15  # use 1h close as the stop loss signal
-    backtest_trading_fee = 0.0005  # Switch to QuickSwap 30 BPS free from the default Binance 5 BPS fee
-    initial_cash = 10_000
 
 
 def create_indicators(
@@ -132,222 +128,83 @@ def create_indicators(
 def decide_trades(
     input: StrategyInput,
 ) -> list[TradeExecution]:
-    """Trade logic."""
 
-    # Resolve some variables we are going to use to here
+
+    # Resolve our pair metadata for our two pair strategy
     parameters = input.parameters
     position_manager = input.get_position_manager()
     state = input.state
     timestamp = input.timestamp
     indicators = input.indicators
-    shift = parameters.clock_shift_bars
-    clock_shift = pd.Timedelta(hours=1) * shift
-    upsample = parameters.target_time_bucket
-    mode = input.execution_context.mode
-    our_pairs = get_strategy_trading_pairs(mode)
+    strategy_universe = input.strategy_universe
 
-    # Execute the daily trade cycle when the clock hour 0..24 is correct for our hourly shift
-    assert upsample.to_timedelta() >= parameters.cycle_duration.to_timedelta(), "Upsample period must be longer than cycle period"
-    assert shift <= 0  # Shift -1 = do action 1 hour later
-
-    # Override the trading fee to simulate worse DEX fees and price impact vs. Binance
-    if mode.is_backtesting():
-        if parameters.backtest_trading_fee:
-            input.pricing_model.set_trading_fee_override(parameters.backtest_trading_fee)
-
-    # Do the clock shift trick
-    if parameters.cycle_duration.to_timedelta() != upsample.to_timedelta():
-        if (input.cycle - 1 + shift) % int(upsample.to_hours()) != 0:
-            return []
-
-    alpha_model = AlphaModel(input.timestamp)
-    btc_pair = position_manager.get_trading_pair(our_pairs[0])
-    eth_pair = position_manager.get_trading_pair(our_pairs[1])
     position_manager.log("decide_trades() start")
+
+    pair = strategy_universe.get_single_pair()
+    cash = position_manager.get_current_cash()
 
     #
     # Indicators
     #
-    # Calculate indicators for each pair.
+
+    # Read the indicator data for the current timestamp,
+    # as calculated from the previous close value.
+    # pandas_ta.bbands creates 3 series (columns) in its output
     #
+    bollinger_bands_ma_length = parameters.bollinger_bands_ma_length
+    std_dev = parameters.std_dev
+    bb_upper_column = f"BBU_{bollinger_bands_ma_length}_{std_dev:.1f}" # pandas_ta internal column naming
+    bb_mid_column = f"BBM_{bollinger_bands_ma_length}_{std_dev:.1f}" # pandas_ta internal column naming
+    bb_lower_column = f"BBL_{bollinger_bands_ma_length}_{std_dev:.1f}" # pandas_ta internal column naming
 
-    # Per-trading pair calcualted data
-    current_rsi_values = {}  # RSI yesterday
-    previous_rsi_values = {}  # RSI day before yesterday
-    current_price = {}  # Close price yesterday
-    momentum = {btc_pair: 0, eth_pair: 0}
-
-    for pair in [btc_pair, eth_pair]:
-        current_price[pair] = indicators.get_price(pair)
-        current_rsi_values[pair] = indicators.get_indicator_value("rsi", index=-1, pair=pair, clock_shift=clock_shift)
-        previous_rsi_values[pair] = indicators.get_indicator_value("rsi", index=-2, pair=pair, clock_shift=clock_shift)
-
-    eth_btc_yesterday = indicators.get_indicator_value("eth_btc", clock_shift=clock_shift)
-    eth_btc_rsi_yesterday = indicators.get_indicator_value("eth_btc_rsi", clock_shift=clock_shift)
-    if eth_btc_rsi_yesterday is not None:
-        eth_momentum = (eth_btc_rsi_yesterday / 100) + 0.5
-        btc_momentum = (1 - (eth_btc_rsi_yesterday / 100)) + 0.5
-        momentum[eth_pair] = eth_momentum ** parameters.momentum_exponent
-        momentum[btc_pair] = btc_momentum ** parameters.momentum_exponent
+    bb_upper = indicators.get_indicator_value("bbands", column=bb_upper_column)
+    bb_mid = indicators.get_indicator_value("bbands", column=bb_mid_column)
+    bb_lower = indicators.get_indicator_value("bbands", column=bb_lower_column)
+    rsi = indicators.get_indicator_value("rsi")
+    last_close_price = indicators.get_price()
 
     #
     # Trading logic
     #
 
-    for pair in [btc_pair, eth_pair]:
+    trades = []
 
-        #
-        # Regime filter
-        #
-        # If no indicator data yet, or regime filter disabled,
-        # be always bullish
-        bullish = True
-        if parameters.regime_filter_ma_length:  # Regime filter is not disabled
-            regime_filter_pair = btc_pair if parameters.regime_filter_only_btc else pair  # Each pair has its own bullish/bearish regime?
-            regime_filter_price = current_price[regime_filter_pair]
-            sma = indicators.get_indicator_value("sma", index=-1, pair=regime_filter_pair, clock_shift=clock_shift)
-            if sma:
-                # We are bearish if close price is beloe SMA
-                bullish = regime_filter_price > sma
+    # Check if we are too early in the backtesting to have enough data to calculate indicators
+    if None in (bb_upper, bb_mid, bb_lower, rsi):
+        return []
 
-        if bullish:
-            rsi_entry = parameters.bullish_rsi_entry
-            rsi_exit = parameters.bullish_rsi_exit
-        else:
-            rsi_entry = parameters.bearish_rsi_entry
-            rsi_exit = parameters.bearish_rsi_exit
+    if not position_manager.is_any_open():
+        # No open positions, decide if BUY in this cycle.
+        # We buy if the price on the daily chart closes above the upper Bollinger Band.
+        if last_close_price > bb_upper and rsi > parameters.rsi_entry:
+            buy_amount = cash * parameters.allocation
+            trades += position_manager.open_1x_long(pair, buy_amount, stop_loss_pct=parameters.stop_loss)
 
-        existing_position = position_manager.get_current_position_for_pair(pair)
-        pair_open = existing_position is not None
-        pair_momentum = momentum.get(pair, 0)
-        signal_strength = max(pair_momentum, 0.1)  # Singal strength must be positive, as we do long-only
-        if pd.isna(signal_strength):
-            signal_strength = 0
-        alpha_model.set_signal(pair, 0)
+    else:
+        # We have an open position, decide if SELL in this cycle.
+        # We close the position when the price closes below the X bars moving average.
+        if last_close_price < bb_mid:
+            trades += position_manager.close_all()
 
-        if pair_open:
-            # We have existing open position for this pair,
-            # keep it open by default unless we get a trigger condition below
-            position_manager.log(f"Pair {pair} already open")
-            alpha_model.set_signal(pair, signal_strength, stop_loss=parameters.stop_loss)
-
-        if current_rsi_values[pair] and previous_rsi_values[pair]:
-
-            # Check for RSI crossing our threshold values in this cycle, compared to the previous cycle
-            if rsi_entry:
-                rsi_cross_above = current_rsi_values[pair] >= rsi_entry and previous_rsi_values[pair] < rsi_entry
-            else:
-                # bearish_rsi_entry = None -> don't trade in bear market
-                rsi_cross_above = False
-
-            rsi_cross_below = current_rsi_values[pair] < rsi_exit and previous_rsi_values[pair] > rsi_exit
-
-            if not pair_open:
-                # Check for opening a position if no position is open
-                if rsi_cross_above:
-                    position_manager.log(f"Pair {pair} crossed above")
-                    alpha_model.set_signal(pair, signal_strength, stop_loss=parameters.stop_loss)
-            else:
-                # We have open position, check for the close condition
-                if rsi_cross_below:
-                    position_manager.log(f"Pair {pair} crossed below")
-                    alpha_model.set_signal(pair, 0)
-
-    # Enable trailing stop loss if we have reached the activation level
-    if parameters.trailing_stop_loss_activation_level is not None and parameters.trailing_stop_loss is not None:
-       for p in state.portfolio.open_positions.values():
-           if p.trailing_stop_loss_pct is None:
-               if current_price[p.pair] >= p.get_opening_price() * parameters.trailing_stop_loss_activation_level:
-                   p.trailing_stop_loss_pct = parameters.trailing_stop_loss
-
-    # Use alpha model and construct a portfolio of two assets
-    alpha_model.select_top_signals(2)
-    alpha_model.assign_weights(weight_passthrouh)
-    alpha_model.normalise_weights()
-    alpha_model.update_old_weights(state.portfolio)
-    portfolio = position_manager.get_current_portfolio()
-    portfolio_target_value = portfolio.get_total_equity() * parameters.allocation
-    alpha_model.calculate_target_positions(position_manager, portfolio_target_value)
-    trades = alpha_model.generate_rebalance_trades_and_triggers(
-        position_manager,
-        min_trade_threshold=parameters.rebalance_threshold * portfolio.get_total_equity(),
-    )
+        # Check if we have reached out level where we activate trailing stop loss
+        current_position = position_manager.get_current_position()
+        if last_close_price >= current_position.get_opening_price() * parameters.trailing_stop_loss_activation_level:
+            current_position.trailing_stop_loss_pct = parameters.trailing_stop_loss
 
     #
     # Visualisations
     #
 
     if input.is_visualisation_enabled():
-
         visualisation = state.visualisation  # Helper class to visualise strategy output
+        visualisation.plot_indicator(timestamp, "BB upper", PlotKind.technical_indicator_on_price, bb_upper, colour="darkblue")
+        visualisation.plot_indicator(timestamp, "BB lower", PlotKind.technical_indicator_on_price, bb_lower, colour="darkblue")
+        visualisation.plot_indicator(timestamp, "BB mid", PlotKind.technical_indicator_on_price, bb_mid, colour="blue")
 
-        # BTC RSI daily
-        if current_rsi_values[btc_pair]:
-            visualisation.plot_indicator(
-                timestamp,
-                f"RSI BTC",
-                PlotKind.technical_indicator_detached,
-                current_rsi_values[btc_pair],
-                colour="orange",
-            )
-
-            # RSI exit value
-            visualisation.plot_indicator(
-                timestamp,
-                f"RSI exit trigger",
-                PlotKind.technical_indicator_overlay_on_detached,
-                rsi_exit,
-                detached_overlay_name=f"RSI BTC",
-                colour="red",
-                label=PlotLabel.hidden,
-            )
-
-            # RSI entry value
-            visualisation.plot_indicator(
-                timestamp,
-                f"RSI entry trigger",
-                PlotKind.technical_indicator_overlay_on_detached,
-                rsi_entry,
-                detached_overlay_name=f"RSI BTC",
-                colour="red",
-                label=PlotLabel.hidden,
-            )
-
-        # ETH RSI daily
-        if current_rsi_values[eth_pair]:
-            visualisation.plot_indicator(
-                timestamp,
-                f"RSI ETH",
-                PlotKind.technical_indicator_overlay_on_detached,
-                current_rsi_values[eth_pair],
-                colour="blue",
-                label=PlotLabel.hidden,
-                detached_overlay_name=f"RSI BTC",
-            )
-
-        if eth_btc_yesterday is not None:
-            visualisation.plot_indicator(
-                timestamp,
-                f"ETH/BTC",
-                PlotKind.technical_indicator_detached,
-                eth_btc_yesterday,
-                colour="grey",
-            )
-
-        if eth_btc_rsi_yesterday is not None:
-            visualisation.plot_indicator(
-                timestamp,
-                f"ETH/BTC RSI",
-                PlotKind.technical_indicator_detached,
-                eth_btc_rsi_yesterday,
-                colour="grey",
-            )
-
-        state.visualisation.add_calculations(timestamp, alpha_model.to_dict())  # Record alpha model thinking
-
-    position_manager.log(
-        f"BTC RSI: {current_rsi_values[btc_pair]}, BTC RSI yesterday: {previous_rsi_values[btc_pair]}",
-    )
+        # Draw the RSI indicator on a separate chart pane.
+        # Visualise the high RSI threshold we must exceed to take a position.
+        visualisation.plot_indicator(timestamp, "RSI", PlotKind.technical_indicator_detached, rsi)
+        visualisation.plot_indicator(timestamp, "RSI entry", PlotKind.technical_indicator_overlay_on_detached, parameters.rsi_entry, colour="red", detached_overlay_name="RSI")
 
     return trades
 
@@ -408,77 +265,39 @@ tags = {StrategyTag.beta, StrategyTag.live}
 
 sort_priority = 99
 
-name = "ETH-BTC-USDC momentum"
+name = "MATIC breakout"
 
-short_description = "A momentum strategy for ETH-USDC and BTC-USDC pairs based on RSI indicators"
+short_description = "MATIC price breakout strategy"
 
 icon = "https://tradingstrategy.ai/avatars/polygon-eth-spot-short.webp"
 
 long_description = """
 # Strategy description
 
-This strategy is a momentum and breakout strategy.
+This strategy is a breakout strategy.
 
-- Based on [RSI technical indicator](https://tradingstrategy.ai/glossary/relative-strength-index-rsi), the strategy is buying when others are buying, and the strategy is selling when others are selling
-- The strategy has [a regime filter](https://tradingstrategy.ai/glossary/regime-filter) to reduce trading in a [bear market](https://tradingstrategy.ai/glossary/bear-market) 
+- Based on [RSI technical indicator](https://tradingstrategy.ai/glossary/relative-strength-index-rsi), the strategy enters to short-lived positions when MATIC price is breaking up 
 
 **Past Performance Is Not Indicative Of Future Results**.
 
 ## Assets and trading venues
 
 - The strategy trades only spot market
-- We trade two trading asset: ETH and BTC
+- We trade a single trading asset: MATIC
 - The strategy keeps reserves in USDC stablecoin
-- The trading happens on QuickSwap and Uniswap on Polygon blockchain
-- The strategy decision cycle is daily rebalance
+- The trading happens on Uniswap on Polygon blockchain
 
 ## Backtesting
 
-The backtesting was performed with Binance ETH-USDT and BTC-USDT data of 2019-2024.
-[Read more about what is backtesting](https://tradingstrategy.ai/glossary/backtest).
-
-The backtesting trading venue (Binance) is different from the live trading venue (Quickswap, Uniswap), because DEX markets
-do not have long enough history to result to a meaningful backtest.
-
-The backtesting period saw one bull market rally that is unlikely to repeat in the same magnitude 
-for the assets we trade.
-
-Past peformance is no guarantee of future results. Like with manual trading, automated trading is unlikely to be perfect.
-There will be variance in the range of 30% - 50% in the results.
-
 ## Profit
-
-The backtested results indicate *80%* yearly profit ([CAGR](https://tradingstrategy.ai/glossary/compound-annual-growth-rate-cagr)). 
 
 ## Risk
 
-This is medium risk strategy with *-50%* backtested [maximum drawdown](https://tradingstrategy.ai/glossary/maximum-drawdown).
-The backtested [Sharpe ratio](https://tradingstrategy.ai/glossary/sharpe) is is *1.00*.
-
-For understanding the risk assessment
-
-- The strategy does not use any leverage
-- The strategy has high maximum drawdown, comparable to buying and holding cryptocurrency  
-- The strategy trades only highly liquid trading pairs which are unlikely to go to zero
-
 ## Benchmark
-
-For the same backtesting period, here are some benchmark of performance of different assets and indices:
-
-- Buy and hold BTC:
-- Buy and hold ETH:
-- SP500 stock index:
-- US treasury notes: 
 
 ## Trading frequency
 
-This strategy is estimated to enter a position every *20 days*. 
-
 ## Robustness
-
-The strategy wins 50% of its trading positions.
-The strategy is not very accurate. The profits 
-come for long running bull market positions.
 
 ## Further information
 

--- a/strategies/matic-eth-usdc.py
+++ b/strategies/matic-eth-usdc.py
@@ -1,4 +1,4 @@
-"""MATIC-ETH-USDC rebalance strategy.
+"""MATIC-USDC breakout strategy.
 
 - See https://tradingstrategy.ai/blog/outperfoming-eth for the strategy development information
 
@@ -8,7 +8,7 @@ To backtest this strategy module locally:
 
     trade-executor \
         backtest \
-        --strategy-file=strategies/matic-eth-usdc.py \
+        --strategy-file=strategies/matic-breakout.py \
         --trading-strategy-api-key=$TRADING_STRATEGY_API_KEY
 
 To see the backtest for longer history, refer to the notebook doing backtest with Binance data.

--- a/tests/units_tests/test_strategy_module.py
+++ b/tests/units_tests/test_strategy_module.py
@@ -1,0 +1,26 @@
+import os
+from pathlib import Path
+
+import pytest
+
+from tradeexecutor.strategy.strategy_module import read_strategy_module
+
+
+@pytest.fixture(scope="module")
+def strategy_file() -> Path:
+    """A state dump with some failed trades we need to unwind.
+
+    Taken as a snapshot from alpha version trade execution run.
+    """
+    f = os.path.join(os.path.dirname(__file__), "..", "..", "strategies", "matic-breakout.py")
+    p = Path(f)
+    assert p.exists()
+    return p
+
+
+def test_read_strategy_module(
+    strategy_file,
+):
+    """Read strategy module and check for some basic information."""
+    mod = read_strategy_module(strategy_file)
+    assert mod.sort_priority == 99

--- a/tradeexecutor/cli/bootstrap.py
+++ b/tradeexecutor/cli/bootstrap.py
@@ -299,6 +299,7 @@ def create_metadata(
     badges: Optional[str] = None,
     tags: Optional[Set[StrategyTag]] = None,
     hot_wallet: Optional[HotWallet] = None,
+    sort_priority=0,
 ) -> Metadata:
     """Create metadata object from the configuration variables."""
 
@@ -349,6 +350,7 @@ def create_metadata(
         key_metrics_backtest_cut_off=datetime.timedelta(days=key_metrics_backtest_cut_off_days),
         badges=Metadata.parse_badges_configuration(badges),
         tags=tags or set(),  # Always fill empty set
+        sort_priority=sort_priority,
     )
 
     return metadata

--- a/tradeexecutor/cli/commands/start.py
+++ b/tradeexecutor/cli/commands/start.py
@@ -336,6 +336,7 @@ def start(
             badges=badges,
             tags=mod.tags,
             hot_wallet=sync_model.get_hot_wallet(),
+            sort_priority=mod.sort_priority,
         )
 
         # Start the queue that relays info from the web server to the strategy executor

--- a/tradeexecutor/state/metadata.py
+++ b/tradeexecutor/state/metadata.py
@@ -172,6 +172,11 @@ class Metadata:
     #:
     tags: Set[StrategyTag] = field(default_factory=set)
 
+    #: The display priority for this strategy.
+    #:
+    #: Higher = the strategy apppears in the frontend first.
+    sort_priority: int = 0
+
     @staticmethod
     def create_dummy() -> "Metadata":
         return Metadata(

--- a/tradeexecutor/strategy/strategy_module.py
+++ b/tradeexecutor/strategy/strategy_module.py
@@ -432,6 +432,12 @@ class StrategyModuleInformation:
     #:
     tags: Optional[Set[StrategyTag]] = None
 
+    #: The display priority for this strategy.
+    #:
+    #: Higher = the strategy apppears in the frontend first.
+    #:
+    sort_priority: int = 0
+
     #: StrategyParameters class.
     #:
     #: trading_strategy_engine_version > "0.5"
@@ -538,6 +544,9 @@ class StrategyModuleInformation:
             for t in self.tags:
                 assert isinstance(t, StrategyTag), f"Expected StrategyTag instance, got {type(t)}: {t}"
 
+        if self.sort_priority:
+            assert type(self.sort_priority) in (int, float), f"sort_priority not a number: {self.sort_priority}"
+
         if self.icon:
             result = urlparse(self.icon)
             assert all([result.scheme, result.netloc]), f"Bad icon URL: {self.icon}"
@@ -618,6 +627,7 @@ def parse_strategy_module(
         short_description=python_module_exports.get("short_description"),
         long_description=python_module_exports.get("long_description"),
         tags=python_module_exports.get("tags"),
+        sort_priority=python_module_exports.get("sort_priority"),
         create_indicators=python_module_exports.get("create_indicators"),
         parameters=python_module_exports.get("parameters"),
     )

--- a/tradeexecutor/strategy/tag.py
+++ b/tradeexecutor/strategy/tag.py
@@ -30,3 +30,6 @@ class StrategyTag(enum.Enum):
 
     #: The strategy is not expected to make profit, but is only running as an infrastructure test
     internal_testing = "internal_testing"
+
+    #: The strategy should appear on the front page hero box showcasing strategies
+    hero = "hero"


### PR DESCRIPTION
- Add new strategy module and metadata attribute `sort_priority` that allows to manually adjust the display order of the strategies in the frontend
- Higher `sort_priority` means strategy comes earlier in the sort order
- Default value is zero
- Deprecated, old, strategies can be moved to the button