### PR TITLE
Add a way to reset the loan position needed for correct accounts

### DIFF
--- a/strategies/test_only/enzyme-polygon-eth-breakout.py
+++ b/strategies/test_only/enzyme-polygon-eth-breakout.py
@@ -1,0 +1,375 @@
+"""ETH ATR based breakout strategy.
+
+Based on eth-breakout 1h notebook in getting-started repo.
+
+To backtest this strategy module locally:
+
+.. code-block:: console
+
+    trade-executor \
+        backtest \
+        --strategy-file=strategies/eth-breakout-atr-1h-aave.py \
+        --trading-strategy-api-key=$TRADING_STRATEGY_API_KEY
+
+
+"""
+
+import datetime
+
+import pandas as pd
+import pandas_ta
+
+from tradingstrategy.lending import LendingProtocolType, LendingReserveDescription
+from tradingstrategy.pair import HumanReadableTradingPairDescription
+from tradingstrategy.utils.groupeduniverse import resample_candles
+from tradingstrategy.chain import ChainId
+from tradingstrategy.client import Client
+from tradingstrategy.timebucket import TimeBucket
+
+from tradeexecutor.analysis.regime import Regime
+from tradeexecutor.strategy.pandas_trader.indicator import IndicatorSet, IndicatorSource 
+from tradeexecutor.strategy.parameters import StrategyParameters
+from tradeexecutor.strategy.trading_strategy_universe import TradingStrategyUniverse
+from tradeexecutor.strategy.execution_context import ExecutionContext, ExecutionMode
+from tradeexecutor.strategy.trading_strategy_universe import load_partial_data
+from tradeexecutor.strategy.universe_model import UniverseOptions
+from tradeexecutor.strategy.default_routing_options import TradeRouting
+from tradeexecutor.strategy.cycle import CycleDuration
+from tradeexecutor.state.visualisation import PlotKind
+from tradeexecutor.state.trade import TradeExecution
+from tradeexecutor.strategy.pandas_trader.strategy_input import StrategyInput
+from tradeexecutor.utils.binance import create_binance_universe
+
+
+trading_strategy_engine_version = "0.5"
+
+
+class Parameters:
+    """Parameteres for this strategy.
+
+    - Collect parameters used for this strategy here
+
+    - Both live trading and backtesting parameters
+    """
+
+    id = "eth-breakout-atr-1h" # Used in cache paths
+
+    cycle_duration = CycleDuration.h1
+    candle_time_bucket = TimeBucket.h1
+    allocation = 0.98
+
+    atr_length = 10  #
+    fract = 3.0  # Fraction between last hourly close and breakout level
+
+    adx_length = 14  # 14 days
+    adx_filter_threshold = 15
+
+    trailing_stop_loss_pct = 0.98
+    trailing_stop_loss_activation_level = 1.075
+    stop_loss_pct = 0.98
+
+    #
+    # Live trading only
+    #
+    chain_id = ChainId.polygon
+    routing = TradeRouting.default  # Pick default routes for trade execution
+    required_history_period = datetime.timedelta(hours=200)
+
+    #
+    # Backtesting only
+    #
+    # Because the underlying DEX live trading market does not have enough
+    # history, we perform the backtesting using Binance data.
+    #
+
+    use_binance_data_in_backtesting = True
+
+    if use_binance_data_in_backtesting:
+        # Perform backesting on binance data instead of DEX data, allows longer backtesting period
+        backtest_start = datetime.datetime(2018, 1, 1)
+        backtest_end = datetime.datetime(2024, 5, 15)
+    else:
+        # WETH-USDC 5 BPS is not available on Polygon unti 2022-08
+        backtest_start = datetime.datetime(2022, 8, 1)
+        backtest_end = datetime.datetime(2024, 5, 15)
+
+    stop_loss_time_bucket = TimeBucket.m5
+    backtest_trading_fee = 0.0005  # Override the default Binance data trading fee and assume we can trade 5 BPS fee on WMATIC-USDC on Polygon on Uniswap v3
+    initial_cash = 10_000
+
+    # A switch to test between lending pool enabled strategy and no lending strategy modes.
+    # Use Aave pools when avaible.
+    # We cannot do lending tests in if we are using Binance data for the strategy backtest,
+    # as Binance does not have a lending market.
+    lending_enabled = True
+
+
+def get_strategy_trading_pairs(execution_mode: ExecutionMode) -> tuple[list[HumanReadableTradingPairDescription], list[LendingReserveDescription] | None]:
+    """Switch between backtest and live trading pairs.
+
+    Because the live trading DEX venues do not have enough history (< 2 years)
+    for meaningful backtesting, we test with Binance CEX data.
+    """
+    if execution_mode.is_live_trading() or not Parameters.use_binance_data_in_backtesting:
+
+        # List of trading pairs we use in the backtest
+        # In this backtest, we use Binance data as it has more price history than DEXes
+        trading_pairs = [
+            (ChainId.polygon, "uniswap-v3", "WETH", "USDC"),
+        ]
+
+        if Parameters.lending_enabled:
+            # We use Aave v3 pool to store our excess cash when we are out of the market
+            lending_reserves = [
+                (ChainId.polygon, LendingProtocolType.aave_v3, "USDC.e"),
+            ]
+        else:
+            lending_reserves = None
+    else:
+        trading_pairs = [
+            (ChainId.centralised_exchange, "binance", "ETH", "USDT")
+        ]
+
+        # We cannot test lending with Binance
+        lending_reserves = None
+
+    return trading_pairs, lending_reserves
+
+
+def create_trading_universe(
+    timestamp: datetime.datetime,
+    client: Client,
+    execution_context: ExecutionContext,
+    universe_options: UniverseOptions,
+) -> TradingStrategyUniverse:
+    """Create the trading universe.
+
+    - For live trading, we load DEX data
+
+    - We backtest with Binance data, as it has more history
+    """
+
+    trading_pairs, lending_reserves = get_strategy_trading_pairs(execution_context.mode)
+
+    if execution_context.mode.is_backtesting():
+        start_at = universe_options.start_at
+        end_at = universe_options.end_at
+        strategy_universe = create_binance_universe(
+            [f"{p[2]}{p[3]}" for p in trading_pairs],
+            candle_time_bucket=Parameters.candle_time_bucket,
+            stop_loss_time_bucket=Parameters.stop_loss_time_bucket,
+            start_at=start_at,
+            end_at=end_at,
+            trading_fee_override=Parameters.backtest_trading_fee,
+        )
+    else:
+        universe_options = UniverseOptions(history_period=Parameters.required_history_period)
+        dataset = load_partial_data(
+            client=client,
+            time_bucket=Parameters.candle_time_bucket,
+            pairs=trading_pairs,
+            execution_context=execution_context,
+            universe_options=universe_options,
+            liquidity=False,
+            stop_loss_time_bucket=Parameters.stop_loss_time_bucket,
+            lending_reserves=lending_reserves,
+        )
+        # Construct a trading universe from the loaded data,
+        # and apply any data preprocessing needed before giving it
+        # to the strategy and indicators
+        strategy_universe = TradingStrategyUniverse.create_from_dataset(
+            dataset,
+            reserve_asset="USDC",
+            forward_fill=True,
+        )
+
+    return strategy_universe
+
+
+def daily_price(open, high, low, close) -> pd.DataFrame:
+    """Resample pricees to daily for ADX filtering."""
+    original_df = pd.DataFrame({
+        "open": open,
+        "high": high,
+        "low": low,
+        "close": close,
+    })
+    daily_df = resample_candles(original_df, pd.Timedelta(days=1))
+    return daily_df
+
+
+def daily_adx(open, high, low, close, length):
+    daily_df = daily_price(open, high, low, close)
+    adx_df = pandas_ta.adx(
+        close=daily_df.close,
+        high=daily_df.high,
+        low=daily_df.low,
+        length=length,
+    )
+    return adx_df
+
+
+def regime(open, high, low, close, length, regime_threshold) -> pd.Series:
+    """A regime filter based on ADX indicator.
+
+    Get the trend of BTC applying ADX on a daily frame.
+
+    - -1 is bear
+    - 0 is sideways
+    - +1 is bull
+    """
+    adx_df = daily_adx(open, high, low, close, length)
+    def regime_filter(row):
+        # ADX, DMP, # DMN
+        average_direction_index, directional_momentum_positive, directional_momentum_negative = row.values
+        if directional_momentum_positive > regime_threshold:
+            return Regime.bull.value
+        elif directional_momentum_negative > regime_threshold:
+            return Regime.bear.value
+        else:
+            return Regime.crab.value
+    regime_signal = adx_df.apply(regime_filter, axis="columns")
+    return regime_signal
+
+
+
+def create_indicators(
+    timestamp: datetime.datetime | None,
+    parameters: StrategyParameters,
+    strategy_universe: TradingStrategyUniverse,
+    execution_context: ExecutionContext
+):
+    indicators = IndicatorSet()
+
+    # https://github.com/twopirllc/pandas-ta/blob/main/pandas_ta/volatility/atr.py
+    indicators.add(
+        "atr",
+        pandas_ta.atr,
+        {"length": parameters.atr_length},
+        IndicatorSource.ohlcv,
+    )
+
+    # ADX https://www.investopedia.com/articles/trading/07/adx-trend-indicator.asp
+    # https://github.com/twopirllc/pandas-ta/blob/main/pandas_ta/trend/adx.py
+    indicators.add(
+        "adx",
+        daily_adx,
+        {"length": parameters.adx_length},
+        IndicatorSource.ohlcv,
+    )
+
+    # Price OHLC resampled to daily
+    indicators.add(
+        "daily_price",
+        daily_price,
+        {},
+        IndicatorSource.ohlcv,
+    )
+
+    # A regime filter to detect the trading pair bear/bull markets
+    indicators.add(
+        "regime",
+        regime,
+        {"length": parameters.adx_length, "regime_threshold": parameters.adx_filter_threshold},
+        IndicatorSource.ohlcv,
+    )
+
+    return indicators
+
+
+def decide_trades(
+    input: StrategyInput,
+) -> list[TradeExecution]:
+
+    #
+    # Decidion cycle setup.
+    # Read all variables we are going to use for the decisions.
+    #
+    parameters = input.parameters
+    position_manager = input.get_position_manager()
+    state = input.state
+    timestamp = input.timestamp
+    indicators = input.indicators
+    strategy_universe = input.strategy_universe
+
+    trading_pairs, lending_reserves = get_strategy_trading_pairs(input.execution_context.mode)
+
+    pair = strategy_universe.get_single_pair()
+    cash = position_manager.get_current_cash()
+
+    lending_enabled = lending_reserves is not None  # Binance backtest does not have lending opportunity
+
+    #
+    # Indicators
+    #
+
+    close_price = indicators.get_price()  # Price the previous 15m candle closed for this decision cycle timestamp
+    atr = indicators.get_indicator_value("atr")  # The ATR value at the time of close price
+    point_of_interest = (timestamp - parameters.cycle_duration.to_pandas_timedelta()).floor(freq="D")  # POI (point of interest): Account 15m of lookahead bias whehn using decision cycle timestamp
+    previous_price = indicators.get_price(timestamp=point_of_interest)  # The price at the start of this hour
+    regime_val = indicators.get_indicator_value("regime", data_delay_tolerance=pd.Timedelta(hours=24))  # Because the regime filter is calculated only daily, we allow some lookback
+
+    if None in (atr, close_price, previous_price):
+        # Not enough historic data,
+        # cannot make decisions yet
+        return []
+
+    # If regime filter does not have enough data at the start of the backtest,
+    # default to bull market
+    if regime_val is None:
+        regime = Regime.bull
+
+    else:
+        regime = Regime(regime_val)  # Convert to enum for readability
+
+    #
+    # Trading logic
+    #
+
+    trades = []
+
+    # We assume a breakout if our current 15m candle has closed
+    # above the 1h starting price + (atr * fraction) target level
+    long_breakout_entry_level = previous_price + atr * parameters.fract
+
+    # Check for open condition - is the price breaking out
+    #
+    if not position_manager.is_any_long_position_open():
+
+        if regime == Regime.bull:
+            if close_price > long_breakout_entry_level:
+
+                # Unwind credit position to have cash to take a directional position
+                if lending_enabled and position_manager.is_any_credit_supply_position_open():
+                    credit_supply_position = position_manager.get_current_credit_supply_position()
+                    trades += position_manager.close_credit_supply_position(credit_supply_position)
+                    cash = float(credit_supply_position.get_quantity())
+
+                trades += position_manager.open_spot(
+                    pair,
+                    value=cash * parameters.allocation,
+                    stop_loss_pct=parameters.stop_loss_pct,
+                )
+    else:
+        # Enable trailing stop loss after we reach the profit taking level
+        #
+        for position in state.portfolio.open_positions.values():
+            if position.trailing_stop_loss_pct is None:
+                close_price = indicators.get_price(position.pair)
+                if close_price >= position.get_opening_price() * parameters.trailing_stop_loss_activation_level:
+                    position.trailing_stop_loss_pct = parameters.trailing_stop_loss_pct
+
+    # Move all cash to to Aave credit to earn interest
+    if lending_enabled:
+        if not position_manager.is_any_credit_supply_position_open() and not position_manager.is_any_long_position_open():
+            amount = cash * 0.9999
+            trades += position_manager.open_credit_supply_position_for_reserves(amount)
+
+    # Visualisations
+    #
+    if input.is_visualisation_enabled():
+        visualisation = state.visualisation
+        visualisation.plot_indicator(timestamp, "ATR", PlotKind.technical_indicator_detached, atr)
+
+    return trades  # Return the list of trades we made in this cycle
+

