### PR TITLE
Refactor position valuation to its own module for reusability

### DIFF
--- a/tests/ethereum/polygon_forked/1delta/test_one_delta_live_credit_supply.py
+++ b/tests/ethereum/polygon_forked/1delta/test_one_delta_live_credit_supply.py
@@ -166,7 +166,7 @@ def test_one_delta_live_credit_supply_open_only(
         ts,
         state,
         trading_strategy_universe,
-        ExecutionMode.real_trading
+        ExecutionMode.simulated_trading
     )
 
     loop.runner.check_accounts(trading_strategy_universe, state)
@@ -262,7 +262,7 @@ def test_one_delta_live_credit_supply_open_and_close(
         ts,
         state,
         trading_strategy_universe,
-        ExecutionMode.real_trading
+        ExecutionMode.simulated_trading
     )
 
     loop.runner.check_accounts(trading_strategy_universe, state)
@@ -300,7 +300,7 @@ def test_one_delta_live_credit_supply_open_and_close(
         ts,
         state,
         trading_strategy_universe,
-        ExecutionMode.real_trading
+        ExecutionMode.simulated_trading
     )
 
     loop.runner.check_accounts(trading_strategy_universe, state)
@@ -409,7 +409,7 @@ def test_one_delta_live_credit_supply_mixed_with_spot(
         ts,
         state,
         trading_strategy_universe,
-        ExecutionMode.real_trading
+        ExecutionMode.simulated_trading
     )
 
     loop.runner.check_accounts(trading_strategy_universe, state)
@@ -447,7 +447,7 @@ def test_one_delta_live_credit_supply_mixed_with_spot(
         ts,
         state,
         trading_strategy_universe,
-        ExecutionMode.real_trading
+        ExecutionMode.simulated_trading
     )
 
     loop.runner.check_accounts(trading_strategy_universe, state)
@@ -538,7 +538,7 @@ def test_one_delta_live_credit_supply_open_and_increase(
         ts,
         state,
         trading_strategy_universe,
-        ExecutionMode.real_trading
+        ExecutionMode.simulated_trading
     )
 
     loop.runner.check_accounts(trading_strategy_universe, state)
@@ -576,7 +576,7 @@ def test_one_delta_live_credit_supply_open_and_increase(
         ts,
         state,
         trading_strategy_universe,
-        ExecutionMode.real_trading
+        ExecutionMode.simulated_trading
     )
 
     loop.runner.check_accounts(trading_strategy_universe, state)
@@ -669,7 +669,7 @@ def test_one_delta_live_credit_supply_open_and_reduce(
         ts,
         state,
         trading_strategy_universe,
-        ExecutionMode.real_trading
+        ExecutionMode.simulated_trading
     )
 
     loop.runner.check_accounts(trading_strategy_universe, state)
@@ -707,7 +707,7 @@ def test_one_delta_live_credit_supply_open_and_reduce(
         ts,
         state,
         trading_strategy_universe,
-        ExecutionMode.real_trading
+        ExecutionMode.simulated_trading
     )
 
     loop.runner.check_accounts(trading_strategy_universe, state)

--- a/tests/ethereum/polygon_forked/1delta/test_one_delta_live_credit_supply.py
+++ b/tests/ethereum/polygon_forked/1delta/test_one_delta_live_credit_supply.py
@@ -128,7 +128,7 @@ def test_one_delta_live_credit_supply_open_only(
         ts,
         state,
         trading_strategy_universe,
-        ExecutionMode.real_trading
+        ExecutionMode.simulated_trading
     )
 
     loop.runner.check_accounts(trading_strategy_universe, state)

--- a/tests/ethereum/polygon_forked/1delta/test_one_delta_live_short.py
+++ b/tests/ethereum/polygon_forked/1delta/test_one_delta_live_short.py
@@ -182,7 +182,7 @@ def test_one_delta_live_strategy_short_open_and_close(
         ts,
         state,
         trading_strategy_universe,
-        ExecutionMode.real_trading
+        ExecutionMode.simulated_trading
     )
 
     loop.runner.check_accounts(trading_strategy_universe, state)
