### PR TITLE
Enzyme redeem dust fix

### DIFF
--- a/strategies/eth-btc-usdc-size-risk.py
+++ b/strategies/eth-btc-usdc-size-risk.py
@@ -295,7 +295,6 @@ def decide_trades(
     alpha_model.normalise_weights(
         investable_equity=portfolio_target_value,
         size_risk_model=size_risk_model,
-
     )
 
     # Load in old weight for each trading pair signal,

--- a/strategies/test_only/enzyme-polygon-eth-btc-rsi.py
+++ b/strategies/test_only/enzyme-polygon-eth-btc-rsi.py
@@ -1,0 +1,722 @@
+"""ETH-BTC-USDC daily RSI strategy.
+
+-  Updated version 2.0 that uses Aave credit positions for extra yield
+
+- See https://tradingstrategy.ai/blog/outperfoming-eth for the strategy development information
+
+To backtest this strategy module locally:
+
+.. code-block:: console
+
+    trade-executor \
+        backtest \
+        --strategy-file=strategy/enzyme-polygon-eth-btc-rsi.py \
+        --trading-strategy-api-key=$TRADING_STRATEGY_API_KEY
+
+"""
+import datetime
+import logging
+import os
+
+import pandas as pd
+import pandas_ta
+from tradeexecutor.state.trade import TradeExecution
+from tradeexecutor.state.visualisation import PlotKind, PlotLabel, PlotShape
+from tradeexecutor.strategy.alpha_model import AlphaModel
+from tradeexecutor.strategy.cycle import CycleDuration
+from tradeexecutor.strategy.default_routing_options import TradeRouting
+from tradeexecutor.strategy.execution_context import (ExecutionContext,
+                                                      ExecutionMode)
+from tradeexecutor.strategy.pandas_trader.indicator import (IndicatorSet,
+                                                            IndicatorSource)
+from tradeexecutor.strategy.pandas_trader.strategy_input import StrategyInput
+from tradeexecutor.strategy.parameters import StrategyParameters
+from tradeexecutor.strategy.tag import StrategyTag
+from tradeexecutor.strategy.trading_strategy_universe import (
+    TradingStrategyUniverse, load_partial_data)
+from tradeexecutor.strategy.tvl_size_risk import USDTVLSizeRiskModel
+from tradeexecutor.strategy.universe_model import UniverseOptions
+from tradeexecutor.strategy.weighting import weight_passthrouh
+from tradeexecutor.utils.binance import create_binance_universe
+from tradingstrategy.chain import ChainId
+from tradingstrategy.client import Client
+from tradingstrategy.lending import (LendingProtocolType,
+                                     LendingReserveDescription)
+from tradingstrategy.pair import HumanReadableTradingPairDescription
+from tradingstrategy.timebucket import TimeBucket
+from tradingstrategy.utils.groupeduniverse import resample_price_series
+
+trading_strategy_engine_version = "0.5"
+
+
+
+class Parameters:
+    """Parameteres for this strategy.
+
+    - Collect parameters used for this strategy here
+
+    - Both live trading and backtesting parameters
+    """
+
+    cycle_duration = CycleDuration.cycle_1d  # Run decide_trades() every 8h
+    candle_time_bucket = TimeBucket.d1  # Use 1h candles as the raw data
+    # target_time_bucket = TimeBucket.d1  # Create synthetic 8h candles
+    clock_shift_bars = 0  # Do not do shifted candles
+
+    rsi_bars = 8  # Number of bars to calculate RSI for each tradingbar
+    eth_btc_rsi_bars = 5  # Number of bars for the momentum factor
+
+    # RSI parameters for bull and bear market
+    bearish_rsi_entry = 65
+    bearish_rsi_exit = 70
+    bullish_rsi_entry = 80
+    bullish_rsi_exit = 65
+
+    regime_filter_ma_length = 200  # Bull/bear MA begime filter in days
+    regime_filter_only_btc = 1   # Use BTC or per-pair regime filter
+
+    allocation = 0.98  # How much cash allocate for volatile positions
+    rebalance_threshold = 0.275  # How much position mix % must change when we rebalance between two open positions
+    initial_cash = 10_000  # Backtesting start cash
+    trailing_stop_loss = None  # Trailing stop loss as 1 - x
+    trailing_stop_loss_activation_level = None  # How much above opening price we must be before starting to use trailing stop loss
+    stop_loss = None  # 0.80  # Hard stop loss when opening a new position
+    momentum_exponent = 3.5  # How much momentum we capture when rebalancing between open positions
+
+    #
+    # Live trading only
+    #
+    chain_id = ChainId.polygon
+    routing = TradeRouting.default  # Pick default routes for trade execution
+    required_history_period = datetime.timedelta(days=regime_filter_ma_length) * 2  # Ask some extra history just in case
+
+    #
+    # Backtesting only
+    #
+
+    initial_cash = 10_000
+    stop_loss_time_bucket = TimeBucket.m15
+    backtest_trading_fee = 0.0030  # Switch to QuickSwap 30 BPS free from the default Binance 5 BPS fee
+
+    use_binance = os.environ.get("USE_BINANCE", "").lower() == "true"  # Integration test override
+
+    if use_binance:
+        backtest_start = datetime.datetime(2020, 1, 1)
+        # backtest_end = datetime.datetime(2024, 4, 20)
+        # backtest_start = datetime.datetime(2022, 6, 1)
+        backtest_end = datetime.datetime(2024, 9, 30)
+        use_credit = False
+
+    else:
+        # dex dates
+        backtest_start = datetime.datetime(2023, 7, 1)
+        backtest_end = datetime.datetime(2024, 9, 30)
+        use_credit = True  # Allow us to flip credit usage on/off in backtesting to more easily test different scenarios
+
+    #
+    # Risk parameters
+    #
+    use_size_risk = not use_binance
+    per_position_cap_of_pool = 0.010  # Cap positions to 1.0% of the underlying pool size
+    max_price_impact = 0.015   # Allow max 1.5% price impact before crashing and needing manual intervention (should never happen per above parameter)
+    aave_min_deposit_threshold_usd = 5.0  # Minimum deposit limit we do into Aave to avoid too small txs
+
+
+def calculate_eth_btc(strategy_universe: TradingStrategyUniverse, mode: ExecutionMode):
+    """Calculate ETH/BTC price used as a rebalance factor."""
+    pair_ids = get_strategy_trading_pairs(mode)
+    eth = strategy_universe.get_pair_by_human_description(pair_ids[1])
+    btc = strategy_universe.get_pair_by_human_description(pair_ids[0])
+    btc_price = strategy_universe.data_universe.candles.get_candles_by_pair(btc.internal_id)
+    eth_price = strategy_universe.data_universe.candles.get_candles_by_pair(eth.internal_id)
+    series = eth_price["close"] / btc_price["close"]  # Divide two series
+    return series
+
+
+def calculate_eth_btc_rsi(strategy_universe: TradingStrategyUniverse, mode: ExecutionMode, length: int):
+    """Calculate x hours RSI for MATIC/ETH price used as the rebalancing factor."""
+    eth_btc_series = calculate_eth_btc(strategy_universe, mode)
+    return pandas_ta.rsi(eth_btc_series, length=length)
+
+
+def calculate_resampled_rsi(pair_close_price_series: pd.Series, length: int, upsample: TimeBucket, shift: int):
+    """Calculate x hours RSI for a particular trading pair"""
+    resampled_close = resample_price_series(pair_close_price_series, upsample.to_pandas_timedelta(), shift=shift)
+    return pandas_ta.rsi(resampled_close, length=length)
+
+
+def calculate_resampled_eth_btc(strategy_universe: TradingStrategyUniverse, mode: ExecutionMode, upsample: TimeBucket, shift: int):
+    """Calculate BTC/ETH price series for x hours."""
+    pair_ids = get_strategy_trading_pairs(mode)
+    eth = strategy_universe.get_pair_by_human_description(pair_ids[1])
+    btc = strategy_universe.get_pair_by_human_description(pair_ids[0])
+    eth_price = strategy_universe.data_universe.candles.get_candles_by_pair(eth.internal_id)
+    btc_price = strategy_universe.data_universe.candles.get_candles_by_pair(btc.internal_id)
+    resampled_eth = resample_price_series(eth_price["close"], upsample.to_pandas_timedelta(), shift=shift)
+    resampled_btc = resample_price_series(btc_price["close"], upsample.to_pandas_timedelta(), shift=shift)
+    series = resampled_eth / resampled_btc
+    return series
+
+
+def calculate_resampled_eth_btc_rsi(strategy_universe: TradingStrategyUniverse, mode: ExecutionMode, length: int, upsample: TimeBucket, shift: int):
+     """Caclulate RSI for MATIC/ETH price series for x hours."""
+     etc_btc = calculate_resampled_eth_btc(strategy_universe, mode, upsample, shift)
+     return pandas_ta.rsi(etc_btc, length=length)
+
+
+def calculate_shifted_sma(pair_close_price_series: pd.Series, length: int, upsample: TimeBucket, shift: int):
+    resampled_close = resample_price_series(pair_close_price_series, upsample.to_pandas_timedelta(), shift=shift)
+    return pandas_ta.sma(resampled_close, length=length)
+
+
+def create_indicators(
+    timestamp: datetime.datetime,
+    parameters: StrategyParameters,
+    strategy_universe: TradingStrategyUniverse,
+    execution_context: ExecutionContext
+):
+    """Create indicators for this trading strategy.
+
+    - Because we use non-standard candle time bucket, we do upsamplign from 1h candles
+    """
+    indicators = IndicatorSet()
+    mode = execution_context.mode  # Switch between live trading and backtesting pairs
+    upsample = parameters.candle_time_bucket  # We do not perform upsample in this strategy
+    shift = parameters.clock_shift_bars
+    indicators.add(
+        "rsi", calculate_resampled_rsi,
+        {"length": parameters.rsi_bars, "upsample": upsample, "shift": shift}
+    )
+    indicators.add(
+        "eth_btc",
+        calculate_resampled_eth_btc,
+        {"upsample": upsample, "mode": mode, "shift": shift},
+        source=IndicatorSource.strategy_universe
+    )
+    indicators.add(
+        "eth_btc_rsi",
+        calculate_resampled_eth_btc_rsi,
+        {"length": parameters.eth_btc_rsi_bars, "mode": mode, "upsample": upsample, "shift": shift},
+        source=IndicatorSource.strategy_universe
+    )
+    indicators.add(
+        "sma",
+        calculate_shifted_sma,
+        {"length": parameters.regime_filter_ma_length, "upsample": upsample, "shift": shift}
+    )
+    return indicators
+
+
+def decide_trades(
+    input: StrategyInput,
+) -> list[TradeExecution]:
+    """Trade logic."""
+
+    # Resolve some variables we are going to use to here
+    parameters = input.parameters
+    position_manager = input.get_position_manager()
+    state = input.state
+    timestamp = input.timestamp
+    indicators = input.indicators
+    shift = parameters.clock_shift_bars
+    clock_shift = pd.Timedelta(hours=1) * shift
+    upsample = parameters.candle_time_bucket
+    mode = input.execution_context.mode
+    our_pairs = get_strategy_trading_pairs(mode)
+
+    # Execute the daily trade cycle when the clock hour 0..24 is correct for our hourly shift
+    assert upsample.to_timedelta() >= parameters.cycle_duration.to_timedelta(), "Upsample period must be longer than cycle period"
+    assert shift <= 0  # Shift -1 = do action 1 hour later
+
+    # Override the trading fee to simulate worse DEX fees and price impact vs. Binance
+    if mode.is_backtesting():
+        if parameters.backtest_trading_fee:
+            input.pricing_model.set_trading_fee_override(parameters.backtest_trading_fee)
+
+    # Do the clock shift trick
+    if parameters.cycle_duration.to_timedelta() != upsample.to_timedelta():
+        if (input.cycle - 1 + shift) % int(upsample.to_hours()) != 0:
+            return []
+
+    alpha_model = AlphaModel(input.timestamp)
+    btc_pair = position_manager.get_trading_pair(our_pairs[0])
+    eth_pair = position_manager.get_trading_pair(our_pairs[1])
+    position_manager.log("decide_trades() start")
+
+    #
+    # Indicators
+    #
+    # Calculate indicators for each pair.
+    #
+
+    # Per-trading pair calcualted data
+    current_rsi_values = {}  # RSI yesterday
+    previous_rsi_values = {}  # RSI day before yesterday
+    current_price = {}  # Close price yesterday
+    momentum = {btc_pair: 0, eth_pair: 0}
+
+    for pair in [btc_pair, eth_pair]:
+        current_price[pair] = indicators.get_price(pair)
+        current_rsi_values[pair] = indicators.get_indicator_value("rsi", index=-1, pair=pair, clock_shift=clock_shift)
+        previous_rsi_values[pair] = indicators.get_indicator_value("rsi", index=-2, pair=pair, clock_shift=clock_shift)
+
+    eth_btc_yesterday = indicators.get_indicator_value("eth_btc", clock_shift=clock_shift)
+    eth_btc_rsi_yesterday = indicators.get_indicator_value("eth_btc_rsi", clock_shift=clock_shift)
+    if eth_btc_rsi_yesterday is not None:
+        eth_momentum = (eth_btc_rsi_yesterday / 100) + 0.5
+        btc_momentum = (1 - (eth_btc_rsi_yesterday / 100)) + 0.5
+        momentum[eth_pair] = eth_momentum ** parameters.momentum_exponent
+        momentum[btc_pair] = btc_momentum ** parameters.momentum_exponent
+
+    #
+    # Trading logic
+    #
+
+    volatile_pairs = [btc_pair, eth_pair]
+
+    for pair in volatile_pairs:
+
+        #
+        # Regime filter
+        #
+        # If no indicator data yet, or regime filter disabled,
+        # be always bullish
+        bullish = True
+        if parameters.regime_filter_ma_length:  # Regime filter is not disabled
+            regime_filter_pair = btc_pair if parameters.regime_filter_only_btc else pair  # Each pair has its own bullish/bearish regime?
+            regime_filter_price = current_price[regime_filter_pair]
+            sma = indicators.get_indicator_value("sma", index=-1, pair=regime_filter_pair, clock_shift=clock_shift)
+            if sma:
+                # We are bearish if close price is beloe SMA
+                bullish = regime_filter_price > sma
+
+        if bullish:
+            rsi_entry = parameters.bullish_rsi_entry
+            rsi_exit = parameters.bullish_rsi_exit
+        else:
+            rsi_entry = parameters.bearish_rsi_entry
+            rsi_exit = parameters.bearish_rsi_exit
+
+        existing_position = position_manager.get_current_position_for_pair(pair)
+        pair_open = existing_position is not None
+        closed_positions = position_manager.get_closed_positions_for_pair(pair)
+        has_no_position = not pair_open and len(closed_positions) == 0 and mode.is_live_trading()
+        pair_momentum = momentum.get(pair, 0)
+        signal_strength = max(pair_momentum, 0.1)  # Singal strength must be positive, as we do long-only
+        if pd.isna(signal_strength):
+            signal_strength = 0
+        alpha_model.set_signal(pair, 0)
+
+        if pair_open:
+            # We have existing open position for this pair,
+            # keep it open by default unless we get a trigger condition below
+            position_manager.log(f"Pair {pair} already open")
+            alpha_model.set_signal(pair, signal_strength, stop_loss=parameters.stop_loss)
+
+        if current_rsi_values[pair] and previous_rsi_values[pair]:
+
+            # Check for RSI crossing our threshold values in this cycle, compared to the previous cycle
+            if rsi_entry:
+                rsi_cross_above = current_rsi_values[pair] >= rsi_entry and previous_rsi_values[pair] < rsi_entry
+            else:
+                # bearish_rsi_entry = None -> don't trade in bear market
+                rsi_cross_above = False
+
+            rsi_cross_below = current_rsi_values[pair] < rsi_exit and previous_rsi_values[pair] > rsi_exit
+
+            if not pair_open:
+                # Check for opening a position if no position is open
+                if rsi_cross_above or has_no_position:
+                    position_manager.log(f"Pair {pair} crossed above")
+                    alpha_model.set_signal(pair, signal_strength, stop_loss=parameters.stop_loss)
+            else:
+                # We have open position, check for the close condition
+                if rsi_cross_below:
+                    position_manager.log(f"Pair {pair} crossed below")
+                    alpha_model.set_signal(pair, 0)
+
+    # Enable trailing stop loss if we have reached the activation level
+    if parameters.trailing_stop_loss_activation_level is not None and parameters.trailing_stop_loss is not None:
+       for p in state.portfolio.open_positions.values():
+           if p.trailing_stop_loss_pct is None:
+               if current_price[p.pair] >= p.get_opening_price() * parameters.trailing_stop_loss_activation_level:
+                   p.trailing_stop_loss_pct = parameters.trailing_stop_loss
+
+    #
+    # Rebalance the portfolio
+    #
+
+    portfolio = position_manager.get_current_portfolio()
+    portfolio_target_value = portfolio.get_total_equity() * parameters.allocation
+
+    # Use alpha model and construct a portfolio of two assets
+    alpha_model.select_top_signals(2)
+    alpha_model.assign_weights(weight_passthrouh)
+
+    if parameters.use_size_risk:
+        # Normalise weights and cap the positions
+        # using the available lit liquidity from DEX pools
+
+        size_risk_model = USDTVLSizeRiskModel(
+            pricing_model=input.pricing_model,
+            per_position_cap=parameters.per_position_cap_of_pool,  # This is how much % by all pool TVL we can allocate for a position
+        )
+
+        alpha_model.update_old_weights(state.portfolio, portfolio_pairs=volatile_pairs)
+        alpha_model.normalise_weights(
+            investable_equity=portfolio_target_value,
+            size_risk_model=size_risk_model,
+        )
+        alpha_model.calculate_target_positions(position_manager, portfolio_target_value)
+
+    else:
+        # On Binance backtesting, we do not have the depth
+        # of the lit liquidity available and we assume our trades
+        # do not have a significant price impact
+
+        alpha_model.normalise_weights()
+        alpha_model.update_old_weights(state.portfolio, portfolio_pairs=volatile_pairs)
+        alpha_model.calculate_target_positions(position_manager, portfolio_target_value)
+
+    trades = []
+
+    #
+    # If we have cash stashed in Aave, withdraw
+    #
+    trades += alpha_model.generate_rebalance_trades_and_triggers(
+        position_manager,
+        min_trade_threshold=parameters.rebalance_threshold * portfolio.get_total_equity(),
+    )
+
+    if len(trades) == 0 and alpha_model.has_any_signal():
+        # Be noisy if our risk parameters are too tight
+        # and we starting to lose positions because of it
+        position_manager.log(
+            f"Generated zero trades even though trade signals: {list(alpha_model.signals.values())}\n" +
+            f"Total equity: {portfolio.get_total_equity()}\n" +
+            f"Rebalance threshold: {parameters.rebalance_threshold}\n",
+            level=logging.WARNING,
+        )
+
+    #
+    # Supply exceed cash as Aave credit
+    #
+    if parameters.use_credit:
+        if len(trades) > 0:
+            # We are going to do rebalancing trades and cash in hand is needed.
+            # We simplify credit handling by always fully closing the credit position,
+            # and then opening it in the next cycle if there are no volatile position rebalances.
+            # Opening and closing Aave positions do not have a fee.
+            if position_manager.is_any_credit_supply_position_open():
+                current_credit_pos = position_manager.get_current_credit_supply_position()
+                trades += position_manager.close_credit_supply_position(current_credit_pos)
+        else:
+            # Check if we can push any extra cash to Aave,
+            # As this cycle did not do any rebalancing trades,
+            # we should be able to push all exceed cash in hand to Aave.
+            cash_to_deposit = position_manager.get_current_cash() * Parameters.allocation
+            trades += position_manager.add_cash_to_credit_supply(
+                cash_to_deposit,
+                min_usd_threshold=Parameters.aave_min_deposit_threshold_usd,
+            )
+
+    #
+    # Visualisations
+    #
+
+    if input.is_visualisation_enabled():
+
+        visualisation = state.visualisation  # Helper class to visualise strategy output
+
+        # BTC RSI daily
+        if current_rsi_values[btc_pair]:
+            visualisation.plot_indicator(
+                timestamp,
+                f"RSI BTC",
+                PlotKind.technical_indicator_detached,
+                current_rsi_values[btc_pair],
+                colour="orange",
+                pair=btc_pair,
+            )
+
+            # RSI exit value
+            visualisation.plot_indicator(
+                timestamp,
+                f"RSI exit trigger",
+                PlotKind.technical_indicator_overlay_on_detached,
+                rsi_exit,
+                detached_overlay_name=f"RSI BTC",
+                colour="red",
+                label=PlotLabel.hidden,
+                pair=btc_pair,
+            )
+
+            # RSI entry value
+            visualisation.plot_indicator(
+                timestamp,
+                f"RSI entry trigger",
+                PlotKind.technical_indicator_overlay_on_detached,
+                rsi_entry,
+                detached_overlay_name=f"RSI BTC",
+                colour="red",
+                label=PlotLabel.hidden,
+                pair=btc_pair,
+            )
+
+        # ETH RSI daily
+        if current_rsi_values[eth_pair]:
+            visualisation.plot_indicator(
+                timestamp,
+                f"RSI ETH",
+                PlotKind.technical_indicator_overlay_on_detached,
+                current_rsi_values[eth_pair],
+                colour="blue",
+                label=PlotLabel.hidden,
+                detached_overlay_name=f"RSI BTC",
+                pair=btc_pair,
+            )
+
+        state.visualisation.add_calculations(timestamp, alpha_model.to_dict())  # Record alpha model thinking
+
+    position_manager.log(
+        f"BTC RSI: {current_rsi_values[btc_pair]}, BTC RSI yesterday: {previous_rsi_values[btc_pair]}",
+    )
+
+    # Trades are automatically natural order, so we have always the correct cash in hand.
+    # Any credit market withdraw will be executed first, then sells, then buys and Aave deposits last.
+    # This will be done by framework by calling:
+    # trades.sort(key=lambda t: t.get_execution_sort_position())
+    return trades
+
+
+def get_strategy_trading_pairs(execution_mode: ExecutionMode) -> list[HumanReadableTradingPairDescription]:
+    """Switch between backtest and live trading pairs.
+
+    Because the live trading DEX venues do not have enough history (< 2 years)
+    for meaningful backtesting, we test with Binance CEX data.
+    """
+
+    use_binance = Parameters.use_binance and execution_mode.is_backtesting()
+
+    if use_binance:
+        assert not execution_mode.is_live_trading(), "Binance market data can be only used for backtesting"
+
+    if use_binance:
+        trading_pairs = [
+             (ChainId.centralised_exchange, "binance", "BTC", "USDT"),
+             (ChainId.centralised_exchange, "binance", "ETH", "USDT"),
+        ]
+
+    else:
+        # Live trading, backtesting DEX data
+
+        # Live trade
+        trading_pairs = [
+            (ChainId.polygon, "quickswap", "WBTC", "WETH", 0.0030),
+            (ChainId.polygon, "uniswap-v3", "WETH", "USDC", 0.0005),
+            (ChainId.polygon, "quickswap", "WETH", "USDC", 0.0030),  # keep this temporarily here for pricing
+        ]
+
+    return trading_pairs
+
+
+def get_lending_reserves(mode: ExecutionMode) -> list[LendingReserveDescription]:
+    """Get lending reserves the strategy needs."""
+
+    use_binance = Parameters.use_binance
+
+    if use_binance:
+        # Credit interest is not available on Binance
+        return []
+    else:
+        # We use Aave v2 in backtesting (longer history)
+        # and Aave v3 in live execution (more liquid market)
+        if mode.is_backtesting():
+            lending_reserves = [
+                (ChainId.polygon, LendingProtocolType.aave_v2, "USDC"),
+            ]
+        else:
+            lending_reserves = [
+                (ChainId.polygon, LendingProtocolType.aave_v3, "USDC.e"),
+            ]
+
+    return lending_reserves
+
+
+def create_trading_universe(
+    timestamp: datetime.datetime,
+    client: Client,
+    execution_context: ExecutionContext,
+    universe_options: UniverseOptions,
+) -> TradingStrategyUniverse:
+    """Create the trading universe.
+
+    - In this example, we load all Binance spot data based on our Binance trading pair list.
+    """
+    trading_pairs = get_strategy_trading_pairs(execution_context.mode)
+    lending_reserves = get_lending_reserves(execution_context.mode)
+
+    use_binance = trading_pairs[0][0] == ChainId.centralised_exchange
+
+    if use_binance:
+        # Backtesting - load Binance data
+        strategy_universe = create_binance_universe(
+            [f"{p[2]}{p[3]}" for p in trading_pairs],
+            candle_time_bucket=Parameters.candle_time_bucket,
+            stop_loss_time_bucket=Parameters.stop_loss_time_bucket,
+            start_at=universe_options.start_at,
+            end_at=universe_options.end_at,
+            trading_fee_override=Parameters.backtest_trading_fee,
+            include_lending=False,
+            forward_fill=True,
+        )
+    else:
+
+        if execution_context.live_trading or execution_context.mode == ExecutionMode.preflight_check:
+            # Live trading
+            start_at, end_at = None, None
+            required_history_period=Parameters.required_history_period
+        else:
+            # Create backtest trading universe
+            required_history_period = None
+            start_at=universe_options.start_at
+            end_at=universe_options.end_at
+
+        dataset = load_partial_data(
+            client,
+            execution_context=execution_context,
+            time_bucket=Parameters.candle_time_bucket,
+            pairs=trading_pairs,
+            universe_options=universe_options,
+            start_at=start_at,
+            end_at=end_at,
+            stop_loss_time_bucket=Parameters.stop_loss_time_bucket,
+            lending_reserves=lending_reserves,
+            required_history_period=required_history_period,
+            liquidity=True,
+            liquidity_time_bucket=TimeBucket.d1,
+        )
+
+        # Filter down to the single pair we are interested in
+        strategy_universe = TradingStrategyUniverse.create_from_dataset(
+            dataset,
+            forward_fill=True,
+            reserve_asset="0x2791bca1f2de4661ed88a30c99a7a9449aa84174"  # USDC.e on Polygon
+        )
+
+    return strategy_universe
+
+
+#
+# Strategy metadata.
+#
+# Displayed in the user interface.
+#
+
+tags = {StrategyTag.beta, StrategyTag.live}
+
+name = "ETH-BTC price surge"
+
+short_description = "ETH and BTC slow moving momentum strategy on Polygon"
+
+icon = "https://tradingstrategy.ai/avatars/polygon-eth-spot-short.webp"
+
+long_description = """
+# Strategy description
+
+This strategy is a momentum and breakout strategy.
+It is ETH and BTC momentum strategy to maximize gains in bull market and avoid losses in bear market, on Polygon
+
+- The strategy trades ETH and BTC over long term time horizon, doing only few trades per a year.
+- The strategy delivers similar profits as buying and holding ETH and BTC, but with much less severe drawdowns.
+- The strategy performs well in long-term Bitcoin [bull market](https://tradingstrategy.ai/glossary/bull-market).
+- In [bear](https://tradingstrategy.ai/glossary/bear-market) and sideways markets the strategy does not perform well.
+- It is based on [RSI technical indicator](https://tradingstrategy.ai/glossary/relative-strength-index-rsi), the strategy is buying when others are buying, and the strategy is selling when others are selling.
+- The strategy deposits excess cash to Aave V3 USDC pool to gain interest on cash
+- This is the second version of this strategy. [See the earlier version](https://tradingstrategy.ai/strategies/enzyme-polygon-eth-btc-usdc). 
+  As the time-in-market os low, the Aave support was added to gain profits on the cash reserves.
+
+**Past performance is not indicative of future results**.
+
+## Assets and trading venues
+
+- The strategy trades only spot market
+- We trade two trading asset: ETH and BTC
+- The strategy keeps reserves in USDC stablecoin
+- The trading happens on QuickSwap and Uniswap on Polygon blockchain
+- The strategy decision cycle is daily rebalances
+
+## Backtesting
+
+The backtesting was performed with Binance ETH-USDT and BTC-USDT data of 2019-2024.
+
+- [See backtesting results](./backtest)
+- [Read more about what is backtesting](https://tradingstrategy.ai/glossary/backtest).
+- Aave USDC interest is not included in the backtest results.
+
+The backtesting trading venue (Binance) is different from the live trading venue (Quickswap, Uniswap), because DEX markets
+do not have long enough history to result to a meaningful backtest.
+
+The backtesting period saw one bull market rally that is unlikely to repeat in the same magnitude 
+for the assets we trade.
+
+Past peformance is no guarantee of future results. Like with manual trading, automated trading is unlikely to be perfect.
+There will be variance in the range of 30% - 50% in the results.
+
+## Profit
+
+The backtested results indicate **80%** estimated yearly profit ([CAGR](https://tradingstrategy.ai/glossary/compound-annual-growth-rate-cagr)). 
+
+This is similar profit as you would get by buying and holding BTC or ETH.
+
+## Risk
+
+This strategy has **-30%** backtested [maximum drawdown](https://tradingstrategy.ai/glossary/maximum-drawdown).
+This is much less severe compared to buy and hold, making the strategy less risky than buy and hold.
+
+For further understanding the key aspescts of risks
+- The strategy does not use any leverage
+- The strategy trades only established, highly liquid, trading pairs which are unlikely to go zero 
+
+## Benchmark
+
+For the same backtesting period, here are some benchmark of performance of different assets and indices:
+
+|                              | CAGR | Maximum drawdown | Sharpe |
+|------------------------------|------|------------------|--------|
+| This strategy                | 84%  | -34%             | 1.78   |
+| SP500 (20 years)             | 11%  | -33%             | 0.72   |
+| Bitcoin (backtesting period) | 76%  | -76%             | 1.17   |
+| Ether (backtesting period)   | 85%  | -79%             | 1.18   |
+
+
+Sources:
+
+- [Our strategy](./backtest)
+- [Buy and hold BTC](./backtest)
+- [Buy and hold ETH](./backtest)
+- [SP500 stock index](https://curvo.eu/backtest/en/portfolio/s-p-500--NoIgygZACgBArABgSANMUBJAokgQnXAWQCUEAOAdlQEYBdeoA?config=%7B%22periodStart%22%3A%222004-02%22%7D)
+
+## Trading frequency
+
+The strategy is very slow moving macro-like strategy.
+
+This strategy is estimated to to rebalance every **20 days** and enter/exit positions even less frequently. 
+
+## Robustness
+
+This strategy does not have good robustness tests available.
+
+## Updates
+
+This is one of the early, simple, strategies deployed on Trading Strategy protocol.
+
+It is likely this strategy will be replaced with a newer, more robust, more optimised, version in some point of the future.
+[Follow Trading Strategy for updates](https://tradingstrategy.ai/community) as you need to move your balance to a new strategy.
+
+## Further information
+
+- Any questions are welcome in [the Discord community chat](https://tradingstrategy.ai/community)
+- See the blog post [on how this strategy is constructed](https://tradingstrategy.ai/blog/outperfoming-eth) 
+
+"""

--- a/tests/mainnet_fork/test_enzyme_redeem_dust.py
+++ b/tests/mainnet_fork/test_enzyme_redeem_dust.py
@@ -67,16 +67,17 @@ def environment(
         "ASSET_MANAGEMENT_MODE": "enzyme",
         "UNIT_TESTING": "true",
         "UNIT_TEST_FORCE_ANVIL": "true",  # check-wallet command legacy hack
-        # "LOG_LEVEL": "disabled",
-        "LOG_LEVEL": "info",
+        "LOG_LEVEL": "disabled",
+        # "LOG_LEVEL": "info",
         "TRADING_STRATEGY_API_KEY": os.environ["TRADING_STRATEGY_API_KEY"],
         "VAULT_ADDRESS": "0xbba6B781e0BAC1798e4E715ef9b1113Bf2387544",
         "VAULT_ADAPTER_ADDRESS": "0x519f26bE61889656e83262ab56D75f00DFDAAEc1",
         "VAULT_PAYMENT_FORWARDER_ADDRESS": "0x638241c16aB5002298B24ED2F0074B4662042258",
         "VAULT_DEPLOYMENT_BLOCK_NUMBER": "60554042",
         "SKIP_SAVE": "true",
-        "PROCESS_REDEMPTION": "true",
+        "PROCESS_REDEMPTION": "true",  # Especially test for the broken redemption event
         "PROCESS_REDEMPTION_END_BLOCK_HINT": str(end_block),
+        "AUTO_APPROVE": "true",   # Disable interactivity for repair command
     }
     return environment
 
@@ -95,12 +96,52 @@ def test_enzyme_redeem_dust(
     - Enzyme redemption request tries to redeem part of this dust (1 unit of aPolUSDC)
 
     - Make sure we can handle the dust redemption request on a closed position
+
+    The problematic SharesRedeemed event:
+
+    .. code-block:: text
+
+        enzyme-polygon-eth-btc-rsi  | tradeexecutor.ethereum.enzyme.vault.UnknownAsset: Asset <aPolUSDC at 0x625e7708f30ca75bfd92586e17077590c60eb4cd> does not map to any open position.
+
+        enzyme-polygon-eth-btc-rsi  | Do not know how to recover. You need to stop trade-executor and run accounting correction.
+        enzyme-polygon-eth-btc-rsi  | Could not process redemption event.
+        enzyme-polygon-eth-btc-rsi  | Redeemed assets:
+        enzyme-polygon-eth-btc-rsi  | <USD Coin (PoS) (USDC) at 0x2791Bca1f2de4661ED88A30C99A7a9449Aa84174, 6 decimals, on chain 137>: 84614952
+        enzyme-polygon-eth-btc-rsi  | <Wrapped Ether (WETH) at 0x7ceB23fD6bC0adD59E62ac25578270cFf1b9f619, 18 decimals, on chain 137>: 0
+        enzyme-polygon-eth-btc-rsi  | <(PoS) Wrapped BTC (WBTC) at 0x1BFD67037B42Cf73acF2047067bd4F2C47D9BfD6, 8 decimals, on chain 137>: 0
+        enzyme-polygon-eth-btc-rsi  | <Aave Polygon USDC (aPolUSDC) at 0x625E7708f30cA75bfd92586e17077590C60eb4cD, 6 decimals, on chain 137>: 1
+        enzyme-polygon-eth-btc-rsi  | EVM event data:
+        enzyme-polygon-eth-btc-rsi  | { 'address': '0xd4d6e8a69a6d4bebbb96188cfc6465d91ae461d6',
+        enzyme-polygon-eth-btc-rsi  |   'blockHash': '0xfa29b55146628d84f3b2990a2458e18064e2daa4427112ace270c40fd879f9d8',
+        enzyme-polygon-eth-btc-rsi  |   'blockNumber': 62094345,
+        enzyme-polygon-eth-btc-rsi  |   'chunk_id': 62093612,
+        enzyme-polygon-eth-btc-rsi  |   'context': None,
+        enzyme-polygon-eth-btc-rsi  |   'data': '0x000000000000000000000000000000000000000000000004e3f298eb47ba54fb0000000000000000000000000000000000000000000000000000000000000060000000000000000000000000000000000000000000000000000000000000010000000000000000000000000000000000000000000000000000000000000000040000000000000000000000002791bca1f2de4661ed88a30c99a7a9449aa841740000000000000000000000007ceb23fd6bc0add59e62ac25578270cff1b9f6190000000000000000000000001bfd67037b42cf73acf2047067bd4f2c47d9bfd6000000000000000000000000625e7708f30ca75bfd92586e17077590c60eb4cd000000000000000000000000000000000000000000000000000000000000000400000000000000000000000000000000000000000000000000000000050b1f28000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000001',
+        enzyme-polygon-eth-btc-rsi  |   'event': <class 'web3._utils.datatypes.SharesRedeemed'>,
+        enzyme-polygon-eth-btc-rsi  |   'logIndex': '0x76',
+        enzyme-polygon-eth-btc-rsi  |   'removed': False,
+        enzyme-polygon-eth-btc-rsi  |   'timestamp': 1726917217,
+        enzyme-polygon-eth-btc-rsi  |   'topics': [ HexBytes('0xbf88879a1555e4d7d38ebeffabce61fdf5e12ea0468abf855a72ec17b432bed5'),
+        enzyme-polygon-eth-btc-rsi  |               HexBytes('0x000000000000000000000000c37b40abdb939635068d3c5f13e7faf686f03b65'),
+        enzyme-polygon-eth-btc-rsi  |               HexBytes('0x000000000000000000000000c37b40abdb939635068d3c5f13e7faf686f03b65')],
+        enzyme-polygon-eth-btc-rsi  |   'transactionHash': '0x0ac5a9eb7f426d3da655549c539bbad6919a9f6addbae3527d33725859e2e02c',
+        enzyme-polygon-eth-btc-rsi  |   'transactionIndex': '0x1f'}
+
+    When running with log level info, the test should spit out warning:
+
+    .. code-block:: text
+
+        2024-10-01 23:03:34 tradeexecutor.ethereum.enzyme.vault                WARNING  Enzyme dust redemption detected and ignored.
+        Asset: <aPolUSDC at 0x625e7708f30ca75bfd92586e17077590c60eb4cd>
+        Epsilon: 0.1000000000000000055511151231257827021181583404541015625
+        Amount: 0.000001
+
+
     """
 
     mocker.patch.dict("os.environ", environment, clear=True)
 
-    with pytest.raises(SystemExit) as sys_exit:
-        app(["repair"], standalone_mode=False)
+    app(["repair"], standalone_mode=False)
 
     with pytest.raises(SystemExit) as sys_exit:
         app(["correct-accounts"], standalone_mode=False)

--- a/tests/mainnet_fork/test_enzyme_redeem_dust.py
+++ b/tests/mainnet_fork/test_enzyme_redeem_dust.py
@@ -1,28 +1,14 @@
 """Test Enzyme redemption where the redemption request has a closed position with dust."""
-import json
 import os
 import secrets
 from pathlib import Path
-from unittest import mock
 
 import pytest
 from _pytest.fixtures import FixtureRequest
 
-from eth_account import Account
-from eth_typing import HexAddress
-from hexbytes import HexBytes
-from web3 import Web3, HTTPProvider
-
 from eth_defi.provider.anvil import AnvilLaunch, launch_anvil
-from eth_defi.chain import install_chain_middleware
-from eth_defi.enzyme.vault import Vault
-from eth_defi.hotwallet import HotWallet
-from eth_defi.token import TokenDetails, fetch_erc20_details
-from eth_defi.trace import assert_transaction_success_with_explanation
 
 from tradeexecutor.cli.main import app
-from tradeexecutor.monkeypatch.web3 import construct_sign_and_send_raw_middleware
-from tradeexecutor.state.state import State
 
 
 pytestmark = pytest.mark.skipif(not os.environ.get("JSON_RPC_POLYGON") or not os.environ.get("TRADING_STRATEGY_API_KEY"), reason="Set JSON_RPC_POLYGON and TRADING_STRATEGY_API_KEY environment variables to run this test")
@@ -30,15 +16,11 @@ pytestmark = pytest.mark.skipif(not os.environ.get("JSON_RPC_POLYGON") or not os
 
 @pytest.fixture()
 def anvil(request: FixtureRequest) -> AnvilLaunch:
-    """Do Ethereum mainnet fork from the damaged situation."""
-
     mainnet_rpc = os.environ["JSON_RPC_POLYGON"]
-
     anvil = launch_anvil(
         mainnet_rpc,
         fork_block_number=62513342,  # The timestamp on when the broken position was created
     )
-
     try:
         yield anvil
     finally:
@@ -56,7 +38,7 @@ def state_file() -> Path:
 @pytest.fixture()
 def strategy_file() -> Path:
     """The strategy module where the broken accounting happened."""
-    p = Path(os.path.join(os.path.dirname(__file__), "..", "..", "strategies", "test_only", "enzyme-polygon-btc-eth-rsi.py"))
+    p = Path(os.path.join(os.path.dirname(__file__), "..", "..", "strategies", "test_only", "enzyme-polygon-eth-btc-rsi.py"))
     assert p.exists(), f"{p.resolve()} missing"
     return p
 
@@ -67,8 +49,7 @@ def environment(
     state_file: Path,
     strategy_file: Path,
     ) -> dict:
-    """Passed to init and start commands as environment variables"""
-    # Set up the configuration for the live trader
+    """Used by CLI commands, for setting up this test environment"""
     environment = {
         "STRATEGY_FILE": strategy_file.as_posix(),
         "PRIVATE_KEY": "0x" + secrets.token_bytes(32).hex(),
@@ -79,7 +60,6 @@ def environment(
         "UNIT_TEST_FORCE_ANVIL": "true",  # check-wallet command legacy hack
         "LOG_LEVEL": "disabled",
         # "LOG_LEVEL": "info",
-        # "CONFIRMATION_BLOCK_COUNT": "0",  # Needed for test backend, Anvil
         "TRADING_STRATEGY_API_KEY": os.environ["TRADING_STRATEGY_API_KEY"],
         "VAULT_ADDRESS": "0xbba6B781e0BAC1798e4E715ef9b1113Bf2387544",
         "VAULT_ADAPTER_ADDRESS": "0x519f26bE61889656e83262ab56D75f00DFDAAEc1",
@@ -90,13 +70,9 @@ def environment(
     return environment
 
 
+@pytest.mark.slow_test_group
 def test_enzyme_redeem_dust(
     environment: dict,
-    web3: Web3,
-    state_file: Path,
-    usdc: TokenDetails,
-    hot_wallet: HotWallet,
-    vault_record_file: Path,
     mocker,
 ):
     """Test Enzyme redemption where the redemption request has a closed position with dust.
@@ -111,10 +87,13 @@ def test_enzyme_redeem_dust(
     """
 
     mocker.patch.dict("os.environ", environment, clear=True)
-    app(["check-accounts"], standalone_mode=False)
-    app(["correct-accounts"], standalone_mode=False)
 
+    with pytest.raises(SystemExit) as sys_exit:
+        app(["check-accounts"], standalone_mode=False)
+    assert sys_exit.value.code == 0
 
-
+    with pytest.raises(SystemExit) as sys_exit:
+        app(["correct-accounts"], standalone_mode=False)
+    assert sys_exit.value.code == 0
 
 

--- a/tests/mainnet_fork/test_enzyme_redeem_dust.py
+++ b/tests/mainnet_fork/test_enzyme_redeem_dust.py
@@ -1,0 +1,120 @@
+"""Test Enzyme redemption where the redemption request has a closed position with dust."""
+import json
+import os
+import secrets
+from pathlib import Path
+from unittest import mock
+
+import pytest
+from _pytest.fixtures import FixtureRequest
+
+from eth_account import Account
+from eth_typing import HexAddress
+from hexbytes import HexBytes
+from web3 import Web3, HTTPProvider
+
+from eth_defi.provider.anvil import AnvilLaunch, launch_anvil
+from eth_defi.chain import install_chain_middleware
+from eth_defi.enzyme.vault import Vault
+from eth_defi.hotwallet import HotWallet
+from eth_defi.token import TokenDetails, fetch_erc20_details
+from eth_defi.trace import assert_transaction_success_with_explanation
+
+from tradeexecutor.cli.main import app
+from tradeexecutor.monkeypatch.web3 import construct_sign_and_send_raw_middleware
+from tradeexecutor.state.state import State
+
+
+pytestmark = pytest.mark.skipif(not os.environ.get("JSON_RPC_POLYGON") or not os.environ.get("TRADING_STRATEGY_API_KEY"), reason="Set JSON_RPC_POLYGON and TRADING_STRATEGY_API_KEY environment variables to run this test")
+
+
+@pytest.fixture()
+def anvil(request: FixtureRequest) -> AnvilLaunch:
+    """Do Ethereum mainnet fork from the damaged situation."""
+
+    mainnet_rpc = os.environ["JSON_RPC_POLYGON"]
+
+    anvil = launch_anvil(
+        mainnet_rpc,
+        fork_block_number=62513342,  # The timestamp on when the broken position was created
+    )
+
+    try:
+        yield anvil
+    finally:
+        #anvil.close(log_level=logging.INFO)
+        anvil.close()
+
+
+@pytest.fixture()
+def state_file() -> Path:
+    p = Path(os.path.join(os.path.dirname(__file__), "redeem-dust.json"))
+    assert p.exists(), f"{p} missing"
+    return p
+
+
+@pytest.fixture()
+def strategy_file() -> Path:
+    """The strategy module where the broken accounting happened."""
+    p = Path(os.path.join(os.path.dirname(__file__), "..", "..", "strategies", "test_only", "enzyme-polygon-btc-eth-rsi.py"))
+    assert p.exists(), f"{p.resolve()} missing"
+    return p
+
+
+@pytest.fixture()
+def environment(
+    anvil: AnvilLaunch,
+    state_file: Path,
+    strategy_file: Path,
+    ) -> dict:
+    """Passed to init and start commands as environment variables"""
+    # Set up the configuration for the live trader
+    environment = {
+        "STRATEGY_FILE": strategy_file.as_posix(),
+        "PRIVATE_KEY": "0x" + secrets.token_bytes(32).hex(),
+        "JSON_RPC_ANVIL": anvil.json_rpc_url,
+        "STATE_FILE": state_file.as_posix(),
+        "ASSET_MANAGEMENT_MODE": "enzyme",
+        "UNIT_TESTING": "true",
+        "UNIT_TEST_FORCE_ANVIL": "true",  # check-wallet command legacy hack
+        "LOG_LEVEL": "disabled",
+        # "LOG_LEVEL": "info",
+        # "CONFIRMATION_BLOCK_COUNT": "0",  # Needed for test backend, Anvil
+        "TRADING_STRATEGY_API_KEY": os.environ["TRADING_STRATEGY_API_KEY"],
+        "VAULT_ADDRESS": "0xbba6B781e0BAC1798e4E715ef9b1113Bf2387544",
+        "VAULT_ADAPTER_ADDRESS": "0x519f26bE61889656e83262ab56D75f00DFDAAEc1",
+        "VAULT_PAYMENT_FORWARDER_ADDRESS": "0x638241c16aB5002298B24ED2F0074B4662042258",
+        "VAULT_DEPLOYMENT_BLOCK_NUMBER": "60554042",
+        "SKIP_SAVE": "true",
+    }
+    return environment
+
+
+def test_enzyme_redeem_dust(
+    environment: dict,
+    web3: Web3,
+    state_file: Path,
+    usdc: TokenDetails,
+    hot_wallet: HotWallet,
+    vault_record_file: Path,
+    mocker,
+):
+    """Test Enzyme redemption where the redemption request has a closed position with dust.
+
+    - The state file contains a closed aPolUSDC position
+
+    - This position has small dust value left
+
+    - Enzyme redemption request tries to redeem part of this dust (1 unit of aPolUSDC)
+
+    - Make sure we can handle the dust redemption request on a closed position
+    """
+
+    mocker.patch.dict("os.environ", environment, clear=True)
+    app(["check-accounts"], standalone_mode=False)
+    app(["correct-accounts"], standalone_mode=False)
+
+
+
+
+

--- a/tradeexecutor/cli/commands/correct_accounts.py
+++ b/tradeexecutor/cli/commands/correct_accounts.py
@@ -72,6 +72,7 @@ def correct_accounts(
     chain_settle_wait_seconds: float = Option(60.0, "--chain-settle-wait-seconds", envvar="CHAIN_SETTLE_WAIT_SECONDS", help="How long we wait after the account correction to see if our broadcasted transactions fixed the issue."),
     skip_save: bool = Option(False, "--skip-save", envvar="SKIP_SAVE", help="Do not update state file. Useful for testing."),
     skip_interest: bool = Option(False, "--skip-interest", envvar="SKIP_INTEREST", help="Do not do interest distribution. If an position balance is fixed down due to redemption, this is useful."),
+    process_redemption: bool = Option(False, "--process-redemption", envvar="PROCESS_REDEMPTION", help="Attempt to process deposit and redemption requests before correcting accounts."),
     transfer_away: bool = Option(False, "--transfer-away", envvar="TRANSFER_AWAY", help="For tokens without assigned position, scoop them to the hot wallet instead of trying to construct a new position"),
 
 ):
@@ -302,6 +303,13 @@ def correct_accounts(
                 raise
     else:
         logger.info("Interest distribution skipped")
+
+    if process_redemption:
+        timestamp = datetime.datetime.utcnow()
+        logger.info("Processing deposits/redemptions, timestamp set to %s", timestamp)
+
+    else:
+        logger.info("Deposit/redemption distribution skipped")
 
     balance_updates = _correct_accounts(
         state,

--- a/tradeexecutor/strategy/account_correction.py
+++ b/tradeexecutor/strategy/account_correction.py
@@ -195,10 +195,10 @@ class AccountingBalanceCheck:
 
 
 def is_relative_mismatch(
-        actual_amount,
-        expected_amount,
-        relative_epsilon,
-        dust_epsilon,
+    actual_amount: Decimal,
+    expected_amount: Decimal,
+    relative_epsilon: float | Decimal,
+    dust_epsilon: float | Decimal,
 ) -> bool:
     """Calculate if we are within the relative tolerance.
 
@@ -208,6 +208,9 @@ def is_relative_mismatch(
 
     - Relative % of the position size
     """
+
+    assert isinstance(actual_amount, Decimal), f"Got {type(actual_amount)}"
+    assert isinstance(expected_amount, Decimal), f"Got {type(expected_amount)}"
 
     # Accounting dust.
     # The position has been closed but we have left fractions of tokens on the account.


### PR DESCRIPTION
- `enzyme-polygon-eth-btc-rsi` executor was crashing, because Enzyme was redeeming 1 raw unit of aPolUSDC on a dusty closed position
- Have a dust filter on any incoming Enzyme redemption event data