### PR TITLE
Fix short position valuation

### DIFF
--- a/tests/ethereum/polygon_forked/generic-router/test_generic_router_live_loop.py
+++ b/tests/ethereum/polygon_forked/generic-router/test_generic_router_live_loop.py
@@ -205,7 +205,7 @@ def test_generic_router_spot_and_short_strategy_manual_tick(
     assert len(portfolio.open_positions) == 1
     
     tolerance = 1e-5
-    assert position.loan.get_borrow_interest() == pytest.approx(1.4860578061962053, abs=tolerance)
+    assert position.loan.get_borrow_interest() == pytest.approx(1.2064069951721614, abs=tolerance)
     tolerance = 1e-4
     assert position.loan.get_collateral_interest() == pytest.approx(13.711178, abs=tolerance)
 

--- a/tradeexecutor/cli/loop.py
+++ b/tradeexecutor/cli/loop.py
@@ -583,6 +583,7 @@ class ExecutionLoop:
 
         routing_state, pricing_model, valuation_method = self.runner.setup_routing(universe)
 
+        # TODO: this seems to be duplicated in tick()
         with self.timed_task_context_manager("revalue_portfolio_statistics"):
             logger.info("Updating position valuations")
             self.runner.revalue_state(clock, state, valuation_method)

--- a/tradeexecutor/ethereum/one_delta/one_delta_valuation.py
+++ b/tradeexecutor/ethereum/one_delta/one_delta_valuation.py
@@ -10,15 +10,7 @@ from tradeexecutor.state.valuation import ValuationUpdate
 
 
 class OneDeltaPoolRevaluator(EthereumPoolRevaluator):
-    """1delta position valuation..
-
-    The position is valued in `sync_interests`
-    and we just return the latest synced data
-    here.
-
-    In backtests, we do this differently, so this
-    valuation methd concerns live strategies only.
-    """
+    """1delta position valuation."""
 
     def __init__(self, pricing_model: OneDeltaLivePricing):
         assert isinstance(pricing_model, OneDeltaLivePricing)
@@ -33,28 +25,28 @@ class OneDeltaPoolRevaluator(EthereumPoolRevaluator):
         pair = position.pair
 
         if pair.is_leverage():
-            loan = position.loan
-            new_price = loan.borrowed.last_usd_price
-            valued_at = loan.borrowed.last_pricing_at
-            new_value = loan.get_net_asset_value()
-            block_number = loan.borrowed_interest.last_updated_block_number
-
-            # also update legacy position.last_token_price
             old_price = position.last_token_price
             old_value = position.get_value()
-            position.revalue_base_asset(valued_at, new_price)
+
+            quantity = abs(position.get_quantity())
+            assert quantity > 0
+            price_structure = self.pricing_model.get_sell_price(ts, pair.get_pricing_pair(), quantity)
+            new_price = price_structure.price
+            new_value = position.revalue_base_asset(ts, float(new_price))
 
             evt = ValuationUpdate(
                 created_at=ts,
                 position_id=position.position_id,
-                valued_at=valued_at,
+                valued_at=ts,
                 new_price=new_price,
                 new_value=new_value,
                 old_price=old_price,
                 old_value=old_value,
-                block_number=block_number,
             )
         elif pair.is_credit_supply():
+            # The position should be valued in `sync_interests`
+            # so we just return the latest synced data here.
+
             loan = position.loan
             new_price = loan.collateral.last_usd_price
             valued_at = loan.collateral.last_pricing_at

--- a/tradeexecutor/ethereum/one_delta/one_delta_valuation.py
+++ b/tradeexecutor/ethereum/one_delta/one_delta_valuation.py
@@ -39,12 +39,19 @@ class OneDeltaPoolRevaluator(EthereumPoolRevaluator):
             new_value = loan.get_net_asset_value()
             block_number = loan.borrowed_interest.last_updated_block_number
 
+            # also update legacy position.last_token_price
+            old_price = position.last_token_price
+            old_value = position.get_value()
+            position.revalue_base_asset(valued_at, new_price)
+
             evt = ValuationUpdate(
                 created_at=ts,
                 position_id=position.position_id,
                 valued_at=valued_at,
-                new_value=new_value,
                 new_price=new_price,
+                new_value=new_value,
+                old_price=old_price,
+                old_value=old_value,
                 block_number=block_number,
             )
         elif pair.is_credit_supply():
@@ -58,8 +65,8 @@ class OneDeltaPoolRevaluator(EthereumPoolRevaluator):
                 created_at=ts,
                 position_id=position.position_id,
                 valued_at=valued_at,
-                new_value=new_value,
                 new_price=new_price,
+                new_value=new_value,
                 block_number=block_number,
             )
         else:

--- a/tradeexecutor/state/position.py
+++ b/tradeexecutor/state/position.py
@@ -1363,11 +1363,6 @@ class TradingPosition(GenericPosition):
         self.last_pricing_at = last_pricing_at
         self.last_token_price = last_token_price
 
-        # TODO: Move this logic to ValuationModel
-        if self.loan:
-            if self.is_short():
-                self.loan.borrowed.revalue(last_token_price, last_pricing_at)
-
         return self.get_value()
 
     def get_value_at_open(self) -> USDollarAmount:

--- a/tradeexecutor/state/position.py
+++ b/tradeexecutor/state/position.py
@@ -1363,6 +1363,9 @@ class TradingPosition(GenericPosition):
         self.last_pricing_at = last_pricing_at
         self.last_token_price = last_token_price
 
+        if self.loan and self.is_short():
+            self.loan.borrowed.revalue(last_token_price, last_pricing_at)
+
         return self.get_value()
 
     def get_value_at_open(self) -> USDollarAmount:

--- a/tradeexecutor/strategy/interest.py
+++ b/tradeexecutor/strategy/interest.py
@@ -294,9 +294,6 @@ def prepare_interest_distribution(
                 )
                 price = price_structure.price
 
-                # Revalue the loan borrowed side right when we have new price
-                p.loan.borrowed.revalue(price, timestamp)
-
             entry = InterestDistributionEntry(
                 side=side,
                 position=p,


### PR DESCRIPTION
- Fix `OneDeltaPoolRevaluator` so it can use latest price from pricing model instead of relying from price from `sync_interests()` cycle
- Add `revalue_base_asset()` logic to `OneDeltaPoolRevaluator`, so legacy `last_token_price` is updated at the same time

Fix #905 