### PR TITLE
Indicator fix 

### DIFF
--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -219,6 +219,7 @@ def test_single_buy(usdc, weth, weth_usdc, start_ts):
     value_after_trade = 1690 * 0.09
     assert trade.get_status() == TradeStatus.success
     assert trade.get_value() == pytest.approx(value_after_trade)
+    assert trade.get_executed_value() == pytest.approx(value_after_trade)
     assert trade.reserve_currency_allocated == 0
     assert trade.get_fees_paid() == pytest.approx(2.50)
 

--- a/tradeexecutor/state/position.py
+++ b/tradeexecutor/state/position.py
@@ -646,6 +646,8 @@ class TradingPosition(GenericPosition):
 
         If the position is closed, the value should be zero
 
+        .. note:: This is the planned value, so may be different fr om the executed value.
+
         :param include_interest:
             Include accrued interest in the valuation.
 

--- a/tradeexecutor/visual/multiple_pairs.py
+++ b/tradeexecutor/visual/multiple_pairs.py
@@ -29,7 +29,6 @@ from tradeexecutor.visual.utils import (
     get_start_and_end,
     get_all_text,
     get_num_detached_and_names,
-    get_num_detached_and_names_no_indicators,
 )
 
 
@@ -124,6 +123,7 @@ def visualise_multiple_pairs(
     show_trades: bool = True,
     detached_indicators: bool = True,
     include_credit_supply_positions: bool = False,
+    legend: bool = True,
 ) -> go.Figure:
     """Visualise single-pair trade execution.
 
@@ -293,12 +293,16 @@ def visualise_multiple_pairs(
             state.name, axes, title, pair_name, volume_axis_name
         )
 
-        if technical_indicators:
-            num_detached_indicators, subplot_names = get_num_detached_and_names(
-                plots, execution_context, volume_bar_modes[i], volume_text, pair_name, detached_indicators,
-            )
-        else:
-            num_detached_indicators, subplot_names = get_num_detached_and_names_no_indicators(execution_context, volume_bar_modes[i], volume_text, pair_name)
+
+        num_detached_indicators, subplot_names = get_num_detached_and_names(
+            technical_indicators,
+            plots, 
+            execution_context, 
+            volume_bar_modes[i], 
+            volume_text, 
+            pair_name, 
+            detached_indicators,
+        )
 
         if not relative_sizing:
             _relative_sizing = [1] + [0.3] * num_detached_indicators
@@ -447,5 +451,8 @@ def visualise_multiple_pairs(
     
     if volume_bars:
         subplot.update_annotations(xshift=40)
+
+    if not legend:
+        subplot.update_layout(showlegend=False)
 
     return subplot

--- a/tradeexecutor/visual/single_pair.py
+++ b/tradeexecutor/visual/single_pair.py
@@ -19,7 +19,7 @@ from tradeexecutor.visual.technical_indicator import overlay_all_technical_indic
 from tradingstrategy.candle import GroupedCandleUniverse
 from tradingstrategy.charting.candle_chart import visualise_ohlcv, make_candle_labels, VolumeBarMode
 
-from tradeexecutor.visual.utils import get_all_positions, get_pair_name_from_first_trade, get_all_text, get_num_detached_and_names, get_pair_base_quote_names, get_start_and_end, export_trades_as_dataframe, visualise_trades, get_num_detached_and_names_no_indicators
+from tradeexecutor.visual.utils import get_all_positions, get_pair_name_from_first_trade, get_all_text, get_num_detached_and_names, get_pair_base_quote_names, get_start_and_end, export_trades_as_dataframe, visualise_trades
 
 
 logger = logging.getLogger(__name__)
@@ -300,6 +300,7 @@ def visualise_single_pair(
     detached_indicators: bool = True,
     hover_text: bool = True,
     include_credit_supply_positions: bool = False,
+    legend: bool = True,
 ) -> go.Figure:
     """Visualise single-pair trade execution.
 
