### PR TITLE
Ignore grid search failures

### DIFF
--- a/tests/backtest/test_grid_search.py
+++ b/tests/backtest/test_grid_search.py
@@ -24,7 +24,7 @@ from tradingstrategy.universe import Universe
 from tradeexecutor.analysis.grid_search import analyse_grid_search_result, render_grid_search_result_table, visualise_heatmap_2d, \
     find_best_grid_search_results
 from tradeexecutor.backtest.grid_search import prepare_grid_combinations, run_grid_search_backtest, perform_grid_search, GridCombination, GridSearchResult, \
-    pick_grid_search_result, pick_best_grid_search_result, GridParameter
+    pick_grid_search_result, pick_best_grid_search_result, GridParameter, create_grid_search_failed_result
 from tradeexecutor.state.identifier import AssetIdentifier, TradingPairIdentifier
 from tradeexecutor.state.state import State
 from tradeexecutor.state.visualisation import PlotKind
@@ -741,3 +741,24 @@ def test_perform_grid_search_with_indicator_dependency_resolution(
         indicator_storage=indicator_storage,
     )
     assert len(results) == 8
+
+
+
+def test_create_failed_result(tmp_path):
+    """See we can serialise a failed result."""
+
+    parameters = {
+        "stop_loss_pct": [0.9, 0.95],
+        "slow_ema_candle_count": [7, 9],
+        "fast_ema_candle_count": [2, 3],
+    }
+
+    combinations = prepare_grid_combinations(parameters, tmp_path)
+
+    r = create_grid_search_failed_result(
+        combination=combinations[0],
+        state=State(),
+        exception=RuntimeError(),
+    )
+
+    assert r.exception is not None