--- a/tests/mainnet_fork/test_correct_credit_position_redemption.py
+++ b/tests/mainnet_fork/test_correct_credit_position_redemption.py
@@ -1,0 +1,126 @@
+"""Test correct credit position where a redemption broke the accounting.
+
+- Test only works with archive node
+"""
+import logging
+import os.path
+import secrets
+import shutil
+from pathlib import Path
+from unittest import mock
+
+import pytest
+from _pytest.fixtures import FixtureRequest
+
+from eth_defi.provider.anvil import AnvilLaunch, launch_anvil
+
+from tradeexecutor.cli.commands.app import app
+
+
+pytestmark = pytest.mark.skipif(not os.environ.get("JSON_RPC_POLYGON") or not os.environ.get("TRADING_STRATEGY_API_KEY"), reason="Set JSON_RPC_ETHEREUM and TRADING_STRATEGY_API_KEY environment variables to run this test")
+
+
+@pytest.fixture()
+def anvil(request: FixtureRequest) -> AnvilLaunch:
+    """Do Ethereum mainnet fork from the damaged situation."""
+
+    mainnet_rpc = os.environ["JSON_RPC_POLYGON"]
+
+    anvil = launch_anvil(
+        mainnet_rpc,
+        fork_block_number=60855854,  # The timestamp on when the broken position was created
+    )
+
+    try:
+        yield anvil
+    finally:
+        #anvil.close(log_level=logging.INFO)
+        anvil.close()
+
+
+@pytest.fixture()
+def state_file() -> Path:
+    """A sample of a state file where we should have an open spot position for WBTC.
+
+    - This position was not opened due to Alchemy JSON-RPC error
+    """
+    p = Path(os.path.join(os.path.dirname(__file__), "credit-position-broken-redemption.json"))
+    assert p.exists(), f"{p} missing"
+    return p
+
+
+@pytest.fixture()
+def strategy_file(tmp_path) -> Path:
+    """Because we modifty state file when fixing it, we need to make a working copy from the master copy."""
+    p = Path(os.path.join(os.path.dirname(__file__), "..", "..", "strategies", "test_only", "enzyme-polygon-eth-breakout.py"))
+    assert p.exists(), f"{p.resolve()} missing"
+    working_copy = tmp_path / "test-copy.state.json"
+    shutil.copyfile(p, working_copy)
+    return working_copy
+
+
+@pytest.fixture()
+def environment(
+    anvil: AnvilLaunch,
+    state_file: Path,
+    strategy_file: Path,
+    ) -> dict:
+    """Set up the env for CLI commands in this unit test."""
+
+    environment = {
+        "STRATEGY_FILE": strategy_file.as_posix(),
+        "PRIVATE_KEY": "0x" + secrets.token_bytes(32).hex(),  # Not needed
+        "JSON_RPC_ANVIL": anvil.json_rpc_url,
+        "STATE_FILE": state_file.as_posix(),
+        "ASSET_MANAGEMENT_MODE": "enzyme",
+        "UNIT_TESTING": "true",
+        "LOG_LEVEL": "disabled",
+        # "LOG_LEVEL": "info",
+        "TRADING_STRATEGY_API_KEY": os.environ["TRADING_STRATEGY_API_KEY"],
+        "VAULT_ADDRESS": "0xe59b7affB1AAf4fB063c8476199BE118D5B9955F",
+        "VAULT_ADAPTER_ADDRESS": "0x1abc5e398775249622a561b2C14E8aeB7fD8e361",
+        "VAULT_PAYMENT_FORWARDER_ADDRESS": "0x73b662A52C57C83dab75f1a9C209b5cE8beaB353",
+        "VAULT_DEPLOYMENT_BLOCK_NUMBER": "57311900",
+        "SKIP_SAVE": "false",  # Need to save between runs
+        "SKIP_INTEREST": "true",  # This must be enabled so that correct-accounts do not crash in early intrest distribution phase
+    }
+    return environment
+
+
+def test_correct_accounts_redemption_on_ausdc(
+    environment: dict,
+):
+    """Fix aUSDC redemption breaking accounts.
+
+    - There was a redemption on aUSDC position
+
+    - The redemption event was not correctly handled (gone missing)
+
+    - We need to correct accounts
+
+    - We need to reset the loan to start interest tracking from zero
+
+    """
+
+    # Accounting is detect to be incorrect
+    with mock.patch.dict('os.environ', environment, clear=True):
+        with pytest.raises(SystemExit) as sys_exit:
+            app(["check-accounts"], standalone_mode=False)
+        assert sys_exit.value.code == 1
+
+    # Fix issued
+    with mock.patch.dict('os.environ', environment, clear=True):
+        with pytest.raises(SystemExit) as sys_exit:
+            app(["correct-accounts"], standalone_mode=False)
+        assert sys_exit.value.code == 0
+
+    # See that the interest distribution now works
+    # and is triggered at the start of correct-accounts command
+    environment = environment.copy()
+    del environment["SKIP_INTEREST"]
+    # environment["LOG_LEVEL"] = "info"
+
+    with mock.patch.dict('os.environ', environment, clear=True):
+        with pytest.raises(SystemExit) as sys_exit:
+            app(["correct-accounts"], standalone_mode=True)
+        assert sys_exit.value.code == 0

