### PR TITLE
Maximum price impact

### DIFF
--- a/strategies/eth-btc-usdc-size-risk.py
+++ b/strategies/eth-btc-usdc-size-risk.py
@@ -67,13 +67,16 @@ class Parameters:
     #
     per_position_cap_of_pool = 0.025  # Cap entires to 2.5% of the underlying pool size
 
+    # We set this here to test this parameter,
+    # but current backtesting setup always assumes 0% price impact
+    max_price_impact = 0.03
+
     #
     # Live trading only
     #
     chain_id = ChainId.ethereum
     routing = TradeRouting.default  # Pick default routes for trade execution
     required_history_period = datetime.timedelta(hours=momentum_lookback_bars + 1)
-    maximum_price_impact = 0.03
 
     #
     # Backtesting only

--- a/strategies/eth-btc-usdc-size-risk.py
+++ b/strategies/eth-btc-usdc-size-risk.py
@@ -73,6 +73,7 @@ class Parameters:
     chain_id = ChainId.ethereum
     routing = TradeRouting.default  # Pick default routes for trade execution
     required_history_period = datetime.timedelta(hours=momentum_lookback_bars + 1)
+    maximum_price_impact = 0.03
 
     #
     # Backtesting only

--- a/strategies/test_only/price_impact_crash.py
+++ b/strategies/test_only/price_impact_crash.py
@@ -1,0 +1,100 @@
+"""See test_price_impact_crash."""
+
+import datetime
+
+from tradeexecutor.strategy.default_routing_options import TradeRouting
+from tradingstrategy.pair import HumanReadableTradingPairDescription
+from tradingstrategy.chain import ChainId
+from tradingstrategy.client import Client
+from tradingstrategy.timebucket import TimeBucket
+
+from tradeexecutor.strategy.pandas_trader.indicator import IndicatorSet
+from tradeexecutor.strategy.parameters import StrategyParameters
+from tradeexecutor.strategy.trading_strategy_universe import TradingStrategyUniverse
+from tradeexecutor.strategy.execution_context import ExecutionContext, ExecutionMode
+from tradeexecutor.strategy.trading_strategy_universe import load_partial_data
+from tradeexecutor.strategy.universe_model import UniverseOptions
+from tradeexecutor.strategy.cycle import CycleDuration
+from tradeexecutor.state.trade import TradeExecution
+from tradeexecutor.strategy.pandas_trader.strategy_input import StrategyInput
+
+
+trading_strategy_engine_version = "0.5"
+
+
+class Parameters:
+    id = "price-impact-crash"
+    cycle_duration = CycleDuration.s1
+    candle_time_bucket = TimeBucket.h1
+    chain_id = ChainId.anvil
+    required_history_period = datetime.timedelta(hours=24)
+    routing = TradeRouting.default
+
+    # Set price impact parameter so that it always crashes
+    max_price_impact = 0.00000001
+
+    # Unused
+    backtest_start = datetime.datetime(2024, 5, 10)
+    backtest_end = datetime.datetime(2024, 5, 15)
+    initial_cash = 10_000
+
+
+
+def get_strategy_trading_pairs(execution_mode: ExecutionMode) -> list[HumanReadableTradingPairDescription]:
+    trading_pairs = [
+        (ChainId.polygon, "uniswap-v3", "WETH", "USDC"),
+    ]
+
+    return trading_pairs
+
+
+def create_trading_universe(
+    timestamp: datetime.datetime,
+    client: Client,
+    execution_context: ExecutionContext,
+    universe_options: UniverseOptions,
+) -> TradingStrategyUniverse:
+    trading_pairs = get_strategy_trading_pairs(execution_context.mode)
+
+    dataset = load_partial_data(
+        client=client,
+        time_bucket=Parameters.candle_time_bucket,
+        pairs=trading_pairs,
+        execution_context=execution_context,
+        universe_options=UniverseOptions(
+            history_period=Parameters.required_history_period,
+            start_at=None,
+            end_at=None,
+        ),
+    )
+    # Construct a trading universe from the loaded data,
+    # and apply any data preprocessing needed before giving it
+    # to the strategy and indicators
+    strategy_universe = TradingStrategyUniverse.create_from_dataset(
+        dataset,
+        reserve_asset="USDC",
+    )
+
+    return strategy_universe
+
+
+def create_indicators(
+    timestamp: datetime.datetime | None,
+    parameters: StrategyParameters,
+    strategy_universe: TradingStrategyUniverse,
+    execution_context: ExecutionContext
+):
+    return IndicatorSet()
+
+
+def decide_trades(input: StrategyInput) -> list[TradeExecution]:
+    position_manager = input.get_position_manager()
+    pair = input.strategy_universe.get_single_pair()
+    # Attempt to open ETH spot position for 100 USD
+    # Will always crash because of Parameters.max_price_impact
+    trades = position_manager.open_spot(
+        pair,
+        value=100.00,
+    )
+    return trades
+

--- a/tests/cli/test_cli_commands.py
+++ b/tests/cli/test_cli_commands.py
@@ -15,7 +15,10 @@ from typer.testing import CliRunner
 from tradeexecutor.cli.main import app
 from tradeexecutor.state.state import State
 
-pytestmark = pytest.mark.skipif(os.environ.get("TRADING_STRATEGY_API_KEY") is None, reason="Set TRADING_STRATEGY_API_KEY environment variable to run this test module")
+pytestmark = pytest.mark.skipif(
+    os.environ.get("TRADING_STRATEGY_API_KEY") is None or os.environ.get("BNB_CHAIN_JSON_RPC") is None,
+    reason="Set TRADING_STRATEGY_API_KEY and BNB_CHAIN_JSON_RPC environment variable to run this test module"
+)
 
 
 @pytest.fixture(scope="session")

--- a/tests/ethereum/polygon_forked/generic-router/test_generic_router.py
+++ b/tests/ethereum/polygon_forked/generic-router/test_generic_router.py
@@ -8,9 +8,11 @@ import pytest as pytest
 
 from eth_defi.balances import fetch_erc20_balances_by_token_list
 from eth_defi.token import TokenDetails
