### PR TITLE
don't allow float/int in crossover check

### DIFF
--- a/tradeexecutor/utils/crossover.py
+++ b/tradeexecutor/utils/crossover.py
@@ -38,7 +38,7 @@ def contains_cross_over(
 
 def contains_cross_under(
         series1: pd.Series, 
-        series2: pd.Series | int | float,
+        series2: pd.Series,
         lookback_period: int = 2,
         must_return_index: bool = False,
 ) -> bool:

--- a/tradeexecutor/utils/crossover.py
+++ b/tradeexecutor/utils/crossover.py
@@ -10,7 +10,7 @@ import operator
     
 def contains_cross_over(
         series1: pd.Series, 
-        series2: pd.Series | int,
+        series2: pd.Series,
         lookback_period: int = 2,
         must_return_index: bool = False,
 ) -> bool:
@@ -33,16 +33,12 @@ def contains_cross_over(
         If must_return_index is True, also returns the index of the crossover. Note the index is a negative index e.g. -1 is the latest index, -2 is the second latest etc.
         
     """
-
-    if isinstance(series2, int | float):
-        series2 = pd.Series([series2] * lookback_period)
-
     return _cross_check(series1, series2, lookback_period, must_return_index, operator.gt, operator.lt)
 
 
 def contains_cross_under(
         series1: pd.Series, 
-        series2: pd.Series | int,
+        series2: pd.Series | int | float,
         lookback_period: int = 2,
         must_return_index: bool = False,
 ) -> bool:
@@ -64,21 +60,26 @@ def contains_cross_under(
         If must_return_index is True, also returns the index of the crossover. Note the index is a negative index e.g. -1 is the latest index, -2 is the second latest etc.
         
     """
-
-    if isinstance(series2, int | float):
-        series2 = pd.Series([series2] * lookback_period)
-
     return _cross_check(series1, series2, lookback_period, must_return_index, operator.lt, operator.gt)
 
 
 def _cross_check(
-    series1, 
-    series2, 
-    lookback_period, 
-    must_return_index, 
-    comparison_operator,
-    unlock_operator,
+    series1: pd.Series, 
+    series2: pd.Series, 
+    lookback_period: int, 
+    must_return_index: bool, 
+    comparison_operator: callable,
+    unlock_operator: callable,
 ):
+    """Private function to check whether there has been a crossover or crossunder between two series.
+    
+    :param series1: Series to check for crossover/under
+    :param series2: Series to check for crossover/under
+    :param lookback_period: Number of periods to look back
+    :param must_return_index: Whether to return the index of the crossover
+    :param comparison_operator: Operator to compare for crossover
+    :param unlock_operator: Operator to unlock the crossover (opposite of comparison_operator)
+    """
     
     assert type(series1) == pd.Series, "Series must be pandas.Series"
     assert type(series2) == pd.Series, "Series must be pandas.Series"


### PR DESCRIPTION
Allowing float/int, as was previously done, in `contains_cross_over` or `contains_cross_under` can lead to many missed crossovers/unders