### PR TITLE
Automatically export backtest results as CSV

### DIFF
--- a/tests/backtest/test_backtest_inline_real_data.py
+++ b/tests/backtest/test_backtest_inline_real_data.py
@@ -26,6 +26,8 @@ from tradeexecutor.strategy.strategy_type import StrategyType
 from tradeexecutor.strategy.default_routing_options import TradeRouting
 from tradeexecutor.strategy.universe_model import UniverseOptions
 
+CI = os.environ.get("CI") == "true"
+
 # https://docs.pytest.org/en/latest/how-to/skipping.html#skip-all-test-functions-of-a-class-or-module
 pytestmark = pytest.mark.skipif(os.environ.get("TRADING_STRATEGY_API_KEY") is None, reason="Set TRADING_STRATEGY_API_KEY environment variable to run this test")
 
@@ -182,6 +184,7 @@ def logger(request):
     return setup_pytest_logging(request, mute_requests=False)
 
 
+@pytest.mark.skipci(CI, reaosn="Too much data / slow / flaky on Github")
 def test_backtest_data_preload(
         logger: logging.Logger,
         persistent_test_client: Client,

--- a/tests/mainnet_fork/test_strategy_fetch_tvl.py
+++ b/tests/mainnet_fork/test_strategy_fetch_tvl.py
@@ -20,6 +20,9 @@ from tradingstrategy.chain import ChainId
 from tradingstrategy.timebucket import TimeBucket
 
 
+CI = os.environ.get("CI") == "true"
+
+
 pytestmark = pytest.mark.skipif(not os.environ.get("JSON_RPC_ETHEREUM") or not os.environ.get("TRADING_STRATEGY_API_KEY"), reason="Set JSON_RPC_ETHEREUM and TRADING_STRATEGY_API_KEY environment variables to run this test")
 
 

--- a/tradeexecutor/analysis/curve.py
+++ b/tradeexecutor/analysis/curve.py
@@ -36,6 +36,7 @@ DEFAULT_BENCHMARK_COLOURS = {
     "BTC": "orange",
     "BTC.e": "orange",
     "cbBTC": "orange",
+    "BNB": "darkorange",
     "ETH": "blue",
     "ETH.e": "blue",
     "MATIC": "purple",

--- a/tradeexecutor/analysis/multi_asset_benchmark.py
+++ b/tradeexecutor/analysis/multi_asset_benchmark.py
@@ -35,6 +35,7 @@ DEFAULT_BENCHMARK_ASSETS = (
     "SOL",
     "WSOL",
     "WAVAX",
+    "WBNB",
 )
 
 

--- a/tradeexecutor/backtest/tearsheet.py
+++ b/tradeexecutor/backtest/tearsheet.py
@@ -155,15 +155,15 @@ class BacktestReporter:
 
 
 def export_backtest_report(
-        state: State,
-        universe: TradingStrategyUniverse,
-        report_template: Path | None = None,
-        output_notebook: Path | None = None,
-        output_html: Path | None = None,
-        output_csv_daily_returns_report: Path | None = None,
-        show_code=False,
-        custom_css: str | None=DEFAULT_CUSTOM_CSS,
-        custom_js: str | None=DEFAULT_CUSTOM_JS,
+    state: State,
+    universe: TradingStrategyUniverse,
+    report_template: Path | None = None,
+    output_notebook: Path | None = None,
+    output_html: Path | None = None,
+    output_csv_daily_returns: Path | None = None,
+    show_code=False,
+    custom_css: str | None=DEFAULT_CUSTOM_CSS,
+    custom_js: str | None=DEFAULT_CUSTOM_JS,
 ) -> NotebookNode:
     """Creates the backtest visual report.
 
@@ -251,10 +251,10 @@ def export_backtest_report(
             with open(output_notebook, 'w', encoding='utf-8') as f:
                 nbformat.write(nb, f)
 
-        if output_csv_daily_returns_report is not None:
+        if output_csv_daily_returns is not None:
             returns_series = calculate_daily_returns(state)
             returns_df = pd.DataFrame({"daily_returns": returns_series})
-            returns_df.to_csv(output_csv_daily_returns_report, index=True)
+            returns_df.to_csv(output_csv_daily_returns, index=True)
 
         # Write a static HTML file based on the notebook
         if output_html is not None:

--- a/tradeexecutor/backtest/tearsheet.py
+++ b/tradeexecutor/backtest/tearsheet.py
@@ -11,6 +11,7 @@ from pathlib import Path
 from tempfile import NamedTemporaryFile
 
 import nbformat
+import pandas as pd
 from bs4 import BeautifulSoup
 from nbclient.exceptions import CellExecutionError
 from nbconvert import HTMLExporter
@@ -20,7 +21,7 @@ from nbformat import NotebookNode
 from tradeexecutor.state.state import State
 from tradeexecutor.strategy.trading_strategy_universe import TradingStrategyUniverse
 from tradeexecutor.utils.notebook import setup_charting_and_output
-
+from tradeexecutor.visual.equity_curve import calculate_daily_returns
 
 logger = logging.getLogger(__name__)
 
@@ -159,6 +160,7 @@ def export_backtest_report(
         report_template: Path | None = None,
         output_notebook: Path | None = None,
         output_html: Path | None = None,
+        output_csv_daily_returns_report: Path | None = None,
         show_code=False,
         custom_css: str | None=DEFAULT_CUSTOM_CSS,
         custom_js: str | None=DEFAULT_CUSTOM_JS,
@@ -248,6 +250,11 @@ def export_backtest_report(
         if output_notebook is not None:
             with open(output_notebook, 'w', encoding='utf-8') as f:
                 nbformat.write(nb, f)
+
+        if output_csv_daily_returns_report is not None:
+            returns_series = calculate_daily_returns(state)
+            returns_df = pd.DataFrame({"daily_returns": returns_series})
+            returns_df.to_csv(output_csv_daily_returns_report, index=True)
 
         # Write a static HTML file based on the notebook
         if output_html is not None:

--- a/tradeexecutor/cli/commands/backtest.py
+++ b/tradeexecutor/cli/commands/backtest.py
@@ -54,6 +54,7 @@ def backtest(
 
     notebook_report: Optional[Path] = shared_options.notebook_report,
     html_report: Optional[Path] = shared_options.html_report,
+    csv_daily_returns_report: Optional[Path] = shared_options.csv_daily_returns_report,
 
     python_profile_report: Optional[Path] = Option(None, envvar="PYTHON_PROFILE_REPORT", help="Write a Python cprof file to check where backtest spends time"),
 
@@ -116,6 +117,9 @@ def backtest(
     if not notebook_report:
         notebook_report = Path(f"state/{id}-backtest.ipynb")
 
+    if not csv_daily_returns_report:
+        csv_daily_returns_report = Path(f"state/{id}-daily-returns.csv")
+
     assert trading_strategy_api_key, "Cannot start the backtest without trading_strategy_api_key - please give command line option or give TRADING_STRATEGY_API_KEY env var"
 
     print(f"Starting backtesting for {strategy_file}")
@@ -163,11 +167,13 @@ def backtest(
         print(f"Exporting report")
         print(f"Notebook: {notebook_report.resolve()}")
         print(f"HTML: {html_report.resolve()}")
+        print(f"CSV: {csv_daily_returns_report.resolve()}")
         export_backtest_report(
             state,
             universe,
             output_notebook=notebook_report,
             output_html=html_report,
+            output_daily_returns_csv=csv_daily_returns_report,
         )
     else:
         print("Report generation skipped")

--- a/tradeexecutor/cli/commands/backtest.py
+++ b/tradeexecutor/cli/commands/backtest.py
@@ -173,7 +173,7 @@ def backtest(
             universe,
             output_notebook=notebook_report,
             output_html=html_report,
-            output_daily_returns_csv=csv_daily_returns_report,
+            output_csv_daily_returns=csv_daily_returns_report,
         )
     else:
         print("Report generation skipped")

--- a/tradeexecutor/cli/commands/shared_options.py
+++ b/tradeexecutor/cli/commands/shared_options.py
@@ -79,6 +79,7 @@ backtest_result = Option(None, envvar="BACKTEST_RESULT", help="State JSON file t
 
 notebook_report = Option(None, envvar="NOTEBOOK_REPORT", help="Jupyter Notebook file where the store the notebook results. If not given defaults to state/{executor-id}-backtest.ipynb.")
 html_report = Option(None, envvar="HTML_REPORT", help="HTML file where the store the notebook results. If not given defaults to state/{executor-id}-backtest.html.")
+csv_daily_returns_report = Option(None, envvar="CSV_REPORT", help="CSV file of daily returns. If not given defaults to state/{executor-id}-daily-returns.csv.")
 
 trading_strategy_api_key = Option(None, envvar="TRADING_STRATEGY_API_KEY", help="Trading Strategy API key")
 

--- a/tradeexecutor/utils/notebook.py
+++ b/tradeexecutor/utils/notebook.py
@@ -3,8 +3,8 @@ import enum
 import logging
 import sys
 
-import pandas as pd
 import matplotlib_inline
+import pandas as pd
 import plotly.io as pio
 
 
@@ -74,8 +74,8 @@ def setup_charting_and_output(
         Make charts and tables more readable with larger fonts
     """
 
-    from plotly.offline import init_notebook_mode
     import plotly.io as pio
+    from plotly.offline import init_notebook_mode
 
     # Get rid of findfont: Font family 'Arial' not found.
     # when running a remote notebook on Jupyter Server on Ubuntu Linux server
@@ -119,6 +119,7 @@ def setup_charting_and_output(
 def set_large_plotly_chart_font(
     title_font_size = 30,
     font_size = 24,
+    legend_font_size = 24,
     line_width = 3,
     base_template="plotly",
 ):
@@ -137,8 +138,8 @@ def set_large_plotly_chart_font(
     # Update the default template
     pio.templates["custom"] = pio.templates[base_template]
     pio.templates["custom"]["layout"]["font"]["size"] = font_size  # Set the default font size
-    pio.templates["custom"]["layout"]["legend"]["font"]["size"] = font_size  # Set the legend font size
-    pio.templates["custom"]["layout"]["legend"]["font"]["size"] = font_size  # Set the legend font size
+    pio.templates["custom"]["layout"]["legend"]["font"]["size"] = legend_font_size  # Set the legend font size
+    pio.templates["custom"]["layout"]["legend"]["font"]["size"] = legend_font_size  # Set the legend font size
     pio.templates["custom"]["layout"]["xaxis"]["title"]["font"]["size"] = font_size  # Set the x-axis title font size
     pio.templates["custom"]["layout"]["yaxis"]["title"]["font"]["size"] = font_size  # Set the y-axis title font size
     pio.templates["custom"]["layout"]["xaxis"]["tickfont"]["size"] = font_size  # Set the x-axis tick font size


### PR DESCRIPTION
- Many capital allocators need daily returns CSV to evaluate strategies