--- a/tradeexecutor/analysis/advanced_metrics.py
+++ b/tradeexecutor/analysis/advanced_metrics.py
@@ -107,6 +107,7 @@ def calculate_advanced_metrics(
         if display:
             quantstats_awful_kwargs = {"internal": True}
 
+        import ipdb ; ipdb.set_trace()
         result = metrics(
             returns,
             benchmark=benchmark,

--- a/tradeexecutor/analysis/advanced_metrics.py
+++ b/tradeexecutor/analysis/advanced_metrics.py
@@ -107,7 +107,6 @@ def calculate_advanced_metrics(
         if display:
             quantstats_awful_kwargs = {"internal": True}
 
-        import ipdb ; ipdb.set_trace()
         result = metrics(
             returns,
             benchmark=benchmark,

--- a/tradeexecutor/backtest/grid_search.py
+++ b/tradeexecutor/backtest/grid_search.py
@@ -1151,10 +1151,30 @@ def perform_grid_search(
 def create_grid_search_failed_result(combination, state, exception: Exception) -> GridSearchResult:
     """Create a result for a crashed backtest."""
 
-    index = pd.DatetimeIndex([pd.Timestamp(1970, 1, 1)])
+    # A lot of dance to avoid division by zero errors when creating metrics table
+    index = pd.DatetimeIndex([pd.Timestamp(1970, 1, 1), pd.Timestamp(1970, 1, 2)])
+    returns = pd.Series([0, 0], dtype="float64", index=index)
+    equity_curve = pd.Series([0, 0], dtype="float64", index=index)
 
-    returns = pd.Series([0], dtype="float64", index=index)
-    equity_curve = pd.Series([0], dtype="float64", index=index)
+    summary = TradeSummary(
+        won=0,
+        lost=0,
+        zero_loss=0,
+        stop_losses=0,
+        undecided=0,
+        realised_profit=0,
+        open_value=0,
+        uninvested_cash=0,
+        initial_cash=0,
+        extra_return=0,
+        duration=datetime.timedelta(0),
+        average_winning_trade_profit_pc=0,
+        average_losing_trade_loss_pc=0,
+        biggest_winning_trade_pc=0,
+        biggest_losing_trade_pc=0,
+        average_duration_of_winning_trades=datetime.timedelta(0),
+        average_duration_of_losing_trades=datetime.timedelta(0),
+    )
 
     metrics = calculate_advanced_metrics(
         returns,
@@ -1170,7 +1190,9 @@ def create_grid_search_failed_result(combination, state, exception: Exception) -
         returns=returns,
         equity_curve=equity_curve,
         metrics=metrics,
+        summary=summary,
         exception=exception,
+        universe_options=None,
     )
 
 

--- a/tradeexecutor/backtest/grid_search.py
+++ b/tradeexecutor/backtest/grid_search.py
@@ -393,6 +393,10 @@ class GridSearchResult:
     #:
     optimiser_search_value: float | None = None
 
+    #: If this grid search failed with an exception store the result here
+    #:
+    exception: Exception | None = None
+
     def __hash__(self):
         return self.combination.__hash__()
 
@@ -1144,6 +1148,32 @@ def perform_grid_search(
     return results
 
 
+def create_grid_search_failed_result(combination, state, exception: Exception) -> GridSearchResult:
+    """Create a result for a crashed backtest."""
+
+    index = pd.DatetimeIndex([pd.Timestamp(1970, 1, 1)])
+
+    returns = pd.Series([0], dtype="float64", index=index)
+    equity_curve = pd.Series([0], dtype="float64", index=index)
+
+    metrics = calculate_advanced_metrics(
+        returns,
+        mode=AdvancedMetricsMode.full,
+        convert_to_daily=False,
+        display=False,
+    )
+
+    return GridSearchResult(
+        combination=combination,
+        state=state,
+        initial_cash=0,
+        returns=returns,
+        equity_curve=equity_curve,
+        metrics=metrics,
+        exception=exception,
+    )
+
+
 def run_grid_search_backtest(
     combination: GridCombination,
     decide_trades: DecideTradesProtocol | DecideTradesProtocol2 | DecideTradesProtocol4,
@@ -1163,6 +1193,7 @@ def run_grid_search_backtest(
     indicator_storage: IndicatorStorage | None = None,
     execution_context=standalone_backtest_execution_context,
     max_workers: int = 0,
+    ignore_wallet_errors=False,
 ) -> GridSearchResult:
     assert isinstance(universe, TradingStrategyUniverse), f"Received {universe}"
 
@@ -1199,32 +1230,46 @@ def run_grid_search_backtest(
 
     # Run the test
     try:
-        state, universe, debug_dump = run_backtest_inline(
-            name=name,
-            start_at=start_at.to_pydatetime(),
-            end_at=end_at.to_pydatetime(),
-            client=None,
-            cycle_duration=cycle_duration,
-            decide_trades=decide_trades,
-            create_trading_universe=None,
-            create_indicators=create_indicators,
-            indicator_combinations=combination.indicators,
-            universe=universe,
-            initial_deposit=initial_deposit,
-            reserve_currency=None,
-            trade_routing=TradeRouting.user_supplied_routing_model,
-            routing_model=routing_model,
-            allow_missing_fees=True,
-            data_delay_tolerance=data_delay_tolerance,
-            engine_version=trading_strategy_engine_version,
-            parameters=parameters,
-            indicator_storage=indicator_storage,
-            grid_search=True,
-            execution_context=execution_context,
-            max_workers=max_workers,
-        )
+        try:
+            state, universe, debug_dump = run_backtest_inline(
+                name=name,
+                start_at=start_at.to_pydatetime(),
+                end_at=end_at.to_pydatetime(),
+                client=None,
+                cycle_duration=cycle_duration,
+                decide_trades=decide_trades,
+                create_trading_universe=None,
+                create_indicators=create_indicators,
+                indicator_combinations=combination.indicators,
+                universe=universe,
+                initial_deposit=initial_deposit,
+                reserve_currency=None,
+                trade_routing=TradeRouting.user_supplied_routing_model,
+                routing_model=routing_model,
+                allow_missing_fees=True,
+                data_delay_tolerance=data_delay_tolerance,
+                engine_version=trading_strategy_engine_version,
+                parameters=parameters,
+                indicator_storage=indicator_storage,
+                grid_search=True,
+                execution_context=execution_context,
+                max_workers=max_workers,
+            )
+        except OutOfBalance as oob:
+            if not ignore_wallet_errors:
+                raise 
 
-    except Exception as e:
+            #
+            # There is a bug in the backtest that tries to use more money 
+            # to trade than we have available.
+            # Usually these bugs must be fixed in the strategy,
+            # but in a grid search we may choose to ignore such strategies
+            # as non-working and mark them down to zero.
+            #
+
+            return create_grid_search_failed_result(combination, state, oob)
+
+    except Exception as e:        
         # Report to the notebook which of the grid search combinations is a problematic one
         tb = traceback.format_exc()
         raise RuntimeError(f"Running a grid search combination failed:\n{combination}\nThe original exception was: {e}\n{tb}") from e

--- a/tradeexecutor/backtest/optimiser.py
+++ b/tradeexecutor/backtest/optimiser.py
@@ -306,7 +306,12 @@ class ObjectiveWrapper:
             
             result.save(include_state=True)
 
-        opt_result = self.search_func(result)
+        if getattr(result, "exception", None) is None:  # Legacy pickle compat
+            opt_result = self.search_func(result)
+        else:
+            # The backtest crashed with an exception,
+            # likely OutOfBalance
+            opt_result = self.filtered_result_value
 
         # Apply result filter and zero out the value for optimiser if needed
         if not self.result_filter(result):


### PR DESCRIPTION
- Allow to set `perform_optimisation(ignore_wallet_errors=True)` which allow the optimiser run to complete, even though some backtests are crashing