### PR TITLE
add slippage_tolerance to TradingPosition

### DIFF
--- a/tradeexecutor/state/position.py
+++ b/tradeexecutor/state/position.py
@@ -282,6 +282,10 @@ class TradingPosition(GenericPosition):
     #: 
     liquidation_price: USDollarAmount | None = None
 
+    #: Maximum allowed slippage percentage (0.0-100.0) when executing trades for this position.
+    #: If None, uses the default slippage tolerance from the strategy parameters.
+    slippage_tolerance: Optional[float] = None
+
     def __repr__(self):
         if self.is_pending():
             return f"<Pending position #{self.position_id} {self.pair} ${self.get_value()}>"
@@ -945,6 +949,9 @@ class TradingPosition(GenericPosition):
         #    assert reserve is None, "Quantity and reserve both cannot be given at the same time"
 
         pair = self.pair
+
+        if self.slippage_tolerance is None and slippage_tolerance is not None:
+            self.slippage_tolerance = slippage_tolerance
 
         if price_structure is not None:
             assert isinstance(price_structure, TradePricing)

--- a/tradeexecutor/strategy/pandas_trader/position_manager.py
+++ b/tradeexecutor/strategy/pandas_trader/position_manager.py
@@ -1013,7 +1013,12 @@ class PositionManager:
 
         reserve_asset, reserve_price = self.state.portfolio.get_default_reserve_asset()
 
-        slippage_tolerance = slippage_tolerance or self.default_slippage_tolerance
+        if slippage_tolerance is not None:
+            trade_slippage_tolerance = slippage_tolerance
+        elif position.slippage_tolerance is not None:
+            trade_slippage_tolerance = position.slippage_tolerance
+        else:
+            trade_slippage_tolerance = self.default_slippage_tolerance
 
         logger.info(
             "Preparing to close position %s, quantity %s, pricing %s, profit %s, slippage tolerance: %f %%",
@@ -1021,7 +1026,7 @@ class PositionManager:
             quantity,
             price_structure,
             position.get_unrealised_profit_usd(),
-            slippage_tolerance,
+            trade_slippage_tolerance,
         )
 
         if not flags:
@@ -1043,7 +1048,7 @@ class PositionManager:
             lp_fees_estimated=price_structure.get_total_lp_fees(),
             planned_mid_price=price_structure.mid_price,
             position=position,
-            slippage_tolerance=slippage_tolerance,
+            slippage_tolerance=trade_slippage_tolerance,
             price_structure=price_structure,
             closing=True,
             flags=flags,

--- a/tradeexecutor/strategy/stop_loss.py
+++ b/tradeexecutor/strategy/stop_loss.py
@@ -188,7 +188,13 @@ def check_position_triggers(
             ]):
                 trigger_type = TradeType.take_profit
                 trigger_price = p.take_profit
-                trades.extend(position_manager.close_position(p, TradeType.take_profit))
+                slippage_tolerance = (
+                                    p.slippage_tolerance 
+                                    if p.slippage_tolerance is not None 
+                                    else position_manager.default_slippage_tolerance
+                                )
+                trades.extend(position_manager.close_position(p, TradeType.take_profit, slippage_tolerance=slippage_tolerance))
+
 
         # Check we need to close position for stop loss
         if p.stop_loss:
@@ -198,8 +204,14 @@ def check_position_triggers(
             ]):
                 trigger_type = TradeType.stop_loss
                 trigger_price = p.stop_loss
-                notes = f"Stoploss:{trigger_price} mid-price:{mid_price}"
-                trades.extend(position_manager.close_position(p, TradeType.stop_loss, notes=notes))
+                slippage_tolerance = (
+                                    p.slippage_tolerance 
+                                    if p.slippage_tolerance is not None 
+                                    else position_manager.default_slippage_tolerance
+                                )                
+                notes = f"Stoploss:{trigger_price} mid-price:{mid_price} slippage_tolerance:{slippage_tolerance}"
+                trades.extend(position_manager.close_position(p, TradeType.stop_loss, notes=notes, slippage_tolerance=slippage_tolerance))
+
 
         if not trigger_type:
             # Stop loss/take profit hardcoded not triggered


### PR DESCRIPTION
Motivation for PR: 
When setting slippage tolerance on spot buys, this doesn't carry to stop loss and trailing stop losses for that position. This can be a problem with tokens that have buy/sell taxes. The slippage should already be preset according to what the buy_tax when placing the initial position

- Add slippage_tolerance to TradingPosition
- Slippage tolerance set in spot buys will carry onto the close_position

New prioritization of slippage_tolerance is: 
- Slippage_tolerance passed in function
- Otherwise, the slippage_tolerance from TradingPosition
- Otherwise, default_slippage_tolerance from PositionManager