### PR TITLE
Add cap to normalise_weight()

### DIFF
--- a/tests/test_rebalance.py
+++ b/tests/test_rebalance.py
@@ -1114,3 +1114,88 @@ def test_alpha_model_decrease_short(
     assert p3.get_value() == pytest.approx(39.542920175)  # Down in value
 
     assert portfolio.get_net_asset_value() == pytest.approx(658.291970175)
+
+
+def test_alpha_model_normalise_weight_capped(
+    single_asset_portfolio: Portfolio,
+    strategy_universe,
+    pricing_model,
+    weth_usdc: TradingPairIdentifier,
+    aave_usdc: TradingPairIdentifier,
+    start_ts,
+):
+    """"Cap the max allocation per asset."""
+
+    portfolio = single_asset_portfolio
+
+    state = State(portfolio=portfolio)
+
+    # Check we have WETH-USDC open
+    position = state.portfolio.get_position_by_trading_pair(weth_usdc)
+    assert position.get_quantity() > 0
+    weth_quantity = position.get_quantity()
+    assert position.get_value() == pytest.approx(157.7)
+
+    # Create the PositionManager that
+    # will create buy/sell trades based on our
+    # trading universe and mock price feeds
+    position_manager = PositionManager(
+        start_ts + datetime.timedelta(days=1),  # Trade on t plus 1 day
+        strategy_universe.data_universe,
+        state,
+        pricing_model,
+    )
+
+    # Go 50% in to AAVE
+    alpha_model = AlphaModel()
+    alpha_model.set_signal(aave_usdc, 0.5)
+    alpha_model.set_signal(weth_usdc, 0.5)
+    alpha_model.select_top_signals(9999)
+    alpha_model.assign_weights(method=weight_passthrouh)
+    alpha_model.normalise_weights(max_weight=0.1)
+
+    # Check we have 50% / 50%
+    for signal in alpha_model.iterate_signals():
+        assert signal.raw_weight == 0.5, f"Bad signal: {signal}"
+        assert signal.normalised_weight == 0.1, f"Bad signal: {signal}"
+
+    # Load in old weight for each trading pair signal,
+    # so we can calculate the adjustment trade size
+    alpha_model.update_old_weights(state.portfolio)
+    assert alpha_model.get_signal_by_pair(weth_usdc).old_value == pytest.approx(157.7)
+
+    # Calculate how much dollar value we want each individual position to be on this strategy cycle,
+    # based on our total available equity
+    portfolio = position_manager.get_current_portfolio()
+    portfolio_target_value = portfolio.get_position_equity_and_loan_nav()
+    alpha_model.calculate_target_positions(position_manager, portfolio_target_value)
+
+    # Check we have 50% / 50%
+    assert alpha_model.get_signal_by_pair(weth_usdc).position_adjust_usd < 0
+    assert alpha_model.get_signal_by_pair(aave_usdc).position_adjust_usd > 0
+
+    # Shift portfolio from current positions to target positions
+    # determined by the alpha signals (momentum)
+    trades = alpha_model.generate_rebalance_trades_and_triggers(position_manager)
+
+    assert len(trades) == 2, f"Got trades: {trades}"
+
+    # Sells go first,
+    # sell 50% of ETH
+    t = trades[0]
+    assert t.is_sell()
+    assert t.is_planned()
+    assert t.pair == weth_usdc
+    assert t.planned_price == pytest.approx(1664.99)
+    # assert t.planned_quantity == pytest.approx(-weth_quantity / 2)
+    # assert t.get_planned_value() == 78.85
+    assert t.planned_quantity == pytest.approx(Decimal("-0.08498802395209580085033707064212649129331111907958984375"))
+    assert t.get_planned_value() == pytest.approx(141.50421)
+
+    # Buy comes next,
+    # buy 50% of AAVE
+    t = trades[1]
+    assert t.is_buy()
+    assert t.is_planned()
+    assert t.planned_price == pytest.approx(100.29999999999998)
+    assert t.get_planned_value() == pytest.approx(15.769999999999998)

--- a/tradeexecutor/strategy/alpha_model.py
+++ b/tradeexecutor/strategy/alpha_model.py
@@ -599,8 +599,10 @@ class AlphaModel:
     def normalise_weights(self, max_weight=1.0):
         """Normalise weights to 0...1 scale.
 
+        After normalising, we can allocate the positionts `normalised_weight * portfolio equity`.
+
         :param max_weight:
-            Do not allow equity allocation to exceed this % for any of the assets.
+            Do not allow equity allocation to exceed this % for any asset.
 
             This may happen if you have a portfolio of max assets of 10,
             but due to market conditions there is signal only for 1-2 pairs.

--- a/tradeexecutor/strategy/alpha_model.py
+++ b/tradeexecutor/strategy/alpha_model.py
@@ -596,11 +596,22 @@ class AlphaModel:
         top_signals = heapq.nlargest(count, filtered_signals, key=lambda s: s.raw_weight)
         self.signals = {s.pair.internal_id: s for s in top_signals}
 
-    def normalise_weights(self):
+    def normalise_weights(self, max_weight=1.0):
+        """Normalise weights to 0...1 scale.
+
+        :param max_weight:
+            Do not allow equity allocation to exceed this % for any of the assets.
+
+            This may happen if you have a portfolio of max assets of 10,
+            but due to market conditions there is signal only for 1-2 pairs.
+            `max_weight` caps the asset allocation, preventing too concentrated
+            positions.
+
+        """
         raw_weights = {s.pair.internal_id: s.raw_weight for s in self.signals.values()}
         normalised = normalise_weights(raw_weights)
         for pair_id, normal_weight in normalised.items():
-            self.signals[pair_id].normalised_weight = normal_weight
+            self.signals[pair_id].normalised_weight = min(normal_weight, max_weight)
 
     def assign_weights(self, method=weight_by_1_slash_n):
         """Convert raw signals to their portfolio weight counterparts.


### PR DESCRIPTION
- When having too few signals/assets to work with, cap the allocation for a single asset