### PR TITLE
Fix live data and indicator index issues

### DIFF
--- a/strategies/matic-breakout.py
+++ b/strategies/matic-breakout.py
@@ -243,7 +243,6 @@ def create_trading_universe(
             execution_context=execution_context,
             universe_options=universe_options,
             liquidity=False,
-            stop_loss_time_bucket=Parameters.stop_loss_time_bucket,
         )
         # Construct a trading universe from the loaded data,
         # and apply any data preprocessing needed before giving it

--- a/tradeexecutor/strategy/pandas_trader/strategy_input.py
+++ b/tradeexecutor/strategy/pandas_trader/strategy_input.py
@@ -543,11 +543,17 @@ class StrategyInput:
 
 _time_frame_cache = cachetools.Cache(maxsize=SERIES_CACHE_SIZE)
 
-def _calculate_and_cache_candle_width(index: pd.DatetimeIndex) -> pd.Timedelta | None:
+def _calculate_and_cache_candle_width(index: pd.DatetimeIndex | pd.MultiIndex) -> pd.Timedelta | None:
     """Get the evenly timestamped index candle/time bar width.
 
     - Cached for speed - cache size might not make sense for large trading pair use cases
     """
+
+    # The original data is in grouped DF
+    if isinstance(index, pd.MultiIndex):
+        # AssertionError: Got index: MultiIndex([(2854997, '2024-04-04 21:00:00'),
+        #        (2854997, '2024-04-04 22:00:00'),
+        index = index.get_level_values(1)
 
     assert isinstance(index, pd.DatetimeIndex), f"Got index: {index}"
 


### PR DESCRIPTION
- We had technical indicators where the `pd.Series.index` was not `pd.DateTimeIndex`
- Always force index to be flat `pd.DateTimeIndex` when indicators are calculated