@@ -219,7 +219,7 @@ def test_one_delta_live_strategy_short_open_and_close(
         ts,
         state,
         trading_strategy_universe,
-        ExecutionMode.real_trading
+        ExecutionMode.simulated_trading
     )
 
     loop.runner.check_accounts(trading_strategy_universe, state)
@@ -342,7 +342,7 @@ def test_one_delta_live_strategy_short_open_accrue_interests(
         ts,
         state,
         trading_strategy_universe,
-        ExecutionMode.real_trading
+        ExecutionMode.simulated_trading
     )
 
     assert len(state.portfolio.open_positions) == 1
@@ -389,7 +389,7 @@ def test_one_delta_live_strategy_short_open_accrue_interests(
         ts,
         state,
         trading_strategy_universe,
-        ExecutionMode.real_trading
+        ExecutionMode.simulated_trading
     )
 
     # position should still be open
@@ -431,7 +431,7 @@ def test_one_delta_live_strategy_short_open_accrue_interests(
         ts,
         state,
         trading_strategy_universe,
-        ExecutionMode.real_trading
+        ExecutionMode.simulated_trading
     )
 
     # # there should be accrued interest now
@@ -549,7 +549,7 @@ def test_one_delta_live_strategy_short_increase(
         ts,
         state,
         trading_strategy_universe,
-        ExecutionMode.real_trading
+        ExecutionMode.simulated_trading
     )
 
     loop.runner.check_accounts(trading_strategy_universe, state)
@@ -586,7 +586,7 @@ def test_one_delta_live_strategy_short_increase(
         ts,
         state,
         trading_strategy_universe,
-        ExecutionMode.real_trading
+        ExecutionMode.simulated_trading
     )
 
     loop.runner.check_accounts(trading_strategy_universe, state)
@@ -700,7 +700,7 @@ def test_one_delta_live_strategy_short_reduce(
         ts,
         state,
         trading_strategy_universe,
-        ExecutionMode.real_trading
+        ExecutionMode.simulated_trading
     )
 
     loop.runner.check_accounts(trading_strategy_universe, state)
@@ -737,7 +737,7 @@ def test_one_delta_live_strategy_short_reduce(
         ts,
         state,
         trading_strategy_universe,
-        ExecutionMode.real_trading
+        ExecutionMode.simulated_trading
     )
 
     loop.runner.check_accounts(trading_strategy_universe, state)

--- a/tests/ethereum/polygon_forked/generic-router/test_generic_router_live_loop.py
+++ b/tests/ethereum/polygon_forked/generic-router/test_generic_router_live_loop.py
@@ -292,7 +292,7 @@ def test_generic_router_spot_and_short_strategy_manual_tick(
         ts,
         state,
         strategy_universe,
-        ExecutionMode.real_trading
+        ExecutionMode.simulated_trading
     )
     assert len(portfolio.open_positions) == 1
 

--- a/tests/ethereum/polygon_forked/generic-router/test_generic_router_live_loop.py
+++ b/tests/ethereum/polygon_forked/generic-router/test_generic_router_live_loop.py
@@ -119,7 +119,7 @@ def test_generic_router_spot_and_short_strategy(
             ts,
             state,
             strategy_universe,
-            ExecutionMode.real_trading
+            ExecutionMode.simulated_trading
         )
         ts += datetime.timedelta(days=1)
         mine(web3, to_int_unix_timestamp(ts))
@@ -218,7 +218,7 @@ def test_generic_router_spot_and_short_strategy_manual_tick(
         ts,
         state,
         strategy_universe,
-        ExecutionMode.real_trading
+        ExecutionMode.simulated_trading
     )
     assert len(portfolio.open_positions) == 1
 
@@ -260,7 +260,7 @@ def test_generic_router_spot_and_short_strategy_manual_tick(
         ts,
         state,
         strategy_universe,
-        ExecutionMode.real_trading
+        ExecutionMode.simulated_trading
     )
     assert len(portfolio.open_positions) == 1
 

--- a/tests/ethereum/test_uniswap_live_stop_loss.py
+++ b/tests/ethereum/test_uniswap_live_stop_loss.py
@@ -382,7 +382,7 @@ def test_live_stop_loss(
         ts,
         state,
         trading_strategy_universe,
-        ExecutionMode.real_trading
+        ExecutionMode.simulated_trading
     )
 
     # After the first tick, we should have synced our reserves and opened the first position