@@ -452,6 +453,9 @@ def visualise_single_pair(
     # Add trade markers if any trades have been made
     if len(trades_df) > 0:
         visualise_trades(fig, candles, trades_df, include_credit_supply_positions=include_credit_supply_positions)
+
+    if not legend:
+        fig.update_layout(showlegend=False)
 
     return fig
 
@@ -650,11 +654,16 @@ def _get_grid_with_candles_volume_indicators(
 
     plots = state.visualisation.plots.values()
     
-    if technical_indicators:
-        num_detached_indicators, subplot_names = get_num_detached_and_names(plots, execution_context, volume_bar_mode, volume_text, pair_name=None, detached_indicators=detached_indicators)
-    else:
-        num_detached_indicators, subplot_names = get_num_detached_and_names_no_indicators(execution_context, volume_bar_mode, volume_text, pair_name=None)
-    
+    num_detached_indicators, subplot_names = get_num_detached_and_names(
+        technical_indicators,
+        plots, 
+        execution_context, 
+        volume_bar_mode, 
+        volume_text, 
+        pair_name=None, 
+        detached_indicators=detached_indicators
+    )
+
     # visualise candles and volume and create empty grid space for technical indicators
     fig = visualise_ohlcv(
         candles,

--- a/tradeexecutor/visual/strategy_state.py
+++ b/tradeexecutor/visual/strategy_state.py
@@ -107,7 +107,7 @@ def draw_multi_pair_strategy_state(
     technical_indicators: Optional[bool] = True,
     pair_ids: Optional[list[PairInternalId]] = None,
     detached_indicators: Optional[bool] = True,
-) -> list[go.Figure]:
+) -> go.Figure:
     """Draw mini price chart images for multiple pairs. Returns a single figure with multiple subplots.
 
     See also

--- a/tradeexecutor/visual/technical_indicator.py
+++ b/tradeexecutor/visual/technical_indicator.py
@@ -23,14 +23,14 @@ logger = logging.getLogger(__name__)
 
 
 def overlay_all_technical_indicators(
-        fig: go.Figure,
-        visualisation: Visualisation,
-        start_at: Optional[pd.Timestamp] = None,
-        end_at: Optional[pd.Timestamp] = None,
-        volume_bar_mode: VolumeBarMode = None,
-        pair_id: Optional[int] = None,
-        start_row: int = None,
-        detached_indicators: bool = True,
+    fig: go.Figure,
+    visualisation: Visualisation,
+    start_at: Optional[pd.Timestamp] = None,
+    end_at: Optional[pd.Timestamp] = None,
+    volume_bar_mode: VolumeBarMode = None,
+    pair_id: Optional[int] = None,
+    start_row: int = None,
+    detached_indicators: bool = True,
 ):
     """Draw all technical indicators from the visualisation over candle chart.
 
@@ -89,15 +89,14 @@ def overlay_all_technical_indicators(
             return
         
         # add trace to plot
+        # only increment row if detached plot
         if plot.kind == PlotKind.technical_indicator_detached:
             cur_row += 1
             detached_plots_to_row[plot.name] = cur_row
             fig.add_trace(trace, row=cur_row, col=1)
         elif plot.kind == PlotKind.technical_indicator_on_price:
-            # don't increment current row
             fig.add_trace(trace, row=start_row, col=1)
         elif plot.kind == PlotKind.technical_indicator_overlay_on_detached:
-            # don't increment current row
             fig.add_trace(trace, row=detached_plots_to_row[plot.detached_overlay_name], col=1)
         else:
             raise NotImplementedError(f"Unknown plot kind: {plot.kind}")

--- a/tradeexecutor/visual/utils.py
+++ b/tradeexecutor/visual/utils.py
@@ -555,21 +555,19 @@ def _get_subplot_names(
     return subplot_names
 
 
-def get_num_detached_and_names(
-    plots: list[Plot],
-    execution_context: ExecutionContext,
-    volume_bar_mode: VolumeBarMode,
+def get_subplot_names(
+    pair_name: str | None,
     volume_axis_name: str,
-    pair_name: str | None = None,
-    detached_indicators: bool = True,
-):
-    """Get num_detached_indicators and subplot_names"""
-
-    assert isinstance(execution_context, ExecutionContext), f"Expected ExecutionContext, got {type(execution_context)}"
-
-    num_detached_indicators = _get_num_detached_indicators(plots, execution_context, volume_bar_mode, detached_indicators)
-    
+    volume_bar_mode: VolumeBarMode,
+    detached_indicators: bool,
+    plots: list[Plot] = None,
+    execution_context: ExecutionContext = None,
+) -> list[str]: 
+    """Get subplot names for detached technical indicators. Overlaid names are appended to the detached plot name.
+    plots and execution_context are only needed if detached_indicators is True."""
     if detached_indicators:
+        # assert isinstance(plots, list), f"Expected list, got {type(plots)}. Shouldn't happen"
+        assert isinstance(execution_context, ExecutionContext), f"Expected ExecutionContext, got {type(execution_context)}. Shouldn't happen"
         subplot_names = _get_subplot_names(
             plots, execution_context, volume_bar_mode, volume_axis_name, pair_name
         )
@@ -578,10 +576,43 @@ def get_num_detached_and_names(
     else:
         subplot_names = [pair_name]
 
+    return subplot_names
+
+def get_num_detached_and_names(
+    technical_indicators: bool,
+    plots: list[Plot],
+    execution_context: ExecutionContext,
+    volume_bar_mode: VolumeBarMode,
+    volume_text: str,
+    pair_name: str | None,
+    detached_indicators: bool,
+):
+    if technical_indicators:
+        num_detached_indicators, subplot_names = _get_num_detached_and_names(
+            plots, execution_context, volume_bar_mode, volume_text, pair_name, detached_indicators,
+        )
+    else:
+        num_detached_indicators, subplot_names = _get_num_detached_and_names_no_indicators(execution_context, volume_bar_mode, volume_text, pair_name)
+
     return num_detached_indicators, subplot_names
 
 
-def get_num_detached_and_names_no_indicators(
+def _get_num_detached_and_names(
+    plots: list[Plot],
+    execution_context: ExecutionContext,
+    volume_bar_mode: VolumeBarMode,
+    volume_axis_name: str,
+    pair_name: str | None = None,
+    detached_indicators: bool = True,
+):
+    """Get num_detached_indicators and subplot_names"""
+    assert isinstance(execution_context, ExecutionContext), f"Expected ExecutionContext, got {type(execution_context)}"
+    num_detached_indicators = _get_num_detached_indicators(plots, execution_context, volume_bar_mode, detached_indicators)
+    subplot_names = get_subplot_names(pair_name, volume_axis_name, volume_bar_mode, detached_indicators, plots, execution_context)
+    return num_detached_indicators, subplot_names
+
+
+def _get_num_detached_and_names_no_indicators(
     execution_context: ExecutionContext,
     volume_bar_mode: VolumeBarMode,
     volume_axis_name: str,
@@ -590,15 +621,9 @@ def get_num_detached_and_names_no_indicators(
     """Get num_detached_indicators and subplot_names. Used when technical_indicators == False"""
 
     assert isinstance(execution_context, ExecutionContext)
-
     if volume_bar_mode == VolumeBarMode.separate:
         num_detached_indicators = 1
     else:
         num_detached_indicators = 0
-    
-    if volume_bar_mode == VolumeBarMode.separate:
-        subplot_names = [pair_name, volume_axis_name]
-    else:
-        subplot_names = [pair_name]
-
+    subplot_names = get_subplot_names(pair_name, volume_axis_name, volume_bar_mode, False)
     return num_detached_indicators, subplot_names


### PR DESCRIPTION
- Fixes #966 and fixes #457
- Only raises an error message when user  tries to use `visualise_single_pair` in multipair universe without providing `pair` argument in `decide_trades`, this should be far less breaking, if at all, than always raising. 
- Some small refactoring for visual util functions
- The legend still shows for all pairs, have opened ticket #968 for this