### PR TITLE
Switch to joblib based pickle for GridSearchResult

### DIFF
--- a/tradeexecutor/backtest/grid_search.py
+++ b/tradeexecutor/backtest/grid_search.py
@@ -541,13 +541,13 @@ class GridSearchResult:
 
         os.makedirs(final_file.parent, exist_ok=True)
 
+        if include_state:
+            self.save_state()
+
         temp = tempfile.NamedTemporaryFile(mode='wb', delete=False, dir=final_file.parent)
         joblib.dump(self, temp.name, compress=("gzip", 3))
         temp.close()
         shutil.move(temp.name, final_file)
-
-        if include_state:
-            self.save_state()
 
     def save_state(self):
         """Save state in a separate file.

--- a/tradeexecutor/backtest/grid_search.py
+++ b/tradeexecutor/backtest/grid_search.py
@@ -542,25 +542,26 @@ class GridSearchResult:
         os.makedirs(final_file.parent, exist_ok=True)
 
         temp = tempfile.NamedTemporaryFile(mode='wb', delete=False, dir=final_file.parent)
-        joblib.dump(self, temp, compress=("gzip", 3))
+        joblib.dump(self, temp.name, compress=("gzip", 3))
         temp.close()
         shutil.move(temp.name, final_file)
 
         if include_state:
-            self.save_state(self.state)
+            self.save_state()
 
-    def save_state(self, state: State):
+    def save_state(self):
         """Save state in a separate file.
 
         - Not a part of the core metrics pickle
 
         - We use pickle and not JSON as it is faster
 
-        - Call after :py:meth:`save`
+        - Called by :py:meth:`save`
         """
+        state = self.state
         final_file = self.combination.get_state_file_path()
         temp = tempfile.NamedTemporaryFile(mode='wb', delete=False, dir=final_file.parent)
-        with open(temp, "wb") as out:
+        with open(temp.name, "wb") as out:
             pickle.dump(state, out)
         temp.close()
         shutil.move(temp.name, final_file)
@@ -574,7 +575,7 @@ class GridSearchResult:
         """
         if self.state is None:
             final_file = self.combination.get_state_file_path()
-            assert final_file.exists(), f"State file {final_file} not written"
+            assert final_file.exists(), f"State file {final_file} not written - did your searcher call save(include_state=True)?"
             gc.disable()
             with open(final_file, "rb") as inp:
                 self.state = pickle.load(inp)

--- a/tradeexecutor/backtest/optimiser.py
+++ b/tradeexecutor/backtest/optimiser.py
@@ -273,7 +273,7 @@ class ObjectiveWrapper:
                 initial_deposit=merged_parameters["initial_cash"],
             )
             logger.info("Backtest %d completed, saving the result", result_index)
-            result.save()
+            result.save(include_state=True)
 
         opt_val = self.search_func(result)
         opt_val.combination = combination


### PR DESCRIPTION
- Joblib should be faster than stdlib pickle for numpy arrays
- Make it possible to save state as the part of the grid search results, now only enabled for the optimiser