### PR TITLE
Custom tagging of trading pairs

### DIFF
--- a/tests/backtest/test_custom_labels.py
+++ b/tests/backtest/test_custom_labels.py
@@ -94,6 +94,7 @@ def decide_trades(input: StrategyInput) -> list[TradeExecution]:
             pass
 
         # Unit test asserts
+        import ipdb ; ipdb.set_trace()
         assert pair.get_tags() == {"L1", "evm", "bluechip"}
         assert pair.base.get_tags() == {"L1", "evm", "bluechip"}
 

--- a/tests/backtest/test_custom_labels.py
+++ b/tests/backtest/test_custom_labels.py
@@ -1,0 +1,140 @@
+"""Add custom labels to trading pairs."""
+import datetime
+import random
+
+import pytest
+
+from tradeexecutor.strategy.universe_model import default_universe_options, UniverseOptions
+from tradingstrategy.candle import GroupedCandleUniverse
+from tradingstrategy.chain import ChainId
+from tradingstrategy.liquidity import GroupedLiquidityUniverse
+from tradingstrategy.timebucket import TimeBucket
+from tradingstrategy.universe import Universe
+
+from tradeexecutor.backtest.backtest_pricing import BacktestPricing
+from tradeexecutor.backtest.backtest_routing import BacktestRoutingModel
+from tradeexecutor.cli.log import setup_pytest_logging
+from tradeexecutor.backtest.backtest_runner import run_backtest_inline
+from tradeexecutor.strategy.trading_strategy_universe import TradingStrategyUniverse, create_pair_universe_from_code, load_partial_data
+from tradeexecutor.strategy.execution_context import ExecutionContext, ExecutionMode, unit_test_execution_context
+from tradeexecutor.strategy.cycle import CycleDuration
+from tradeexecutor.strategy.reserve_currency import ReserveCurrency
+from tradeexecutor.state.trade import TradeExecution
+from tradeexecutor.state.identifier import AssetIdentifier, TradingPairIdentifier
+from tradeexecutor.strategy.pandas_trader.indicator import IndicatorSet
+from tradeexecutor.strategy.pandas_trader.strategy_input import StrategyInput
+from tradeexecutor.strategy.strategy_module import StrategyParameters
+from tradeexecutor.strategy.tvl_size_risk import USDTVLSizeRiskModel
+from tradeexecutor.testing.synthetic_ethereum_data import generate_random_ethereum_address
+from tradeexecutor.testing.synthetic_exchange_data import generate_exchange, generate_simple_routing_model
+from tradeexecutor.testing.synthetic_price_data import generate_ohlcv_candles, generate_tvl_candles
+
+
+
+def create_trading_universe(
+    ts: datetime.datetime,
+    client: Client,
+    execution_context: ExecutionContext,
+    universe_options: UniverseOptions,
+) -> TradingStrategyUniverse:
+
+    assert universe_options.start_at
+
+    pairs = [
+        (ChainId.polygon, "uniswap-v3", "WETH", "USDC", 0.0005)
+    ]
+
+    dataset = load_partial_data(
+        client,
+        execution_context=unit_test_execution_context,
+        time_bucket=TimeBucket.d1,
+        pairs=pairs,
+        universe_options=default_universe_options,
+        start_at=universe_options.start_at,
+        end_at=universe_options.end_at,
+    )
+
+    strategy_universe = TradingStrategyUniverse.create_single_pair_universe(dataset)
+
+    # Set custom labels on a trading pair
+    weth_usdc = strategy_universe.get_pair_by_human_description(pairs[0])
+
+    # Add some custom tags on the trading pair
+    weth_usdc.base.set_tags({"L1", "EVM", "bluechip"})
+
+    return strategy_universe
+
+
+@pytest.fixture(scope="module")
+def logger(request):
+    """Setup test logger."""
+    return setup_pytest_logging(request, mute_requests=False)
+
+
+@pytest.fixture()
+def routing_model(synthetic_universe) -> BacktestRoutingModel:
+    return generate_simple_routing_model(synthetic_universe)
+
+
+@pytest.fixture()
+def pricing_model(synthetic_universe, routing_model) -> BacktestPricing:
+    pricing_model = BacktestPricing(
+        synthetic_universe.data_universe.candles,
+        routing_model,
+        allow_missing_fees=True,
+    )
+    return pricing_model
+
+
+def create_indicators(timestamp: datetime.datetime, parameters: StrategyParameters, strategy_universe: TradingStrategyUniverse, execution_context: ExecutionContext):
+    # No indicators needed
+    return IndicatorSet()
+
+
+def decide_trades(input: StrategyInput) -> list[TradeExecution]:
+    """Example of storing and loading custom variables."""
+
+    cycle = input.cycle
+    state = input.state
+
+    for pair in input.strategy_universe.iterate_pairs():
+        if "L1" in pair.get_tags():
+            # Do some tradign logic for L1 tokens only
+            pass
+
+        # Unit test asserts
+        assert pair.get_tags() == {"L1", "evm", "bluechip"}
+        assert pair.base.get_tags() == {"L1", "evm", "bluechip"}
+
+    return []
+
+
+def test_custom_tags(persistent_test_client, tmp_path):
+    """Test custom labelling of trading pairs"""
+
+    client = persistent_test_client
+
+    # Start with $1M cash, far exceeding the market size
+    class Parameters:
+        backtest_start = datetime.datetime(2020, 1, 1)
+        backtest_end = datetime.datetime(2020, 1, 7)
+        initial_cash = 1_000_000
+        cycle_duration = CycleDuration.cycle_1d
+
+    # Run the test
+    result = run_backtest_inline(
+        client=None,
+        decide_trades=decide_trades,
+        create_indicators=create_indicators,
+        create_trading_universe=create_trading_universe,
+        reserve_currency=ReserveCurrency.usdc,
+        engine_version="0.5",
+        parameters=StrategyParameters.from_class(Parameters),
+        mode=ExecutionMode.unit_testing,
+    )
+
+    # Variables are readable after the backtest
+    state = result.state
+    assert len(state.other_data.data.keys()) == 29  # We stored data for 29 decide_trades cycles
+    assert state.other_data.data[1]["my_value"] == 1      # We can read historic values
+

