### PR TITLE
Add visualisation.get_series(), new weighting

### DIFF
--- a/tests/backtest/test_backtest_inline_real_data.py
+++ b/tests/backtest/test_backtest_inline_real_data.py
@@ -220,3 +220,5 @@ def test_run_inline_real_backtest(
 
     assert len(debug_dump) == 216
 
+
+

--- a/tests/test_strategy_state_visualisation.py
+++ b/tests/test_strategy_state_visualisation.py
@@ -212,3 +212,7 @@ def test_visualise_strategy_state(
     # using a web brower
     if os.environ.get("SHOW_IMAGE"):
         open_plotly_figure_in_browser(image)
+
+    # Test raw data access
+    series = state.visualisation.get_series("Slow EMA")
+    assert len(series) > 0

--- a/tradeexecutor/analysis/curve.py
+++ b/tradeexecutor/analysis/curve.py
@@ -29,11 +29,16 @@ SPECIAL_SERIES_ATTRIBUTES = {"name", "colour", "curve", "period"}
 #:
 #: See :py:func:`tradeexecutor.visual.bnechmark.visualise_equity_curves`
 #:
+#:
+#: See https://community.plotly.com/t/plotly-colours-list/11730/3
+#:
 DEFAULT_BENCHMARK_COLOURS = {
     "BTC": "orange",
     "ETH": "blue",
     "MATIC": "purple",
     "ARB": "red",
+    "DOGE": "darkorange",
+    "PEPE": "darkmagenta",
     "All cash": "black",
     "Strategy": "green",
 }

--- a/tradeexecutor/state/visualisation.py
+++ b/tradeexecutor/state/visualisation.py
@@ -334,7 +334,9 @@ class Visualisation:
     It is not used in any trading, but can help and visualize
     trade backtesting and execution.
 
-    See :py:meth:`plot_indicator` for usage.
+    - See :py:meth:`plot_indicator` for how to draw plots inside `decide_trades()`
+
+    - See :py:func:`get_series` how to extract data for charting as :py:class:`pd.Series`.
     """
 
     #: Messages for each strategy cycle.
@@ -607,5 +609,24 @@ class Visualisation:
     def get_total_points(self) -> int:
         """Get number of data points stored in all plots."""
         return sum([len(p.points) for p in self.plots.values()])
-        
 
+    def get_series(
+        self,
+        name: str,
+    ) -> pd.Series:
+        """Get plot data for charts and tables.
+
+        :param name:
+            Same as in :py:func:`plot_indicator`
+
+        :return:
+            Pandas series with DateTimeIndex and float values.
+        """
+        plot = self.plots.get(name)
+        assert plot is not None, f"No plot named {name}, we have {list(self.plots.keys())}"
+        timestamps = list(plot.points.keys())
+        values = plot.points.values()
+        datetime_index = pd.to_datetime(timestamps, unit='s')
+        series = pd.Series(values, index=datetime_index)
+        return series
+        

--- a/tradeexecutor/strategy/alpha_model.py
+++ b/tradeexecutor/strategy/alpha_model.py
@@ -557,10 +557,11 @@ class AlphaModel:
                 old_pair=old_synthetic_pair,
             )
 
-    def select_top_signals(self,
-                           count: int,
-                           threshold=0.0,
-                           ):
+    def select_top_signals(
+        self,
+        count: int,
+        threshold=0.0,
+    ):
         """Chooses top signals.
 
         Choose trading pairs to the next rebalance by their signal strength.

--- a/tradeexecutor/strategy/weighting.py
+++ b/tradeexecutor/strategy/weighting.py
@@ -148,6 +148,33 @@ def weight_by_1_slash_signal(alpha_signals: Dict[PairInternalId, Signal]) -> Dic
     - Higher the signal, smaller the weight
 
     - E.g. volatility weighted (more volatility, less alloaction)
+
+    Example:
+
+    .. code-block:: python
+
+        alpha_model = AlphaModel(timestamp)
+
+        available_pairs = get_included_pairs_per_month(input)
+        top_pairs = available_pairs[0:parameters.max_pairs_per_month]
+
+        assets_chosen_count = 0
+
+        for pair in top_pairs:
+
+            volatility = indicators.get_indicator_value("volatility", pair=pair)
+            if volatility is None:
+                # Back buffer has not filled up yet with enough data,
+                # skip to the next pair
+                continue
+
+            if volatility >= parameters.minimum_volatility_threshold:
+                # Include this pair for the ranking for each tick
+                alpha_model.set_signal(
+                    pair,
+                    volatility,
+                )
+                assets_chosen_count += 1
     """
     weighed_signals = {}
     for id, value in alpha_signals.items():

--- a/tradeexecutor/strategy/weighting.py
+++ b/tradeexecutor/strategy/weighting.py
@@ -117,7 +117,7 @@ def normalise_weights(weights: Dict[PairInternalId, Weight]) -> Dict[PairInterna
 
 
 def weight_by_1_slash_n(alpha_signals: Dict[PairInternalId, Signal]) -> Dict[PairInternalId, Weight]:
-    """Use 1/N weighting system to generate portfolio weightings from the raw alpha signals.
+    """Use 1/N (position) weighting system to generate portfolio weightings from the raw alpha signals.
 
     - The highest alpha gets portfolio allocation 1/1
 
@@ -137,6 +137,21 @@ def weight_by_1_slash_n(alpha_signals: Dict[PairInternalId, Signal]) -> Dict[Pai
     for idx, tuple in enumerate(sorted_alpha, 1):
         pair_id, alpha = tuple
         weighed_signals[pair_id] = 1 / idx
+    return weighed_signals
+
+
+def weight_by_1_slash_signal(alpha_signals: Dict[PairInternalId, Signal]) -> Dict[PairInternalId, Weight]:
+    """Use 1/signal weighting system to generate portfolio weightings from the raw alpha signals.
+
+    - All signals are weighted 1/signal
+
+    - Higher the signal, smaller the weight
+
+    - E.g. volatility weighted (more volatility, less alloaction)
+    """
+    weighed_signals = {}
+    for id, value in alpha_signals.items():
+        weighed_signals[id] = 1 / value
     return weighed_signals
 
 


### PR DESCRIPTION
- Add `visualisation.get_series()` so you can easily chart custom indicators in notebooks
- Add new weighting method `weight_by_1_slash_signal` for volatility weighting
- Add some new default colours for benchmark assets
