### PR TITLE
Improve web status endpoint

### DIFF
--- a/tests/web/test_webhook_api.py
+++ b/tests/web/test_webhook_api.py
@@ -171,8 +171,8 @@ def test_run_state(logger, server_url):
 
     # Not exported
     assert data["source_code"] is None
-    assert data["visualisation"]["large_image"] is None
-    assert data["visualisation"]["small_image"] is None
+    assert data["visualisation"] is None
+    assert data["read_only_state_copy"] is None
 
     # Version info is there
     assert data["version"]["tag"] == "v1"

--- a/tradeexecutor/cli/commands/webapi.py
+++ b/tradeexecutor/cli/commands/webapi.py
@@ -1,0 +1,133 @@
+"""Web API command
+
+Example::
+
+    poetry run trade-executor webapi --strategy-file=strategies/enzyme-polygon-matic-usdc.py
+"""
+
+import datetime
+import faulthandler
+import logging
+import os
+import time
+from decimal import Decimal
+from pathlib import Path
+from queue import Queue
+from typing import Optional
+
+import typer
+import waitress
+
+from . import shared_options
+from .app import app
+from ..bootstrap import prepare_executor_id, prepare_cache, create_metadata, create_state_store
+from ..log import setup_logging, setup_discord_logging, setup_logstash_logging, setup_file_logging
+from ..version_info import VersionInfo
+from ...state.state import State
+from ...strategy.execution_model import AssetManagementMode
+from ...strategy.run_state import RunState
+from ...strategy.strategy_module import read_strategy_module, StrategyModuleInformation
+from ...webhook.server import create_pyramid_app
+
+
+logger = logging.getLogger(__name__)
+
+
+@app.command()
+def webapi(
+
+    # Strategy assets
+    id: str = shared_options.id,
+    name: Optional[str] = shared_options.name,
+    short_description: Optional[str] = typer.Option(None, envvar="SHORT_DESCRIPTION", help="Short description for metadata"),
+    long_description: Optional[str] = typer.Option(None, envvar="LONG_DESCRIPTION", help="Long description for metadata"),
+    badges: Optional[str] = typer.Option(None, envvar="BADGES", help="Comma separated list of badges to be displayed on the strategy tile"),
+    icon_url: Optional[str] = typer.Option(None, envvar="ICON_URL", help="Strategy icon for web rendering and Discord avatar"),
+
+    strategy_file: Path = shared_options.strategy_file,
+
+    # Webhook server options
+    http_port: int = typer.Option(3456, envvar="HTTP_PORT", help="Which HTTP port to listen. The default is 3456, the default port of Pyramid web server."),
+    http_host: str = typer.Option("0.0.0.0", envvar="HTTP_HOST", help="The IP address to bind for the web server. By default listen to all IP addresses available in the run-time environment."),
+    http_username: str = typer.Option(None, envvar="HTTP_USERNAME", help="Username for HTTP Basic Auth protection of webhooks"),
+    http_password: str = typer.Option(None, envvar="HTTP_PASSWORD", help="Password for HTTP Basic Auth protection of webhooks"),
+
+    # Logging
+    file_log_level: Optional[str] = typer.Option("info", envvar="FILE_LOG_LEVEL", help="Log file log level. The default log file is logs/id.log."),
+
+    # Logging
+    log_level: str = shared_options.log_level,
+
+    # Various file configurations
+    state_file: Optional[Path] = shared_options.state_file,
+    cache_path: Optional[Path] = shared_options.cache_path,
+):
+    """Launch Trade Executor instance."""
+    global logger
+
+    started_at = datetime.datetime.utcnow()
+
+    # Guess id from the strategy file
+    id = prepare_executor_id(id, strategy_file)
+
+    # We always need a name-*-
+    if not name:
+        if strategy_file:
+            name = os.path.basename(strategy_file)
+        else:
+            name = "Unnamed backtest"
+
+    if not log_level:
+        log_level = logging.INFO
+
+    # Make sure unit tests run logs do not get polluted
+    # Don't touch any log levels, but
+    # make sure we have logger.trading() available when
+    # log_level is "disabled"
+    logger = setup_logging(log_level, in_memory_buffer=True)
+
+    setup_file_logging(
+        f"logs/{id}.log",
+        file_log_level,
+        http_logging=True,
+    )
+
+    if not state_file:
+        state_file = f"state/{id}.json"
+
+    cache_path = prepare_cache(id, cache_path, False)
+    mod = read_strategy_module(strategy_file)
+
+    if state_file:
+        store = create_state_store(Path(state_file))
+
+    metadata = create_metadata(
+        name,
+        short_description,
+        long_description,
+        icon_url,
+        AssetManagementMode.dummy,
+        chain_id=mod.get_default_chain_id(),
+        vault=None,
+    )
+
+    # Start the queue that relays info from the web server to the strategy executor
+    command_queue = Queue()
+
+    run_state = RunState()
+    run_state.version = VersionInfo.read_docker_version()
+    run_state.executor_id = id
+
+    # Set up read-only state sync
+    if not store.is_pristine():
+        run_state.read_only_state_copy = store.load()
+
+    app = create_pyramid_app(
+        http_username,
+        http_password,
+        command_queue,
+        store,
+        metadata,
+        run_state,
+    )
+    waitress.serve(app, host=http_host, port=http_port)

--- a/tradeexecutor/cli/main.py
+++ b/tradeexecutor/cli/main.py
@@ -21,6 +21,7 @@ from .commands.repair import repair
 from .commands.retry import retry
 from .commands.visualise import visualise
 from .commands.init import init
+from .commands.webapi import webapi
 
 # Dummy export commands even though they are already registered
 # to make the linter happy
@@ -28,5 +29,5 @@ __all__ = [
     app, check_wallet, check_universe, hello, start, perform_test_trade, 
     version, repair, console, init, reset, enzyme_asset_list, enzyme_deploy_vault,
     close_all, show_positions, backtest, correct_accounts, check_accounts, 
-    reset_deposits, export, retry, visualise,
+    reset_deposits, export, retry, visualise, webapi
 ]

--- a/tradeexecutor/strategy/run_state.py
+++ b/tradeexecutor/strategy/run_state.py
@@ -7,7 +7,6 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Optional, TypedDict
 
-import dataclasses_json
 from dataclasses_json import dataclass_json
 from tblib import Traceback
 
@@ -249,11 +248,13 @@ class RunState:
 
         Special fields like source code and images are not exported.
         """
-        data = self.to_dict()
-        del data["source_code"]
-        del data["visualisation"]
-        del data["read_only_state_copy"]
-        return RunState(**data)
+        self_copy = copy.deepcopy(self)
+        
+        self_copy.source_code = None
+        self_copy.visualisation = None
+        self_copy.read_only_state_copy = None
+
+        return RunState(**self_copy.to_dict())
 
     def on_save_hook(self, state: State):
         """Called by JSONStateStore.sync()"""

--- a/tradeexecutor/strategy/run_state.py
+++ b/tradeexecutor/strategy/run_state.py
@@ -249,12 +249,12 @@ class RunState:
         Special fields like source code and images are not exported.
         """
         self_copy = copy.deepcopy(self)
-        
+
         self_copy.source_code = None
         self_copy.visualisation = None
         self_copy.read_only_state_copy = None
 
-        return RunState(**self_copy.to_dict())
+        return self_copy
 
     def on_save_hook(self, state: State):
         """Called by JSONStateStore.sync()"""


### PR DESCRIPTION
- Create a command to run web server directly without execution loop
- Improve `/status` endpoint: `to_dict()` is very slow when state file is big, so we have to remove `read_only_state_copy` before that