### PR TITLE
More indicator parameters

### DIFF
--- a/tradeexecutor/strategy/pandas_trader/indicator.py
+++ b/tradeexecutor/strategy/pandas_trader/indicator.py
@@ -1913,7 +1913,7 @@ def calculate_and_load_indicators(
     if create_indicators:
         assert indicators is None, f"Give either indicators or create_indicators, not both"
         assert parameters is not None, f"parameters argument must be given if you give create_indicators"
-        indicators = prepare_indicators(create_indicators, parameters, strategy_universe, execution_context, timestamp=timestamp)
+        indicators = prepare_indicators(create_indicators, parameters, strategy_universe, execution_context, timestamp=strategy_cycle_timestamp)
 
     assert isinstance(indicators, IndicatorSet), f"Got class {type(indicators)} when IndicatorSet expected"
 

--- a/tradeexecutor/strategy/pandas_trader/indicator.py
+++ b/tradeexecutor/strategy/pandas_trader/indicator.py
@@ -285,7 +285,13 @@ class IndicatorDefinition:
     def is_per_pair(self) -> bool:
         return self.source.is_per_pair()
 
-    def calculate_by_pair_external(self, pair: TradingPairIdentifier, resolver: "IndicatorDependencyResolver") -> pd.DataFrame | pd.Series:
+    def calculate_by_pair_external(
+        self,
+        pair: TradingPairIdentifier,
+        resolver: "IndicatorDependencyResolver",
+        timestamp: pd.Timestamp | None,
+        execution_context: ExecutionContext,
+    ) -> pd.DataFrame | pd.Series:
         """Calculate indicator for external data.
 
         :param pair:
@@ -306,7 +312,14 @@ class IndicatorDefinition:
         except Exception as e:
             raise IndicatorCalculationFailed(f"Could not calculate external data indicator {self.name} ({self.func}) for parameters {self.parameters}, pair {pair}") from e
 
-    def calculate_by_pair(self, input: pd.Series, pair: TradingPairIdentifier, resolver: "IndicatorDependencyResolver") -> pd.DataFrame | pd.Series:
+    def calculate_by_pair(
+        self,
+        input: pd.Series,
+        pair: TradingPairIdentifier,
+        resolver: "IndicatorDependencyResolver",
+        timestamp: pd.Timestamp | None,
+        execution_context: ExecutionContext,
+    ) -> pd.DataFrame | pd.Series:
         """Calculate the underlying indicator value.
 
         :param input:
@@ -321,30 +334,48 @@ class IndicatorDefinition:
         """
         try:
             input_fixed = _flatten_index(input)
-            ret = self.func(input_fixed, **self._fix_parameters_for_function_signature(resolver, pair))
+            ret = self.func(input_fixed, **self._fix_parameters_for_function_signature(resolver, pair, timestamp, execution_context))
             return self._check_good_return_value(ret)
         except Exception as e:
             raise IndicatorCalculationFailed(f"Could not calculate indicator {self.name} ({self.func}) for parameters {self.parameters}, input data is {len(input)} rows: {e}, pair is {pair}") from e
 
-    def calculate_dependencies_only_per_pair(self, pair: TradingPairIdentifier, resolver: "IndicatorDependencyResolver") -> pd.DataFrame | pd.Series:
+    def calculate_dependencies_only_per_pair(
+        self,
+        pair: TradingPairIdentifier,
+        resolver: "IndicatorDependencyResolver",
+        timestamp: pd.Timestamp | None,
+        execution_context: ExecutionContext,
+    ) -> pd.DataFrame | pd.Series:
         """Calculate the indicator value that only takes other indicators as input."""
         assert self.dependency_order > 1, "Dependency-based indicator order cannot be first. Did you forget to declare dependencies?"
         try:
-            ret = self.func( **self._fix_parameters_for_function_signature(resolver, pair))
+            ret = self.func( **self._fix_parameters_for_function_signature(resolver, pair, timestamp, execution_context))
             return self._check_good_return_value(ret)
         except Exception as e:
             raise IndicatorCalculationFailed(f"Could not calculate indicator {self.name} ({self.func}) for parameters {self.parameters}, input data is {len(input)} rows: {e}, pair is {pair}") from e
 
-    def calculate_dependencies_only_per_universe(self, resolver: "IndicatorDependencyResolver") -> pd.DataFrame | pd.Series:
+    def calculate_dependencies_only_per_universe(
+        self,
+        resolver: "IndicatorDependencyResolver",
+        timestamp: pd.Timestamp | None,
+        execution_context: ExecutionContext,
+    ) -> pd.DataFrame | pd.Series:
         """Calculate the indicator value that only takes other indicators as input."""
         assert self.dependency_order > 1, "Dependency-based indicator order cannot be first. Did you forget to declare dependencies?"
         try:
-            ret = self.func( **self._fix_parameters_for_function_signature(resolver, pair=None))
+            ret = self.func( **self._fix_parameters_for_function_signature(resolver, None, timestamp, execution_context))
             return self._check_good_return_value(ret)
         except Exception as e:
             raise IndicatorCalculationFailed(f"Could not calculate indicator {self.name} ({self.func}) for parameters {self.parameters}, input data is {len(input)} rows: {e}") from e
 
-    def calculate_by_pair_ohlcv(self, candles: pd.DataFrame, pair: TradingPairIdentifier, resolver: "IndicatorDependencyResolver") -> pd.DataFrame | pd.Series:
+    def calculate_by_pair_ohlcv(
+        self,
+        candles: pd.DataFrame,
+        pair: TradingPairIdentifier,
+        resolver: "IndicatorDependencyResolver",
+        timestamp: pd.Timestamp | None,
+        execution_context: ExecutionContext,
+    ) -> pd.DataFrame | pd.Series:
         """Calculate the underlying OHCLV indicator value.
 
         Assume function can take parameters: `open`, `high`, `low`, `close`, `volume`,
@@ -375,7 +406,7 @@ class IndicatorDefinition:
         if len(full_kwargs) == 0:
             raise IndicatorCalculationFailed(f"Could not calculate OHLCV indicator {self.name} ({self.func}): does not take any of function arguments from {needed_args}")
 
-        fixed_params = self._fix_parameters_for_function_signature(resolver, pair)
+        fixed_params = self._fix_parameters_for_function_signature(resolver, pair, timestamp, execution_context)
 
         full_kwargs.update(fixed_params)
 
@@ -385,7 +416,13 @@ class IndicatorDefinition:
         except Exception as e:
             raise IndicatorCalculationFailed(f"Could not calculate indicator {self.name} ({self.func}) for parameters {self.parameters}, candles is {len(candles)} rows, {candles.columns} columns\nThe original exception was: {e}") from e
 
-    def calculate_universe(self, input: TradingStrategyUniverse, resolver: "IndicatorDependencyResolver") -> pd.DataFrame | pd.Series:
+    def calculate_universe(
+        self,
+        input: TradingStrategyUniverse,
+        resolver: "IndicatorDependencyResolver",
+        timestamp: pd.Timestamp | None,
+        execution_context: ExecutionContext,
+    ) -> pd.DataFrame | pd.Series:
         """Calculate the underlying indicator value.
 
         :param input:
@@ -399,7 +436,7 @@ class IndicatorDefinition:
 
         """
         try:
-            ret = self.func(input, **self._fix_parameters_for_function_signature(resolver, None))
+            ret = self.func(input, **self._fix_parameters_for_function_signature(resolver, None, timestamp, execution_context))
             return self._check_good_return_value(ret)
         except Exception as e:
             raise IndicatorCalculationFailed(f"Could not calculate indicator {self.name} ({self.func}) for parameters {self.parameters}, input universe is {input}.\nException is {e}\n\n To use Python debugger, set `max_workers=1`, and if doing a grid search, also set `multiprocess=False`") from e
@@ -408,10 +445,16 @@ class IndicatorDefinition:
         assert isinstance(df, (pd.Series, pd.DataFrame)), f"Indicator did not return pd.DataFrame or pd.Series: {self.name}, we got {type(df)}\nCheck you are using IndicatorSource correcly e.g. IndicatorSource.close_price when creating indicators"
         return df
 
-    def _fix_parameters_for_function_signature(self, resolver: "IndicatorDependencyResolver", pair: TradingPairIdentifier | None) -> dict:
-        """Update parameters to include resolver if the indicator needs it.
+    def _fix_parameters_for_function_signature(
+        self,
+        resolver: "IndicatorDependencyResolver",
+        pair: TradingPairIdentifier | None,
+        timestamp: pd.Timestamp | None,
+        execution_context: ExecutionContext | None,
+    ) -> dict:
+        """Update parameters to include optional parameter if the indicator needs them.
 
-        This was a late addon, so we cram it in here.
+        - This was a late addon, so we cram it in here.
         """
 
         parameters = self.parameters.copy()
@@ -423,6 +466,16 @@ class IndicatorDefinition:
         if pair:
             if "pair" in func_args:
                 parameters["pair"] = pair
+
+        if timestamp:
+            assert isinstance(timestamp, pd.Timestamp)
+            if "timestamp" in func_args:
+                parameters["timestamp"] = pair
+
+        if execution_context:
+            assert isinstance(execution_context, ExecutionContext)
+            if "execution_context" in func_args:
+                parameters["execution_context"] = pair
 
         return parameters
 
@@ -1066,6 +1119,8 @@ def _calculate_and_save_indicator_result(
     storage: DiskIndicatorStorage | MemoryIndicatorStorage,
     key: IndicatorKey,
     all_indicators: set[IndicatorKey],
+    execution_context: ExecutionContext,
+    strategy_cycle_timestamp: datetime.datetime,
 ) -> IndicatorResult | None:
     """Calculate an indicator result.
 
@@ -1094,6 +1149,12 @@ def _calculate_and_save_indicator_result(
 
     indicator = key.definition
 
+    # Use pd.Timestamp() because we deal with pd.Series()
+    if strategy_cycle_timestamp:
+        timestamp = pd.Timestamp(strategy_cycle_timestamp)
+    else:
+        timestamp = None
+
     if indicator.is_per_pair():
         assert key.pair.internal_id, f"Per-pair indicator lacks pair internal_id: {key.pair}"
         try:
@@ -1101,22 +1162,55 @@ def _calculate_and_save_indicator_result(
                 case IndicatorSource.open_price:
                     column = "open"
                     input = strategy_universe.data_universe.candles.get_samples_by_pair(key.pair.internal_id)[column]
-                    data = indicator.calculate_by_pair(input, key.pair, resolver)
+                    data = indicator.calculate_by_pair(
+                        input,
+                        key.pair,
+                        resolver=resolver,
+                        timestamp=timestamp,
+                        execution_context=execution_context
+                    )
                 case IndicatorSource.close_price:
                     column = "close"
                     input = strategy_universe.data_universe.candles.get_samples_by_pair(key.pair.internal_id)[column]
-                    data = indicator.calculate_by_pair(input, key.pair, resolver)
+                    data = indicator.calculate_by_pair(
+                        input,
+                        key.pair,
+                        resolver=resolver,
+                        timestamp=timestamp,
+                        execution_context=execution_context
+                    )
                 case IndicatorSource.ohlcv:
                     input = strategy_universe.data_universe.candles.get_samples_by_pair(key.pair.internal_id)
-                    data = indicator.calculate_by_pair_ohlcv(input, key.pair, resolver)
+                    data = indicator.calculate_by_pair_ohlcv(
+                        input,
+                        key.pair,
+                        resolver=resolver,
+                        timestamp=timestamp,
+                        execution_context=execution_context
+                    )
                 case IndicatorSource.tvl:
                     assert strategy_universe.data_universe.liquidity is not None, "TVL/liquidity data not loaded, trying to create TVL indicator"
                     input = strategy_universe.data_universe.liquidity.get_samples_by_pair(key.pair.internal_id)
-                    data = indicator.calculate_by_pair_ohlcv(input, key.pair, resolver)
+                    data = indicator.calculate_by_pair_ohlcv(
+                        input,
+                        key.pair,
+                        resolver=resolver,
+                        timestamp=timestamp,
+                        execution_context=execution_context
+                    )
                 case IndicatorSource.external_per_pair:
-                    data = indicator.calculate_by_pair_external(key.pair, resolver)
+                    data = indicator.calculate_by_pair_external(
+                        key.pair,
+                        resolver=resolver,
+                        timestamp=timestamp,
+                        execution_context=execution_context
+                    )
                 case IndicatorSource.dependencies_only_per_pair:
-                    data = indicator.calculate_dependencies_only_per_pair(key.pair, resolver)
+                    data = indicator.calculate_dependencies_only_per_pair(
+                        key.pair,
+                        resolver=resolver,
+                        timestamp=timestamp,
+                        execution_context=execution_context,                    )
                 case _:
                     raise NotImplementedError(f"Unsupported input source {key.pair} {key.definition} {indicator.source}")
 
@@ -1135,9 +1229,18 @@ def _calculate_and_save_indicator_result(
         # Calculate indicator over the whole universe
         match indicator.source:
             case IndicatorSource.strategy_universe:
-                data = indicator.calculate_universe(strategy_universe, resolver)
+                data = indicator.calculate_universe(
+                    strategy_universe,
+                    resolver=resolver,
+                    timestamp=timestamp,
+                    execution_context=execution_context,
+                )
             case IndicatorSource.dependencies_only_universe:
-                data = indicator.calculate_dependencies_only_per_universe(resolver)
+                data = indicator.calculate_dependencies_only_per_universe(
+                    resolver=resolver,
+                    timestamp=timestamp,
+                    execution_context=execution_context
+                )
             case _:
                 raise NotImplementedError(f"Unsupported input source {key.pair} {key.definition} {indicator.source}")
 
@@ -1612,6 +1715,7 @@ def calculate_indicators(
     label: str | None = None,
     all_combinations: set[IndicatorKey] | None = None,
     verbose=True,
+    strategy_cycle_timestamp: datetime.datetime = None,
 ) -> IndicatorResultMap:
     """Calculate indicators for which we do not have cached data yet.
 
@@ -1654,7 +1758,7 @@ def calculate_indicators(
 
     task_args: list[CalculateTaskArguments] = []
     for key in remaining:
-        task_args.append((storage, key, all_combinations))
+        task_args.append((storage, key, all_combinations, strategy_cycle_timestamp, execution_context))
 
     results = {}
 
@@ -1773,7 +1877,7 @@ def calculate_and_load_indicators(
     max_workers: int | Callable = get_safe_max_workers_count,
     max_readers: int | Callable = get_safe_max_workers_count,
     verbose=True,
-    timestamp: datetime.datetime = None,
+    strategy_cycle_timestamp: datetime.datetime = None,
 ) -> IndicatorResultMap:
     """Precalculate all indicators.
 
@@ -1841,6 +1945,7 @@ def calculate_and_load_indicators(
         max_workers=max_workers,
         all_combinations=all_combinations,
         verbose=verbose,
+        strategy_cycle_timestamp=strategy_cycle_timestamp,
     )
 
     result = cached | calculated
@@ -1862,6 +1967,7 @@ def calculate_and_load_indicators_inline(
     create_indicators: CreateIndicatorsProtocol = None,
     storage: IndicatorStorage | None = None,
     max_workers: int | Callable = get_safe_max_workers_count,
+    strategy_cycle_timestamp: datetime.datetime = None,
 ) -> "tradeexecutor.strategy.pandas_trader.strategy_input.StrategyInputIndicators":
     """Calculate indicators in the notebook itself, before starting the backtest.
 

--- a/tradeexecutor/strategy/pandas_trader/runner.py
+++ b/tradeexecutor/strategy/pandas_trader/runner.py
@@ -61,7 +61,11 @@ class PandasTraderRunner(StrategyRunner):
         debug_details: dict,
         indicators:StrategyInputIndicators | None = None,
         ) -> List[TradeExecution]:
-        """Run one strategy tick."""
+        """Run one strategy tick.
+
+        :param clock:
+            Strategy cycle timestamp
+        """
 
         assert isinstance(strategy_universe, TradingStrategyUniverse)
         universe = strategy_universe.data_universe
@@ -425,7 +429,7 @@ class PandasTraderRunner(StrategyRunner):
             execution_context=self.execution_context,
             indicators=indicators,
             parameters=self.parameters,
-            timestamp=timestamp,
+            strategy_cycle_timestamp=timestamp,
         )
 
         strategy_input_indicators = StrategyInputIndicators(


### PR DESCRIPTION
- Expose `timestamp` and `execution_context` for indicator calculations
- Needed for forward-filled indicators
- Create an example of `tvl` indicator that is forward filled