--- a/tests/backtest/test_other_data.py
+++ b/tests/backtest/test_other_data.py
@@ -169,5 +169,3 @@ def test_other_data(strategy_universe, tmp_path):
     assert len(state.other_data.data.keys()) == 29  # We stored data for 29 decide_trades cycles
     assert state.other_data.data[1]["my_value"] == 1      # We can read historic values
 
-
-labels to trading pairs."""

--- a/tests/backtest/test_other_data.py
+++ b/tests/backtest/test_other_data.py
@@ -169,3 +169,5 @@ def test_other_data(strategy_universe, tmp_path):
     assert len(state.other_data.data.keys()) == 29  # We stored data for 29 decide_trades cycles
     assert state.other_data.data[1]["my_value"] == 1      # We can read historic values
 
+
+labels to trading pairs."""

--- a/tradeexecutor/backtest/data_preload.py
+++ b/tradeexecutor/backtest/data_preload.py
@@ -7,7 +7,7 @@ import pandas as pd
 from tradeexecutor.strategy.strategy_module import CreateTradingUniverseProtocol
 from tradeexecutor.strategy.trading_strategy_universe import TradingStrategyUniverse
 from tradingstrategy.client import Client, BaseClient
-from tradingstrategy.environment.jupyter import download_with_tqdm_progress_bar
+from tradingstrategy.environment.default_environment import download_with_tqdm_progress_bar
 
 from tradeexecutor.strategy.execution_context import ExecutionMode, ExecutionContext
 from tradeexecutor.strategy.universe_model import UniverseOptions