--- a/tests/mainnet_fork/test_correct_credit_position_redemption.py
+++ b/tests/mainnet_fork/test_correct_credit_position_redemption.py
@@ -17,12 +17,12 @@ from eth_defi.provider.anvil import AnvilLaunch, launch_anvil
 from tradeexecutor.cli.commands.app import app
 
 
-pytestmark = pytest.mark.skipif(not os.environ.get("JSON_RPC_POLYGON") or not os.environ.get("TRADING_STRATEGY_API_KEY"), reason="Set JSON_RPC_ETHEREUM and TRADING_STRATEGY_API_KEY environment variables to run this test")
+pytestmark = pytest.mark.skipif(not os.environ.get("JSON_RPC_POLYGON") or not os.environ.get("TRADING_STRATEGY_API_KEY"), reason="Set JSON_RPC_POLYGON and TRADING_STRATEGY_API_KEY environment variables to run this test")
 
 
 @pytest.fixture()
 def anvil(request: FixtureRequest) -> AnvilLaunch:
-    """Do Ethereum mainnet fork from the damaged situation."""
+    """Do mainnet fork from the damaged situation."""
 
     mainnet_rpc = os.environ["JSON_RPC_POLYGON"]
 
@@ -39,24 +39,20 @@ def anvil(request: FixtureRequest) -> AnvilLaunch:
 
 
 @pytest.fixture()