--- a/tests/ethereum/test_uniswap_v3_live_stop_loss.py
+++ b/tests/ethereum/test_uniswap_v3_live_stop_loss.py
@@ -420,7 +420,7 @@ def test_live_stop_loss(
         ts,
         state,
         trading_strategy_universe,
-        ExecutionMode.real_trading
+        ExecutionMode.simulated_trading
     )
 
     # After the first tick, we should have synced our reserves and opened the first position

--- a/tests/mainnet_fork/aave_v3/test_aave_v3_live_credit_supply.py
+++ b/tests/mainnet_fork/aave_v3/test_aave_v3_live_credit_supply.py
@@ -120,7 +120,7 @@ def test_aave_v3_live_credit_supply_open_only(
         ts,
         state,
         strategy_universe,
-        ExecutionMode.real_trading
+        ExecutionMode.simulated_trading
     )
 
     loop.runner.check_accounts(strategy_universe, state)
@@ -158,7 +158,7 @@ def test_aave_v3_live_credit_supply_open_only(
         ts,
         state,
         strategy_universe,
-        ExecutionMode.real_trading
+        ExecutionMode.simulated_trading
     )
 
     loop.runner.check_accounts(strategy_universe, state)
@@ -246,7 +246,7 @@ def test_aave_v3_live_credit_supply_open_and_increase(
         ts,
         state,
         strategy_universe,
-        ExecutionMode.real_trading
+        ExecutionMode.simulated_trading
     )
 
     loop.runner.check_accounts(strategy_universe, state)
@@ -284,7 +284,7 @@ def test_aave_v3_live_credit_supply_open_and_increase(
         ts,
         state,
         strategy_universe,
-        ExecutionMode.real_trading
+        ExecutionMode.simulated_trading
     )
 
     loop.runner.check_accounts(strategy_universe, state)
@@ -372,7 +372,7 @@ def test_aave_v3_live_credit_supply_open_and_reduce(
         ts,
         state,
         strategy_universe,
-        ExecutionMode.real_trading
+        ExecutionMode.simulated_trading
     )
 
     loop.runner.check_accounts(strategy_universe, state)
@@ -410,7 +410,7 @@ def test_aave_v3_live_credit_supply_open_and_reduce(
         ts,
         state,
         strategy_universe,
-        ExecutionMode.real_trading
+        ExecutionMode.simulated_trading
     )
 
     loop.runner.check_accounts(strategy_universe, state)

--- a/tests/mainnet_fork/test_enzyme_guard_perform_test_aave_v3.py
+++ b/tests/mainnet_fork/test_enzyme_guard_perform_test_aave_v3.py
@@ -9,6 +9,7 @@ import pytest
 
 from eth_account import Account
 from eth_typing import HexAddress
+import flaky
 from hexbytes import HexBytes
 from web3 import Web3, HTTPProvider
 
