### PR TITLE
Add CLI trading pair debug command

### DIFF
--- a/strategies/test_only/base-ath.py
+++ b/strategies/test_only/base-ath.py
@@ -126,7 +126,7 @@ class Parameters:
     min_volume = 25_000  # USD
     min_tvl_prefilter = 1_250_000  # USD - to reduce number of trading pairs for backtest-purposes only
     min_tvl = 1_250_000  # USD - set to same as above if you want to avoid any survivorship bias
-    min_token_sniffer_score = 90  # 20 = AAVE
+    min_token_sniffer_score = 20  # 20 = AAVE
 
     #
     # Yield on cash
@@ -156,6 +156,7 @@ class Parameters:
 SUPPORTING_PAIRS = [
     (ChainId.base, "uniswap-v2", "WETH", "USDC", 0.0030),
     (ChainId.base, "uniswap-v3", "WETH", "USDC", 0.0005),
+    (ChainId.base, "uniswap-v2", "EAI", "WETH", 0.0030),  # Crappy token tax pair
     (ChainId.base, "uniswap-v3", "cbBTC", "WETH", 0.0030),    # Only trading since October
 ]
 

--- a/tests/cli/test_cli_trading_pair.py
+++ b/tests/cli/test_cli_trading_pair.py
@@ -1,0 +1,42 @@
+import os
+from pathlib import Path
+
+import pytest
+
+from tradeexecutor.cli.main import app
+
+
+@pytest.fixture(scope="session")
+def unit_test_cache_path(persistent_test_cache_path):
+    """Where unit tests  cache files.
+
+    We have special path for CLI tests to make sure CLI tests
+    always do fresh downloads.
+    """
+    return persistent_test_cache_path
+
+
+@pytest.mark.slow_test_group
+def test_cli_trading_pair(
+    unit_test_cache_path: str,
+    mocker,
+    tmp_path,
+):
+    """trading-pair command works"""
+
+    strategy_path = Path(os.path.join(os.path.dirname(__file__), "..", "..", "strategies", "test_only", "base-ath.py"))
+
+    environment = {
+        "TRADING_STRATEGY_API_KEY": os.environ["TRADING_STRATEGY_API_KEY"],
+        "STRATEGY_FILE": strategy_path.as_posix(),
+        "CACHE_PATH": tmp_path.as_posix(),
+        "LOG_LEVEL": "info",
+        "UNIT_TESTING": "true",
+        "MAX_DATA_DELAY_MINUTES": "99999",
+        "TOKEN_ADDRESS": "0x6797b6244fa75f2e78cdffc3a4eb169332b730cc",  # EAI
+    }
+
+    mocker.patch.dict("os.environ", environment, clear=True)
+    app(["trading-pair"], standalone_mode=False)
+
+

--- a/tradeexecutor/cli/commands/check_universe.py
+++ b/tradeexecutor/cli/commands/check_universe.py
@@ -11,7 +11,7 @@ import pandas as pd
 from .app import app
 from ..bootstrap import prepare_executor_id, prepare_cache
 from ..log import setup_logging
-from ..universe import load_universe
+from ..universe import setup_universe
 from ...analysis.pair import display_strategy_universe
 from ...strategy.bootstrap import import_strategy_file
 from ...strategy.cycle import CycleDuration, snap_to_previous_tick