-def state_file() -> Path:
-    """A sample of a state file where we should have an open spot position for WBTC.
-
-    - This position was not opened due to Alchemy JSON-RPC error
-    """
+def state_file(tmp_path) -> Path:
+    """Because we modifty state file when fixing it, we need to make a working copy from the master copy."""
     p = Path(os.path.join(os.path.dirname(__file__), "credit-position-broken-redemption.json"))
     assert p.exists(), f"{p} missing"
-    return p
-
-
-@pytest.fixture()
-def strategy_file(tmp_path) -> Path:
-    """Because we modifty state file when fixing it, we need to make a working copy from the master copy."""
-    p = Path(os.path.join(os.path.dirname(__file__), "..", "..", "strategies", "test_only", "enzyme-polygon-eth-breakout.py"))
-    assert p.exists(), f"{p.resolve()} missing"
     working_copy = tmp_path / "test-copy.state.json"
     shutil.copyfile(p, working_copy)
     return working_copy
+
+
+@pytest.fixture()
+def strategy_file() -> Path:
+    p = Path(os.path.join(os.path.dirname(__file__), "..", "..", "strategies", "test_only", "enzyme-polygon-eth-breakout.py"))
+    assert p.exists(), f"{p.resolve()} missing"
+    return p
 
 
 @pytest.fixture()