+
 from tradeexecutor.ethereum.execution import EthereumExecution
 from tradeexecutor.strategy.account_correction import calculate_account_corrections
 from tradeexecutor.strategy.asset import get_relevant_assets, build_expected_asset_map
+from tradeexecutor.strategy.execution_context import unit_test_execution_context
 from tradingstrategy.chain import ChainId
 from web3 import Web3
 
@@ -248,7 +250,11 @@ def test_generic_routing_close_position_across_markets(
         generic_pricing_model
     )
     trades = position_manager.close_all()
-    post_process_trade_decision(state, trades)
+    post_process_trade_decision(
+        state,
+        unit_test_execution_context,
+        trades,
+    )
 
     short_close = trades[-1]
     assert short_close.is_short()

--- a/tests/ethereum/polygon_forked/generic-router/test_short_flags.py
+++ b/tests/ethereum/polygon_forked/generic-router/test_short_flags.py
@@ -161,7 +161,7 @@ def test_short_flags(
     )
     trades = position_manager.close_all()
 
-    post_process_trade_decision(state, trades)
+    post_process_trade_decision(state, unit_test_execution_context, trades)
 
     # Only last trade has close_protocol_last
     assert TradeFlag.close in trades[0].flags

--- a/tests/mainnet_fork/test_price_impact_crash.py
+++ b/tests/mainnet_fork/test_price_impact_crash.py
@@ -1,0 +1,202 @@
+"""Test that the strategy crashes if price impact tolerance is xeeced."""
+import json
+import os
+import secrets
+from pathlib import Path
+from unittest import mock
+
+import pytest
+
+from eth_account import Account
+from eth_typing import HexAddress
+from hexbytes import HexBytes
+from web3 import Web3, HTTPProvider
+
+from eth_defi.provider.anvil import AnvilLaunch, launch_anvil, mine
+from eth_defi.chain import install_chain_middleware
+from eth_defi.enzyme.vault import Vault
+from eth_defi.hotwallet import HotWallet
+from eth_defi.token import TokenDetails, fetch_erc20_details
+from eth_defi.trace import assert_transaction_success_with_explanation
+from eth_defi.event_reader.reorganisation_monitor import create_reorganisation_monitor
+
+from tradeexecutor.cli.main import app
+from tradeexecutor.monkeypatch.web3 import construct_sign_and_send_raw_middleware
+from tradeexecutor.state.state import State
+from tradeexecutor.ethereum.enzyme.vault import EnzymeVaultSyncModel
+
+
+pytestmark = pytest.mark.skipif(
+    not os.environ.get("JSON_RPC_POLYGON")
+    or not os.environ.get("TRADING_STRATEGY_API_KEY"),
+    reason="Set POLYGON_JSON_RPC and TRADING_STRATEGY_API_KEY environment variables to run this test",
+)
+
+
+@pytest.fixture()
+def usdc_whale() -> HexAddress:
+    """A random account picked from Polygon that holds a lot of USDC."""
+    # https://polygonscan.com/token/0x2791bca1f2de4661ed88a30c99a7a9449aa84174#balances
+    return HexAddress("0x72A53cDBBcc1b9efa39c834A540550e23463AAcB")
+
+
+@pytest.fixture()
+def anvil(usdc_whale) -> AnvilLaunch:
+    """Launch Polygon fork."""
+    rpc_url = os.environ["JSON_RPC_POLYGON"]
+
+    anvil = launch_anvil(
+        fork_url=rpc_url,
+        unlocked_addresses=[usdc_whale],
+        fork_block_number=58_000_000,
+    )
+    try:
+        yield anvil
+    finally:
+        anvil.close()
+
+
+@pytest.fixture()
+def web3(anvil) -> Web3:
+    """Set up the Anvil Web3 connection.
+
+    Also perform the Anvil state reset for each test.
+    """
+    web3 = Web3(HTTPProvider(anvil.json_rpc_url, request_kwargs={"timeout": 10}))
+    web3.middleware_onion.clear()
+    install_chain_middleware(web3)
+    return web3
+
+
+@pytest.fixture()
+def deployer(web3) -> HexAddress:
+    """Deployer account.
+
+    - This account will deploy all smart contracts
+
+    - Starts with 10,000 ETH
+    """
+    return web3.eth.accounts[0]
+
+
+@pytest.fixture
+def usdc(web3) -> TokenDetails:
+    details = fetch_erc20_details(web3, "0x2791Bca1f2de4661ED88A30C99A7a9449Aa84174")
+    return details
+
+
+@pytest.fixture
+def ausdc(web3) -> TokenDetails:
+    """Get aPolUSDC on Polygon."""
+    return fetch_erc20_details(web3, "0x625E7708f30cA75bfd92586e17077590C60eb4cD", contract_name="aave_v3/AToken.json")
+
+
+@pytest.fixture
+def hot_wallet(
+    web3,
+    deployer,
+    usdc: TokenDetails,
+    usdc_whale,
+) -> HotWallet:
+    """Create hot wallet for the signing tests.
+
+    Top is up with some gas money and 500 USDC.
+    """
+    private_key = HexBytes(secrets.token_bytes(32))
+    account = Account.from_key(private_key)
+    wallet = HotWallet(account)
+    wallet.sync_nonce(web3)
+    tx_hash = web3.eth.send_transaction(
+        {"to": wallet.address, "from": deployer, "value": 15 * 10**18}
+    )
+    assert_transaction_success_with_explanation(web3, tx_hash)
+    tx_hash = usdc.contract.functions.transfer(
+        wallet.address, 200_000 * 10**6
+    ).transact({"from": usdc_whale})
+    assert_transaction_success_with_explanation(web3, tx_hash)
+
+    # Add to the local signer chain
+    web3.middleware_onion.add(construct_sign_and_send_raw_middleware(account))
+
+    return wallet
+
+
+@pytest.fixture()
+def strategy_file() -> Path:
+    """Where do we load our strategy file."""
+    return (
+        Path(os.path.dirname(__file__))
+        / ".."
+        / ".."
+        / "strategies"
+        / "test_only"
+        / "price_impact_crash.py"
+    )
+
+
+@pytest.fixture()
+def vault_record_file(tmp_path) -> Path:
+    return Path(tmp_path) / "vault-info.json"
+
+
+@pytest.fixture()
+def state_file(tmp_path) -> Path:
+    """The state file for the tests.
+
+    Always start with an empty file.
+    """
+    path = Path(f"{tmp_path}/price_impact_crash.state.json")
+    if path.exists():
+        os.remove(path)
+    return path
+
+
+@pytest.fixture()
+def environment(
+    anvil: AnvilLaunch,
+    hot_wallet: HotWallet,
+    state_file: Path,
+    strategy_file: Path,
+    vault_record_file: Path,
+) -> dict:
+    """Passed to init and start commands as environment variables"""
+    # Set up the configuration for the live trader
+    environment = {
+        "EXECUTOR_ID": "price_impact_crash",
+        "STRATEGY_FILE": strategy_file.as_posix(),
+        "PRIVATE_KEY": hot_wallet.account.key.hex(),
+        "JSON_RPC_ANVIL": anvil.json_rpc_url,
+        "STATE_FILE": state_file.as_posix(),
+        "ASSET_MANAGEMENT_MODE": "hot_wallet",
+        "UNIT_TESTING": "true",
+        "LOG_LEVEL": "disabled",
+        "CONFIRMATION_BLOCK_COUNT": "0",  # Needed for test backend, Anvil
+        "TRADING_STRATEGY_API_KEY": os.environ["TRADING_STRATEGY_API_KEY"],
+        "PATH": os.environ["PATH"],  # Needs forge
+        "MAX_CYCLES": "3",  # Run decide_trades() max 2 times
+        "MAX_DATA_DELAY_MINUTES": str(24 * 60),
+    }
+    return environment
+
+
+def test_price_impact_crash(
+    environment: dict,
+    state_file: Path,
+    mocker,
+):
+    """Crash trade executor with a price impact trip wire.
+
+    - Start a strategy against Anvil fork of mainnnet
+
+    - Do a trade every second
+
+    - Parameters.max_price_impact is set to such a low value that it will crash on the first trade
+    """
+
+    mocker.patch.dict("os.environ", environment, clear=True)
+
+    app(["init"], standalone_mode=False)
+
+    # run the strategy
+    app(["start"], standalone_mode=False)
+