@@ -54,7 +54,7 @@ def check_universe(
 
     execution_context = console_command_execution_context
 
-    universe_init = load_universe(
+    universe_init = setup_universe(
         trading_strategy_api_key=trading_strategy_api_key,
         cache_path=cache_path,
         max_data_delay_minutes=max_data_delay_minutes,

--- a/tradeexecutor/cli/commands/check_universe.py
+++ b/tradeexecutor/cli/commands/check_universe.py
@@ -15,6 +15,7 @@ from tradingstrategy.client import Client
 from .app import app
 from ..bootstrap import prepare_executor_id, prepare_cache
 from ..log import setup_logging
+from ..universe import load_universe
 from ...analysis.pair import display_strategy_universe
 from ...strategy.bootstrap import import_strategy_file
 from ...strategy.cycle import CycleDuration, snap_to_previous_tick
@@ -61,52 +62,21 @@ def check_universe(
 
     assert trading_strategy_api_key, "TRADING_STRATEGY_API_KEY missing"
 
-    client = Client.create_live_client(
-        trading_strategy_api_key,
-        cache_path=cache_path,
-        settings_path=None,
-    )
-    client.clear_caches()
-
     execution_context = preflight_execution_context
 
-    max_data_delay = datetime.timedelta(minutes=max_data_delay_minutes)
-
-    run_description: StrategyExecutionDescription = strategy_factory(
-        execution_model=None,
+    universe_init = load_universe(
+        trading_strategy_api_key=trading_strategy_api_key,
+        cache_path=cache_path,
+        max_data_delay_minutes=max_data_delay_minutes,
+        strategy_factory=strategy_factory,
         execution_context=execution_context,
-        timed_task_context_manager=timed_task,
-        sync_model=None,
-        valuation_model_factory=None,
-        pricing_model_factory=None,
-        approval_model=None,
-        client=client,
-        run_state=RunState(),
     )
 
-    parameters = run_description.runner.parameters
-    if parameters:
-        logger.info(
-            "Strategy parameters:\n%s",
-            dump_parameters(parameters)
-        )
-        universe_options = UniverseOptions.from_strategy_parameters_class(
-            parameters,
-            execution_context,
-        )
-    else:
-        universe_options = UniverseOptions()
-
-    # Check that Parameters gives us period how much history we need
-    engine_version = run_description.trading_strategy_engine_version
-    if engine_version:
-        if version.parse(engine_version) >= version.parse("0.5"):
-            parameters = run_description.runner.parameters
-            assert parameters, f"Engine version {engine_version}, but runner lacks decoded strategy parameters"
-            assert "required_history_period" in parameters, f"Strategy lacks Parameters.required_history_period. We have {parameters}"
-
     # Deconstruct strategy input
-    universe_model: TradingStrategyUniverseModel = run_description.universe_model
+    universe_model = universe_init.universe_model
+    universe_options = universe_init.universe_options
+    max_data_delay = universe_init.max_data_delay
+    run_description = universe_init.run_description
 
     ts = datetime.datetime.utcnow()
     logger.info("Performing universe data check for timestamp %s", ts)

--- a/tradeexecutor/cli/commands/check_universe.py
+++ b/tradeexecutor/cli/commands/check_universe.py
@@ -6,12 +6,8 @@ from pathlib import Path
 from typing import Optional
 
 import pandas as pd
-import typer
 
 
-from packaging import version
-
-from tradingstrategy.client import Client
 from .app import app
 from ..bootstrap import prepare_executor_id, prepare_cache
 from ..log import setup_logging
@@ -19,15 +15,9 @@ from ..universe import load_universe
 from ...analysis.pair import display_strategy_universe
 from ...strategy.bootstrap import import_strategy_file
 from ...strategy.cycle import CycleDuration, snap_to_previous_tick
-from ...strategy.description import StrategyExecutionDescription
-from ...strategy.execution_context import preflight_execution_context
+from ...strategy.execution_context import  console_command_execution_context
 from ...strategy.pandas_trader.indicator import calculate_and_load_indicators_inline, MemoryIndicatorStorage
-from ...strategy.parameters import dump_parameters
-from ...strategy.run_state import RunState
-from ...strategy.trading_strategy_universe import TradingStrategyUniverseModel
-from ...strategy.universe_model import UniverseOptions
 from ...utils.cpu import get_safe_max_workers_count
-from ...utils.timer import timed_task
 from . import shared_options
 
 
@@ -37,7 +27,7 @@ def check_universe(
     strategy_file: Path = shared_options.strategy_file,
     trading_strategy_api_key: str = shared_options.trading_strategy_api_key,
     cache_path: Optional[Path] = shared_options.cache_path,
-    max_data_delay_minutes: int = typer.Option(24*60, envvar="MAX_DATA_DELAY_MINUTES", help="How fresh the OHCLV data for our strategy must be before failing"),
+    max_data_delay_minutes: int = shared_options.max_data_delay_minutes,
     log_level: str = shared_options.log_level,
     max_workers: int | None = shared_options.max_workers,
 ):
@@ -62,7 +52,7 @@ def check_universe(
 
     assert trading_strategy_api_key, "TRADING_STRATEGY_API_KEY missing"
 
-    execution_context = preflight_execution_context
+    execution_context = console_command_execution_context
 
     universe_init = load_universe(
         trading_strategy_api_key=trading_strategy_api_key,

--- a/tradeexecutor/cli/commands/shared_options.py
+++ b/tradeexecutor/cli/commands/shared_options.py
@@ -121,6 +121,9 @@ max_workers = Option(None, envvar="MAX_WORKERS", help="Maximum number of worker 
 position_type = Option("open_and_frozen", envvar="POSITION_TYPE", help="Which position types to display")
 
 
+max_data_delay_minutes = typer.Option(24*60, envvar="MAX_DATA_DELAY_MINUTES", help="How fresh the OHCLV data for our strategy must be before failing")
+
+
 def parse_comma_separated_list(ctx: typer.Context, value: str) -> list[str] | Any:
     """Support comma separated, whitespaced, list as a command line argument with Typer.
 

--- a/tradeexecutor/cli/commands/trading_pair.py
+++ b/tradeexecutor/cli/commands/trading_pair.py
@@ -1,4 +1,5 @@
 """Print out the trading pair data."""
+import datetime
 import enum
 import logging
 from pathlib import Path
@@ -7,12 +8,17 @@ from typing import Optional
 from tabulate import tabulate
 from typer import Option
 
-from tradingstrategy.client import Client
-from tradingstrategy.transport.token_cache import read_token_cache, calculate_token_cache_summary, display_token_metadata
 from . import shared_options
 from .app import app
 from .shared_options import required_option
 from ..bootstrap import prepare_cache, prepare_executor_id
+from ..log import setup_logging
+from ..universe import load_universe
+from ...state.identifier import TradingPairIdentifier
+from ...strategy.bootstrap import import_strategy_file
+from ...strategy.execution_context import console_command_execution_context
+from ...strategy.trading_strategy_universe import TradingStrategyUniverse
+
 
 logger = logging.getLogger(__name__)
 
@@ -30,74 +36,93 @@ class PrintTokenOption(enum.Enum):
 @app.command()
 def trading_pair(
     id: str = shared_options.id,
-    strategy_file = Option(None, envvar="STRATEGY_FILE", help="Python trading strategy module to use for running the strategy"),
+    strategy_file: Path = shared_options.strategy_file,
     cache_path: Optional[Path] = shared_options.cache_path,
+    max_data_delay_minutes: int = shared_options.max_data_delay_minutes,
+    log_level: str = shared_options.log_level,
+    max_workers: int | None = shared_options.max_workers,
     purge: PurgeType = Option("none", envvar="PURGE_TYPE", help="Which cache data should be purged"),
     unit_testing: bool = shared_options.unit_testing,
     trading_strategy_api_key: str = required_option(shared_options.trading_strategy_api_key),
+    token_address: str = Option(..., envvar="TOKEN_ADDRESS", help="ERC-20 address of base token of a trading pair"),
 ):
     """Display and update trading pair data.
 
     Displays information regarding a particular trading pair. Allow force refresh the caches.
     """
 
-    # Drive id and cache path from the strategy file
-    if id is not None or strategy_file is not None:
-        print(f"Deriving cache path from strategy id: {id} and strategy module: {strategy_file}")
-        id = prepare_executor_id(id, strategy_file)
-        cache_path = prepare_cache(id, cache_path, unit_testing)
-        print(f"Cache path is: {cache_path}")
-    else:
-        # Use default ~/.tradingstrategy cache path
-        pass
+    global logger
 
-    client = Client.create_live_client(
-        api_key=trading_strategy_api_key,
-        cache_path=cache_path,  # Set via environment variable for unit testing
-        settings_path=None,  # No interactive settings file with live execution
+    id = prepare_executor_id(id, strategy_file)
+
+    logger = setup_logging(log_level)
+    if log_level != "disabled":
+        assert logger.level <= logging.INFO, "Log level must be at least INFO to get output from this command"
+
+    logger.info("Loading strategy file %s", strategy_file)
+
+    strategy_factory = import_strategy_file(strategy_file)
+
+    cache_path = prepare_cache(id, cache_path)
+
+    assert trading_strategy_api_key, "TRADING_STRATEGY_API_KEY missing"
+
+    execution_context = console_command_execution_context
+
+    universe_init = load_universe(
+        trading_strategy_api_key=trading_strategy_api_key,
+        cache_path=cache_path,
+        max_data_delay_minutes=max_data_delay_minutes,
+        strategy_factory=strategy_factory,
+        execution_context=execution_context,
     )
 
+    # Deconstruct strategy input
+    universe_model = universe_init.universe_model
+    universe_options = universe_init.universe_options
+
+    ts = datetime.datetime.utcnow()
+    logger.info("Performing universe data check for timestamp %s", ts)
+    strategy_universe = universe_model.construct_universe(ts, execution_context.mode, universe_options)
+
+    assert isinstance(strategy_universe, TradingStrategyUniverse)
+
+    trading_pairs: list[TradingPairIdentifier] = []
+
+    token_address = token_address.lower()
+    if token_address:
+        for pair in strategy_universe.iterate_pairs():
+            if pair.base.address == token_address:
+                trading_pairs.append(pair)
+
+    logger.info(f"We have total {strategy_universe.get_pair_count()} trading pairs")
+    logger.info(f"Matched {len(trading_pairs)} pairs")
+    for idx, pair in enumerate(trading_pairs):
+        logger.info(f"Pair #{idx + 1}")
+        info = pair.get_diagnostics_info(extended=True)
+
+        table_data = [[k, v] for k, v in info.items()]
+        logger.info("\n%s", tabulate(table_data, headers=["Property", "Value"], tablefmt="fancy_grid"))
 
 
-    cached_entries = list(read_token_cache(client.transport))
-
-    summary = calculate_token_cache_summary(cached_entries)
-
-    table = [[key, value] for key, value in summary.items()]
-
-    path = client.transport.get_abs_cache_path() / 'token-metadata'
-    print(f"Cache path: {path}")
-    print("Token metadata cache contents:")
-    print(tabulate(table, headers=["Key", "Value"], tablefmt="fancy_grid"))
-
-    match purge:
-        case PurgeType.none:
-            purge_entries = []
-        case PurgeType.missing_tokensniffer_data:
-            purge_entries = [e for e in cached_entries if not e.has_tokensniffer_data()]
-        case PurgeType.all:
-            purge_entries = cached_entries
-        case _:
-            raise NotImplementedError(f"PurgeType {purge} not implemented")
-
-    if print_option == PrintTokenOption.all:
-        # Print tokens
-        if len(cached_entries) == 0:
-            print("No data")
-        else:
-            print("Cache contents:")
-        data = display_token_metadata(cached_entries)
-        print(tabulate(data, headers="keys", tablefmt="fancy_grid"))
-
-    if purge_entries:
-        if not unit_testing:
-            resp = input(f"Do you want to purge {len(purge_entries)} tokens from cache? [y/N]")
-        else:
-            resp = "y"
-        if resp == "y":
-            for e in purge_entries:
-                print(f"Deleting {e.path}")
-                e.purge()
-            print(f"Purged {len(purge_entries)} tokens from cache")
-    else:
-        print("Nothing to purge")
+    # if print_option == PrintTokenOption.all:
+    #     # Print tokens
+    #     if len(cached_entries) == 0:
+    #         print("No data")
+    #     else:
+    #         print("Cache contents:")
+    #     data = display_token_metadata(cached_entries)
+    #     print(tabulate(data, headers="keys", tablefmt="fancy_grid"))
+    #
+    # if purge_entries:
+    #     if not unit_testing:
+    #         resp = input(f"Do you want to purge {len(purge_entries)} tokens from cache? [y/N]")
+    #     else:
+    #         resp = "y"
+    #     if resp == "y":
+    #         for e in purge_entries:
+    #             print(f"Deleting {e.path}")
+    #             e.purge()
+    #         print(f"Purged {len(purge_entries)} tokens from cache")
+    # else:
+    #     print("Nothing to purge")

--- a/tradeexecutor/cli/commands/trading_pair.py
+++ b/tradeexecutor/cli/commands/trading_pair.py
@@ -1,0 +1,103 @@
+"""Print out the trading pair data."""
+import enum
+import logging
+from pathlib import Path
+from typing import Optional
+
+from tabulate import tabulate
+from typer import Option
+
+from tradingstrategy.client import Client
+from tradingstrategy.transport.token_cache import read_token_cache, calculate_token_cache_summary, display_token_metadata
+from . import shared_options
+from .app import app
+from .shared_options import required_option
+from ..bootstrap import prepare_cache, prepare_executor_id
+
+logger = logging.getLogger(__name__)
+
+
+class PurgeType(enum.Enum):
+    none = "none"
+    all = "all"
+
+
+class PrintTokenOption(enum.Enum):
+    none = "none"
+    all = "all"
+
+
+@app.command()
+def trading_pair(
+    id: str = shared_options.id,
+    strategy_file = Option(None, envvar="STRATEGY_FILE", help="Python trading strategy module to use for running the strategy"),
+    cache_path: Optional[Path] = shared_options.cache_path,
+    purge: PurgeType = Option("none", envvar="PURGE_TYPE", help="Which cache data should be purged"),
+    unit_testing: bool = shared_options.unit_testing,
+    trading_strategy_api_key: str = required_option(shared_options.trading_strategy_api_key),
+):
+    """Display and update trading pair data.
+
+    Displays information regarding a particular trading pair. Allow force refresh the caches.
+    """
+
+    # Drive id and cache path from the strategy file
+    if id is not None or strategy_file is not None:
+        print(f"Deriving cache path from strategy id: {id} and strategy module: {strategy_file}")
+        id = prepare_executor_id(id, strategy_file)
+        cache_path = prepare_cache(id, cache_path, unit_testing)
+        print(f"Cache path is: {cache_path}")
+    else:
+        # Use default ~/.tradingstrategy cache path
+        pass
+
+    client = Client.create_live_client(
+        api_key=trading_strategy_api_key,
+        cache_path=cache_path,  # Set via environment variable for unit testing
+        settings_path=None,  # No interactive settings file with live execution
+    )
+
+
+
+    cached_entries = list(read_token_cache(client.transport))
+
+    summary = calculate_token_cache_summary(cached_entries)
+
+    table = [[key, value] for key, value in summary.items()]
+
+    path = client.transport.get_abs_cache_path() / 'token-metadata'
+    print(f"Cache path: {path}")
+    print("Token metadata cache contents:")
+    print(tabulate(table, headers=["Key", "Value"], tablefmt="fancy_grid"))
+
+    match purge:
+        case PurgeType.none:
+            purge_entries = []
+        case PurgeType.missing_tokensniffer_data:
+            purge_entries = [e for e in cached_entries if not e.has_tokensniffer_data()]
+        case PurgeType.all:
+            purge_entries = cached_entries
+        case _:
+            raise NotImplementedError(f"PurgeType {purge} not implemented")
+
+    if print_option == PrintTokenOption.all:
+        # Print tokens
+        if len(cached_entries) == 0:
+            print("No data")
+        else:
+            print("Cache contents:")
+        data = display_token_metadata(cached_entries)
+        print(tabulate(data, headers="keys", tablefmt="fancy_grid"))
+
+    if purge_entries:
+        if not unit_testing:
+            resp = input(f"Do you want to purge {len(purge_entries)} tokens from cache? [y/N]")
+        else:
+            resp = "y"
+        if resp == "y":
+            for e in purge_entries:
+                print(f"Deleting {e.path}")
+                e.purge()
+            print(f"Purged {len(purge_entries)} tokens from cache")
+    else:
+        print("Nothing to purge")

--- a/tradeexecutor/cli/commands/trading_pair.py
+++ b/tradeexecutor/cli/commands/trading_pair.py
@@ -13,7 +13,7 @@ from .app import app
 from .shared_options import required_option
 from ..bootstrap import prepare_cache, prepare_executor_id
 from ..log import setup_logging
-from ..universe import load_universe
+from ..universe import setup_universe
 from ...state.identifier import TradingPairIdentifier
 from ...strategy.bootstrap import import_strategy_file
 from ...strategy.execution_context import console_command_execution_context
@@ -69,7 +69,7 @@ def trading_pair(
 
     execution_context = console_command_execution_context
 
-    universe_init = load_universe(
+    universe_init = setup_universe(
         trading_strategy_api_key=trading_strategy_api_key,
         cache_path=cache_path,
         max_data_delay_minutes=max_data_delay_minutes,

--- a/tradeexecutor/cli/main.py
+++ b/tradeexecutor/cli/main.py
@@ -20,6 +20,7 @@ from .commands.show_positions import show_positions
 from .commands.start import start
 from .commands.perform_test_trade import perform_test_trade
 from .commands.token_cache import token_cache
+from .commands.trading_pair import trading_pair
 from .commands.version import version
 from .commands.repair import repair
 from .commands.retry import retry
@@ -38,5 +39,5 @@ __all__ = [
     version, repair, console, init, reset, enzyme_asset_list, enzyme_deploy_vault,
     lagoon_deploy_vault, close_all, close_position, show_positions, show_valuation, backtest, correct_accounts, check_accounts,
     reset_deposits, export, retry, visualise, webapi,
-    deploy_guard, check_position_triggers, send_log_message, token_cache
+    deploy_guard, check_position_triggers, send_log_message, token_cache, trading_pair
 ]

--- a/tradeexecutor/cli/universe.py
+++ b/tradeexecutor/cli/universe.py
@@ -1,0 +1,91 @@
+"""Command line universe construction helpers"""
+import datetime
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Optional, Callable
+import logging
+
+from packaging import version
+
+from tradeexecutor.strategy.description import StrategyExecutionDescription
+from tradeexecutor.strategy.execution_context import preflight_execution_context, ExecutionContext
+from tradeexecutor.strategy.parameters import dump_parameters
+from tradeexecutor.strategy.run_state import RunState
+from tradeexecutor.strategy.trading_strategy_universe import TradingStrategyUniverseModel
+from tradeexecutor.strategy.universe_model import UniverseOptions
+from tradingstrategy.client import Client
+
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class UniverseInitData:
+    client: Client
+    universe_model: TradingStrategyUniverseModel
+    universe_options: UniverseOptions
+    max_data_delay: datetime.timedelta
+    run_description: StrategyExecutionDescription
+
+
+def load_universe(
+    trading_strategy_api_key: str,
+    cache_path: Optional[Path],
+    max_data_delay_minutes: int,
+    strategy_factory: Callable,
+    execution_context: ExecutionContext,
+) -> UniverseInitData:
+    """Load trading strategy"""
+
+    client = Client.create_live_client(
+        trading_strategy_api_key,
+        cache_path=cache_path,
+        settings_path=None,
+    )
+    client.clear_caches()
+
+    max_data_delay = datetime.timedelta(minutes=max_data_delay_minutes)
+
+    run_description: StrategyExecutionDescription = strategy_factory(
+        execution_model=None,
+        execution_context=execution_context,
+        timed_task_context_manager=timed_task,
+        sync_model=None,
+        valuation_model_factory=None,
+        pricing_model_factory=None,
+        approval_model=None,
+        client=client,
+        run_state=RunState(),
+    )
+
+    parameters = run_description.runner.parameters
+    if parameters:
+        logger.info(
+            "Strategy parameters:\n%s",
+            dump_parameters(parameters)
+        )
+        universe_options = UniverseOptions.from_strategy_parameters_class(
+            parameters,
+            execution_context,
+        )
+    else:
+        universe_options = UniverseOptions()
+
+    # Check that Parameters gives us period how much history we need
+    engine_version = run_description.trading_strategy_engine_version
+    if engine_version:
+        if version.parse(engine_version) >= version.parse("0.5"):
+            parameters = run_description.runner.parameters
+            assert parameters, f"Engine version {engine_version}, but runner lacks decoded strategy parameters"
+            assert "required_history_period" in parameters, f"Strategy lacks Parameters.required_history_period. We have {parameters}"
+
+    # Deconstruct strategy input
+    universe_model: TradingStrategyUniverseModel = run_description.universe_model
+
+    return UniverseInitData(
+        client=client,
+        universe_model=universe_model,
+        universe_options=universe_options,
+        max_data_delay=max_data_delay,
+        run_description=run_description,
+    )

--- a/tradeexecutor/cli/universe.py
+++ b/tradeexecutor/cli/universe.py
@@ -49,7 +49,7 @@ def load_universe(
     run_description: StrategyExecutionDescription = strategy_factory(
         execution_model=None,
         execution_context=execution_context,
-        timed_task_context_manager=timed_task,
+        timed_task_context_manager=execution_context.timed_task_context_manager,
         sync_model=None,
         valuation_model_factory=None,
         pricing_model_factory=None,

--- a/tradeexecutor/cli/universe.py
+++ b/tradeexecutor/cli/universe.py
@@ -8,7 +8,7 @@ import logging
 from packaging import version
 
 from tradeexecutor.strategy.description import StrategyExecutionDescription
-from tradeexecutor.strategy.execution_context import preflight_execution_context, ExecutionContext
+from tradeexecutor.strategy.execution_context import ExecutionContext
 from tradeexecutor.strategy.parameters import dump_parameters
 from tradeexecutor.strategy.run_state import RunState
 from tradeexecutor.strategy.trading_strategy_universe import TradingStrategyUniverseModel
@@ -28,14 +28,20 @@ class UniverseInitData:
     run_description: StrategyExecutionDescription
 
 
-def load_universe(
+def setup_universe(
     trading_strategy_api_key: str,
     cache_path: Optional[Path],
     max_data_delay_minutes: int,
     strategy_factory: Callable,
     execution_context: ExecutionContext,
 ) -> UniverseInitData:
-    """Load trading strategy"""
+    """Setup universe loading for a trading strategy.
+
+    - Intended to bootstrap CLI scripts
+    - We need strategy module loaded and decoded
+    - Extract create_universe() factory from the module
+    - Don't call the factory yet
+    """
 
     client = Client.create_live_client(
         trading_strategy_api_key,

--- a/tradeexecutor/strategy/trading_strategy_universe.py
+++ b/tradeexecutor/strategy/trading_strategy_universe.py
@@ -1910,8 +1910,8 @@ def translate_trading_pair(dex_pair: DEXPair, cache: dict | None = None) -> Trad
             # TODO: Legacy, remove
             pair.other_data.update({
                 "token_sniffer_data": {
-                    "swap_simulation": token_sniffer_data["swap_simulation"],
-                    "score": token_sniffer_data["score"],
+                    "swap_simulation": token_sniffer_data.get("swap_simulation"),
+                    "score": token_sniffer_data.get("score"),
                 }
             })
         else:

--- a/tradeexecutor/strategy/trading_strategy_universe.py
+++ b/tradeexecutor/strategy/trading_strategy_universe.py
@@ -1894,13 +1894,26 @@ def translate_trading_pair(dex_pair: DEXPair, cache: dict | None = None) -> Trad
     if dex_pair.other_data:
         # Because other_data is very heavy, we should only copy fields we really care.
         # Below are the whitelisted fields.
-        if "token_sniffer_data" in dex_pair.other_data:
-            pair.other_data = {
+
+        pair.other_data = {}
+
+        # Pass TokenMetadata instance
+        token_metadata = dex_pair.other_data.get("token_metadata")
+        pair.other_data["token_metadata"] = token_metadata
+
+        if token_metadata:
+            token_sniffer_data = token_metadata.token_sniffer_data
+        else:
+            token_sniffer_data = dex_pair.other_data.get("token_sniffer_data")
+
+        if token_sniffer_data:
+            # TODO: Legacy, remove
+            pair.other_data.update({
                 "token_sniffer_data": {
-                    "swap_simulation": dex_pair.other_data["token_sniffer_data"]["swap_simulation"],
-                    "score": dex_pair.other_data["token_sniffer_data"]["score"],
+                    "swap_simulation": token_sniffer_data["swap_simulation"],
+                    "score": token_sniffer_data["score"],
                 }
-            }
+            })
         else:
             # Skip other_data.top_pair_data
             pass


### PR DESCRIPTION
- Add `trading-pair` CLI command
- Allow diagnose and flush caches for individual trading pair
- Most useful for checking CoinGecko, TokenSniffer and such data