--- a/tradeexecutor/state/identifier.py
+++ b/tradeexecutor/state/identifier.py
@@ -715,6 +715,16 @@ class AssetWithTrackedValue:
         if self.quantity < 0:
             self.quantity = Decimal(0)
 
+    def reset(self, quantity: Decimal):
+        """Reset the loan quantity.
+
+        See also :py:func:`tradeexecutor.strategy.lending_protocol_leverage.reset_credit_supply_loan`.
+        """
+        assert isinstance(quantity, Decimal)
+        self.quantity = quantity
+        self.interest_rate_at_open = None
+        self.last_interest_rate = None
+
 
 
 

--- a/tradeexecutor/state/interest.py
+++ b/tradeexecutor/state/interest.py
@@ -70,6 +70,10 @@ class Interest:
     #:
     interest_payments: Decimal = ZERO_DECIMAL
 
+    #: If we repair/reset this interest tracked, when this happened.
+    #:
+    reset_at: datetime.datetime | None = None
+
     def __repr__(self):
         return f"<Interest, current principal + interest {self.last_token_amount}, current tracked interest gains {self.last_accrued_interest}>"
 
@@ -126,13 +130,24 @@ class Interest:
 
         assert self.last_token_amount >= 0, f"last_token_amount cannot go negative. Got {self.last_token_amount} on {self}, delta was {delta}, epsilon was {epsilon}"
 
