### PR TITLE
Template notebooks

### DIFF
--- a/tradeexecutor/analysis/multi_asset_benchmark.py
+++ b/tradeexecutor/analysis/multi_asset_benchmark.py
@@ -32,6 +32,7 @@ def get_benchmark_data(
     interesting_assets=("BTC", "WBTC", "ETH", "WETH", "WMATIC", "MATIC"),
     cumulative_with_initial_cash: USDollarAmount =0.0,
     asset_colours=DEFAULT_BENCHMARK_COLOURS,
+    start_at: pd.Timestamp | None = None,
 ) -> pd.DataFrame:
     """Get returns series of different benchmark index assets from the universe.
 
@@ -96,6 +97,10 @@ def get_benchmark_data(
     df = pd.DataFrame()
     for name, pair in benchmark_assets.items():
         price_series = strategy_universe.data_universe.candles.get_candles_by_pair(pair.internal_id)["close"]
+
+        if start_at:
+            price_series = price_series.loc[start_at:]
+
         assert len(price_series.dropna()) != 0, f"Failed to read benchmark price series for {name}: {pair}"
         if isinstance(price_series.index, pd.MultiIndex):
             index_fixed_series = pd.Series(data=price_series.values, index=price_series.index.get_level_values(1))

--- a/tradeexecutor/backtest/backtest_runner.py
+++ b/tradeexecutor/backtest/backtest_runner.py
@@ -859,9 +859,13 @@ def run_backtest_inline(
         parameters.validate_backtest()
 
     if start_at is None and end_at is None:
-        start_at, end_at = universe.data_universe.candles.get_timestamp_range()
-        start_at = start_at.to_pydatetime()
-        end_at = end_at.to_pydatetime()
+        if parameters:
+            start_at = parameters.backtest_start
+            end_at = parameters.backtest_end
+        else:
+            start_at, end_at = universe.data_universe.candles.get_timestamp_range()
+            start_at = start_at.to_pydatetime()
+            end_at = end_at.to_pydatetime()
 
     if start_at:
         assert isinstance(start_at, datetime.datetime)

--- a/tradeexecutor/backtest/backtest_runner.py
+++ b/tradeexecutor/backtest/backtest_runner.py
@@ -859,7 +859,7 @@ def run_backtest_inline(
         parameters.validate_backtest()
 
     if start_at is None and end_at is None:
-        if parameters:
+        if parameters and hasattr(parameters, "backtest_start") and hasattr(parameters, "backtest_end"):
             start_at = parameters.backtest_start
             end_at = parameters.backtest_end
         else:

--- a/tradeexecutor/visual/grid_search.py
+++ b/tradeexecutor/visual/grid_search.py
@@ -84,6 +84,7 @@ def visualise_single_grid_search_result_benchmark(
     benchmarks = get_benchmark_data(
         strategy_universe,
         cumulative_with_initial_cash=initial_cash or getattr(result, "initial_cash", None),  # Legacy support hack
+        start_at=equity.index[0],
     )
 
     benchmark_series = [v for k, v in benchmarks.items()]


### PR DESCRIPTION
- Adjusts backtest to use `backtest_start` and `backtest_end` from `StrategyParameters` if provided
- Trims grid search benchmark start date to match equity curve