### PR TITLE
Slippage tolerance using token tax

### DIFF
--- a/tests/backtest/test_token_tax.py
+++ b/tests/backtest/test_token_tax.py
@@ -1,0 +1,136 @@
+"""Test token tax (buy tax, sell tax) inside decide_trades loop and stop loss.
+
+"""
+import os
+
+import datetime
+
+import pytest
+
+from tradeexecutor.strategy.pandas_trader.indicator import IndicatorSet, DiskIndicatorStorage
+from tradeexecutor.strategy.pandas_trader.strategy_input import StrategyInput
+from tradeexecutor.strategy.strategy_module import StrategyParameters
+from tradingstrategy.client import Client
+from tradingstrategy.chain import ChainId
+from tradingstrategy.timebucket import TimeBucket
+
+from tradeexecutor.backtest.backtest_runner import run_backtest_inline
+from tradeexecutor.strategy.trading_strategy_universe import TradingStrategyUniverse, load_partial_data
+from tradeexecutor.strategy.execution_context import ExecutionContext, unit_test_execution_context, ExecutionMode
+from tradeexecutor.strategy.cycle import CycleDuration
+from tradeexecutor.strategy.reserve_currency import ReserveCurrency
+from tradeexecutor.strategy.universe_model import UniverseOptions, default_universe_options
+from tradeexecutor.state.trade import TradeExecution
+
+
+# https://docs.pytest.org/en/latest/how-to/skipping.html#skip-all-test-functions-of-a-class-or-module
+pytestmark = pytest.mark.skipif(os.environ.get("TRADING_STRATEGY_API_KEY") is None, reason="Set TRADING_STRATEGY_API_KEY environment variable to run this test")
+
+
+
+def create_trading_universe(
+    ts: datetime.datetime,
+    client: Client,
+    execution_context: ExecutionContext,
+    universe_options: UniverseOptions,
+) -> TradingStrategyUniverse:
+
+    assert universe_options.start_at
+
+    # TRUMP has ~1% buy and sell tax
+    pairs = [
+        (ChainId.ethereum, "uniswap-v2", "TRUMP", "WETH"),
+        (ChainId.ethereum, "uniswap-v3", "WETH", "USDC", 0.0005)  # Needed for routing USDC->WETH->TRUMP
+    ]
+
+    dataset = load_partial_data(
+        client,
+        execution_context=unit_test_execution_context,
+        time_bucket=TimeBucket.d1,
+        pairs=pairs,
+        universe_options=default_universe_options,
+        start_at=universe_options.start_at,
+        end_at=universe_options.end_at,
+    )
+
+    strategy_universe = TradingStrategyUniverse.create_from_dataset(
+        dataset,
+        reserve_asset="0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+    )
+    return strategy_universe
+
+
+@pytest.fixture()
+def strategy_universe(persistent_test_client: Client):
+    return create_trading_universe(
+        datetime.datetime.now(),
+        persistent_test_client,
+        unit_test_execution_context,
+        UniverseOptions(start_at=datetime.datetime(2023, 1, 1), end_at=datetime.datetime(2023, 2, 1))
+    )
+
+
+
+def decide_trades(input: StrategyInput) -> list[TradeExecution]:
+    # Example decide trades that generates buy, sell and stop loss sell events for the given real price data
+
+    position_manager = input.get_position_manager()
+
+    if input.cycle % 3 == 0:
+        # Set a buy
+        pass
+
+    if position_manager.is_any_open():
+        # Natural sell
+        position_manager.close_all()
+
+    return []
+
+
+def create_indicators(
+    timestamp,
+    parameters,
+    strategy_universe,
+    execution_context,
+) -> IndicatorSet:
+    indicator_set = IndicatorSet()
+    return indicator_set
+
+
+def test_token_tax(strategy_universe, tmp_path):
+    """Test DecideTradesProtocolV4
+
+    - Check that StrategyInput is passed correctly in backtesting (only backtesting, not live trading)
+    """
+
+    class Parameters:
+        cycle_duration = CycleDuration.cycle_1d
+        initial_cash = 10_000
+        backtest_start = datetime.datetime(2024, 6, 1)
+        backtest_end = datetime.datetime(2024, 7, 1)
+
+    indicator_storage = DiskIndicatorStorage(tmp_path, strategy_universe.get_cache_key())
+
+    # Check that we have token tax data for TRUMP
+    trump_weth = strategy_universe.get_pair_by_human_description(
+        (ChainId.ethereum, "uniswap-v2", "TRUMP", "WETH")
+    )
+
+    assert trump_weth.base.get_buy_tax() == pytest.approx(1.0)
+    assert trump_weth.base.get_sell_tax() == pytest.approx(1.0)
+
+    # Run the test
+    result = run_backtest_inline(
+        client=None,
+        decide_trades=decide_trades,
+        create_indicators=create_indicators,
+        universe=strategy_universe,
+        reserve_currency=ReserveCurrency.usdc,
+        engine_version="0.5",
+        parameters=StrategyParameters.from_class(Parameters),
+        mode=ExecutionMode.unit_testing,
+        indicator_storage=indicator_storage,
+    )
+
+    state, universe, debug_dump = result
+    assert len(state.portfolio.closed_positions) == 15

--- a/tests/backtest/test_token_tax.py
+++ b/tests/backtest/test_token_tax.py
@@ -51,6 +51,7 @@ def create_trading_universe(
         universe_options=default_universe_options,
         start_at=universe_options.start_at,
         end_at=universe_options.end_at,
+        pair_extra_metadata=True,  # Enable loading of TokenSniffer data
     )
 
     strategy_universe = TradingStrategyUniverse.create_from_dataset(
@@ -116,8 +117,9 @@ def test_token_tax(strategy_universe, tmp_path):
         (ChainId.ethereum, "uniswap-v2", "TRUMP", "WETH")
     )
 
-    assert trump_weth.base.get_buy_tax() == pytest.approx(1.0)
-    assert trump_weth.base.get_sell_tax() == pytest.approx(1.0)
+    # Is accurate 1.0, as rounded to 2 decimals
+    assert trump_weth.get_buy_tax() == 1.0
+    assert trump_weth.get_sell_tax() == 1.0
 
     # Run the test
     result = run_backtest_inline(
@@ -133,4 +135,4 @@ def test_token_tax(strategy_universe, tmp_path):
     )
 
     state, universe, debug_dump = result
-    assert len(state.portfolio.closed_positions) == 15
+    assert len(state.portfolio.closed_positions) == 0

--- a/tests/ethereum/polygon_forked/generic-router/test_generic_router_end_to_end.py
+++ b/tests/ethereum/polygon_forked/generic-router/test_generic_router_end_to_end.py
@@ -239,6 +239,7 @@ def test_generic_routing_live_trading_start_spot_only(
         assert len(state.portfolio.closed_positions) == 8
 
 
+@flaky.flaky
 def test_generic_routing_test_trade_spot_only(
     environment: dict,
     web3: Web3,

--- a/tests/mainnet_fork/test_enzyme_guard_credit_positions.py
+++ b/tests/mainnet_fork/test_enzyme_guard_credit_positions.py
@@ -166,6 +166,7 @@ def environment(
     return environment
 
 
+@flaky.flaky
 def test_enzyme_guard_credit_positions(
     environment: dict,
     web3: Web3,

--- a/tests/test_binance_data.py
+++ b/tests/test_binance_data.py
@@ -204,7 +204,7 @@ def test_create_binance_universe():
     assert len(data_universe.lending_reserves.reserves) == 2
     assert data_universe.chains == {BINANCE_CHAIN_ID}
     assert len(data_universe.pairs.df) == 1
-    assert len(data_universe.pairs.df.columns) == 37
+    assert len(data_universe.pairs.df.columns) >= 37
     # pairs df can have nans
 
     assert len(data_universe.lending_candles.variable_borrow_apr.df) == 4

--- a/tradeexecutor/backtest/backtest_runner.py
+++ b/tradeexecutor/backtest/backtest_runner.py
@@ -862,7 +862,6 @@ def run_backtest_inline(
         # https://www.python.org/dev/peps/pep-3102/
         raise TypeError("Only keyword arguments accepted")
 
-
     if parameters is not None:
         if type(parameters) == type:
             # Class like definition
@@ -874,6 +873,10 @@ def run_backtest_inline(
 
         if not grid_search:
             assert not parameters.get("grid_search"), f"Grid search parameters were passed to a single backtest: {parameters}"
+
+        # Override run_inline_backtest() default arg if strategy parameters are given
+        if parameters.slippage_tolerance:
+            max_slippage = parameters.slippage_tolerance
 
     if start_at is None and end_at is None:
         if parameters and hasattr(parameters, "backtest_start") and hasattr(parameters, "backtest_end"):

--- a/tradeexecutor/backtest/backtest_runner.py
+++ b/tradeexecutor/backtest/backtest_runner.py
@@ -20,10 +20,9 @@ from tradeexecutor.backtest.backtest_sync import BacktestSyncModel
 from tradeexecutor.backtest.legacy_backtest_sync import BacktestSyncer
 from tradeexecutor.backtest.backtest_valuation import BacktestValuationModel
 from tradeexecutor.backtest.simulated_wallet import SimulatedWallet
-from tradeexecutor.cli.commands.shared_options import max_slippage
 from tradeexecutor.cli.log import setup_notebook_logging, setup_custom_log_levels, setup_strategy_logging
 from tradeexecutor.cli.loop import ExecutionLoop, ExecutionTestHook
-from tradeexecutor.ethereum.routing_data import get_routing_model, get_backtest_routing_model
+from tradeexecutor.ethereum.routing_data import get_backtest_routing_model
 from tradeexecutor.state.state import State
 from tradeexecutor.state.store import NoneStore
 from tradeexecutor.state.types import USDollarAmount
@@ -34,7 +33,7 @@ from tradeexecutor.strategy.execution_context import ExecutionContext, Execution
 from tradeexecutor.strategy.generic.generic_pricing_model import GenericPricing
 from tradeexecutor.strategy.generic.generic_router import GenericRouting
 from tradeexecutor.strategy.pandas_trader.indicator import CreateIndicatorsProtocolV1, calculate_and_load_indicators, DiskIndicatorStorage, IndicatorSet, \
-    IndicatorKey, load_indicators, CreateIndicatorsProtocol, call_create_indicators, IndicatorResultMap
+    IndicatorKey, load_indicators, CreateIndicatorsProtocol, call_create_indicators
 from tradeexecutor.strategy.pandas_trader.runner import PandasTraderRunner
 from tradeexecutor.strategy.pandas_trader.strategy_input import StrategyInputIndicators
 from tradeexecutor.strategy.strategy_module import parse_strategy_module, \
@@ -875,7 +874,7 @@ def run_backtest_inline(
             assert not parameters.get("grid_search"), f"Grid search parameters were passed to a single backtest: {parameters}"
 
         # Override run_inline_backtest() default arg if strategy parameters are given
-        if parameters.slippage_tolerance:
+        if parameters.has_parameter("slippage_tolerance"):
             max_slippage = parameters.slippage_tolerance
 
     if start_at is None and end_at is None:

--- a/tradeexecutor/state/identifier.py
+++ b/tradeexecutor/state/identifier.py
@@ -325,6 +325,25 @@ class AssetIdentifier:
         assert type(tags) == set
         self.other_data["tags"] = tags
 
+    def get_buy_tax(self) -> Percent | None:
+        """Get buy tax associated with this token if any.
+
+        .. note ::
+
+            This property should be per trading pair, but all other DEX systems use per token tax values.
+        """
+        return self.other_data.get("buy_tax")
+
+    def get_sell_tax(self) -> Percent | None:
+        """Get sell tax associated with this token if any.
+
+        .. note ::
+
+            This property should be per trading pair, but all other DEX systems use per token tax values.
+
+        """
+        return self.other_data.get("sell_tax")
+
 
 class TradingPairKind(enum.Enum):
     """What kind of trading position this is.

--- a/tradeexecutor/state/identifier.py
+++ b/tradeexecutor/state/identifier.py
@@ -742,6 +742,25 @@ class TradingPairIdentifier:
         underlying = self.underlying_spot_pair or self
         return underlying.base.get_tags()
 
+    def get_buy_tax(self) -> Percent | None:
+        """Get buy tax associated with this token if any.
+
+        .. note ::
+
+            This property should be per trading pair, but all other DEX systems use per token tax values.
+        """
+        return self.base.get_buy_tax()
+
+    def get_sell_tax(self) -> Percent | None:
+        """Get sell tax associated with this token if any.
+
+        .. note ::
+
+            This property should be per trading pair, but all other DEX systems use per token tax values.
+
+        """
+        return self.base.get_sell_tax()
+
 
 @dataclass_json
 @dataclass(slots=True)

--- a/tradeexecutor/state/trade.py
+++ b/tradeexecutor/state/trade.py
@@ -715,8 +715,8 @@ class TradeExecution:
         assert self.opened_at.tzinfo is None, f"We got a datetime {self.opened_at} with tzinfo {self.opened_at.tzinfo}"
 
         if self.slippage_tolerance:
-            # Sanity check
-            assert self.slippage_tolerance < 0.15, f"Cannot set slippage tolerance more than 15%, got {self.slippage_tolerance}"
+            # Hardcoded sanity check
+            assert self.slippage_tolerance < 0.33, f"Cannot set slippage tolerance more than 33%, got {self.slippage_tolerance} for {self.pair}, trade id {self.trade_id}"
         
     @property
     def strategy_cycle_at(self) -> datetime.datetime:

--- a/tradeexecutor/strategy/pandas_trader/position_manager.py
+++ b/tradeexecutor/strategy/pandas_trader/position_manager.py
@@ -690,7 +690,7 @@ class PositionManager:
 
         if not slippage_tolerance:
             slippage_tolerance = self.pricing_model.calculate_trade_adjusted_slippage_tolerance(
-                pair=pair,
+                pair=executor_pair,
                 direction="buy",
                 default_slippage_tolerance=self.default_slippage_tolerance,
             )

--- a/tradeexecutor/strategy/pandas_trader/position_manager.py
+++ b/tradeexecutor/strategy/pandas_trader/position_manager.py
@@ -220,6 +220,9 @@ class PositionManager:
         # Only legacy strategies should not have StrategyParameters.slippage_tolerance set
         if default_slippage_tolerance is None:
             default_slippage_tolerance = DEFAULT_SLIPPAGE_TOLERANCE
+
+        assert default_slippage_tolerance < 0.15, f"default_slippage_tolerance looks too high: {default_slippage_tolerance * 100} %"
+
         self.default_slippage_tolerance = default_slippage_tolerance
 
         reserve_currency, reserve_price = state.portfolio.get_default_reserve_asset()
@@ -1032,6 +1035,9 @@ class PositionManager:
                 direction="sell",
                 default_slippage_tolerance=self.default_slippage_tolerance,
             )
+
+        # Hardcoded safety check
+        assert slippage_tolerance < 0.33, f"Slippage tolerance does not look real {slippage_tolerance} for {pair}, sell tax is {pair.get_sell_tax()}"
 
         logger.info(
             "Preparing to close position %s, quantity %s, pricing %s, profit %s, slippage tolerance: %f %%",

--- a/tradeexecutor/strategy/pandas_trader/strategy_input.py
+++ b/tradeexecutor/strategy/pandas_trader/strategy_input.py
@@ -17,7 +17,7 @@ from tradeexecutor.state.state import State
 from tradeexecutor.state.types import USDollarPrice
 from tradeexecutor.strategy.execution_context import ExecutionContext
 from tradeexecutor.strategy.pandas_trader.indicator import IndicatorResultMap, IndicatorSet, IndicatorKey, IndicatorNotFound, InvalidForMultipairStrategy
-from tradeexecutor.strategy.pandas_trader.position_manager import PositionManager
+from tradeexecutor.strategy.pandas_trader.position_manager import PositionManager, DEFAULT_SLIPPAGE_TOLERANCE
 from tradeexecutor.strategy.parameters import StrategyParameters
 from tradeexecutor.strategy.pricing_model import PricingModel
 from tradeexecutor.strategy.trading_strategy_universe import TradingStrategyUniverse
@@ -844,7 +844,8 @@ class StrategyInput:
             self.timestamp,
             self.strategy_universe,
             self.state,
-            self.pricing_model
+            self.pricing_model,
+            default_slippage_tolerance=self.parameters.slippage_tolerance or DEFAULT_SLIPPAGE_TOLERANCE,
         )
 
     def get_default_pair(self) -> TradingPairIdentifier:

--- a/tradeexecutor/strategy/pandas_trader/strategy_input.py
+++ b/tradeexecutor/strategy/pandas_trader/strategy_input.py
@@ -845,7 +845,7 @@ class StrategyInput:
             self.strategy_universe,
             self.state,
             self.pricing_model,
-            default_slippage_tolerance=self.parameters.slippage_tolerance or DEFAULT_SLIPPAGE_TOLERANCE,
+            default_slippage_tolerance=self.parameters.get("slippage_tolerance") or DEFAULT_SLIPPAGE_TOLERANCE,
         )
 
     def get_default_pair(self) -> TradingPairIdentifier:

--- a/tradeexecutor/strategy/parameters.py
+++ b/tradeexecutor/strategy/parameters.py
@@ -216,6 +216,19 @@ class StrategyParameters(MutableAttributeDict):
             all_params = ", ".join(key for key, val in self.iterate_parameters())
             raise AttributeError(f"Strategy parameters lacks parameter: {name}\nWe have: {all_params}")
 
+    def has_parameter(self, name: str) -> bool:
+        """Is a specific parameter set?.
+
+        Example:
+
+        .. code-block:: python
+
+            if parameters.has_parameter("slippage_tolerance"):
+                max_slippage = parameters.slippage_tolerance
+        """
+        assert type(name) == str
+        return name in self
+
     def iterate_parameters(self) -> Iterable[Tuple[str, any]]:
         """Iterate over parameter definitions."""
         return self.items()

--- a/tradeexecutor/strategy/parameters.py
+++ b/tradeexecutor/strategy/parameters.py
@@ -100,6 +100,12 @@ class StrategyParameters(MutableAttributeDict):
         value = parameters.rsi_low
         value = parameters["rsi_low"]  # Are equal
 
+    If you are not sure if the parameter exists, you can still use `dict.get()` access:
+
+    .. code-block:: python
+
+        max_slippage = self.parameters.get("slippage_tolerance") or 0.0050
+
     Example parameter definition:
 
     .. code-block:: python

--- a/tradeexecutor/strategy/pricing_model.py
+++ b/tradeexecutor/strategy/pricing_model.py
@@ -1,5 +1,6 @@
 """Asset pricing model."""
 
+import logging
 import abc
 import datetime
 from decimal import Decimal, ROUND_DOWN
@@ -12,6 +13,8 @@ from tradeexecutor.strategy.routing import RoutingModel
 from tradeexecutor.strategy.universe_model import StrategyExecutionUniverse
 from tradeexecutor.strategy.trade_pricing import TradePricing
 
+
+logger = logging.getLogger(__name__)
 
 
 class PricingModel(abc.ABC):
@@ -214,20 +217,35 @@ class PricingModel(abc.ABC):
 
         - Mainly a hook to deal with :term:`token tax` tokens on spot market
 
-        - Make sure you have token tax data included with your `PandasPairUniverse`, see details at TODO.
+        - Make sure you have token tax data included with your `PandasPairUniverse`, see details in
+          :py:mod:`tradingstrategy.utils.token_extra_data` - otherwise token tax data is not available
+
+        - Override to add custom per-pair slippage handling
 
         :return:
             Use `default_slippage_tolerance` if the token does not need special slippage.
         """
 
+        assert isinstance(pair, TradingPairIdentifier), f"Got {type(pair)} instead of TradingPairIdentifier"
+
         assert default_slippage_tolerance is not None, "default_slippage_tolerance must be set"
 
         if direction == "buy":
-            return default_slippage_tolerance + (pair.base.get_buy_tax() or 0)
+            special_tolerance = pair.base.get_buy_tax()
         elif direction == "sell":
-            return default_slippage_tolerance + (pair.base.get_sell_tax() or 0)
+            special_tolerance = pair.base.get_sell_tax()
+        else:
+            raise NotImplementedError(f"Does not know: {direction}")
 
-        return default_slippage_tolerance
+        logger.info(
+            "Adjusting slippage tolerance for %s, direction %s, default: %s, special %s",
+            pair,
+            direction,
+            default_slippage_tolerance,
+            special_tolerance,
+        )
+
+        return default_slippage_tolerance + (special_tolerance or 0)
 
 
 class FixedPricing(PricingModel):

--- a/tradeexecutor/strategy/pricing_model.py
+++ b/tradeexecutor/strategy/pricing_model.py
@@ -5,7 +5,6 @@ import datetime
 from decimal import Decimal, ROUND_DOWN
 from typing import Callable, Optional, Literal
 
-from strategies.test_only.pancakeswap import debug
 from tradeexecutor.state.identifier import TradingPairIdentifier
 from tradeexecutor.state.types import USDollarPrice, Percent, USDollarAmount, TokenAmount
 from tradeexecutor.strategy.execution_model import ExecutionModel

--- a/tradeexecutor/strategy/runner.py
+++ b/tradeexecutor/strategy/runner.py
@@ -929,9 +929,10 @@ class StrategyRunner(abc.ABC):
                 universe,
                 state,
                 stop_loss_pricing_model,
+                default_slippage_tolerance=self.parameters.slippage_tolerance,
             )
 
-            triggered_trades = check_position_triggers(position_manager,self.execution_context)
+            triggered_trades = check_position_triggers(position_manager, self.execution_context)
             triggered_trades = post_process_trade_decision(
                 state,
                 self.execution_context,

--- a/tradeexecutor/strategy/runner.py
+++ b/tradeexecutor/strategy/runner.py
@@ -929,7 +929,7 @@ class StrategyRunner(abc.ABC):
                 universe,
                 state,
                 stop_loss_pricing_model,
-                default_slippage_tolerance=self.parameters.slippage_tolerance if self.parameters else None,
+                default_slippage_tolerance=self.parameters.get("slippage_tolerance") if self.parameters else None,
             )
 
             triggered_trades = check_position_triggers(position_manager, self.execution_context)

--- a/tradeexecutor/strategy/runner.py
+++ b/tradeexecutor/strategy/runner.py
@@ -929,7 +929,7 @@ class StrategyRunner(abc.ABC):
                 universe,
                 state,
                 stop_loss_pricing_model,
-                default_slippage_tolerance=self.parameters.slippage_tolerance,
+                default_slippage_tolerance=self.parameters.slippage_tolerance if self.parameters else None,
             )
 
             triggered_trades = check_position_triggers(position_manager, self.execution_context)

--- a/tradeexecutor/strategy/trading_strategy_universe.py
+++ b/tradeexecutor/strategy/trading_strategy_universe.py
@@ -1815,7 +1815,7 @@ def translate_trading_pair(dex_pair: DEXPair, cache: dict | None = None) -> Trad
         pair.other_data = dex_pair.other_data  # Pass by reference to save time
 
     if cache is not None:
-        cache[pair.internal_id] = dex_pair
+        cache[pair.internal_id] = pair
 
     return pair
 

--- a/tradeexecutor/strategy/trading_strategy_universe.py
+++ b/tradeexecutor/strategy/trading_strategy_universe.py
@@ -38,7 +38,8 @@ from tradingstrategy.utils.groupeduniverse import filter_for_pairs, NoDataAvaila
 from tradeexecutor.strategy.execution_context import ExecutionMode, ExecutionContext
 from tradeexecutor.state.identifier import AssetIdentifier, TradingPairIdentifier, TradingPairKind, AssetType
 from tradeexecutor.strategy.universe_model import StrategyExecutionUniverse, UniverseModel, DataTooOld, UniverseOptions, default_universe_options
-
+from tradingstrategy.utils.token_extra_data import load_extra_metadata
+from tradingstrategy.utils.token_filter import add_base_quote_address_columns
 
 logger = logging.getLogger(__name__)
 
@@ -1721,7 +1722,7 @@ def translate_token(
     )
 
 
-def translate_trading_pair(pair: DEXPair, cache: dict | None = None) -> TradingPairIdentifier:
+def translate_trading_pair(dex_pair: DEXPair, cache: dict | None = None) -> TradingPairIdentifier:
     """Translate trading pair from client download to the trade executor.
 
     Trading Strategy client uses compressed columnar data for pairs and tokens.
@@ -1747,44 +1748,44 @@ def translate_trading_pair(pair: DEXPair, cache: dict | None = None) -> TradingP
     """
 
     if cache is not None:
-        cached = cache.get(pair.pair_id)
+        cached = cache.get(dex_pair.pair_id)
         if cached is not None:
             return cached
 
-    assert isinstance(pair, DEXPair), f"Expected DEXPair, got {type(pair)}"
-    assert pair.base_token_decimals is not None, f"Base token missing decimals: {pair}"
-    assert pair.quote_token_decimals is not None, f"Quote token missing decimals: {pair}"
+    assert isinstance(dex_pair, DEXPair), f"Expected DEXPair, got {type(dex_pair)}"
+    assert dex_pair.base_token_decimals is not None, f"Base token missing decimals: {dex_pair}"
+    assert dex_pair.quote_token_decimals is not None, f"Quote token missing decimals: {dex_pair}"
 
     base = AssetIdentifier(
-        chain_id=pair.chain_id.value,
-        address=pair.base_token_address,
-        token_symbol=pair.base_token_symbol,
-        decimals=pair.base_token_decimals,
+        chain_id=dex_pair.chain_id.value,
+        address=dex_pair.base_token_address,
+        token_symbol=dex_pair.base_token_symbol,
+        decimals=dex_pair.base_token_decimals,
     )
     quote = AssetIdentifier(
-        chain_id=pair.chain_id.value,
-        address=pair.quote_token_address,
-        token_symbol=pair.quote_token_symbol,
-        decimals=pair.quote_token_decimals,
+        chain_id=dex_pair.chain_id.value,
+        address=dex_pair.quote_token_address,
+        token_symbol=dex_pair.quote_token_symbol,
+        decimals=dex_pair.quote_token_decimals,
     )
 
-    if pair.fee and isnan(pair.fee):
+    if dex_pair.fee and isnan(dex_pair.fee):
         # Repair some broken data
         fee = None
     else:
         # Convert DEXPair.fee BPS to %
         # So, after this, fee can either be multiplier or None
-        if pair.fee is not None:
+        if dex_pair.fee is not None:
             # If BPS fee is set it must be more than 1 BPS.
             # Allow explicit fee = 0 in testing.
             # if pair.fee != 0:
             #     assert pair.fee > 1, f"DEXPair fee must be in BPS, got {pair.fee}"
 
             # can receive fee in bps or multiplier, but not raw form
-            if pair.fee >= 1:
-                fee = pair.fee / 10_000
+            if dex_pair.fee >= 1:
+                fee = dex_pair.fee / 10_000
             else:
-                fee = pair.fee
+                fee = dex_pair.fee
 
             # highest fee tier is currently 1% and lowest in 0.01%
             if fee != 0:
@@ -1795,17 +1796,26 @@ def translate_trading_pair(pair: DEXPair, cache: dict | None = None) -> TradingP
     pair = TradingPairIdentifier(
         base=base,
         quote=quote,
-        pool_address=pair.address,
-        internal_id=pair.pair_id,
-        info_url=pair.get_trading_pair_page_url(),
-        exchange_address=pair.exchange_address,
+        pool_address=dex_pair.address,
+        internal_id=dex_pair.pair_id,
+        info_url=dex_pair.get_trading_pair_page_url(),
+        exchange_address=dex_pair.exchange_address,
         fee=fee,
-        reverse_token_order=pair.token0_symbol != pair.base_token_symbol,
-        exchange_name=pair.exchange_name,
+        reverse_token_order=dex_pair.token0_symbol != dex_pair.base_token_symbol,
+        exchange_name=dex_pair.exchange_name,
     )
 
+    # Need to be loaded with load_extra_metadata()
+    if dex_pair.buy_tax:
+        pair.base.other_data["buy_tax"] = dex_pair.buy_tax
+        pair.base.other_data["sell_tax"] = dex_pair.sell_tax
+
+    # Need to be loaded with load_extra_metadata()
+    if dex_pair.other_data:
+        pair.other_data = dex_pair.other_data  # Pass by reference to save time
+
     if cache is not None:
-        cache[pair.internal_id] = pair
+        cache[pair.internal_id] = dex_pair
 
     return pair
 
@@ -2006,6 +2016,7 @@ def load_partial_data(
     name: str | None = None,
     candle_progress_bar_desc: str | None = None,
     lending_candle_progress_bar_desc: str | None = None,
+    pair_extra_metadata=False,
 ) -> Dataset:
     """Load pair data for given trading pairs.
 
@@ -2129,6 +2140,11 @@ def load_partial_data(
     :param lending_candle_progress_bar_desc:
         Override the default progress bar message
 
+    :param pair_extra_metadata:
+        Load TokenSniffer data, buy/sell tax and other extra metadata.
+
+        Slow and API endpoint severely limited. Use only if you are dealing with a limited number of pairs.
+
     :return:
         Datataset containing the requested data
 
@@ -2214,6 +2230,15 @@ def load_partial_data(
 
             # Eliminate the pairs we are not interested in from the database
             filtered_pairs_df = pairs_df.loc[pairs_df["pair_id"].isin(our_pair_ids)]
+
+        if pair_extra_metadata:
+            # Load token tax data
+            filtered_pairs_df = filtered_pairs_df.copy()
+            filtered_pairs_df = add_base_quote_address_columns(filtered_pairs_df)
+            filtered_pairs_df = load_extra_metadata(
+                pairs_df=filtered_pairs_df,
+                client=client,
+            )
 
         # Autogenerate names by the pair count
         if not name:

--- a/tradeexecutor/strategy/trading_strategy_universe.py
+++ b/tradeexecutor/strategy/trading_strategy_universe.py
@@ -1806,7 +1806,9 @@ def translate_trading_pair(dex_pair: DEXPair, cache: dict | None = None) -> Trad
     )
 
     # Need to be loaded with load_extra_metadata()
-    if dex_pair.buy_tax:
+    if dex_pair.buy_tax and dex_pair.buy_tax < 900:
+        # 900+ are error codes for built-in internal token tax measurer
+        # that should be no longer used - don't bring over these error codes from DEXPair
         pair.base.other_data["buy_tax"] = dex_pair.buy_tax
         pair.base.other_data["sell_tax"] = dex_pair.sell_tax
 

--- a/tradeexecutor/strategy/universe_model.py
+++ b/tradeexecutor/strategy/universe_model.py
@@ -119,25 +119,32 @@ class UniverseOptions:
             return f"{self.history_period} back from today"
 
     @staticmethod
-    def from_strategy_parameters_class(Parameters: Type[StrategyParameters], execution_context: ExecutionContext) -> "UniverseOptions":
-        """Extract backtesting range or live history load range based on if we are doing live trading."""
+    def from_strategy_parameters_class(
+            parameters: Type[StrategyParameters] | StrategyParameters,
+            execution_context: ExecutionContext,
+    ) -> "UniverseOptions":
+        """Extract backtesting range or live history load range based on if we are doing live trading.
+
+        :param parameters:
+            StrategyParameters instance or raw class.
+        """
 
         assert isinstance(execution_context, ExecutionContext)
 
         if execution_context.mode.is_backtesting():
 
-            assert Parameters.backtest_start, "Parameters.backtest_start missing"
-            assert Parameters.backtest_end, "Parameters.backtest_end missing"
+            assert parameters.backtest_start, "Parameters.backtest_start missing"
+            assert parameters.backtest_end, "Parameters.backtest_end missing"
 
             return UniverseOptions(
-                start_at=Parameters.backtest_start,
-                end_at=Parameters.backtest_end,
+                start_at=parameters.backtest_start,
+                end_at=parameters.backtest_end,
             )
         else:
             return UniverseOptions(
                 start_at=None,
                 end_at=None,
-                history_period=Parameters.required_history_period,
+                history_period=parameters.required_history_period,
             )
 
 #: Shorthand method for no specifc trading univese fine tuning options set


### PR DESCRIPTION
- Add `load_partial_data(pair_extra_metadata=True)` to fetch token tax data, among other TokenSniffer metadata
- [See limitations here](https://github.com/tradingstrategy-ai/trading-strategy/blob/8900173a6b17a57c380335554867f4843b4256f8/tradingstrategy/utils/token_extra_data.py#L9), and this is put together