-    def reset(self, amount: Decimal):
+    def reset(
+        self,
+        amount: Decimal,
+        block_timestamp: datetime.datetime,
+        block_number: BlockNumber,
+    ):
         """Reset the loan token amount.
 
         - Used in the manual account correction
 
         """
         self.last_token_amount = amount
+        self.last_updated_at = datetime.datetime.utcnow()
+        self.last_event_at = block_timestamp
+        self.last_accrued_interest = Decimal(0)
+        self.last_updated_block_number = block_number
+        self.interest_payments = Decimal(0)
+        self.reset_at = datetime.datetime.utcnow()
         assert self.last_token_amount >= 0, f"last_token_amount cannot go negative. Got {self.last_token_amount} on {self}, delta was {delta}, epsilon was {epsilon}"
 
 

--- a/tradeexecutor/state/interest.py
+++ b/tradeexecutor/state/interest.py
@@ -126,5 +126,15 @@ class Interest:
 
         assert self.last_token_amount >= 0, f"last_token_amount cannot go negative. Got {self.last_token_amount} on {self}, delta was {delta}, epsilon was {epsilon}"
 
+    def reset(self, amount: Decimal):
+        """Reset the loan token amount.
+
+        - Used in the manual account correction
+
+        """
+        self.last_token_amount = amount
+        assert self.last_token_amount >= 0, f"last_token_amount cannot go negative. Got {self.last_token_amount} on {self}, delta was {delta}, epsilon was {epsilon}"
+
+
 
 