--- a/tests/mainnet_fork/test_price_impact_crash.py
+++ b/tests/mainnet_fork/test_price_impact_crash.py
@@ -3,7 +3,6 @@ import json
 import os
 import secrets
 from pathlib import Path
-from unittest import mock
 
 import pytest
 
@@ -12,18 +11,15 @@ from eth_typing import HexAddress
 from hexbytes import HexBytes
 from web3 import Web3, HTTPProvider
 
-from eth_defi.provider.anvil import AnvilLaunch, launch_anvil, mine
+from eth_defi.provider.anvil import AnvilLaunch, launch_anvil
 from eth_defi.chain import install_chain_middleware
-from eth_defi.enzyme.vault import Vault
 from eth_defi.hotwallet import HotWallet
 from eth_defi.token import TokenDetails, fetch_erc20_details
 from eth_defi.trace import assert_transaction_success_with_explanation
-from eth_defi.event_reader.reorganisation_monitor import create_reorganisation_monitor
 
 from tradeexecutor.cli.main import app
 from tradeexecutor.monkeypatch.web3 import construct_sign_and_send_raw_middleware
-from tradeexecutor.state.state import State
-from tradeexecutor.ethereum.enzyme.vault import EnzymeVaultSyncModel
+from tradeexecutor.strategy.trade_pricing import PriceImpactToleranceExceeded
 
 
 pytestmark = pytest.mark.skipif(
@@ -182,8 +178,10 @@ def test_price_impact_crash(
 
     mocker.patch.dict("os.environ", environment, clear=True)
 
+    # Initialise state.json
     app(["init"], standalone_mode=False)
 
-    # run the strategy
-    app(["start"], standalone_mode=False)
+    # Run a single cycle of the strategy
+    with pytest.raises(PriceImpactToleranceExceeded):
+        app(["start"], standalone_mode=False)
 

--- a/tests/mainnet_fork/test_price_impact_crash.py
+++ b/tests/mainnet_fork/test_price_impact_crash.py
@@ -86,12 +86,6 @@ def usdc(web3) -> TokenDetails:
 
 
 @pytest.fixture
-def ausdc(web3) -> TokenDetails:
-    """Get aPolUSDC on Polygon."""
-    return fetch_erc20_details(web3, "0x625E7708f30cA75bfd92586e17077590C60eb4cD", contract_name="aave_v3/AToken.json")
-
-
-@pytest.fixture
 def hot_wallet(
     web3,
     deployer,
@@ -133,12 +127,6 @@ def strategy_file() -> Path:
         / "price_impact_crash.py"
     )
 
-
-@pytest.fixture()
-def vault_record_file(tmp_path) -> Path:
-    return Path(tmp_path) / "vault-info.json"
-
-
 @pytest.fixture()
 def state_file(tmp_path) -> Path:
     """The state file for the tests.
@@ -157,7 +145,6 @@ def environment(
     hot_wallet: HotWallet,
     state_file: Path,
     strategy_file: Path,
-    vault_record_file: Path,
 ) -> dict:
     """Passed to init and start commands as environment variables"""
     # Set up the configuration for the live trader
@@ -173,7 +160,7 @@ def environment(
         "CONFIRMATION_BLOCK_COUNT": "0",  # Needed for test backend, Anvil
         "TRADING_STRATEGY_API_KEY": os.environ["TRADING_STRATEGY_API_KEY"],
         "PATH": os.environ["PATH"],  # Needs forge
-        "MAX_CYCLES": "3",  # Run decide_trades() max 2 times
+        "RUN_SINGLE_CYCLE": "true",  # Should crash on the first cycle
         "MAX_DATA_DELAY_MINUTES": str(24 * 60),
     }
     return environment

--- a/tests/strategy_tests/test_eth_btc_trade_size.py
+++ b/tests/strategy_tests/test_eth_btc_trade_size.py
@@ -39,12 +39,10 @@ def environment(
         "STRATEGY_FILE": strategy_file.as_posix(),
         "STATE_FILE": state_file.as_posix(),
         "UNIT_TESTING": "true",
-        "LOG_LEVEL": "info",
+        "LOG_LEVEL": "disabled",
         "TRADING_STRATEGY_API_KEY": os.environ["TRADING_STRATEGY_API_KEY"],
         "USE_BINANCE": "false",  # Force to use DEX data for TVL and lending
         "GENERATE_REPORT": "false"
-                           ""
-                           ""
     }
     return environment
 

--- a/tests/strategy_tests/test_eth_btc_trade_size.py
+++ b/tests/strategy_tests/test_eth_btc_trade_size.py
@@ -90,6 +90,7 @@ def test_eth_btc_trade_size(
             # Check this was correctly filled in
             if t.price_structure:
                 # TODO: Why not always filled?
+                # Make sure PositionManager passes trade.price_structure along
                 assert t.price_impact_tolerance == 0.03, f"price_impact_tolerance missing on {t}, price_structure: {t.price_structure}"
                 price_impact_tolerance_count += 1
 

--- a/tests/web/test_webhook_main_loop_crash.py
+++ b/tests/web/test_webhook_main_loop_crash.py
@@ -1,6 +1,5 @@
 """Webhook stays alive after the trade execution loop crashes."""
 import os
-import random
 import secrets
 import subprocess
 import time
@@ -21,6 +20,9 @@ from tradeexecutor.cli.main import app
 logger = logging.getLogger(__name__)
 
 
+
+
+
 @pytest.fixture()
 def strategy_path() -> Path:
     """Where do we load our strategy file."""
@@ -36,6 +38,7 @@ def hot_wallet_private_key() -> HexBytes:
     return HexBytes(secrets.token_bytes(32))
 
 
+@pytest.mark.skipif(os.environ.get("BNB_CHAIN_JSON_RPC") is None, reason="Set BNB_CHAIN_JSON_RPC environment variable to Binance Smart Chain node to run this test")
 def test_main_loop_crash_with_catch(
     strategy_path,
     hot_wallet_private_key

--- a/tradeexecutor/backtest/backtest_runner.py
+++ b/tradeexecutor/backtest/backtest_runner.py
@@ -20,6 +20,7 @@ from tradeexecutor.backtest.backtest_sync import BacktestSyncModel
 from tradeexecutor.backtest.legacy_backtest_sync import BacktestSyncer
 from tradeexecutor.backtest.backtest_valuation import BacktestValuationModel
 from tradeexecutor.backtest.simulated_wallet import SimulatedWallet
+from tradeexecutor.cli.commands.shared_options import max_slippage
 from tradeexecutor.cli.log import setup_notebook_logging, setup_custom_log_levels, setup_strategy_logging
 from tradeexecutor.cli.loop import ExecutionLoop, ExecutionTestHook
 from tradeexecutor.ethereum.routing_data import get_routing_model, get_backtest_routing_model
@@ -199,6 +200,7 @@ class BacktestSetup:
             decide_trades=self.decide_trades,
             execution_context=execution_context,
             parameters=self.parameters,
+            max_price_impact=self.parameters.get("max_price_impact"),
         )
 
         return StrategyExecutionDescription(

--- a/tradeexecutor/backtest/backtest_runner.py
+++ b/tradeexecutor/backtest/backtest_runner.py
@@ -200,7 +200,7 @@ class BacktestSetup:
             decide_trades=self.decide_trades,
             execution_context=execution_context,
             parameters=self.parameters,
-            max_price_impact=self.parameters.get("max_price_impact"),
+            max_price_impact=self.parameters and self.parameters.get("max_price_impact"),
         )
 
         return StrategyExecutionDescription(

--- a/tradeexecutor/cli/bootstrap.py
+++ b/tradeexecutor/cli/bootstrap.py
@@ -37,6 +37,7 @@ from tradeexecutor.monkeypatch.dataclasses_json import patch_dataclasses_json
 from tradeexecutor.state.metadata import Metadata, OnChainData
 from tradeexecutor.state.state import State
 from tradeexecutor.state.store import JSONFileStore, SimulateStore
+from tradeexecutor.state.types import Percent
 from tradeexecutor.strategy.default_routing_options import TradeRouting
 from tradeexecutor.strategy.generic.generic_router import GenericRouting
 from tradeexecutor.strategy.pricing_model import PricingModelFactory
@@ -108,13 +109,13 @@ def create_web3_config(
 
 
 def create_execution_model(
-        routing_hint: Optional[TradeRouting],
-        tx_builder: Optional[TransactionBuilder],
-        confirmation_timeout: datetime.timedelta,
-        confirmation_block_count: int,
-        max_slippage: float,
-        min_gas_balance: Optional[Decimal],
-        mainnet_fork=False,
+    routing_hint: Optional[TradeRouting],
+    tx_builder: Optional[TransactionBuilder],
+    confirmation_timeout: datetime.timedelta,
+    confirmation_block_count: int,
+    max_slippage: float,
+    min_gas_balance: Optional[Decimal],
+    mainnet_fork=False,
 ):
     """Set up the code transaction building logic.
 
@@ -166,17 +167,17 @@ def create_execution_model(
 
 
 def create_execution_and_sync_model(
-        asset_management_mode: AssetManagementMode,
-        private_key: str,
-        web3config: Web3Config,
-        confirmation_timeout: datetime.timedelta,
-        confirmation_block_count: int,
-        max_slippage: float,
-        min_gas_balance: Optional[Decimal],
-        vault_address: Optional[str],
-        vault_adapter_address: Optional[str],
-        vault_payment_forwarder_address: Optional[str],
-        routing_hint: Optional[TradeRouting] = None,
+    asset_management_mode: AssetManagementMode,
+    private_key: str,
+    web3config: Web3Config,
+    confirmation_timeout: datetime.timedelta,
+    confirmation_block_count: int,
+    max_slippage: float,
+    min_gas_balance: Optional[Decimal],
+    vault_address: Optional[str],
+    vault_adapter_address: Optional[str],
+    vault_payment_forwarder_address: Optional[str],
+    routing_hint: Optional[TradeRouting] = None,
 ) -> Tuple[ExecutionModel, SyncModel, ValuationModelFactory, PricingModelFactory]:
     """Set up the wallet sync and execution mode for the command line client."""
 

--- a/tradeexecutor/cli/commands/start.py
+++ b/tradeexecutor/cli/commands/start.py
@@ -16,31 +16,24 @@ from typing import Optional
 import typer
 
 from eth_defi.gas import GasPriceMethod
-from tradeexecutor.strategy.strategy_module import parse_strategy_module
-from tradeexecutor.strategy.strategy_module import parse_strategy_module
 from tradingstrategy.chain import ChainId
-from tradingstrategy.client import Client
-from tradingstrategy.testing.uniswap_v2_mock_client import UniswapV2MockClient
 from tradingstrategy.timebucket import TimeBucket
 
 from . import shared_options
-from .app import app, TRADE_EXECUTOR_VERSION
+from .app import app
 from ..bootstrap import prepare_executor_id, prepare_cache, create_web3_config, create_state_store, \
     create_execution_and_sync_model, create_metadata, create_approval_model, create_client
-from ..log import setup_logging, setup_discord_logging, setup_logstash_logging, setup_file_logging, \
-    setup_custom_log_levels
+from ..log import setup_logging, setup_discord_logging, setup_logstash_logging, setup_file_logging
 from ..loop import ExecutionLoop
 from ..result import display_backtesting_results
 from ..version_info import VersionInfo
 from ..watchdog import stop_watchdog
 from ...ethereum.enzyme.vault import EnzymeVaultSyncModel
-from ...ethereum.uniswap_v2.uniswap_v2_routing import UniswapV2Routing
 from ...state.state import State
 from ...state.store import NoneStore, JSONFileStore
 from ...strategy.approval import ApprovalType
 from ...strategy.bootstrap import import_strategy_file
 from ...strategy.cycle import CycleDuration
-from ...strategy.default_routing_options import TradeRouting
 from ...strategy.execution_context import ExecutionContext, ExecutionMode
 from ...strategy.execution_model import AssetManagementMode
 from ...strategy.parameters import dump_parameters
@@ -136,7 +129,7 @@ def start(
     key_metrics_backtest_cut_off_days: float = typer.Option(90, envvar="KEY_METRIC_BACKTEST_CUT_OFF_DAYS", help="How many days live data is collected until key metrics are switched from backtest to live trading based"),
     check_accounts: bool = typer.Option(True, "--check-accounts", envvar="CHECK_ACCOUNTS", help="Do extra accounting checks to track mismatch balances"),
     sync_treasury_on_startup: bool = typer.Option(True, "--sync-treasury-on-startup", envvar="SYNC_TREASURY_ON_STARTUP", help="Sync treasury events before starting any trading"),
-    visulisation: bool = typer.Option(True, "--visualisation", envvar="VISUALISATION", help="Disable generation of charts using Kaleido library. Helps with issues with broken installations"),
+    visualisation: bool = typer.Option(True, "--visualisation", envvar="VISUALISATION", help="Disable generation of charts using Kaleido library. Helps with issues with broken installations"),
 
     run_single_cycle: bool = typer.Option(False, "--run-single-cycle", envvar="RUN_SINGLE_CYCLE", help="Run a single strategy decision cycle and exist, regardless of the current pending state."),
 
@@ -532,7 +525,7 @@ def start(
         sync_treasury_on_startup=sync_treasury_on_startup,
         create_indicators=mod.create_indicators,
         parameters=mod.parameters,
-        visualisation=visulisation,
+        visualisation=visualisation,
         max_price_impact=mod.get_max_price_impact(),
     )
 

--- a/tradeexecutor/cli/commands/start.py
+++ b/tradeexecutor/cli/commands/start.py
@@ -532,7 +532,8 @@ def start(
         sync_treasury_on_startup=sync_treasury_on_startup,
         create_indicators=mod.create_indicators,
         parameters=mod.parameters,
-        visulisation=visulisation,
+        visualisation=visulisation,
+        max_price_impact=mod.get_max_price_impact(),
     )
 
     # Crash gracefully at the start up if our main loop cannot set itself up

--- a/tradeexecutor/cli/loop.py
+++ b/tradeexecutor/cli/loop.py
@@ -25,6 +25,7 @@ from tradeexecutor.ethereum.enzyme.vault import EnzymeVaultSyncModel
 from tradeexecutor.ethereum.tx import TransactionBuilder
 from tradeexecutor.ethereum.wallet import perform_gas_level_checks
 from tradeexecutor.state.metadata import Metadata
+from tradeexecutor.state.types import Percent
 from tradeexecutor.statistics.in_memory_statistics import refresh_run_state
 from tradeexecutor.statistics.statistics_table import serialise_long_short_stats_as_json_table
 from tradeexecutor.strategy.account_correction import check_accounts, UnexpectedAccountingCorrectionIssue
@@ -157,7 +158,8 @@ class ExecutionLoop:
             sync_treasury_on_startup: bool = False,
             create_indicators: CreateIndicatorsProtocol = None,
             parameters: StrategyParameters = None,
-            visulisation: bool = True,
+            visualisation: bool = True,
+            max_price_impact: Percent | None = None,
     ):
         """See main.py for details."""
 
@@ -193,12 +195,12 @@ class ExecutionLoop:
         self.create_indicators = create_indicators
         self.parameters = parameters
 
+        # TODO: Spell out individual variables for type hinting support
         args = locals().copy()
         args.pop("self")
 
         assert "execution_context" in args, "execution_context required"
 
-        # TODO: Spell out individual variables for type hinting support
         self.__dict__.update(args)
 
         self.timed_task_context_manager = self.execution_context.timed_task_context_manager
@@ -230,7 +232,7 @@ class ExecutionLoop:
         # We hide once-downloaded universe here for live loop
         # tests that perform live trading against forked chain in a fast cycle (1s)
         self.unit_testing_universe: StrategyExecutionUniverse | None = None
-        self.visulisation = visulisation
+        self.visulisation = visualisation
 
     def is_backtest(self) -> bool:
         """Are we doing a backtest execution."""
@@ -1382,6 +1384,7 @@ class ExecutionLoop:
             create_indicators=self.create_indicators,
             parameters=self.parameters,
             visualisation=self.visulisation,
+            max_price_impact=self.max_price_impact,
         )
 
         self.init_live_run_state(run_description)

--- a/tradeexecutor/state/trade.py
+++ b/tradeexecutor/state/trade.py
@@ -420,9 +420,19 @@ class TradeExecution:
     #: If you are usinga vault-based trading, slippage tolerance must be always set
     #: to calculate the asset delta.
     #:
-    #: See also :py:meth:`calculate_asset_deltas`.
+    #: See also :py:meth:`calculate_asset_deltas` and :py:attr:`price_impact_tolerance`.
     #:
-    slippage_tolerance: Optional[float] = None
+    slippage_tolerance: Optional[Percent] = None
+
+    #: Price-impact tolerance check used for this trade.
+    #:
+    #: No need to manually fill - automatically filled from `Parameters.max_price_impact`.
+    #:
+    #: Filled in by `post_process_trade_decision()`.
+    #:
+    #: See also :py:attr:`slippage_tolerance`.
+    #:
+    price_impact_tolerance: Optional[Percent] = None
 
     #: LP fee % recorded before the execution starts.
     #:

--- a/tradeexecutor/strategy/bootstrap.py
+++ b/tradeexecutor/strategy/bootstrap.py
@@ -12,6 +12,7 @@ from contextlib import AbstractContextManager
 from pathlib import Path
 from typing import Optional
 
+from tradeexecutor.state.types import Percent
 from tradeexecutor.strategy.default_routing_options import TradeRouting
 from tradeexecutor.strategy.pandas_trader.indicator import CreateIndicatorsProtocolV1, CreateIndicatorsProtocol
 from tradeexecutor.strategy.parameters import StrategyParameters
@@ -109,6 +110,7 @@ def make_factory_from_strategy_mod(mod: StrategyModuleInformation) -> StrategyFa
             create_indicators: CreateIndicatorsProtocol | None = None,
             parameters: StrategyParameters | None = None,
             visualisation=True,
+            max_price_impact: Percent | None = None,
             **kwargs) -> StrategyExecutionDescription:
 
         # Migration assert
@@ -157,13 +159,15 @@ def make_factory_from_strategy_mod(mod: StrategyModuleInformation) -> StrategyFa
             create_indicators=create_indicators,
             parameters=parameters,
             visualisation=visualisation,
+            max_price_impact=max_price_impact,
         )
 
         logger.info(
-            "Starting strategy runner in execution mode %s:\n%s\nVisualisations are: %s",
+            "Starting strategy runner in execution mode %s:\n%s\nVisualisations are: %s\nmax_price_impact is: %s",
             execution_context.mode.name,
             runner.__class__.__name__,
             visualisation,
+            max_price_impact,
         )
 
         return StrategyExecutionDescription(

--- a/tradeexecutor/strategy/factory.py
+++ b/tradeexecutor/strategy/factory.py
@@ -7,6 +7,7 @@ from typing import Protocol, Optional
 
 from contextlib import AbstractContextManager
 
+from tradeexecutor.state.types import Percent
 from tradingstrategy.client import Client, BaseClient
 
 from tradeexecutor.strategy.sync_model import SyncMethodV0, SyncModel
@@ -36,6 +37,7 @@ class StrategyFactory(Protocol):
         timed_task_context_manager: AbstractContextManager,
         approval_model: ApprovalModel,
         routing_model: Optional[RoutingModel] = None,
+        max_price_impact: Percent | None = None,
         **kwargs) -> StrategyExecutionDescription:
         """
 

--- a/tradeexecutor/strategy/pandas_trader/position_manager.py
+++ b/tradeexecutor/strategy/pandas_trader/position_manager.py
@@ -912,6 +912,7 @@ class PositionManager:
                 notes=notes,
                 pending=pending,
                 position=position,
+                price_structure=price_structure,
             )
         else:
             # Sell

--- a/tradeexecutor/strategy/parameters.py
+++ b/tradeexecutor/strategy/parameters.py
@@ -9,7 +9,7 @@ from skopt.space import Dimension
 from tabulate import tabulate
 from web3.datastructures import MutableAttributeDict
 
-from tradeexecutor.state.types import USDollarAmount
+from tradeexecutor.state.types import USDollarAmount, Percent
 from tradeexecutor.strategy.cycle import CycleDuration
 from tradeexecutor.strategy.default_routing_options import TradeRouting
 
@@ -47,6 +47,20 @@ class CoreStrategyParameters(TypedDict):
     #: How much data load for each strategy cycle in live trading
     #:
     required_history_period: datetime.timedelta | None
+
+    #: Live trading setting for the maximum price impact.
+    #:
+    #: A tripwire check.
+    #:
+    #: If we exceed this price impact for any trade,
+    #: crash the trade-executor before executing the trades.
+    #: This is to protect the capital in the case
+    #: some pool liquidity action is funny when a major single
+    #: LP withdraws the liquidity.
+    #:
+    #: See :py:class:`PriceImpactToleranceExceeded`
+    #:
+    maximum_price_impact: Percent | None
 
 
 class StrategyParameters(MutableAttributeDict):

--- a/tradeexecutor/strategy/parameters.py
+++ b/tradeexecutor/strategy/parameters.py
@@ -58,6 +58,9 @@ class CoreStrategyParameters(TypedDict):
     #: some pool liquidity action is funny when a major single
     #: LP withdraws the liquidity.
     #:
+    #: The parameter must be LP fee inclusive
+    #: e.g. for the 5 BPS pool ever set this value lower than `0.0005`.
+    #:
     #: See :py:class:`PriceImpactToleranceExceeded`
     #:
     maximum_price_impact: Percent | None

--- a/tradeexecutor/strategy/runner.py
+++ b/tradeexecutor/strategy/runner.py
@@ -19,7 +19,7 @@ from tradeexecutor.backtest.backtest_execution import BacktestExecutionFailed
 from tradeexecutor.ethereum.ethereum_protocol_adapters import EthereumPairConfigurator
 from tradeexecutor.ethereum.tx import TransactionBuilder
 from tradeexecutor.state.store import StateStore
-from tradeexecutor.state.types import BlockNumber
+from tradeexecutor.state.types import BlockNumber, Percent
 from tradeexecutor.statistics.core import update_statistics
 from tradeexecutor.statistics.statistics_table import StatisticsTable
 from tradeexecutor.strategy.account_correction import check_accounts, UnexpectedAccountingCorrectionIssue
@@ -40,6 +40,7 @@ from tradeexecutor.strategy.pandas_trader.position_manager import PositionManage
 from tradeexecutor.strategy.pricing_model import PricingModelFactory, PricingModel
 from tradeexecutor.strategy.routing import RoutingModel, RoutingState
 from tradeexecutor.strategy.stop_loss import check_position_triggers
+from tradeexecutor.strategy.trade_pricing import PriceImpactToleranceExceeded
 from tradeexecutor.strategy.trading_strategy_universe import TradingStrategyUniverse
 from tradeexecutor.strategy.universe_model import StrategyExecutionUniverse
 
@@ -87,6 +88,7 @@ class StrategyRunner(abc.ABC):
         parameters: StrategyParameters = None,
         create_indicators: CreateIndicatorsProtocol = None,\
         visualisation=True,
+        maximum_price_impact: Percent | None = None,
     ):
         """
         :param engine_version:
@@ -115,6 +117,7 @@ class StrategyRunner(abc.ABC):
         self.parameters = parameters
         self.create_indicators = create_indicators
         self.visualisation = visualisation
+        self.maximum_price_impact = maximum_price_impact
 
         # We need 60 seconds wait to read balances
         # after trades only on a real trading,
@@ -1035,13 +1038,23 @@ class StrategyRunner(abc.ABC):
             pass
 
 
-def post_process_trade_decision(state: State, trades: List[TradeExecution]):
-    """Set any extra flags on trades needed.
+def post_process_trade_decision(
+    state: State,
+    trades: List[TradeExecution],
+    maximum_price_impact: Percent | None = None,
+):
+    """Set any extra flags and do extra checks on trades.
 
     - Mainly to deal with the fact that if trades close a final position on lending
 
-    TODO: Currently we do not pass enough information in :py:class:`TradingPairIdentifier`
-    so here we take a hack shortcut to set close_protocol_all. W
+    :param maximum_price_impact:
+        What is the allowed maximum price impact of a single trade.
+
+        Trades must have their `trade.price_structure` data filled
+        to detect.
+
+    :raise PriceImpactToleranceExceeded:
+        If any of the trades is detected to have too much price impact.
     """
 
     # TODO: Write a full logic here, only supports closing shorts now,
@@ -1049,6 +1062,22 @@ def post_process_trade_decision(state: State, trades: List[TradeExecution]):
     lending_positions_open = [p for p in state.portfolio.open_positions.values() if p.is_leverage()]
     lending_position_closing_trades = [t for t in trades if t.pair.is_leverage() and TradeFlag.close in t.flags]
     assert len(lending_positions_open) >= len(lending_position_closing_trades), "We cannot close more than we have open"
+
+    # TODO: Currently we do not pass enough information in :py:class:`TradingPairIdentifier`
+    # so here we take a hack shortcut to set close_protocol_all.
     if len(lending_position_closing_trades) == len(lending_positions_open) and len(lending_positions_open) > 0:
         lending_position_closing_trades[-1].flags.add(TradeFlag.close_protocol_last)
+
+    if maximum_price_impact is not None:
+        for t in trades:
+            if t.price_structure is not None:
+                impact = t.price_structure.get_price_impact()
+                if impact > maximum_price_impact:
+                    raise PriceImpactToleranceExceeded(
+                        f"Trade {t} has too much price impact\n"
+                        f"Maximum allowed: {maximum_price_impact * 100} %\n"
+                        f"Trade impact: {impact * 100} %\n"
+                        f"Trade pricing: {t.price_structure}\n"
+                    )
+
     return trades

--- a/tradeexecutor/strategy/runner.py
+++ b/tradeexecutor/strategy/runner.py
@@ -88,7 +88,7 @@ class StrategyRunner(abc.ABC):
         parameters: StrategyParameters = None,
         create_indicators: CreateIndicatorsProtocol = None,\
         visualisation=True,
-        maximum_price_impact: Percent | None = None,
+        max_price_impact: Percent | None = None,
     ):
         """
         :param engine_version:
@@ -117,7 +117,7 @@ class StrategyRunner(abc.ABC):
         self.parameters = parameters
         self.create_indicators = create_indicators
         self.visualisation = visualisation
-        self.maximum_price_impact = maximum_price_impact
+        self.max_price_impact = max_price_impact
 
         # We need 60 seconds wait to read balances
         # after trades only on a real trading,
@@ -131,10 +131,11 @@ class StrategyRunner(abc.ABC):
             self.trade_settle_wait = trade_settle_wait
 
         logger.info(
-            "Created strategy runner %s, engine version %s, running mode %s",
+            "Created strategy runner: %s, engine version: %s, running mode: %s, max_price_impact: %s",
             self.__class__.__name__,
             self.execution_context.engine_version,
             self.execution_context.mode.name,
+            self.max_price_impact
         )
 
         # If planned and executed price is % off then
@@ -743,7 +744,11 @@ class StrategyRunner(abc.ABC):
                                            f"Old positions before decide_trades(): {old_position_ids}\n"
                                            f"New positions after decide_trades(): {new_position_ids}\n")
 
-                rebalance_trades = post_process_trade_decision(state, rebalance_trades)
+                rebalance_trades = post_process_trade_decision(
+                    state,
+                    rebalance_trades,
+                    max_price_impact=self.max_price_impact,
+                )
 
                 # Log what our strategy decided
                 if self.is_progress_report_needed():
