### PR TITLE
Force loading lending candles time bucket to be 1h

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -185,10 +185,12 @@ filterwarnings = [
     "ignore:::.*.jsonschema",
     # DeprecationWarning: Subclassing validator classes is not intended to be part of their public API. A future version will make doing so an error, as the behavior of subclasses isn't guaranteed to stay the same between releases of jsonschema. Instead, prefer composition of validators, wrapping them in an object owned entirely by the downstream library.
     "ignore:::.*.validators",
+    "ignore:::.*.codec",
     "ignore::DeprecationWarning:openapi_spec_validator.*:",
     #  DeprecationWarning: abi.decode_single() is deprecated and will be removed in version 4.0.0 in favor of abi.decode()
     "ignore::DeprecationWarning:eth_abi.*:",
-    "ignore:::.*.codec",
+    "ignore::DeprecationWarning:eth_tester.*:",
     "ignore::DeprecationWarning:pandas.*:",
     "ignore::DeprecationWarning:quantstats.*:",
+    "ignore::DeprecationWarning:pkg_resources.*:",
 ]

--- a/tests/backtest/test_backtest_credit_supply_mock.py
+++ b/tests/backtest/test_backtest_credit_supply_mock.py
@@ -131,10 +131,10 @@ def test_backtest_open_only_credit_supply_mock_data(
 
     interest = credit_position.loan.collateral_interest
     assert interest.opening_amount == Decimal("10000.00")
-    assert credit_position.get_accrued_interest() == pytest.approx(5.8392619598023785)
-    assert credit_position.get_quantity() == pytest.approx(Decimal(10005.8392619598023785))
-    assert credit_position.get_value() == pytest.approx(10005.8392619598023785)
-    assert portfolio.get_total_equity() == pytest.approx(10005.8392619598023785)
+    assert credit_position.get_accrued_interest() == pytest.approx(5.777347790050936)
+    assert credit_position.get_quantity() == pytest.approx(Decimal(10005.77734779005093525703117))
+    assert credit_position.get_value() == pytest.approx(10005.77734779005093525703117)
+    assert portfolio.get_total_equity() == pytest.approx(10005.77734779005093525703117)
 
     analysis = build_trade_analysis(state.portfolio)
     summary = analysis.calculate_summary_statistics(state=state)
@@ -205,8 +205,7 @@ def test_backtest_open_and_close_credit_supply_mock_data(
 
     assert credit_position.trades[2].planned_reserve == pytest.approx(Decimal(10002.67867669078453209820816))
     assert credit_position.trades[2].executed_reserve == pytest.approx(Decimal(10002.67867669078453209820816))
-    assert credit_position.trades[2].get_claimed_interest() == pytest.approx(2.67867669078453209820816)
-
+    assert credit_position.trades[2].get_claimed_interest() == pytest.approx(2.6798862879357706)
 
     ausdc = universe.get_credit_supply_pair().base
 
@@ -217,13 +216,13 @@ def test_backtest_open_and_close_credit_supply_mock_data(
     assert len(interest_events) > 0, "No interest added on the position"
     assert interest_events[0].asset == ausdc
 
-    assert credit_position.calculate_accrued_interest_quantity(ausdc) == Decimal('2.67867669078453209820816')  # Non-denormalised interest
+    assert credit_position.calculate_accrued_interest_quantity(ausdc) == pytest.approx(Decimal('2.67988628793577073776570'))  # Non-denormalised interest
     assert interest.last_token_amount == Decimal('0')
-    assert interest.last_accrued_interest == Decimal('2.67867669078453209820816')
+    assert interest.last_accrued_interest == pytest.approx(Decimal('2.67988628793577073776570'))
 
     assert credit_position.get_quantity() == Decimal('0')  # Closed positions do not have quantity left
     assert credit_position.get_value() == pytest.approx(0)  # Closed positions do not have value left
-    assert credit_position.get_claimed_interest() == pytest.approx(2.67867669078453209820816)  # Interest was claimed during closing
+    assert credit_position.get_claimed_interest() == pytest.approx(2.6798862879357706)  # Interest was claimed during closing
     assert credit_position.get_accrued_interest() == pytest.approx(0)  # Denormalised interest
 
     assert portfolio.get_cash() == pytest.approx(10002.67867669078453209820816)
@@ -233,7 +232,7 @@ def test_backtest_open_and_close_credit_supply_mock_data(
     analysis = build_trade_analysis(state.portfolio)
     summary = analysis.calculate_summary_statistics(state=state)
 
-    assert summary.total_claimed_interest == pytest.approx(2.678676690784532)
+    assert summary.total_claimed_interest == pytest.approx(2.6798862879357706)
     assert summary.total_interest_paid_usd == 0
     assert summary.delta_neutral == 1
     assert summary.total_positions == 1

--- a/tests/backtest/test_backtest_credit_supply_real_data.py
+++ b/tests/backtest/test_backtest_credit_supply_real_data.py
@@ -115,10 +115,10 @@ def test_backtest_open_only_credit_supply_real_data(
     assert len(credit_position.balance_updates) == 30
     
     assert credit_position.loan.collateral_interest.opening_amount == Decimal("10000.00")
-    assert credit_position.get_accrued_interest() == pytest.approx(5.8392619598023785)
-    assert credit_position.get_quantity() == pytest.approx(Decimal('10005.83926195980237824844194'))
-    assert credit_position.get_value() == pytest.approx(10005.8392619598023785)
-    assert portfolio.get_total_equity() == pytest.approx(10005.8392619598023785)
+    assert credit_position.get_accrued_interest() == pytest.approx(5.777347790050936)
+    assert credit_position.get_quantity() == pytest.approx(Decimal(10005.77734779005093525703117))
+    assert credit_position.get_value() == pytest.approx(10005.77734779005093525703117)
+    assert portfolio.get_total_equity() == pytest.approx(10005.77734779005093525703117)
 
 
 def test_backtest_open_and_close_credit_supply_real_data(
@@ -179,9 +179,9 @@ def test_backtest_open_and_close_credit_supply_real_data(
 
     interest = credit_position.loan.collateral_interest
     assert interest.opening_amount == Decimal("10000.00")
-    assert credit_position.calculate_accrued_interest_quantity(credit_position.loan.collateral.asset) == pytest.approx(Decimal('2.67867669078453209820818'))
+    assert credit_position.calculate_accrued_interest_quantity(credit_position.loan.collateral.asset) == pytest.approx(Decimal(2.67988628793577073776570))
     assert interest.last_token_amount == pytest.approx(Decimal('0'))
-    assert interest.last_accrued_interest == pytest.approx(Decimal('2.67867669078453209820818'))
+    assert interest.last_accrued_interest == pytest.approx(Decimal(2.67988628793577073776570))
 
     assert credit_position.get_accrued_interest() == Decimal(0)  # Accrued interest should be 0 for closed position
     assert credit_position.get_quantity() == Decimal('0')  # Closed positions do not have quantity left

--- a/tests/backtest/test_backtest_short_real_data.py
+++ b/tests/backtest/test_backtest_short_real_data.py
@@ -118,8 +118,8 @@ def test_backtest_open_only_short_real_data(
     assert position.is_short()
 
     assert position.get_value_at_open() == pytest.approx(19990)
-    assert position.get_accrued_interest() == pytest.approx(-25.344613324794)
-    assert position.loan.get_borrow_interest() == pytest.approx(42.85655994224133)
-    assert position.loan.get_collateral_interest() == pytest.approx(17.511946617447332)
-    assert position.get_value() == Decimal(3768.3435985152573)
+    assert position.get_accrued_interest() == pytest.approx(-24.92161841152006)
+    assert position.loan.get_borrow_interest() == pytest.approx(42.24788443388282)
+    assert position.loan.get_collateral_interest() == pytest.approx(17.326266022362756)
+    assert position.get_value() == pytest.approx(Decimal(3768.7665934285287))
 

--- a/tests/backtest/test_decide_trades_v3.py
+++ b/tests/backtest/test_decide_trades_v3.py
@@ -133,7 +133,7 @@ def test_decide_trades_v03(
 
     interest = credit_position.loan.collateral_interest
     assert interest.opening_amount == Decimal("10000.00")
-    assert credit_position.get_accrued_interest() == pytest.approx(5.8392619598023785)
-    assert credit_position.get_quantity() == pytest.approx(Decimal(10005.8392619598023785))
-    assert credit_position.get_value() == pytest.approx(10005.8392619598023785)
-    assert portfolio.get_total_equity() == pytest.approx(10005.8392619598023785)
+    assert credit_position.get_accrued_interest() == pytest.approx(5.777347790050936)
+    assert credit_position.get_quantity() == pytest.approx(Decimal(10005.77734779005093525703117))
+    assert credit_position.get_value() == pytest.approx(10005.77734779005093525703117)
+    assert portfolio.get_total_equity() == pytest.approx(10005.77734779005093525703117)

--- a/tests/backtest/test_grid_search.py
+++ b/tests/backtest/test_grid_search.py
@@ -258,7 +258,7 @@ def test_perform_grid_search_single_thread(
     assert len(table) == 2 * 2 * 2
     row = table.iloc[0]
     # assert row["stop_loss_pct"] == 0.9
-    assert row["CAGR"] == pytest.approx(0.011721966693938546)
+    assert row["CAGR"] == pytest.approx(0.011682534679563261)
     assert row["Positions"] == 2
 
     render_grid_search_result_table(table)

--- a/tests/ethereum/polygon_forked/1delta/test_one_delta_live_credit_supply.py
+++ b/tests/ethereum/polygon_forked/1delta/test_one_delta_live_credit_supply.py
@@ -178,8 +178,8 @@ def test_one_delta_live_credit_supply_open_only(
     assert position.loan.get_collateral_value() == pytest.approx(1000.000308)
     assert position.loan.get_collateral_value() > old_col_value
     assert position.loan.get_collateral_interest() > 0
-    assert position.loan.collateral.interest_rate_at_open == pytest.approx(0.15336368478574258)
-    assert position.loan.collateral.last_interest_rate == pytest.approx(0.15336368478574258)
+    assert position.loan.collateral.interest_rate_at_open == pytest.approx(0.09283768887858043)
+    assert position.loan.collateral.last_interest_rate == pytest.approx(0.09283768887858043)
 
 
 def test_one_delta_live_credit_supply_open_and_close(

--- a/tests/interest/test_lending_dataset.py
+++ b/tests/interest/test_lending_dataset.py
@@ -48,7 +48,7 @@ def test_load_lending_dataset(persistent_test_client: Client):
         (ChainId.polygon, LendingProtocolType.aave_v3, "USDC.e")
     )
     assert rates["open"][pd.Timestamp("2023-01-01")] == pytest.approx(0.6998308843795215)
-    assert rates["close"][pd.Timestamp("2023-01-01")] == pytest.approx(0.6589076823528996)
+    assert rates["close"][pd.Timestamp("2023-01-01")] == pytest.approx(0.7001845728826266)    
 
 
 def test_construct_trading_universe_with_lending(persistent_test_client: Client):
@@ -66,7 +66,7 @@ def test_construct_trading_universe_with_lending(persistent_test_client: Client)
     dataset = load_partial_data(
         client,
         execution_context=unit_test_execution_context,
-        time_bucket=TimeBucket.d1,
+        time_bucket=TimeBucket.d7,
         pairs=pairs,
         universe_options=default_universe_options,
         start_at=pd.Timestamp("2023-01-01"),
@@ -86,7 +86,12 @@ def test_construct_trading_universe_with_lending(persistent_test_client: Client)
         (ChainId.polygon, LendingProtocolType.aave_v3, "USDC.e")
     )
     assert rates["open"][pd.Timestamp("2023-01-01")] == pytest.approx(0.6998308843795215)
-    assert rates["close"][pd.Timestamp("2023-01-01")] == pytest.approx(0.6589076823528996)
+    assert rates["close"][pd.Timestamp("2023-01-01")] == pytest.approx(0.7001845728826266)
+
+    # check lending candles are in 1h bucket regardless of the trading pair bucket
+    supply_df = strategy_universe.data_universe.lending_candles.supply_apr.df.tail(2)
+    assert supply_df.iloc[0].timestamp == pd.Timestamp("2023-01-31 23:00:00")
+    assert supply_df.iloc[1].timestamp == pd.Timestamp("2023-02-01 00:00:00")
 
 
 def test_get_credit_supply_trading_pair(persistent_test_client: Client):

--- a/tradeexecutor/strategy/trading_strategy_universe.py
+++ b/tradeexecutor/strategy/trading_strategy_universe.py
@@ -2187,7 +2187,7 @@ def load_partial_data(
 
             lending_candles_map = client.fetch_lending_candles_for_universe(
                 lending_reserve_universe,
-                bucket=time_bucket,
+                bucket=TimeBucket.h1,
                 candle_types=lending_candle_types,
                 start_time=data_load_start_at,
                 end_time=end_at,


### PR DESCRIPTION
Currently lending candles are loaded with same time bucket as the main trading data bucket.
Since the purpose of lending candles is totally different, mainly for calculating interest rate, we should get it as realtime as posisble

Fix #1037 