### PR TITLE
On indicator data generation, record the error

### DIFF
--- a/strategies/test_only/memecoin_index.py
+++ b/strategies/test_only/memecoin_index.py
@@ -506,8 +506,10 @@ def volume_inclusion_criteria(
     mask = filtered_series >= min_volume
 
     # Turn to a series of lists
-    series = mask.groupby(level='timestamp').apply(lambda x: x.index.get_level_values('pair_id').tolist())
-    return series
+    data = mask.groupby(level='timestamp').apply(lambda x: x.index.get_level_values('pair_id').tolist())
+
+
+    return data
 
 
 def included_pair_count(

--- a/tradeexecutor/strategy/pandas_trader/indicator.py
+++ b/tradeexecutor/strategy/pandas_trader/indicator.py
@@ -136,10 +136,6 @@ class IndicatorSource(enum.Enum):
     #:
     external_per_pair = "external_per_pair"
 
-    #: The indicator takes strategy universe + all earlier indicators as an input.
-    #:
-    earlier_indicators = "earlier_indicators"
-
     def is_per_pair(self) -> bool:
         """This indicator is calculated to all trading pairs."""
         return self in (IndicatorSource.open_price, IndicatorSource.close_price, IndicatorSource.ohlcv, IndicatorSource.external_per_pair)
@@ -294,25 +290,6 @@ class IndicatorDefinition:
         try:
             input_fixed = _flatten_index(input)
             ret = self.func(input_fixed, **self._fix_parameters_for_function_signature(resolver, pair))
-
-            # Some debug logging
-            if ret is None:
-                diagnostics_text = "<none>"
-            else:
-                if len(ret) >= 1:
-                    last_value = ret.iloc[-1]
-                    last_value_at = ret.index[-1]
-                    diagnostics_text = f"{len(ret)} rows, last value {last_value}, at {last_value_at}"
-                else:
-                    diagnostics_text = f"{ret}"
-
-            logger.info(
-                "Indicator calculated: %s, pair: %s, data: %s",
-                self.name,
-                pair.get_ticker(),
-                diagnostics_text,
-            )
-
             return self._check_good_return_value(ret)
         except Exception as e:
             raise IndicatorCalculationFailed(f"Could not calculate indicator {self.name} ({self.func}) for parameters {self.parameters}, input data is {len(input)} rows: {e}, pair is {pair}") from e
@@ -412,7 +389,7 @@ class IndicatorKey:
 
     #: Trading pair if this indicator is specific to a pair
     #:
-    #: Note if this indicator is for the whole strategy
+    #: `None` if this indicator is for the whole universe, using everything as an input.
     #:
     pair: TradingPairIdentifier | None
 
@@ -1097,13 +1074,28 @@ def _calculate_and_save_indicator_result(
         match indicator.source:
             case IndicatorSource.strategy_universe:
                 data = indicator.calculate_universe(strategy_universe, resolver)
-            case IndicatorSource.earlier_indicators:
-                data = indicator.calculate_earlier_indicators(strategy_universe, resolver)
             case _:
                 raise NotImplementedError(f"Unsupported input source {key.pair} {key.definition} {indicator.source}")
 
     assert data is not None, f"Indicator function {indicator.name} ({indicator.func}) did not return any result, received Python None instead"
 
+    # Some debug logging
+    if data is None:
+        diagnostics_text = "<none>"
+    else:
+        if len(data) >= 1:
+            last_value = data.iloc[-1]
+            last_value_at = data.index[-1]
+            diagnostics_text = f"{len(data)} rows, last value {last_value}, at {last_value_at}"
+        else:
+            diagnostics_text = f"{data}"
+
+    logger.info(
+        "Indicator calculated: %s, pair: %s, data: %s",
+        key.definition.name,
+        key.pair.get_ticker() if key.pair else "<universe>",
+        diagnostics_text,
+    )
     result = storage.save(key, data)
     return result
 


### PR DESCRIPTION
- Set `series.attrs["error"]` or `df.attrs["error"]` when we raise an exception or get no data when generating indicators
- Tune down logging level of these errors, as they break the Discord logger