### PR TITLE
Deploy guard

### DIFF
--- a/tests/enzyme/conftest.py
+++ b/tests/enzyme/conftest.py
@@ -423,11 +423,11 @@ def enzyme_deployment(
 
 @pytest.fixture()
 def enzyme_vault_contract(
-        web3,
-        deployer,
-        usdc,
-        user_1,
-        enzyme_deployment,
+    web3,
+    deployer,
+    usdc,
+    user_1,
+    enzyme_deployment,
 ) -> Contract:
     """Create an example vault.
 

--- a/tests/enzyme/test_enzyme_end_to_end.py
+++ b/tests/enzyme/test_enzyme_end_to_end.py
@@ -89,6 +89,29 @@ def hot_wallet(web3, deployer, user_1, usdc: Contract, vault: Vault) -> HotWalle
 
 
 @pytest.fixture()
+def enzyme_vault_contract(
+    web3,
+    deployer,
+    usdc,
+    user_1,
+    hot_wallet,
+    enzyme_deployment,
+) -> Contract:
+    """Create an example vault.
+
+    - USDC nominatead
+
+    - user_1 is the owner
+    """
+    comptroller_contract, vault_contract = enzyme_deployment.create_new_vault(
+        hot_wallet.address,
+        usdc,
+    )
+
+    return vault_contract
+
+
+@pytest.fixture()
 def strategy_file() -> Path:
     """Where do we load our strategy file."""
     return Path(os.path.dirname(__file__)) / "../../strategies/test_only" / "enzyme_end_to_end.py"
@@ -729,8 +752,8 @@ def test_enzyme_perform_test_trade_with_redeployed_guard(
     - If the guard deployment is broken, the test trade should not success
     """
 
-    owner = user_1
-    assert vault.get_owner() == owner
+
+    assert vault.get_owner() == hot_wallet.address
     report_file = tmp_path / "guard.json"
     env = environment.copy()
     env["VAULT_ADDRESS"] = vault.address

--- a/tests/enzyme/test_enzyme_end_to_end.py
+++ b/tests/enzyme/test_enzyme_end_to_end.py
@@ -735,6 +735,7 @@ def test_deploy_guard_for_vault(
         app(["deploy-guard"], standalone_mode=False)
 
 
+@pytest.mark.skip(reason="Currently Enzyme does not way to update AdapterPolicy. Instead, the whole vault needs to be reconfigured with 7 days delay.")
 def test_enzyme_perform_test_trade_with_redeployed_guard(
     environment: dict,
     web3: Web3,

--- a/tests/enzyme/test_enzyme_end_to_end.py
+++ b/tests/enzyme/test_enzyme_end_to_end.py
@@ -638,7 +638,6 @@ def test_enzyme_correct_accounts_for_closed_position_transfer_away(
         assert e.value.code == 0
 
 
-@pytest.mark.slow_test_group
 def test_deploy_guard_standalone(
     environment: dict,
     web3: Web3,
@@ -659,7 +658,6 @@ def test_deploy_guard_standalone(
         app(["deploy-guard"], standalone_mode=False)
 
 
-@pytest.mark.slow_test_group
 def test_deploy_guard_for_vault(
     environment: dict,
     web3: Web3,

--- a/tests/enzyme/test_enzyme_end_to_end.py
+++ b/tests/enzyme/test_enzyme_end_to_end.py
@@ -707,6 +707,7 @@ def test_enzyme_perform_test_trade_with_redeployed_guard(
     env["VAULT_ADDRESS"] = vault.address
     env["VAULT_ADAPTER_ADDRESS"] = vault.generic_adapter.address
     env["REPORT_FILE"] = report_file
+    env["UPDATE_GENERIC_ADAPTER"] = "true"
 
     cli = get_command(app)
 
@@ -732,9 +733,14 @@ def test_enzyme_perform_test_trade_with_redeployed_guard(
 
     # Check the deployed address look somewhat correct
     report_data = json.load(report_file.open("rt"))
+    vault = Vault.fetch(
+        web3,
+        vault_address=vault.address,
+        generic_adapter_address=vault.generic_adapter.address,
+    )
     assert report_data["allow_receiver"] == vault.address
     assert report_data["allow_sender"] == vault.generic_adapter.address
-    assert report_data["guard"] == vault.address
+    assert report_data["guard"] == vault.guard_contract.address
 
     with patch.dict(os.environ, env, clear=True):
         cli.main(args=["perform-test-trade"], standalone_mode=False)

--- a/tests/enzyme/test_enzyme_end_to_end.py
+++ b/tests/enzyme/test_enzyme_end_to_end.py
@@ -706,8 +706,10 @@ def test_enzyme_perform_test_trade_with_redeployed_guard(
     env = environment.copy()
     env["VAULT_ADDRESS"] = vault.address
     env["VAULT_ADAPTER_ADDRESS"] = vault.generic_adapter.address
-    env["REPORT_FILE"] = report_file
+    env["REPORT_FILE"] = str(report_file)
     env["UPDATE_GENERIC_ADAPTER"] = "true"
+    env["WHITELISTED_ASSETS"] = " ".join([usdc.address, weth.address])
+    env["COMPTROLLER_LIB"] = enzyme_deployment.contracts.comptroller_lib.address
 
     cli = get_command(app)
 

--- a/tests/enzyme/test_enzyme_end_to_end.py
+++ b/tests/enzyme/test_enzyme_end_to_end.py
@@ -637,3 +637,49 @@ def test_enzyme_correct_accounts_for_closed_position_transfer_away(
             cli.main(args=["correct-accounts"])
         assert e.value.code == 0
 
+
+@pytest.mark.slow_test_group
+def test_deploy_guard_standalone(
+    environment: dict,
+    web3: Web3,
+    state_file: Path,
+    usdc: Contract,
+    weth: Contract,
+    deployer: HexAddress,
+):
+    """Deploy GuardV0 smart contract standalone.
+
+    - Don't associate with any vault
+    """
+
+    env = environment.copy()
+    env["WHITELISTED_ASSETS"] = " ".join([usdc.address, weth.address])
+
+    with patch.dict(os.environ, env, clear=True):
+        app(["deploy-guard"], standalone_mode=False)
+
+
+@pytest.mark.slow_test_group
+def test_deploy_guard_for_vault(
+    environment: dict,
+    web3: Web3,
+    state_file: Path,
+    usdc: Contract,
+    weth: Contract,
+    vault: Vault,
+    deployer: HexAddress,
+):
+    """Deploy GuardV0 smart contract for an existing vault.
+
+    - Update guard to use the vault, and vault generic adapter use the guard
+    """
+
+    env = environment.copy()
+    env.update({
+        "VAULT_ADDRESS": vault.address,
+        "VAULT_ADAPTER_ADDRESS": vault.generic_adapter.address,
+        "WHITELISTED_ASSETS": " ".join([usdc.address, weth.address]),
+    })
+
+    with patch.dict(os.environ, env, clear=True):
+        app(["deploy-guard"], standalone_mode=False)

--- a/tests/mainnet_fork/test_enzyme_guard_credit_positions.py
+++ b/tests/mainnet_fork/test_enzyme_guard_credit_positions.py
@@ -198,8 +198,11 @@ def test_enzyme_guard_credit_positions(
     # Deposit some USDC to the vault to start
     deposit_amount = 500 * 10**6
     vault = Vault.fetch(web3, vault_info["vault"])
-    tx_hash = usdc.contract.functions.approve(vault_info["comptroller"], deposit_amount).transact({"from": hot_wallet.address})
+    tx_hash = usdc.contract.functions.approve(vault.comptroller.address, deposit_amount).transact({"from": hot_wallet.address})
     assert_transaction_success_with_explanation(web3, tx_hash)
+    assert usdc.contract.functions.balanceOf(hot_wallet.address).call() == deposit_amount
+    assert vault.denomination_token.address == usdc.address
+
     tx_hash = vault.comptroller.functions.buyShares(deposit_amount, 1).transact({"from": hot_wallet.address})
     assert_transaction_success_with_explanation(web3, tx_hash)
     assert usdc.contract.functions.balanceOf(vault.address).call() == deposit_amount

--- a/tradeexecutor/cli/commands/deploy_guard.py
+++ b/tradeexecutor/cli/commands/deploy_guard.py
@@ -218,8 +218,11 @@ def deploy_guard(
             )
 
             whitelist_sender_receiver(
-                allow_sender=generic_adapter.address,
+                web3,
+                guard,
+                hot_wallet,
                 allow_receiver=vault.address,
+                allow_sender=generic_adapter.address,
             )
         else:
             generic_adapter = None

--- a/tradeexecutor/cli/commands/deploy_guard.py
+++ b/tradeexecutor/cli/commands/deploy_guard.py
@@ -77,7 +77,9 @@ def deploy_guard(
     aave: bool = Option(False, envvar="AAVE", help="Whitelist Aave aUSDC deposits"),
 
     vault_address: Optional[str] = shared_options.vault_address,
-    vault_adapter_address: Optional[str] = shared_options.vault_adapter_address,
+    vault_adapter_address: Optional[str] = shared_options.vault_address,
+
+    report_file: Optional[Path] = Option(None, envvar="REPORT_FILE", help="JSON file path where we wrote information about the deployment"),
 
 ):
     """Deploy a new Guard smart contract.
@@ -191,6 +193,17 @@ def deploy_guard(
         raise RuntimeError(f"Deployment failed. Hot wallet: {hot_wallet.address}, denomination asset: {denomination_token.address}\n{e}") from e
 
     logger.info("Guard deployed at %s", guard.address)
+
+    # Used to expose info to unit testing
+    if report_file:
+        with report_file.open("wt") as out:
+            data = {
+                "guard": guard.address,
+                "allow_receiver": allow_receiver,
+                "allow_sender": allow_sender,
+            }
+            json.dump(data, out)
+
     logger.info("All ok")
 
     web3config.close()

--- a/tradeexecutor/cli/commands/deploy_guard.py
+++ b/tradeexecutor/cli/commands/deploy_guard.py
@@ -38,7 +38,7 @@ from typing import Optional
 from typer import Option
 
 from eth_defi.abi import get_deployed_contract
-from eth_defi.enzyme.generic_adapter_vault import deploy_guard as _deploy_guard, deploy_generic_adapter_with_guard, whitelist_sender_receiver
+from eth_defi.enzyme.generic_adapter_vault import deploy_guard as _deploy_guard, deploy_generic_adapter_with_guard, whitelist_sender_receiver, bind_vault
 from eth_defi.enzyme.policy import update_adapter_policy
 from eth_defi.enzyme.vault import Vault
 from eth_defi.hotwallet import HotWallet
@@ -195,7 +195,6 @@ def deploy_guard(
             generic_adapter = deploy_generic_adapter_with_guard(
                 enzyme_deployment,
                 hot_wallet,
-                vault,
                 guard,
                 etherscan_api_key,
             )
@@ -211,6 +210,14 @@ def deploy_guard(
                 }
             )
 
+            bind_vault(
+                generic_adapter,
+                vault.vault,
+                production,
+                "",
+                hot_wallet,
+            )
+
             update_adapter_policy(
                 vault,
                 generic_adapter,
@@ -218,7 +225,6 @@ def deploy_guard(
             )
 
             whitelist_sender_receiver(
-                web3,
                 guard,
                 hot_wallet,
                 allow_receiver=vault.address,

--- a/tradeexecutor/cli/commands/deploy_guard.py
+++ b/tradeexecutor/cli/commands/deploy_guard.py
@@ -227,8 +227,8 @@ def deploy_guard(
             whitelist_sender_receiver(
                 guard,
                 hot_wallet,
-                allow_receiver=vault.address,
-                allow_sender=generic_adapter.address,
+                allow_receiver=generic_adapter.address,
+                allow_sender=vault.address,
             )
         else:
             generic_adapter = None

--- a/tradeexecutor/cli/commands/deploy_guard.py
+++ b/tradeexecutor/cli/commands/deploy_guard.py
@@ -1,0 +1,206 @@
+"""deploy-guard CLI command.
+
+See :ref:`vault deployment` for the full documentation how to use this command.
+
+Example how to manually test:
+
+.. code-block:: shell
+
+    export SIMULATE=true
+    export FUND_NAME="Up only and then more"
+    export FUND_SYMBOL="UP"
+    export TERMS_OF_SERVICE_ADDRESS="0x24BB78E70bE0fC8e93Ce90cc8A586e48428Ff515"
+    export VAULT_RECORD_FILE="/tmp/sample-vault-deployment.json"
+    export OWNER_ADDRESS="0x238B0435F69355e623d99363d58F7ba49C408491"
+
+    #
+    # Asset configuration
+    #
+
+    # USDC
+    export DENOMINATION_ASSET="0x2791Bca1f2de4661ED88A30C99A7a9449Aa84174"
+    # Whitelisted tokens for Polygon: WETH, WMATIC
+    export WHITELISTED_ASSETS="0x7ceb23fd6bc0add59e62ac25578270cff1b9f619 0x0d500B1d8E8eF31E21C99d1Db9A6444d3ADf1270"
+
+    #
+    # Secret configuration
+    #
+
+    export JSON_RPC_POLYGON=
+    export PRIVATE_KEY=
+    # Is Polygonscan.com API key, passed to Forge
+    export ETHERSCAN_API_KEY=
+
+    trade-executor enzyme-deploy-vault
+"""
+
+import json
+import logging
+import os.path
+import sys
+from pathlib import Path
+from pprint import pformat
+from typing import Optional
+
+from typer import Option
+
+from eth_defi.abi import get_deployed_contract
+from eth_defi.deploy import deploy_contract
+from eth_defi.enzyme.deployment import POLYGON_DEPLOYMENT, EnzymeDeployment, ETHEREUM_DEPLOYMENT
+from eth_defi.enzyme.generic_adapter_vault import deploy_vault_with_generic_adapter
+from eth_defi.hotwallet import HotWallet
+from eth_defi.token import fetch_erc20_details
+from tradeexecutor.cli.guard import generate_whitelist
+from tradeexecutor.monkeypatch.web3 import construct_sign_and_send_raw_middleware
+from tradingstrategy.chain import ChainId
+
+from tradeexecutor.cli.bootstrap import create_web3_config
+from tradeexecutor.cli.commands import shared_options
+from tradeexecutor.cli.commands.app import app
+from tradeexecutor.cli.log import setup_logging
+
+
+@app.command()
+def deploy_guard(
+    log_level: str = shared_options.log_level,
+    json_rpc_binance: Optional[str] = shared_options.json_rpc_binance,
+    json_rpc_polygon: Optional[str] = shared_options.json_rpc_polygon,
+    json_rpc_avalanche: Optional[str] = shared_options.json_rpc_avalanche,
+    json_rpc_ethereum: Optional[str] = shared_options.json_rpc_ethereum,
+    json_rpc_arbitrum: Optional[str] = shared_options.json_rpc_arbitrum,
+    json_rpc_anvil: Optional[str] = shared_options.json_rpc_anvil,
+    private_key: str = shared_options.private_key,
+
+    denomination_asset: Optional[str] = Option(None, envvar="DENOMINATION_ASSET", help="Stablecoin asset used for vault denomination"),
+    owner_address: Optional[str] = Option(None, envvar="OWNER_ADDRESS", help="The protocol or multisig address that is set as the owner of the vault"),
+    terms_of_service_address: Optional[str] = Option(None, envvar="TERMS_OF_SERVICE_ADDRESS", help="The address of the terms of service smart contract"),
+    whitelisted_assets: Optional[str] = Option(..., envvar="WHITELISTED_ASSETS", help="Space separarted list of ERC-20 addresses this vault can trade. Denomination asset does not need to be whitelisted separately."),
+
+    vault_address: Optional[str] = Option(None, envvar="VAULT_ADDRESS", help="Address of the Enzyme vault to associate the guard with"),
+
+    unit_testing: bool = shared_options.unit_testing,
+    production: bool = Option(False, envvar="PRODUCTION", help="Set production metadata flag true for the deployment."),
+    simulate: bool = Option(False, envvar="SIMULATE", help="Simulate deployment using Anvil mainnet work, when doing manual deployment testing."),
+    etherscan_api_key: Optional[str] = Option(None, envvar="ETHERSCAN_API_KEY", help="Etherscan API key need to verify the contracts on a production deployment."),
+    one_delta: bool = Option(False, envvar="ONE_DELTA", help="Whitelist 1delta interaction with GuardV0 smart contract."),
+    aave: bool = Option(False, envvar="AAVE", help="Whitelist Aave aUSDC deposits"),
+
+
+):
+    """Deploy a new Guard smart contract.
+
+    - Can be assigned to Enzyme vault
+
+    - Can be assigned to a standalone multisig
+    """
+
+    logger = setup_logging(log_level)
+
+    web3config = create_web3_config(
+        json_rpc_binance=json_rpc_binance,
+        json_rpc_polygon=json_rpc_polygon,
+        json_rpc_avalanche=json_rpc_avalanche,
+        json_rpc_ethereum=json_rpc_ethereum,
+        json_rpc_anvil=json_rpc_anvil,
+        json_rpc_arbitrum=json_rpc_arbitrum,
+        simulate=simulate,
+    )
+
+    if not web3config.has_any_connection():
+        raise RuntimeError("Vault deploy requires that you pass JSON-RPC connection to one of the networks")
+
+    web3config.choose_single_chain()
+
+    web3 = web3config.get_default()
+    chain_id = ChainId(web3.eth.chain_id)
+
+    logger.info("Connected to chain %s", chain_id.name)
+
+    hot_wallet = HotWallet.from_private_key(private_key)
+    hot_wallet.sync_nonce(web3)
+    web3.middleware_onion.add(construct_sign_and_send_raw_middleware(hot_wallet.account))
+
+    # Build the list of whitelisted assets GuardV0 allows us to trade
+    whitelisted_asset_details, usdc = generate_whitelist(web3, whitelisted_assets)
+
+    # No other supported Enzyme deployments
+    match chain_id:
+        case ChainId.ethereum:
+            deployment_info = ETHEREUM_DEPLOYMENT
+            enzyme_deployment = EnzymeDeployment.fetch_deployment(web3, ETHEREUM_DEPLOYMENT, deployer=hot_wallet.address)
+            denomination_token = fetch_erc20_details(web3, deployment_info["usdc"])
+            one_delta = False
+        case ChainId.polygon:
+            deployment_info = POLYGON_DEPLOYMENT
+            enzyme_deployment = EnzymeDeployment.fetch_deployment(web3, POLYGON_DEPLOYMENT, deployer=hot_wallet.address)
+            denomination_token = fetch_erc20_details(web3, deployment_info["usdc"])
+            one_delta = True
+        case _:
+            raise NotImplementedError()
+
+    # Check the chain is online
+    logger.info(f"  Chain id is {web3.eth.chain_id:,}")
+    logger.info(f"  Latest block is {web3.eth.block_number:,}")
+
+    asset_manager_address = hot_wallet.address
+
+    if owner_address is None:
+        owner_address = hot_wallet.address
+
+    if simulate:
+        logger.info("Simulation deployment")
+    else:
+        logger.info("Ready to deploy")
+
+    logger.info("-" * 80)
+    logger.info("Deployer hot wallet: %s", hot_wallet.address)
+    logger.info("Deployer balance: %f, nonce %d", hot_wallet.get_native_currency_balance(web3), hot_wallet.current_nonce)
+    logger.info("Whitelisted assets: %s", ", ".join([a.symbol for a in whitelisted_asset_details]))
+    logger.info("Whitelisting 1delta and Aave: %s", one_delta)
+
+    if owner_address != hot_wallet.address:
+        logger.info("Ownership will be transferred to %s", owner_address)
+    else:
+        logger.warning("Ownership will be retained at the deployer %s", hot_wallet.address)
+
+    if asset_manager_address != hot_wallet.address:
+        logger.info("Asset manager is %s", asset_manager_address)
+    else:
+        logger.info("No separate asset manager role set: will use the current hot wallet as the asset manager")
+
+    logger.info("-" * 80)
+
+    if not (simulate or unit_testing):
+        confirm = input("Ok [y/n]? ")
+        if not confirm.lower().startswith("y"):
+            print("Aborted")
+            sys.exit(1)
+    try:
+        guard = deploy_guard(
+            enzyme_deployment,
+            hot_wallet,
+            asset_manager=hot_wallet.address,
+            owner=owner_address,
+            denomination_asset=denomination_token.contract,
+            whitelisted_assets=whitelisted_asset_details,
+            etherscan_api_key=etherscan_api_key if not simulate else None,  # Only verify when not simulating
+            production=production,
+            one_delta=one_delta,
+            aave=aave,
+        )
+
+    except Exception as e:
+
+        logger.error("Failed to deploy, is_mainnet_fork(): %s", web3config.is_mainnet_fork())
+
+        if web3config.is_mainnet_fork():
+            # Try to get some useful debug info from Anvil
+            web3config.close(logging.ERROR)
+
+        raise RuntimeError(f"Deployment failed. Hot wallet: {hot_wallet.address}, denomination asset: {denomination_token.address}") from e
+
+    logger("Guard deployed at %s", guard.address)
+    logger.info("All ok")
+
+    web3config.close()
+

--- a/tradeexecutor/cli/commands/enzyme_deploy_vault.py
+++ b/tradeexecutor/cli/commands/enzyme_deploy_vault.py
@@ -146,7 +146,8 @@ def enzyme_deploy_vault(
         hot_wallet,
         comptroller_lib=comptroller_lib
     )
-    denomination_token = enzyme_deployment.usdc
+    denomination_token = whitelisted_asset_details[0]
+    # import ipdb ; ipdb.set_trace()
 
     # Check the chain is online
     logger.info(f"  Chain id is {web3.eth.chain_id:,}")
@@ -228,9 +229,9 @@ def enzyme_deploy_vault(
             # Try to get some useful debug info from Anvil
             web3config.close(logging.ERROR)
 
-        logger.exception(e)  # TODO: Typer does not display this exception?
+        logger.exception(e)  # The fancy traceback formatter does not do nested
 
-        raise RuntimeError(f"Deployment failed. Hot wallet: {hot_wallet.address}, denomination asset: {denomination_token.address}.\n{e}") from e
+        raise RuntimeError(f"Deployment failed. Hot wallet: {hot_wallet.address}.\nException: {e}") from e
 
     if vault_record_file and (not simulate):
         # Make a small file, mostly used to communicate with unit tests

--- a/tradeexecutor/cli/commands/shared_options.py
+++ b/tradeexecutor/cli/commands/shared_options.py
@@ -85,3 +85,6 @@ unit_testing = Option(False, "--unit-testing", envvar="UNIT_TESTING", help="The 
 pair: Optional[str] = Option(None, "--pair", envvar="PAIR", help="Must be specified for a multipair universe.")
 
 all_pairs: Optional[str] = Option(None, "--all-pairs", envvar="ALL_PAIRS", help="Whether to perform a test trade for each pair in the universe. If not given, then the pair option must be specified.")
+
+
+comptroller_lib = Option(None, envvar="COMPTROLLER_LIB", help="Enzyme's ComptrollerLib address for custom deployments")

--- a/tradeexecutor/cli/guard.py
+++ b/tradeexecutor/cli/guard.py
@@ -9,10 +9,12 @@ from tradingstrategy.chain import ChainId
 SUPPORTED_DENOMINATION_TOKENS  = ("USDC", "USDC.e",)
 
 
-def generate_whitelist(web3, whitelisted_assets: list[str]) -> list[TokenDetails]:
+def generate_whitelist(web3, whitelisted_assets: str) -> list[TokenDetails]:
     """Look up token details we are about to whitelist.
 
-    :param whilisted_assets:
+    :param whitelisted_assets:
+        Space separated list.
+
         Assets to whitelist, first must be the vault denomination token.
 
     :return:
@@ -51,18 +53,18 @@ def get_enzyme_deployment(
     match chain_id:
         case ChainId.ethereum:
             deployment_info = ETHEREUM_DEPLOYMENT
-            enzyme_deployment = EnzymeDeployment.fetch_deployment(web3, ETHEREUM_DEPLOYMENT, deployer=hot_wallet.address)
+            enzyme_deployment = EnzymeDeployment.fetch_deployment(web3, ETHEREUM_DEPLOYMENT, deployer=deployer.address)
             #denomination_token = fetch_erc20_details(web3, deployment_info["usdc"])
             one_delta = False
         case ChainId.polygon:
             deployment_info = POLYGON_DEPLOYMENT
-            enzyme_deployment = EnzymeDeployment.fetch_deployment(web3, POLYGON_DEPLOYMENT, deployer=hot_wallet.address)
+            enzyme_deployment = EnzymeDeployment.fetch_deployment(web3, POLYGON_DEPLOYMENT, deployer=deployer.address)
             # denomination_token = fetch_erc20_details(web3, deployment_info["usdc"])
             one_delta = True
         case _:
             assert comptroller_lib, f"You need to give Enzyme's ComptrollerLib address for a chain {chain_id}"
             #assert denomination_asset, f"You need to give denomination_asset for a chain {chain_id}"
-            enzyme_deployment = EnzymeDeployment.fetch_deployment(web3, {"comptroller_lib": comptroller_lib}, deployer=hot_wallet.address)
+            enzyme_deployment = EnzymeDeployment.fetch_deployment(web3, {"comptroller_lib": comptroller_lib}, deployer=deployer.address)
             #denomination_token = fetch_erc20_details(web3, denomination_asset)
 
     return enzyme_deployment

--- a/tradeexecutor/cli/guard.py
+++ b/tradeexecutor/cli/guard.py
@@ -1,0 +1,29 @@
+"""Vault security related common functions"""
+from eth_defi.token import fetch_erc20_details, TokenDetails
+
+
+def generate_whitelist(web3, whitelisted_assets: list[str]) -> tuple[list[TokenDetails], str]:
+    """Look up token details we are about to whitelist.
+
+    :return:
+        Tuple (Token list, address of USDC token)
+
+    """
+    # Build the list of whitelisted assets GuardV0 allows us to trade
+    whitelisted_asset_details = []
+    for token_address in whitelisted_assets.split():
+        token_address = token_address.strip()
+        if token_address:
+            whitelisted_asset_details.append(fetch_erc20_details(web3, token_address))
+
+    assert len(whitelisted_asset_details) >= 1, "You need to whitelist at least one token as a trading pair"
+
+    if whitelisted_asset_details[0].symbol == "USDC":
+        # Unit test path
+        usdc = whitelisted_asset_details[0].contract
+        whitelisted_asset_details = whitelisted_asset_details[1:]
+    else:
+        # Will read from the chain
+        usdc = None
+
+    return whitelisted_asset_details, usdc

--- a/tradeexecutor/cli/guard.py
+++ b/tradeexecutor/cli/guard.py
@@ -1,9 +1,14 @@
 """Vault security related common functions"""
 from eth_defi.token import fetch_erc20_details, TokenDetails
 
+SUPPORTED_DENOMINATION_TOKENS  = ("USDC", "USDC.e",)
 
-def generate_whitelist(web3, whitelisted_assets: list[str]) -> tuple[list[TokenDetails], str]:
+
+def generate_whitelist(web3, whitelisted_assets: list[str]) -> list[TokenDetails]:
     """Look up token details we are about to whitelist.
+
+    :param whilisted_assets:
+        Assets to whitelist, first must be the vault denomination token.
 
     :return:
         Tuple (Token list, address of USDC token)
@@ -17,13 +22,5 @@ def generate_whitelist(web3, whitelisted_assets: list[str]) -> tuple[list[TokenD
             whitelisted_asset_details.append(fetch_erc20_details(web3, token_address))
 
     assert len(whitelisted_asset_details) >= 1, "You need to whitelist at least one token as a trading pair"
-
-    if whitelisted_asset_details[0].symbol == "USDC":
-        # Unit test path
-        usdc = whitelisted_asset_details[0].contract
-        whitelisted_asset_details = whitelisted_asset_details[1:]
-    else:
-        # Will read from the chain
-        usdc = None
-
-    return whitelisted_asset_details, usdc
+    assert whitelisted_asset_details[0].symbol in SUPPORTED_DENOMINATION_TOKENS, f"Got {whitelisted_assets[0]}"
+    return whitelisted_asset_details

--- a/tradeexecutor/cli/guard.py
+++ b/tradeexecutor/cli/guard.py
@@ -1,4 +1,4 @@
-"""Vault security related common functions"""
+"""Vault security related common functions for CLI commands"""
 from web3 import Web3
 
 from eth_defi.enzyme.deployment import EnzymeDeployment, ETHEREUM_DEPLOYMENT, POLYGON_DEPLOYMENT

--- a/tradeexecutor/cli/guard.py
+++ b/tradeexecutor/cli/guard.py
@@ -38,6 +38,7 @@ def get_enzyme_deployment(
     chain_id: ChainId,
     deployer: HotWallet,
     comptroller_lib: str | None = None,
+    allowed_adapters_policy: str | None = None,
 ) -> EnzymeDeployment:
     """
 
@@ -62,9 +63,17 @@ def get_enzyme_deployment(
             # denomination_token = fetch_erc20_details(web3, deployment_info["usdc"])
             one_delta = True
         case _:
+            # Local unit test deployment.
+            # Because addresses are random, they need to be explicitly passed
+            # to any command line command
             assert comptroller_lib, f"You need to give Enzyme's ComptrollerLib address for a chain {chain_id}"
-            #assert denomination_asset, f"You need to give denomination_asset for a chain {chain_id}"
-            enzyme_deployment = EnzymeDeployment.fetch_deployment(web3, {"comptroller_lib": comptroller_lib}, deployer=deployer.address)
-            #denomination_token = fetch_erc20_details(web3, denomination_asset)
+            enzyme_deployment = EnzymeDeployment.fetch_deployment(
+                web3,
+                {
+                    "comptroller_lib": comptroller_lib,
+                    "allowed_adapters_policy": allowed_adapters_policy,
+                },
+                deployer=deployer.address
+            )
 
     return enzyme_deployment

--- a/tradeexecutor/cli/main.py
+++ b/tradeexecutor/cli/main.py
@@ -1,4 +1,5 @@
 """Command-line entry point for the daemon build on the top of Typer."""
+
 from .commands import enzyme_deploy_vault
 from .commands.app import app
 from .commands.backtest import backtest
@@ -8,6 +9,7 @@ from .commands.check_wallet import check_wallet
 from .commands.close_all import close_all
 from .commands.console import console
 from .commands.correct_accounts import correct_accounts
+from .commands.deploy_guard import deploy_guard
 from .commands.enzyme_asset_list import enzyme_asset_list
 from .commands.export import export
 from .commands.hello import hello
@@ -29,5 +31,6 @@ __all__ = [
     app, check_wallet, check_universe, hello, start, perform_test_trade, 
     version, repair, console, init, reset, enzyme_asset_list, enzyme_deploy_vault,
     close_all, show_positions, backtest, correct_accounts, check_accounts, 
-    reset_deposits, export, retry, visualise, webapi
+    reset_deposits, export, retry, visualise, webapi,
+    deploy_guard
 ]

--- a/tradeexecutor/strategy/interest.py
+++ b/tradeexecutor/strategy/interest.py
@@ -465,15 +465,14 @@ def accrue_interest(
 
     """
 
-
     if interest_distribution.duration == ZERO_TIMEDELTA:
         logger.info("accrue_interest(): Interest distribution duration zero, we probably got called twice in a row")
         return
 
     assert interest_distribution.duration > ZERO_TIMEDELTA, f"Tried to distribute interest for negative timespan {interest_distribution.start} - {interest_distribution.end}"
 
-    block_number_str = f"{block_number:,}" if block_number else "<no block>"
-    logger.info(f"accrue_interest({block_timestamp}, {block_number_str})")
+    block_number_str = f"{block_number,}" if block_number else "<no block>"
+    logger.info(f"accrue_interest(block_timestamp={block_timestamp}, {block_number_str})")
 
     part_of_year = interest_distribution.duration / aave_financial_year
 


### PR DESCRIPTION
- Add a separate `deploy-guard` CLI command
- Currently this command is a bit useless, as the migration path for the guard goes through Enzyme vault `createReconfigurationRequest` function and 7 days delay that is not yet supported