--- a/tradeexecutor/cli/commands/perform_test_trade.py
+++ b/tradeexecutor/cli/commands/perform_test_trade.py
@@ -186,7 +186,10 @@ def perform_test_trade(
 
     try:
         if all_pairs:
+            logger.info("Testing all pairs, we have %d pairs", universe.get_pair_count())
             for pair in universe.data_universe.pairs.iterate_pairs():
+
+                logger.info("Making test trade for %s", pair)
 
                 _p = construct_identifier_from_pair(pair)
                 p = parse_pair_data(_p)

--- a/tradeexecutor/cli/commands/webapi.py
+++ b/tradeexecutor/cli/commands/webapi.py
@@ -10,7 +10,7 @@ import faulthandler
 import logging
 import os
 import time
-from decimal import Decimal
+from decimal import Decimal 
 from pathlib import Path
 from queue import Queue
 from typing import Optional

--- a/tradeexecutor/state/identifier.py
+++ b/tradeexecutor/state/identifier.py
@@ -143,7 +143,6 @@ class AssetIdentifier:
                     # Do some trading logic for L1 tokens only
                     pass
 
-
             return []
 
 

--- a/tradeexecutor/state/identifier.py
+++ b/tradeexecutor/state/identifier.py
@@ -264,6 +264,8 @@ class AssetIdentifier:
 
         - Be wary of `AssetIdentifier` life time as it is passed by value, not be reference,
           so you cannot update instance data after it has been copied to open positions, etc.
+
+        - `translate_trading_pair()` is the critical method for understanding and managing identifier life times
         """
         assert type(tags) == set
         self.other_data["tags"] = tags

--- a/tradeexecutor/state/identifier.py
+++ b/tradeexecutor/state/identifier.py
@@ -78,7 +78,21 @@ class AssetIdentifier:
 
     As internal token_ids and pair_ids may be unstable, trading pairs and tokens are explicitly
     referred by their smart contract addresses when a strategy decision moves to the execution.
-    We duplicate data here to make sure we have a persistent record that helps to diagnose the sisues.
+    We duplicate data here to make sure we have a persistent record that helps to diagnose the issues.
+
+    Setting custom data:
+
+    - Both :py:class:`AssetIdentifier` and :py:class:`TradingPairIdentifier` offer :py:attr:`AssetIdentifier.other_data` allowing you to set custom attribtues.
+
+    - You must set these attributes in `create_trading_universe` function.
+
+    - For more information see `test_custom_labels`.
+
+    Example:
+
+    .. code-block:: python
+
+
     """
 
     #: See https://chainlist.org/

--- a/tradeexecutor/state/identifier.py
+++ b/tradeexecutor/state/identifier.py
@@ -123,7 +123,9 @@ class AssetIdentifier:
     #: Be wary of the life cycle of the instances. The life time of the class instances
     #: tied to the trading universe that is recreated for every strategy cycle.
     #:
-    other_data: Optional[dict] = None
+    #: See also :py:meth:`get_tags`.
+    #:
+    other_data: Optional[dict] = field(default_factory=dict)
 
     def __str__(self):
         if self.underlying:
@@ -240,7 +242,14 @@ class AssetIdentifier:
     def set_tags(self, tags: set[str]):
         """Set tags for this asset.
 
-        - - See also :py:meth:`get_tags`
+        - See also :py:meth:`get_tags`
+
+        - See also :py:meth:`other_data`
+
+        - Must be called in `create_trading_universe`
+
+        - Be wary of `AssetIdentifier` life time as it is passed by value, not be reference,
+          so you cannot update instance data after it has been copied to open positions, etc.
         """
         assert type(tags) == set
         self.other_data["tags"] = tags
@@ -428,7 +437,7 @@ class TradingPairIdentifier:
     #: Be wary of the life cycle of the instances. The life time of the class instances
     #: tied to the trading universe that is recreated for every strategy cycle.
     #:
-    other_data: Optional[dict] = None
+    other_data: Optional[dict] = field(default_factory=dict)
 
     def __post_init__(self):
         assert self.base.chain_id == self.quote.chain_id, "Cross-chain trading pairs are not possible"
@@ -640,7 +649,8 @@ class TradingPairIdentifier:
 
         - See :py:meth:`AssetIdentifier.get_tags`
         """
-        return self.underlying_spot_pair.base.get_tags()
+        underlying = self.underlying_spot_pair or self
+        return underlying.base.get_tags()
 
 
 @dataclass_json

--- a/tradeexecutor/strategy/trading_strategy_universe.py
+++ b/tradeexecutor/strategy/trading_strategy_universe.py
@@ -1174,7 +1174,7 @@ class TradingStrategyUniverse(StrategyExecutionUniverse):
         reserve_token = None
         for p in pair_universe.iterate_pairs():
             if p.quote_token_symbol == reserve_token_symbol:
-                translated_pair = translate_trading_pair(p, cache=self.pair_cache)
+                translated_pair = translate_trading_pair(p)
                 reserve_token = translated_pair.quote
 
         assert reserve_token, f"Reserve token {reserve_token_symbol} missing the specified pair quote tokens of {reserve_token}"

--- a/tradeexecutor/strategy/trading_strategy_universe.py
+++ b/tradeexecutor/strategy/trading_strategy_universe.py
@@ -11,7 +11,7 @@ import datetime
 import pickle
 import textwrap
 from abc import abstractmethod
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 import logging
 from math import isnan
 from pathlib import Path
@@ -181,6 +181,14 @@ class TradingStrategyUniverse(StrategyExecutionUniverse):
     #:
     price_data_delay_tolerance: datetime.timedelta | None = None
 
+    #: Translated asset and trading pair identifier cache.
+    #:
+    #: - When called `asset.set_tags()` or setting `asset.other_data()` it is stored here.
+    #:
+    #: - See :py:meth:`warm_up_data`
+    #:
+    pair_cache: dict = field(default_factory=dict)
+
     def __repr__(self):
         pair_count = self.data_universe.pairs.get_count()
         if pair_count <= 3:
@@ -310,7 +318,7 @@ class TradingStrategyUniverse(StrategyExecutionUniverse):
         else:
             dex_pair = pair
 
-        return translate_trading_pair(dex_pair)
+        return translate_trading_pair(dex_pair, cache=self.pair_cache)
 
     def can_open_spot(
             self,
@@ -395,6 +403,16 @@ class TradingStrategyUniverse(StrategyExecutionUniverse):
             return value > 0
         except NoDataAvailable:
             return False
+
+    def warm_up_data(self):
+        """Make sure all data is properly
+
+        - Trading pair data must be preprocessed before we can call `set_tags()` or set `other_data`
+
+        - See :py:attr:`pair_cache` for details
+        """
+        for pair in self.iterate_pairs():
+            logger.info("Warmed up pair: %s", pair)
 
     def can_open_short(
         self,
@@ -565,7 +583,7 @@ class TradingStrategyUniverse(StrategyExecutionUniverse):
         """
         assert self.data_universe.exchange_universe, "You must set universe.exchange_universe to be able to use this method"
         pair = self.data_universe.pairs.get_pair_by_human_description(self.data_universe.exchange_universe, desc)
-        return translate_trading_pair(pair)
+        return translate_trading_pair(pair, cache=self.pair_cache)
 
     def iterate_pairs(self) -> Iterable[TradingPairIdentifier]:
         """Iterate over all available trading pairs.
@@ -573,7 +591,7 @@ class TradingStrategyUniverse(StrategyExecutionUniverse):
         - Different from :py:meth:`tradingstrategy.pair.PandasPairUniverse.iterate_pairs` as this yields `TradingPairIdentifier` instances
         """
         for p in self.data_universe.pairs.iterate_pairs():
-            yield translate_trading_pair(p)
+            yield translate_trading_pair(p, cache=self.pair_cache)
 
     def iterate_credit_for_reserve(self) -> Iterable[TradingPairIdentifier]:
         """Iterate over all available credit supply pairs.
@@ -832,7 +850,7 @@ class TradingStrategyUniverse(StrategyExecutionUniverse):
         pair = self.data_universe.pairs.get_pair_by_smart_contract(address)
         if not pair:
             return None
-        return translate_trading_pair(pair)
+        return translate_trading_pair(pair, cache=self.pair_cache)
 
     def get_single_pair(self) -> TradingPairIdentifier:
         """Get the single trading pair in this universe.
@@ -841,7 +859,7 @@ class TradingStrategyUniverse(StrategyExecutionUniverse):
             If we have more than one trading pair
         """
         pair = self.data_universe.pairs.get_single()
-        return translate_trading_pair(pair)
+        return translate_trading_pair(pair, cache=self.pair_cache)
 
     def get_single_chain(self) -> ChainId:
         """Get the single trading pair in this universe.
@@ -1156,7 +1174,7 @@ class TradingStrategyUniverse(StrategyExecutionUniverse):
         reserve_token = None
         for p in pair_universe.iterate_pairs():
             if p.quote_token_symbol == reserve_token_symbol:
-                translated_pair = translate_trading_pair(p)
+                translated_pair = translate_trading_pair(p, cache=self.pair_cache)
                 reserve_token = translated_pair.quote
 
         assert reserve_token, f"Reserve token {reserve_token_symbol} missing the specified pair quote tokens of {reserve_token}"
@@ -1691,7 +1709,7 @@ def translate_token(
     )
 
 
-def translate_trading_pair(pair: DEXPair) -> TradingPairIdentifier:
+def translate_trading_pair(pair: DEXPair, cache: dict | None = None) -> TradingPairIdentifier:
     """Translate trading pair from client download to the trade executor.
 
     Trading Strategy client uses compressed columnar data for pairs and tokens.
@@ -1707,7 +1725,19 @@ def translate_trading_pair(pair: DEXPair) -> TradingPairIdentifier:
 
 
     This is called when a trade is made: this is the moment when trade executor data format must be made available.
+
+    :param cache:
+        Cache of constructed objects.
+
+        Pair internal id -> TradingPairIdentifier
+
+        See :py:class:`tradingstrategy.state.identifier.AssetIdentifier` for life cycle notes.
     """
+
+    if cache is not None:
+        cached = cache.get(pair.pair_id)
+        if cached is not None:
+            return cached
 
     assert isinstance(pair, DEXPair), f"Expected DEXPair, got {type(pair)}"
     assert pair.base_token_decimals is not None, f"Base token missing decimals: {pair}"
@@ -1750,7 +1780,7 @@ def translate_trading_pair(pair: DEXPair) -> TradingPairIdentifier:
         else:
             fee = None
 
-    return TradingPairIdentifier(
+    pair = TradingPairIdentifier(
         base=base,
         quote=quote,
         pool_address=pair.address,
@@ -1761,6 +1791,11 @@ def translate_trading_pair(pair: DEXPair) -> TradingPairIdentifier:
         reverse_token_order=pair.token0_symbol != pair.base_token_symbol,
         exchange_name=pair.exchange_name,
     )
+
+    if cache is not None:
+        cache[pair.internal_id] = pair
+
+    return pair
 
 
 def translate_credit_reserve(


### PR DESCRIPTION
- Add `other_data` structure to assets and trading pairs
- Add a standard way of tagging assets with `AssetIdentifier.set_tags`
- Update tests to reflect stablecoin classification change in TS package