--- a/tradeexecutor/strategy/account_correction.py
+++ b/tradeexecutor/strategy/account_correction.py
@@ -34,6 +34,7 @@ from tradeexecutor.state.repair import close_position_with_empty_trade
 from tradeexecutor.state.trade import TradeFlag, TradeExecution
 from tradeexecutor.strategy.dust import DEFAULT_DUST_EPSILON, get_dust_epsilon_for_pair, get_dust_epsilon_for_asset, DEFAULT_RELATIVE_EPSILON, \
     get_relative_epsilon_for_asset
+from tradeexecutor.strategy.lending_protocol_leverage import reset_credit_supply_loan
 from tradeexecutor.strategy.pandas_trader.position_manager import PositionManager
 from tradeexecutor.strategy.pricing_model import PricingModel
 from tradeexecutor.strategy.trading_strategy_universe import translate_trading_pair, TradingStrategyUniverse
@@ -468,6 +469,14 @@ def apply_accounting_correction(
             assert position.get_quantity() > 0, \
                 f"Spoit position should have positive quantity, got {position} with {position.get_quantity()}\n" \
                 f"Accounting correction is: {correction}"
+
+        if position.is_credit_supply():
+            reset_credit_supply_loan(
+                position,
+                timestamp=correction.timestamp,
+                quantity=correction.actual_amount,
+                block_number=correction.block_number,
+            )
 
     elif isinstance(position, ReservePosition):
         # No fancy method to correct reserves

--- a/tradeexecutor/strategy/interest.py
+++ b/tradeexecutor/strategy/interest.py
@@ -305,7 +305,7 @@ def prepare_interest_distribution(
                 if not p.is_credit_supply():
                     assert not p.is_long(), f"Cannot handle position: {p}"
                 underlying = asset.get_pricing_asset()
-                assert underlying.is_stablecoin(), f"Asset is collateral but not stablecoin based: {asset}"
+                assert underlying.is_stablecoin(), f"Asset is collateral but not stablecoin based: {asset}. Unsupported yet."
                 price = 1.0
             else:
                 price_structure = pricing_model.get_sell_price(

--- a/tradeexecutor/strategy/lending_protocol_leverage.py
+++ b/tradeexecutor/strategy/lending_protocol_leverage.py
@@ -14,7 +14,7 @@ from tradeexecutor.state.identifier import (
 from tradeexecutor.state.interest import Interest
 from tradeexecutor.state.loan import Loan, LiquidationRisked
 from tradeexecutor.state.trade import TradeExecution
-from tradeexecutor.state.types import USDollarAmount, LeverageMultiplier
+from tradeexecutor.state.types import USDollarAmount, LeverageMultiplier, BlockNumber
 from tradeexecutor.utils.accuracy import COLLATERAL_EPSILON, CLOSE_POSITION_COLLATERAL_EPSILON
 
 
@@ -288,6 +288,7 @@ def update_short_loan(
 def reset_credit_supply_loan(
     position: "tradeexecutor.state.position.TradingPosition",
     timestamp: datetime.datetime,
+    block_number: BlockNumber,
     quantity: Decimal,
     reserve_currency_exchange_rate=1.0,
 ):
@@ -295,24 +296,21 @@ def reset_credit_supply_loan(
 
     - When manual account correction is executed
 
-    See also :py:func:`update_credit_supply_loan`.
+    - See `test_correct_accounts_redemption_on_ausdc` for executing this on a code path
+
+    - See also :py:func:`update_credit_supply_loan`.
     """
 
     assert position.pair.is_credit_supply()
-
+    assert block_number
+    assert quantity
     loan = position.loan
-
-    loan.collateral.change_quantity_and_value(
+    assert loan.borrowed is None, "Should be collateral only"
+    loan.collateral.reset(quantity)  # Reset core quantity
+    loan.collateral_interest.reset(
         quantity,
-        reserve_currency_exchange_rate,
-        timestamp,
-        allow_negative=True,
-    )
-
-    # also adjust amount in collateral_interest
-    loan.collateral_interest.reset(quantity)
-
-    # Sanity check
-    loan.check_health()
-
+        block_timestamp=timestamp,
+        block_number=block_number,
+    )  # Reset gained and distributed interest
+    loan.check_health()  # Sanity check
     return loan


### PR DESCRIPTION
- When performing `correct-accounts`, reset any tracked interest rate data for aUSDC positions as we have lost the tracking of interest rates in these manual repair cases