@@ -163,6 +164,7 @@ def environment(
     return environment
 
 
+@flaky.flaky
 def test_enzyme_guard_perform_test_trade_aave(
     environment: dict,
     web3: Web3,

--- a/tradeexecutor/cli/close_position.py
+++ b/tradeexecutor/cli/close_position.py
@@ -65,6 +65,10 @@ def close_single_or_all_positions(
     logger.info("Sync model is %s", sync_model)
     logger.info("Trading university reserve asset is %s", universe.get_reserve_asset())
 
+    if sync_model.has_async_deposits():
+        logger.info("Vault must be revalued before proceeding, using: %s", sync_model.__class__.__name__)
+        pass
+
     # Sync any incoming stablecoin transfers
     # that have not been synced yet
     balance_updates = sync_model.sync_treasury(

--- a/tradeexecutor/cli/close_position.py
+++ b/tradeexecutor/cli/close_position.py
@@ -10,6 +10,7 @@ from web3 import Web3
 
 from tradeexecutor.analysis.position import display_positions
 from tradeexecutor.ethereum.enzyme.vault import EnzymeVaultSyncModel
+from tradeexecutor.strategy.execution_context import ExecutionContext
 from tradeexecutor.strategy.sync_model import SyncModel
 from tradeexecutor.strategy.valuation import ValuationModel
 from tradeexecutor.strategy.valuation_update import update_position_valuations
@@ -32,6 +33,7 @@ class CloseAllAborted(Exception):
 def close_single_or_all_positions(
     web3: Web3,
     execution_model: ExecutionModel,
+    execution_context: ExecutionContext,
     pricing_model: PricingModel,
     sync_model: SyncModel,
     state: State,
@@ -58,6 +60,7 @@ def close_single_or_all_positions(
     assert isinstance(sync_model, SyncModel)
     assert isinstance(universe, TradingStrategyUniverse)
     assert isinstance(valuation_model, ValuationModel)
+    assert isinstance(execution_context, ExecutionContext)
 
     if position_id is not None:
         assert type(position_id) is int, f"Got: {position_id} {type(position_id)}"
@@ -78,7 +81,7 @@ def close_single_or_all_positions(
             timestamp=ts,
             state=state,
             universe=universe,
-            execution_context=execution_model.execution_context,
+            execution_context=execution_context,
             routing_state=routing_state,
             valuation_model=valuation_model,
             long_short_metrics_latest=None,

--- a/tradeexecutor/cli/commands/close_all.py
+++ b/tradeexecutor/cli/commands/close_all.py
@@ -172,17 +172,18 @@ def close_all(
 
     _close_all(
         web3config.get_default(),
-        execution_model,
-        pricing_model,
-        sync_model,
-        state,
-        universe,
-        runner.routing_model,
-        routing_state,
+        execution_model=execution_model,
+        pricing_model=pricing_model,
+        sync_model=sync_model,
+        state=state,
+        universe=universe,
+        routing_model=runner.routing_model,
+        routing_state=routing_state,
         slippage_tolerance=slippage_tolerance,
         interactive=interactive,
         unit_testing=unit_testing,
         valuation_model=valuation_model,
+        execution_context=execution_context,
     )
 
     # Store the test trade data in the strategy history

--- a/tradeexecutor/cli/commands/close_all.py
+++ b/tradeexecutor/cli/commands/close_all.py
@@ -162,7 +162,7 @@ def close_all(
     )
 
     runner = run_description.runner
-    routing_state, pricing_model, valuation_method = runner.setup_routing(universe)
+    routing_state, pricing_model, valuation_model = runner.setup_routing(universe)
 
     # Set slippge tolerance from the strategy file
     slippage_tolerance = 0.01
@@ -181,6 +181,8 @@ def close_all(
         routing_state,
         slippage_tolerance=slippage_tolerance,
         interactive=interactive,
+        unit_testing=unit_testing,
+        valuation_model=valuation_model,
     )
 
     # Store the test trade data in the strategy history

--- a/tradeexecutor/cli/commands/close_position.py
+++ b/tradeexecutor/cli/commands/close_position.py
@@ -177,18 +177,18 @@ def close_position(
 
     close_single_or_all_positions(
         web3config.get_default(),
-        execution_model,
-        pricing_model,
-        sync_model,
-        state,
-        universe,
-        runner.routing_model,
-        routing_state,
+        execution_model=execution_model,
+        pricing_model=pricing_model,
+        sync_model=sync_model,
+        state=state,
+        universe=universe,
+        routing_model=runner.routing_model,
+        routing_state=routing_state,
         slippage_tolerance=slippage_tolerance,
         interactive=interactive,
-        position_id=position_id,
-        valuation_model=valuation_model,
         unit_testing=unit_testing,
+        valuation_model=valuation_model,
+        execution_context=execution_context,
     )
 
     # Store the test trade data in the strategy history

--- a/tradeexecutor/cli/commands/close_position.py
+++ b/tradeexecutor/cli/commands/close_position.py
@@ -167,7 +167,7 @@ def close_position(
     )
 
     runner = run_description.runner
-    routing_state, pricing_model, valuation_method = runner.setup_routing(universe)
+    routing_state, pricing_model, valuation_model = runner.setup_routing(universe)
 
     # Set slippge tolerance from the strategy file
     slippage_tolerance = 0.01
@@ -187,6 +187,8 @@ def close_position(
         slippage_tolerance=slippage_tolerance,
         interactive=interactive,
         position_id=position_id,
+        valuation_model=valuation_model,
+        unit_testing=unit_testing,
     )
 
     # Store the test trade data in the strategy history

--- a/tradeexecutor/cli/loop.py
+++ b/tradeexecutor/cli/loop.py
@@ -590,6 +590,7 @@ class ExecutionLoop:
         clock: datetime.datetime,
         state: State,
         universe: StrategyExecutionUniverse,
+        execution_mode: ExecutionMode = None,
     ):
         """Revalue positions and update statistics.
 
@@ -597,7 +598,15 @@ class ExecutionLoop:
         and added to the state.
 
         :param clock: Real-time or historical clock
+
+        :param execution_mode:
+            Legacy argument, ignored.
         """
+
+        if execution_mode is None:
+            execution_mode = self.execution_context.mode
+
+        assert execution_mode == self.execution_context.mode, f"ExecutionMode given: {execution_mode}, context has: {self.execution_context.mode}"
 
         # Set up the execution to perform the valuation
 
@@ -970,7 +979,7 @@ class ExecutionLoop:
             )
 
             # Revalue our portfolio
-            self.update_position_valuations(ts, state, universe, self.execution_context.mode)
+            self.update_position_valuations(ts, state, universe)
 
             # Check for termination in integration testing.
             # TODO: Get rid of this and only support date ranges to run tests

--- a/tradeexecutor/statistics/core.py
+++ b/tradeexecutor/statistics/core.py
@@ -208,8 +208,8 @@ def update_statistics(
         strategy_cycle_or_wall_clock
     )
     
-    if execution_mode.is_live_trading() and execution_mode != ExecutionMode.unit_testing_trading:
-        assert long_short_metrics_latest, "long short metrics should be provided in live trading"
+    if execution_mode.is_live_trading() and execution_mode not in (ExecutionMode.unit_testing_trading, ExecutionMode.one_off):
+        assert long_short_metrics_latest, f"long short metrics should be provided in live trading, trading mode is: {execution_mode}"
     
     if long_short_metrics_latest:
         logger.info("Serialising long_short_metrics_latest")

--- a/tradeexecutor/strategy/pandas_trader/position_manager.py
+++ b/tradeexecutor/strategy/pandas_trader/position_manager.py
@@ -2647,7 +2647,7 @@ class PositionManager:
           and rebalances
 
         - This is to check that strategy internal logic is coherent
-
+xz
         - For example, too high filtering parameters of alpha model trade generation
           may cause us not to generate enough trades
 

--- a/tradeexecutor/strategy/valuation_update.py
+++ b/tradeexecutor/strategy/valuation_update.py
@@ -1,0 +1,75 @@
+import datetime
+import logging
+
+from tradeexecutor.state.state import State
+from tradeexecutor.statistics.core import update_statistics
+from tradeexecutor.statistics.statistics_table import StatisticsTable
+from tradeexecutor.strategy.execution_context import ExecutionMode, ExecutionContext
+from tradeexecutor.strategy.pricing_model import PricingModel
+from tradeexecutor.strategy.routing import RoutingState
+from tradeexecutor.strategy.universe_model import StrategyExecutionUniverse
+from tradeexecutor.strategy.valuation import revalue_state, ValuationModel
+
+logger = logging.getLogger(__name__)
+
+
+def update_position_valuations(
+    timestamp: datetime.datetime,
+    state: State,
+    universe: StrategyExecutionUniverse,
+    execution_context: ExecutionContext,
+    valuation_model: ValuationModel,
+    routing_state: RoutingState,
+    long_short_metrics_latest: StatisticsTable | None = None,
+):
+    """Revalue positions and update statistics.
+
+    - Revalue all positions
+
+    - Push new valuation update to onchain if needed (Lagoon)
+
+    - Update statistics
+
+    A new statistics entry is calculated for portfolio and all of its positions
+    and added to the state.
+
+    Example:
+
+
+
+    :param timestamp:
+        Real-time or historical clock
+
+    :param long_short_metrics_latest:
+        Needed to calculate short statistics.
+
+        Can be None - statistics skipped.
+    """
+
+    # Set up the execution to perform the valuation
+
+    assert isinstance(universe, StrategyExecutionUniverse)
+    assert isinstance(execution_context, ExecutionContext)
+    assert isinstance(routing_state, RoutingState)
+
+    timed_task_context_manager = execution_context.timed_task_context_manager
+
+    if len(state.portfolio.reserves) == 0:
+        logger.info("The strategy has no reserves or deposits yet")
+
+    # TODO: this seems to be duplicated in tick()
+    with timed_task_context_manager("revalue_portfolio_statistics"):
+        logger.info("Updating position valuations")
+        revalue_state(state, timestamp, valuation_model)
+
+    with timed_task_context_manager("update_statistics"):
+        logger.info("Updating position statistics after revaluation")
+
+        update_statistics(
+            timestamp,
+            state.stats,
+            state.portfolio,
+            execution_context.mode,
+            long_short_metrics_latest=long_short_metrics_latest,
+        )
+

--- a/tradeexecutor/strategy/valuation_update.py
+++ b/tradeexecutor/strategy/valuation_update.py
@@ -41,7 +41,43 @@ def update_position_valuations(
 
     Example:
 
+    .. code-block:: python
 
+        logger.info("Sync model is %s", sync_model)
+        logger.info("Trading university reserve asset is %s", universe.get_reserve_asset())
+
+        # Use unit_testing flag so this code path is easier to check
+        if sync_model.has_async_deposits() or unit_testing:
+            logger.info("Vault must be revalued before proceeding, using: %s", sync_model.__class__.__name__)
+            update_position_valuations(
+                timestamp=ts,
+                state=state,
+                universe=universe,
+                execution_context=execution_context,
+                routing_state=routing_state,
+                valuation_model=valuation_model,
+                long_short_metrics_latest=None,
+            )
+
+        # Sync any incoming stablecoin transfers
+        # that have not been synced yet
+        balance_updates = sync_model.sync_treasury(
+            ts,
+            state,
+            list(universe.reserve_assets),
+            post_valuation=True,
+        )
+
+        logger.info("We received balance update events: %s", balance_updates)
+
+        # Velvet capital code path
+        if sync_model.has_position_sync():
+            sync_model.sync_positions(
+                ts,
+                state,
+                universe,
+                pricing_model
+            )
 
     :param timestamp:
         Real-time or historical clock

--- a/tradeexecutor/strategy/valuation_update.py
+++ b/tradeexecutor/strategy/valuation_update.py
@@ -1,11 +1,17 @@
+"""Valuation update logic handling.
+
+- Internal valuation calculations
+
+- Posting new valuation onchain
+"""
+
 import datetime
 import logging
 
 from tradeexecutor.state.state import State
 from tradeexecutor.statistics.core import update_statistics
 from tradeexecutor.statistics.statistics_table import StatisticsTable
-from tradeexecutor.strategy.execution_context import ExecutionMode, ExecutionContext
-from tradeexecutor.strategy.pricing_model import PricingModel
+from tradeexecutor.strategy.execution_context import ExecutionContext
 from tradeexecutor.strategy.routing import RoutingState
 from tradeexecutor.strategy.universe_model import StrategyExecutionUniverse
 from tradeexecutor.strategy.valuation import revalue_state, ValuationModel

--- a/tradeexecutor/testing/simulated_execution_loop.py
+++ b/tradeexecutor/testing/simulated_execution_loop.py
@@ -152,13 +152,13 @@ def set_up_simulated_execution_loop_uniswap_v2(
 
 
 def set_up_simulated_execution_loop_uniswap_v3(
-        *ignore,
-        web3: Web3,
-        decide_trades: DecideTradesProtocol,
-        universe: StrategyExecutionUniverse,
-        routing_model: UniswapV3Routing,
-        state: State,
-        wallet_account: LocalAccount,
+    *ignore,
+    web3: Web3,
+    decide_trades: DecideTradesProtocol,
+    universe: StrategyExecutionUniverse,
+    routing_model: UniswapV3Routing,
+    state: State,
+    wallet_account: LocalAccount,
 ) -> ExecutionLoop:
     """Set up a simulated execution loop for Uniswap V3.
 


### PR DESCRIPTION
- Refactor valuation so that it can be more easily called outside the main loop
- Needed for `close-position` command on Lagoon vault