### PR TITLE
Don't allow to run correct-accounts if unexecuted tradeS

### DIFF
--- a/tradeexecutor/cli/commands/correct_accounts.py
+++ b/tradeexecutor/cli/commands/correct_accounts.py
@@ -14,7 +14,7 @@ from typer import Option
 from eth_defi.hotwallet import HotWallet
 from eth_defi.provider.broken_provider import get_almost_latest_block_number
 
-from tradeexecutor.strategy.account_correction import correct_accounts as _correct_accounts, check_accounts, UnknownTokenPositionFix
+from tradeexecutor.strategy.account_correction import correct_accounts as _correct_accounts, check_accounts, UnknownTokenPositionFix, check_state_internal_coherence
 from .app import app
 from ..bootstrap import prepare_executor_id, create_web3_config, create_sync_model, create_client, backup_state, create_execution_and_sync_model
 from ..log import setup_logging
@@ -256,6 +256,8 @@ def correct_accounts(
 
     if len(corrections) == 0:
         logger.info("No account corrections found")
+
+    check_state_internal_coherence(state)
 
     if isinstance(sync_model, EnzymeVaultSyncModel):
         vault = sync_model.vault

--- a/tradeexecutor/strategy/account_correction.py
+++ b/tradeexecutor/strategy/account_correction.py
@@ -925,3 +925,13 @@ def check_accounts(
     df = df.fillna("")
     df = df.replace({pd.NaT: ""})
     return clean, df
+
+
+def check_state_internal_coherence(state: State):
+    """Check that we do not have any positions with non-executed trades."""
+
+    for p in state.portfolio.get_open_and_frozen_positions():
+        quantity = p.get_quantity()
+        trading_quantity = p.get_available_trading_quantity()
+        assert quantity == trading_quantity, f"Position {p}, quantity {quantity}, available for trading {trading_quantity}, probably unexecuted trades. You need to run repair command first."
+

--- a/tradeexecutor/strategy/account_correction.py
+++ b/tradeexecutor/strategy/account_correction.py
@@ -674,7 +674,6 @@ def open_missing_spot_position(
 
     """
 
-
     logger.info("Fixing missing open position: %s", correction)
 
     pair_universe = strategy_universe.data_universe.pairs
@@ -690,9 +689,17 @@ def open_missing_spot_position(
     if len(matching_pairs) == 0:
         raise RuntimeError(f"Could not find any spot pair for asset {correction.asset} for correction {correction}")
 
-    assert len(matching_pairs) == 1, f"Found multiple matching trading pairs for asset {correction.asset}, correction {correction}, {matching_pairs}"
+    #
+    # We can have a strategy where the same base token is on multiple pairs,
+    # then assume we get can one with the lowest fees
+    #
+    if len(matching_pairs) > 1:
+        logger.warning(f"Found multiple matching trading pairs for asset {correction.asset}, correction {correction}, {matching_pairs}")
+        pair = sorted(matching_pairs, key=lambda tp: tp.fee)
+        logger.warning(f"Will pick one with the highest fees: {pair}")
+    else:
+        pair = matching_pairs[0]
 
-    pair = matching_pairs[0]
     assert pair.is_spot(), f"Not spot: {pair}"
 
     quantity = correction.quantity


### PR DESCRIPTION
- Running correct-accounts if you have unexecuted trades will result to invalid balances
- Allow correct-accounts to handle opening a new spot for a token that has multiple pairs