@@ -922,7 +927,11 @@ class StrategyRunner(abc.ABC):
             )
 
             triggered_trades = check_position_triggers(position_manager,self.execution_context)
-            triggered_trades = post_process_trade_decision(state, triggered_trades)
+            triggered_trades = post_process_trade_decision(
+                state,
+                triggered_trades,
+                max_price_impact=self.max_price_impact,
+            )
             approved_trades = self.approval_model.confirm_trades(state, triggered_trades)
             if approved_trades:
                 logger.info("Executing %d stop loss/take profit trades at %s", len(approved_trades), clock)
@@ -1041,13 +1050,13 @@ class StrategyRunner(abc.ABC):
 def post_process_trade_decision(
     state: State,
     trades: List[TradeExecution],
-    maximum_price_impact: Percent | None = None,
+    max_price_impact: Percent | None = None,
 ):
     """Set any extra flags and do extra checks on trades.
 
     - Mainly to deal with the fact that if trades close a final position on lending
 
-    :param maximum_price_impact:
+    :param max_price_impact:
         What is the allowed maximum price impact of a single trade.
 
         Trades must have their `trade.price_structure` data filled
@@ -1056,6 +1065,12 @@ def post_process_trade_decision(
     :raise PriceImpactToleranceExceeded:
         If any of the trades is detected to have too much price impact.
     """
