### PR TITLE
Tag pair fee in indicator cache

### DIFF
--- a/tests/backtest/test_indicator.py
+++ b/tests/backtest/test_indicator.py
@@ -117,7 +117,7 @@ def test_setup_up_indicator_storage_per_pair(tmp_path, strategy_universe):
 
     # pandas_ta function signature changes in every releease
     assert str(ind_path).startswith(str(Path(tmp_path) / storage.universe_key))
-    assert str(ind_path).endswith("(length=21)-WETH-USDC.parquet")
+    assert str(ind_path).endswith("(length=21)-WETH-USDC-30.parquet"), f"Got: {ind_path}"
     # / "sma_dfc27ff4"
 
 
@@ -130,6 +130,7 @@ def test_setup_up_indicator_universe(tmp_path, strategy_universe):
         name="foobar",
         func=lambda length: pd.Series(),
         parameters={"length": 21},
+        source=IndicatorSource.strategy_universe,
     )
 
     key = IndicatorKey(None, ind)
@@ -160,7 +161,7 @@ def test_setup_up_indicator_storage_two_parameters(tmp_path, strategy_universe):
     # Signature changes in every pandas_ta release
     ind_path = storage.get_indicator_path(key)
     # assert ind_path == Path(tmp_path) / storage.universe_key / "sma_dfc27ff4(length=21,offset=1)-WETH-USDC.parquet"
-    assert str(ind_path).endswith("-WETH-USDC.parquet")
+    assert str(ind_path).endswith("-WETH-USDC-30.parquet"), f"Got: {ind_path}"
 
 
 

--- a/tests/mainnet_fork/test_enzyme_credit_position.py
+++ b/tests/mainnet_fork/test_enzyme_credit_position.py
@@ -5,6 +5,7 @@ import secrets
 from pathlib import Path
 from unittest import mock
 
+import flaky
 import pytest
 
 from eth_account import Account
@@ -282,6 +283,8 @@ def test_enzyme_credit_positions_with_big_size(
         assert reserve_position.get_value() == pytest.approx(3960)
 
 
+# ERROR tests/mainnet_fork/test_enzyme_credit_position.py::test_enzyme_credit_position_redemption - requests.exceptions.ReadTimeout: HTTPConnectionPool(host='localhost', port=20415): Read timed out. (read timeout=10)
+@flaky.flaky
 def test_enzyme_credit_position_redemption(
     web3: Web3,
     vault: Vault,

--- a/tests/web/test_webhook_api.py
+++ b/tests/web/test_webhook_api.py
@@ -5,6 +5,7 @@ import tempfile
 from pathlib import Path
 from queue import Queue
 
+import flaky
 import pytest
 import requests
 from eth_defi.utils import find_free_port
@@ -90,6 +91,8 @@ def test_ping(logger,server_url):
     assert resp.json() == {"ping": "pong"}
 
 
+# OSError: [Errno 98] Address already in use
+@flaky.flaky
 def test_metadata(logger, server_url):
     """Get executor metadata"""
     resp = requests.get(f"{server_url}/metadata")

--- a/tradeexecutor/state/identifier.py
+++ b/tradeexecutor/state/identifier.py
@@ -562,7 +562,7 @@ class TradingPairIdentifier:
         return hash((self.base.address, self.quote.address, self.fee))
 
     def __eq__(self, other: "TradingPairIdentifier | None"):
-
+        # TODO: Include exchange slug in comparison
         if other is None:
             return False
 

--- a/tradeexecutor/state/identifier.py
+++ b/tradeexecutor/state/identifier.py
@@ -567,7 +567,7 @@ class TradingPairIdentifier:
             return False
 
         assert isinstance(other, TradingPairIdentifier), f"Got {other}"
-        return self.base == other.base and self.quote == other.quote
+        return self.base == other.base and self.quote == other.quote and self.fee == other.fee
 
     @property
     def chain_id(self) -> int:

--- a/tradeexecutor/strategy/pandas_trader/indicator.py
+++ b/tradeexecutor/strategy/pandas_trader/indicator.py
@@ -441,7 +441,7 @@ class IndicatorKey:
             return f"{pair.base.token_symbol}-{pair.quote.token_symbol}{fee_slug}"
         else:
             # Indicator calculated over the universe
-            assert self.definition.source == IndicatorSource.strategy_universe
+            assert self.definition.source == IndicatorSource.strategy_universe, f"Got: {self.definition}, {self.definition.source}"
             return "universe"
 
     def __eq__(self, other):

--- a/tradeexecutor/strategy/pandas_trader/indicator.py
+++ b/tradeexecutor/strategy/pandas_trader/indicator.py
@@ -435,7 +435,7 @@ class IndicatorKey:
         if pair is not None:
             # TODO: Include 3 letter exchange id to discriminate between uni v2 and uni v3
             if pair.fee != 0.30:
-                fee_slug = f"-{int(pair.fee * 100)}"
+                fee_slug = f"-{int(pair.fee * 10_000)}"
             else:
                 fee_slug = ""
             return f"{pair.base.token_symbol}-{pair.quote.token_symbol}{fee_slug}"

--- a/tradeexecutor/strategy/pandas_trader/indicator.py
+++ b/tradeexecutor/strategy/pandas_trader/indicator.py
@@ -431,13 +431,14 @@ class IndicatorKey:
 
     def get_pair_cache_id(self) -> str:
         """Get unique value for this trading pair or 'universe' if there isn't one."""
-        if self.pair is not None:
+        pair = self.pair
+        if pair is not None:
             # TODO: Include 3 letter exchange id to discriminate between uni v2 and uni v3
-            if self.pair.fee != 0.30:
-                fee_slug = f"-{int(self.pair.fee * 100)}"
+            if pair.fee != 0.30:
+                fee_slug = f"-{int(pair.fee * 100)}"
             else:
                 fee_slug = ""
-            return f"{self.base.token_symbol}-{self.quote.token_symbol}{fee_slug}"
+            return f"{pair.base.token_symbol}-{pair.quote.token_symbol}{fee_slug}"
         else:
             # Indicator calculated over the universe
             assert self.definition.source == IndicatorSource.strategy_universe


### PR DESCRIPTION
- Having both Uni v2 and v3 pair at the same time broken indicator cache
- Fix `TradingPairIdentifier.__eq__` to consider fee