### PR TITLE
Visualise single position

### DIFF
--- a/tradeexecutor/backtest/optimiser.py
+++ b/tradeexecutor/backtest/optimiser.py
@@ -224,6 +224,7 @@ class ObjectiveWrapper:
         real_space_rounding: Decimal,
         log_level: int,
         result_filter: ResultFilter,
+        draw_visualisation: bool,
     ):
         self.search_func = search_func
         self.pickled_universe_fname = pickled_universe_fname
@@ -238,6 +239,7 @@ class ObjectiveWrapper:
         self.log_level = log_level
         self.result_filter = result_filter
         self.filtered_result_value = 0
+        self.draw_visualisation = draw_visualisation
 
     def __call__(
         self,
@@ -284,6 +286,7 @@ class ObjectiveWrapper:
             # Make sure we drag the engine version along
             execution_context = dataclasses.replace(scikit_optimizer_context)
             execution_context.engine_version = self.trading_strategy_engine_version
+            execution_context.force_visualisation = self.draw_visualisation
 
             result = run_grid_search_backtest(
                 combination,
@@ -426,6 +429,7 @@ def perform_optimisation(
     log_level: int | None=None,
     result_filter:ResultFilter = MinTradeCountFilter(50),
     bad_result_value=0,
+    draw_visualisation=False,
 ) -> OptimiserResult:
     """Search different strategy parameters using an optimiser.
 
@@ -491,6 +495,13 @@ def perform_optimisation(
 
     :param bad_result_value:
         What placeholder value we use for the optimiser when `result_filter` does not like the outcome.
+
+    :param draw_visualisation:
+        Draw and collect visualisation data during the backtest execution when optimising.
+
+        This will slow down optimisation: use this only if you really want to collect the data.
+
+        In `decide_trades()` function, `input.is_visualisation_enabled()` will return True.
 
     :return:
         Grid search results for different combinations.
@@ -562,6 +573,7 @@ def perform_optimisation(
         real_space_rounding=real_space_rounding,
         result_filter=result_filter,
         log_level=log_level,
+        draw_visualisation=draw_visualisation,
     )
 
     name = parameters.get("name") or parameters.get("id") or "backtest"

--- a/tradeexecutor/state/position.py
+++ b/tradeexecutor/state/position.py
@@ -300,6 +300,28 @@ class TradingPosition(GenericPosition):
         """
         return pprint.pformat(asdict(self), width=160)
 
+    def get_human_summary(self) -> dict:
+        """Get the human readable debug dump.
+
+        :return:
+            Human readable dict
+        """
+
+        return {
+            "Position id": self.position_id,
+            "Pair": self.pair.get_ticker(),
+            "Type": self.pair.kind.name,
+            "Trade count": self.get_trade_count(),
+            "PnL %": self.get_unrealised_and_realised_profit_percent() * 100,
+            "PnL USD": self.get_realised_profit_usd(),
+            "Started at": self.get_first_trade().executed_at,
+            "Ended at": self.get_last_trade().executed_at,
+            "Duration": self.get_duration(),
+            "Entry price": self.get_opening_price(),
+            "Exit price": self.get_closing_price(),
+            "Quantity (open)": self.get_first_trade().executed_quantity,
+        }
+
     def is_open(self) -> bool:
         """This is an open trading position."""
         return self.closed_at is None

--- a/tradeexecutor/strategy/execution_context.py
+++ b/tradeexecutor/strategy/execution_context.py
@@ -194,6 +194,16 @@ class ExecutionContext:
     #:
     progress_bars: bool = True
 
+    #: Force collection of visualisation and draw data during grid search and optimisation.
+    #:
+    #: Slows down the process a bit.
+    #: Note that changing this parameter means that you need to manually deleted previous cached results,
+    #: as this is stored as the part of the backtest state.
+    #:
+    #: See `perform_optimisation(draw_visualisation)` argument.
+    #:
+    force_visualisation: bool = False
+
     def __repr__(self):
         version_str = f"v{self.engine_version}" if self.engine_version else "unspecified engine version"
         return f"<ExecutionContext {self.mode.name}, {version_str}>"
@@ -207,9 +217,9 @@ class ExecutionContext:
     def has_visualisation(self) -> bool:
         """Should backtest spend time to draw custom visualisations.
 
-        - Disabled for the grid search for the speed
+        - By default, disabled for the grid search/optimiser for the speed
         """
-        return not(self.grid_search or self.optimiser)
+        return self.force_visualisation or not(self.grid_search or self.optimiser)
 
     @property
     def live_trading(self) -> bool:

--- a/tradeexecutor/utils/list.py
+++ b/tradeexecutor/utils/list.py
@@ -1,0 +1,10 @@
+"""List utilities."""
+
+def get_linearly_sampled_items(lst: list, count: int):
+    """Get N items from a list, equally distributed over the index."""
+    if len(lst) < count:
+        return lst
+
+    step = (len(lst) - 1) / (count - 1)
+    indices = [round(i * step) for i in range(count)]
+    return [lst[i] for i in indices]

--- a/tradeexecutor/utils/notebook.py
+++ b/tradeexecutor/utils/notebook.py
@@ -68,6 +68,9 @@ def setup_charting_and_output(
         Default 20 is too low to display summary tables.
     """
 
+    from plotly.offline import init_notebook_mode
+    import plotly.io as pio
+
     # Get rid of findfont: Font family 'Arial' not found.
     # when running a remote notebook on Jupyter Server on Ubuntu Linux server
     # https://stackoverflow.com/questions/42097053/matplotlib-cannot-find-basic-fonts/76136516#76136516
@@ -81,11 +84,9 @@ def setup_charting_and_output(
     if mode == OutputMode.static:
 
          # https://stackoverflow.com/a/52956402/315168
-        from plotly.offline import init_notebook_mode
         init_notebook_mode()
 
         # https://stackoverflow.com/a/74609837/315168
-        import plotly.io as pio
         pio.kaleido.scope.default_format = image_format
 
         # https://plotly.com/python/renderers/#overriding-the-default-renderer
@@ -95,6 +96,12 @@ def setup_charting_and_output(
         # Have SVGs default pixel with
         current_renderer.width = width
         current_renderer.height = height
+    elif mode == OutputMode.interactive:
+        # https://plotly.com/python/renderers/#setting-the-default-renderer
+        pio.renderers.default = "notebook_connected"
+        init_notebook_mode(connected=False)
+    else:
+        raise NotImplementedError(f"Unknown rendering mode: {mode}")
 
     # TODO: Currently we do not reset interactive mode if the notebook has been run once
     # If you run setup_charting_and_output(offline) once you are stuck offline

--- a/tradeexecutor/utils/profile.py
+++ b/tradeexecutor/utils/profile.py
@@ -1,0 +1,29 @@
+"""Python cProf utilities"""
+
+import cProfile
+import pstats
+from contextlib import contextmanager
+
+@contextmanager
+def profiled(count=30):
+    """Run a Python snippet and show the spent time.
+
+    - A crude profiling for notebooks / scripts
+
+    Example:
+
+    .. code-block:: python
+
+        # Usage
+        with profiled():
+            # Your code section to profile goes here
+            for i in range(1000000):
+                _ = i ** 2
+    """
+    pr = cProfile.Profile()
+    pr.enable()
+    yield
+    pr.disable()
+    stats = pstats.Stats(pr)
+    stats.sort_stats('cumulative').print_stats(30)
+

--- a/tradeexecutor/visual/single_pair.py
+++ b/tradeexecutor/visual/single_pair.py
@@ -740,9 +740,9 @@ def visualise_single_position(
     start_at_around = start_at - buffer
     end_at_around = end_at + buffer
 
-    title = f"#{position.position_id}: {position.get_realised_profit_usd()} USD"
+    title = f"Position #{position.position_id}: {position.get_unrealised_and_realised_profit_percent()*100}%, {position.get_realised_profit_usd()} USD"
 
-    return visualise_single_pair(
+    fig = visualise_single_pair(
         state=state,
         execution_context=execution_context,
         candle_universe=strategy_universe.data_universe.candles,
@@ -752,3 +752,14 @@ def visualise_single_position(
         title=title,
     )
 
+    # No title needed to display
+    fig.update_layout(
+        title="",
+    )
+
+    # https://community.plotly.com/t/excessive-margins-in-graphs-how-to-remove/49094/2
+    fig.update_layout(
+        margin=dict(l=5, r=5, t=5, b=5),
+    )
+
+    return fig

--- a/tradeexecutor/visual/single_pair.py
+++ b/tradeexecutor/visual/single_pair.py
@@ -721,6 +721,48 @@ def visualise_single_position(
 
     - Give you an overview what failed in the trade
 
+    - We draw the technical indicators if the source data has them (`input.visualisation == True`).
+
+    Example:
+
+    .. code-block:: python
+
+        from tradeexecutor.utils.list import get_linearly_sampled_items
+        from tradeexecutor.visual.single_pair import visualise_single_position
+        from tradeexecutor.utils.profile import profiled
+
+        # We are always using interactive charting mode for single position visualisation
+        setup_charting_and_output(OutputMode.interactive)
+
+        state = best_pick.hydrate_state()
+        portfolio = state.portfolio
+
+        pair = strategy_universe.get_pair_by_human_description(trading_pairs[0])  # We examine positions for this trading pair only
+        examinaned_position_count = 3  # We are linearly sampling this many failing trades for visualisation
+        area_around_candels = 40  # How many candles before and after entry and exit
+
+        all_positions = list(portfolio.get_all_positions())
+        positions_lost = [p for p in all_positions if p.is_loss()]
+
+        print(f"Total lost positions for {pair.get_ticker()} is {len(positions_lost)} / {len(all_positions)}. We are visualising {examinaned_position_count} of these.")
+        # Take 3 positions equally weighted from the time line
+
+        examined_positions = get_linearly_sampled_items(positions_lost, count=examinaned_position_count)
+
+        for position in examined_positions:
+            position_summary = pd.Series(position.get_human_summary())
+            display(position_summary)
+            fig = visualise_single_position(
+                state=state,
+                strategy_universe=strategy_universe,
+                position=position,
+                area_around=area_around_candels,
+            )
+            display(fig)
+
+    :param position:
+        A single trading position to visualise
+
     :param area_around:
         How many candles display before and start of the position
     """
@@ -740,8 +782,6 @@ def visualise_single_position(
     start_at_around = start_at - buffer
     end_at_around = end_at + buffer
 
-    title = f"Position #{position.position_id}: {position.get_unrealised_and_realised_profit_percent()*100}%, {position.get_realised_profit_usd()} USD"
-
     fig = visualise_single_pair(
         state=state,
         execution_context=execution_context,
@@ -749,9 +789,9 @@ def visualise_single_position(
         start_at=start_at_around,
         end_at=end_at_around,
         pair_id=position.pair.internal_id,
-        title=title,
     )
 
+    # title = f"Position #{position.position_id}: {position.get_unrealised_and_realised_profit_percent()*100}%, {position.get_realised_profit_usd()} USD"
     # No title needed to display
     fig.update_layout(
         title="",
@@ -759,7 +799,7 @@ def visualise_single_position(
 
     # https://community.plotly.com/t/excessive-margins-in-graphs-how-to-remove/49094/2
     fig.update_layout(
-        margin=dict(l=5, r=5, t=5, b=5),
+        margin=dict(l=0, r=0, t=0, b=0),
     )
 
     return fig

--- a/tradeexecutor/visual/technical_indicator.py
+++ b/tradeexecutor/visual/technical_indicator.py
@@ -141,10 +141,14 @@ def export_plot_as_dataframe(
         Internal Plot object from the strategy state.
 
     :param start_at:
-        Crop range
+        Crop range.
+
+        Inclusive.
 
     :param end_at:
         Crop range
+
+        Inclusive.
 
     :param correct_look_ahead_bias_negation:
         How many candles to shift the data if the source plot was adjusted for the look ahead bias.
@@ -152,8 +156,8 @@ def export_plot_as_dataframe(
         See :py:class:`tradeexecutor.state.visualisation.RecordingTime` for more information.
     """
     if start_at or end_at:
-        start_at_unix = start_at.timestamp()
-        end_at_unix = end_at.timestamp()
+        start_at_unix = start_at.timestamp() if start_at else 0
+        end_at_unix = end_at.timestamp() if end_at else pd.Timestamp("2099-1-1").timestamp()
 
         data = [{"timestamp": time, "value": value} for time, value in plot.points.items() if start_at_unix <= time <= end_at_unix]
     else:
@@ -166,6 +170,7 @@ def export_plot_as_dataframe(
     # Convert timestamp to pd.Timestamp column
     df = pd.DataFrame(data)
     # .values claims to offer extra speedup trick
+    # https://stackoverflow.com/questions/65948018/how-to-convert-unix-epoch-time-to-datetime-with-timezone-in-pandas
     df["timestamp"] = pd.to_datetime(df["timestamp"].values, unit='s', utc=True).tz_localize(None)
     df = df.set_index(pd.DatetimeIndex(df["timestamp"]))
 

--- a/tradeexecutor/visual/technical_indicator.py
+++ b/tradeexecutor/visual/technical_indicator.py
@@ -165,7 +165,8 @@ def export_plot_as_dataframe(
 
     # Convert timestamp to pd.Timestamp column
     df = pd.DataFrame(data)
-    df["timestamp"] = pd.to_datetime(df["timestamp"].values, unit='s', utc=True)
+    # .values claims to offer extra speedup trick
+    df["timestamp"] = pd.to_datetime(df["timestamp"].values, unit='s', utc=True).tz_localize(None)
     df = df.set_index(pd.DatetimeIndex(df["timestamp"]))
 
     # TODO: Not a perfect implementation, will

--- a/tradeexecutor/visual/technical_indicator.py
+++ b/tradeexecutor/visual/technical_indicator.py
@@ -151,12 +151,13 @@ def export_plot_as_dataframe(
 
         See :py:class:`tradeexecutor.state.visualisation.RecordingTime` for more information.
     """
-    data = []
+    if start_at or end_at:
+        start_at_unix = start_at.timestamp()
+        end_at_unix = end_at.timestamp()
 
-    start_at_unix = start_at.astype('int64') // 10**9
-    end_at_unix = start_at.astype('int64') // 10 ** 9
-
-    data = [{"timestamp": time, "value": value} for time, value in plot.points.items() if start_at_unix <= time <= end_at_unix]
+        data = [{"timestamp": time, "value": value} for time, value in plot.points.items() if start_at_unix <= time <= end_at_unix]
+    else:
+        data = [{"timestamp": time, "value": value} for time, value in plot.points.items()]
 
     # set_index fails if the frame is empty
     if len(data) == 0:
@@ -164,7 +165,7 @@ def export_plot_as_dataframe(
 
     # Convert timestamp to pd.Timestamp column
     df = pd.DataFrame(data)
-    df["timestamp"] = to_datetime(df["timestamp"], unit='s', utc=True)
+    df["timestamp"] = pd.to_datetime(df["timestamp"].values, unit='s', utc=True)
     df = df.set_index(pd.DatetimeIndex(df["timestamp"]))
 
     # TODO: Not a perfect implementation, will


### PR DESCRIPTION
- Add `perform_optimisation(draw_visualisation=False)`
    - By default visualisations are disabled in the optimiser, as they slow down the optimisation process
- Add `visualise_single_position()` to diagnose lost trades
- Optimise `export_plot_as_dataframe`
    - Use optimised path for `pd.to_datetime`
    - Force UTC timezone during the conversation as it gives better performance: **might cause timezone breakage and out of sync issues if some other charting functions did not force UTC before**    
    - Much further speedups possible by passing UNIX timestamp in raw to Plotly instead of converting it forth and back to pd.DateTime
- Add some profiling and list utils