+
+    logger.info(
+        "post_process_trade_decision(): Post-processing %d trades, max_price_impact: %s",
+        len(trades),
+        max_price_impact,
+    )
 
     # TODO: Write a full logic here, only supports closing shorts now,
     # assuming everything lending is short
@@ -1068,16 +1083,17 @@ def post_process_trade_decision(
     if len(lending_position_closing_trades) == len(lending_positions_open) and len(lending_positions_open) > 0:
         lending_position_closing_trades[-1].flags.add(TradeFlag.close_protocol_last)
 
-    if maximum_price_impact is not None:
+    if max_price_impact is not None:
         for t in trades:
             if t.price_structure is not None:
                 impact = t.price_structure.get_price_impact()
-                if impact > maximum_price_impact:
+                if impact > max_price_impact:
                     raise PriceImpactToleranceExceeded(
                         f"Trade {t} has too much price impact\n"
-                        f"Maximum allowed: {maximum_price_impact * 100} %\n"
+                        f"Maximum allowed: {max_price_impact * 100} %\n"
                         f"Trade impact: {impact * 100} %\n"
                         f"Trade pricing: {t.price_structure}\n"
                     )
+                t.price_impact_tolerance = max_price_impact
 
     return trades

--- a/tradeexecutor/strategy/runner.py
+++ b/tradeexecutor/strategy/runner.py
@@ -1091,6 +1091,8 @@ def post_process_trade_decision(
             price_structure = t.price_structure
 
             if execution_context.live_trading:
+                # TODO: Why not always filled?
+                # Make sure PositionManager passes trade.price_structure along
                 assert price_structure is not None, f"Live trading running, but trade missing price structure {t}"
 
             if price_structure is not None:

--- a/tradeexecutor/strategy/strategy_module.py
+++ b/tradeexecutor/strategy/strategy_module.py
@@ -617,7 +617,7 @@ class StrategyModuleInformation:
 
     def get_max_price_impact(self) -> Percent | None:
         if self.parameters:
-            val = self.parameters.get("get_max_price_imapact")
+            val = self.parameters.get("max_price_impact")
             assert isinstance(val, (float, NoneType)), f"Expected float, got {type(val)}: {val}"
             return val
         return None

--- a/tradeexecutor/strategy/strategy_module.py
+++ b/tradeexecutor/strategy/strategy_module.py
@@ -16,6 +16,7 @@ import pandas
 import pandas as pd
 from web3.datastructures import AttributeDict, ReadableAttributeDict
 
+from tradeexecutor.state.types import Percent
 from tradeexecutor.strategy.engine_version import SUPPORTED_TRADING_STRATEGY_ENGINE_VERSIONS, TradingStrategyEngineVersion
 from tradeexecutor.strategy.pandas_trader.indicator import CreateIndicatorsProtocolV1, CreateIndicatorsProtocol
 from tradeexecutor.strategy.pandas_trader.strategy_input import StrategyInput
@@ -612,6 +613,13 @@ class StrategyModuleInformation:
             assert isinstance(val, (datetime.timedelta, NoneType)), f"Expected datetime, got {type(val)}: {val}"
             return val
 
+        return None
+
+    def get_max_price_impact(self) -> Percent | None:
+        if self.parameters:
+            val = self.parameters.get("get_max_price_imapact")
+            assert isinstance(val, (float, NoneType)), f"Expected float, got {type(val)}: {val}"
+            return val
         return None
 
 


### PR DESCRIPTION
- Add explicit maximum price impact tolerance tripwire
    - Crash trade-executor if we detect a trade with more impact attempts to be executed
- Add `Parameters.max_price_impact` so a strategy can have rough control on what kind of trades are allowed
   - Use `SizeRiskModel` in `decide_trades()` to resize trades to that `max_price_impact` will be never reached