### PR TITLE
Add sanity check to double check availble trading vs. quantity

### DIFF
--- a/tradeexecutor/cli/close_all.py
+++ b/tradeexecutor/cli/close_all.py
@@ -120,6 +120,10 @@ def close_all(
     for p in open_positions:
         logger.info("  Position: %s, quantity %s", p, p.get_quantity())
 
+        trading_quantity = p.get_available_trading_quantity()
+        quantity = p.get_quantity()
+        assert trading_quantity == quantity, f"Position quantity vs. available trading quantity mismatch. Probably unexecuted trades? {quantity} vs. {trading_quantity}"
+
     if interactive:
         confirmation = input("Attempt to cloes positions [y/n]").lower()
         if confirmation != "y":
@@ -128,10 +132,6 @@ def close_all(
     for p in open_positions:
         # Create trades to open the position
         logger.info("Closing position %s", p)
-
-        trading_quantity = p.get_available_trading_quantity()
-        quantity = p.get_quantity()
-        assert trading_quantity == quantity, f"Position quantiy vs. available trading quantity mismatch. Probably unexecuted trades? {quantity} vs. {trading_quantity}"
 
         trades = position_manager.close_position(p)
 

--- a/tradeexecutor/cli/close_all.py
+++ b/tradeexecutor/cli/close_all.py
@@ -131,7 +131,7 @@ def close_all(
 
         trading_quantity = p.get_available_trading_quantity()
         quantity = p.get_quantity()
-        assert f"Position quantiy vs. available trading quantity mismatch. Probably unexecuted trades? {quantity} vs. {trading_quantity}"
+        assert trading_quantity == quantity, f"Position quantiy vs. available trading quantity mismatch. Probably unexecuted trades? {quantity} vs. {trading_quantity}"
 
         trades = position_manager.close_position(p)
 

--- a/tradeexecutor/cli/close_all.py
+++ b/tradeexecutor/cli/close_all.py
@@ -128,6 +128,11 @@ def close_all(
     for p in open_positions:
         # Create trades to open the position
         logger.info("Closing position %s", p)
+
+        trading_quantity = p.get_available_trading_quantity()
+        quantity = p.get_quantity()
+        assert f"Position quantiy vs. available trading quantity mismatch. Probably unexecuted trades? {quantity} vs. {trading_quantity}"
+
         trades = position_manager.close_position(p)
 
         assert len(trades) == 1


### PR DESCRIPTION
- Add extra checks to CLI `close-all` command as if there are accounting issues, the closed position amounts will be incorrect