### PR TITLE
Fix last valuation timestamp read for Aave positions

### DIFF
--- a/tradeexecutor/cli/commands/start.py
+++ b/tradeexecutor/cli/commands/start.py
@@ -605,6 +605,12 @@ def start(
             if isinstance(store, JSONFileStore):
                 logger.info("Wrote backtest result to %s", store.path.absolute())
 
+        if run_single_cycle:
+            if len(state.portfolio.frozen_positions) > 0:
+                logger.error("After single cycle run, we have frozen positions")
+                for p in state.portfolio.frozen_positions.values():
+                    logger.error("Position: %s", p)
+
     except KeyboardInterrupt as e:
 
         # CTRL+C shutdown or watch dog crash

--- a/tradeexecutor/ethereum/lagoon/vault.py
+++ b/tradeexecutor/ethereum/lagoon/vault.py
@@ -207,7 +207,7 @@ class LagoonVaultSyncModel(AddressSyncModel):
         for p in state.portfolio.get_open_and_frozen_positions():
             if p.get_quantity() != 0:
                 # Frozen positions may have quantity of 0 (failed open trades) and cannot have value
-                updated_ago = now - p.last_pricing_at
+                updated_ago = now - p.get_last_valued_at()
                 assert updated_ago < self.valuation_data_freshness, f"Position {p} pricing was too old for Lagoon valuation update. Now: {now}, updated at: {p.last_pricing_at}, diff: {updated_ago}"
 
         # TODO: Replace with pure onchain valuation mechanism?

--- a/tradeexecutor/strategy/interest.py
+++ b/tradeexecutor/strategy/interest.py
@@ -472,7 +472,7 @@ def accrue_interest(
     assert interest_distribution.duration > ZERO_TIMEDELTA, f"Tried to distribute interest for negative timespan {interest_distribution.start} - {interest_distribution.end}"
 
     block_number_str = f"{block_number,}" if block_number else "<no block>"
-    logger.info(f"accrue_interest(block_timestamp={block_timestamp}, {block_number_str})")
+    logger.info(f"accrue_interest(block_timestamp={block_timestamp:,}, {block_number_str})")
 
     part_of_year = interest_distribution.duration / aave_financial_year
 
@@ -599,7 +599,7 @@ def set_interest_checkpoint(
     if distribution is not None:
         state.sync.interest.last_distribution = distribution
 
-    block_number_str = f"{block_number,}" if block_number else "<no block>"
+    block_number_str = f"{block_number:,}" if block_number else "<no block>"
     logger.info(f"Interest check point set to {timestamp}, block: {block_number_str}")
 
 


### PR DESCRIPTION
- Lagoon vault valuation sync could not complete, because it thought the timestamp is too old