### PR TITLE
Display universe, ignore forard fill

### DIFF
--- a/tests/backtest/test_forward_fill.py
+++ b/tests/backtest/test_forward_fill.py
@@ -215,7 +215,7 @@ def test_forward_fill_too_old(persistent_test_client: Client):
     with pytest.raises(DataTooOld):
         TradingStrategyUniverseModel.check_data_age(
             ts=now_,
-            universe=strategy_universe,
+            strategy_universe=strategy_universe,
             best_before_duration=datetime.timedelta(days=30),
         )
 

--- a/tradeexecutor/analysis/pair.py
+++ b/tradeexecutor/analysis/pair.py
@@ -26,6 +26,7 @@ def display_strategy_universe(
     sort_numeric=True,
     limit: int | None = None,
     compact=False,
+    ignore_forward_fill=True,
 ) -> pd.DataFrame:
     """Displays a constructed trading strategy universe in table format.
 
@@ -141,6 +142,7 @@ def display_strategy_universe(
                     pair=pair.internal_id,
                     when=candle_now,
                     tolerance=tolerance,
+                    ignore_forward_fill=ignore_forward_fill,
                 )
                 candles = strategy_universe.data_universe.candles.get_candles_by_pair(pair.internal_id)
                 data["first_price_at"] = candles.index[0]

--- a/tradeexecutor/cli/loop.py
+++ b/tradeexecutor/cli/loop.py
@@ -748,8 +748,14 @@ class ExecutionLoop:
         universe = self.universe_model.preload_universe(self.universe_options, self.execution_context)
         universe = cast(TradingStrategyUniverse, universe)
 
+        # Check that we have fresh enough data to start trading
         if self.max_data_delay:
-            TradingStrategyUniverseModel.check_data_age(universe, self.max_data_delay)
+            ts = datetime.datetime.utcnow()
+            TradingStrategyUniverseModel.check_data_age(
+                ts,
+                universe,
+                self.max_data_delay,
+            )
 
         logger.info("Warmed up universe %s", universe)
         return universe

--- a/tradeexecutor/cli/loop.py
+++ b/tradeexecutor/cli/loop.py
@@ -73,7 +73,7 @@ from tradeexecutor.strategy.factory import StrategyFactory
 from tradeexecutor.strategy.pricing_model import PricingModelFactory
 from tradeexecutor.strategy.runner import StrategyRunner
 from tradeexecutor.strategy.cycle import CycleDuration, snap_to_next_tick, snap_to_previous_tick, round_datetime_up
-from tradeexecutor.strategy.trading_strategy_universe import TradingStrategyUniverse
+from tradeexecutor.strategy.trading_strategy_universe import TradingStrategyUniverse, TradingStrategyUniverseModel
 from tradeexecutor.strategy.universe_model import UniverseModel, StrategyExecutionUniverse, UniverseOptions
 from tradeexecutor.strategy.valuation import ValuationModelFactory
 from tradingstrategy.client import Client, BaseClient
@@ -747,6 +747,10 @@ class ExecutionLoop:
         assert self.execution_context.mode.is_live_trading()
         universe = self.universe_model.preload_universe(self.universe_options, self.execution_context)
         universe = cast(TradingStrategyUniverse, universe)
+
+        if self.max_data_delay:
+            TradingStrategyUniverseModel.check_data_age(universe, self.max_data_delay)
+
         logger.info("Warmed up universe %s", universe)
         return universe
 

--- a/tradeexecutor/cli/loop.py
+++ b/tradeexecutor/cli/loop.py
@@ -991,6 +991,7 @@ class ExecutionLoop:
                 indicators=self.backtest_strategy_indicators,
             )
 
+
             # Revalue our portfolio
             self.update_position_valuations(ts, state, universe)
 

--- a/tradeexecutor/strategy/pandas_trader/runner.py
+++ b/tradeexecutor/strategy/pandas_trader/runner.py
@@ -155,18 +155,18 @@ class PandasTraderRunner(StrategyRunner):
         """Check the data looks more or less sane."""
 
         assert isinstance(universe, TradingStrategyUniverse)
-        universe = universe.data_universe
+        data_universe = universe.data_universe
 
         now_ = ts
 
-        if len(universe.exchanges) == 0:
+        if len(data_universe.exchanges) == 0:
             raise PreflightCheckFailed("Exchange count zero")
 
-        if universe.pairs.get_count() == 0:
+        if data_universe.pairs.get_count() == 0:
             raise PreflightCheckFailed("Pair count zero")
 
         # Don't assume we have candle or liquidity data e.g. for the testing strategies
-        if universe.candles is not None:
+        if data_universe.candles is not None and self.max_data_age:
             TradingStrategyUniverseModel.check_data_age(ts, universe, self.max_data_age)
 
     def refresh_visualisations(self, state: State, universe: TradingStrategyUniverse):

--- a/tradeexecutor/strategy/pandas_trader/runner.py
+++ b/tradeexecutor/strategy/pandas_trader/runner.py
@@ -18,7 +18,7 @@ from tradeexecutor.strategy.pricing_model import PricingModel
 from tradeexecutor.strategy.routing import RoutingState, RoutingModel
 from tradeexecutor.strategy.strategy_module import DecideTradesProtocol, DecideTradesProtocol2, DecideTradesProtocol3, DecideTradesProtocol4
 from tradeexecutor.strategy.sync_model import SyncModel
-from tradeexecutor.strategy.trading_strategy_universe import TradingStrategyUniverse, translate_trading_pair
+from tradeexecutor.strategy.trading_strategy_universe import TradingStrategyUniverse, translate_trading_pair, TradingStrategyUniverseModel
 
 from tradeexecutor.state.state import State
 from tradeexecutor.state.trade import TradeExecution
@@ -167,12 +167,7 @@ class PandasTraderRunner(StrategyRunner):
 
         # Don't assume we have candle or liquidity data e.g. for the testing strategies
         if universe.candles is not None:
-            if universe.candles.get_candle_count() > 0:
-                start, end = universe.candles.get_timestamp_range()
-
-                if self.max_data_age is not None:
-                    if now_ - end > self.max_data_age:
-                        raise PreflightCheckFailed(f"We do not have up-to-date data for candles. Last candles are at {end}")
+            TradingStrategyUniverseModel.check_data_age(ts, universe, self.max_data_age)
 
     def refresh_visualisations(self, state: State, universe: TradingStrategyUniverse):
         """Updates the visualisation images for the strategy.

--- a/tradeexecutor/strategy/trading_strategy_universe.py
+++ b/tradeexecutor/strategy/trading_strategy_universe.py
@@ -1698,6 +1698,7 @@ class TradingStrategyUniverseModel(UniverseModel):
                     f"Candle data {candle_start} - {candle_end} is too old to work with\n" \
                     f"we require threshold {max_age}, diff is {diff}, asked best before duration is {best_before_duration}\n"
                     f"Forward-filled data is {no_ff_candle_start} - {no_ff_candle_end}\n"
+                    f"More information in logs"
                 )
 
         if universe.liquidity is not None:

--- a/tradeexecutor/strategy/trading_strategy_universe.py
+++ b/tradeexecutor/strategy/trading_strategy_universe.py
@@ -1684,7 +1684,7 @@ class TradingStrategyUniverseModel(UniverseModel):
 
                 logger.error(
                     "Universe data too old. Non-forward-filled sata is:\n%s",
-
+                    universe_output_msg,
                 )
 
                 raise DataTooOld(

--- a/tradeexecutor/strategy/trading_strategy_universe.py
+++ b/tradeexecutor/strategy/trading_strategy_universe.py
@@ -1677,7 +1677,12 @@ class TradingStrategyUniverseModel(UniverseModel):
             if candle_end < max_age:
                 diff = max_age - candle_end
 
-                universe_dump_df = display_strategy_universe(universe)
+                universe_dump_df = display_strategy_universe(
+                    universe,
+                    show_volume=False,
+                    show_tax=False,
+                    show_tvl=False,
+                )
                 universe_output_msg = tabulate(
                     universe_dump_df,
                     headers="keys",

--- a/tradeexecutor/strategy/trading_strategy_universe.py
+++ b/tradeexecutor/strategy/trading_strategy_universe.py
@@ -20,7 +20,6 @@ from typing import List, Optional, Callable, Tuple, Set, Dict, Iterable, Collect
 import pandas as pd
 from tabulate import tabulate
 
-from tradeexecutor.analysis.pair import display_strategy_universe
 from tradingstrategy.lending import LendingReserveUniverse, LendingReserveDescription, LendingCandleType, LendingCandleUniverse, UnknownLendingReserve, LendingProtocolType, LendingReserve
 from tradingstrategy.token import Token
 from tradingstrategy.candle import GroupedCandleUniverse
@@ -1653,6 +1652,9 @@ class TradingStrategyUniverseModel(UniverseModel):
         :return:
             The data timestamp
         """
+
+        # Avoid circular import
+        from tradeexecutor.analysis.pair import display_strategy_universe
 
         assert isinstance(universe, TradingStrategyUniverse), f"Expected TradingStrategyUniverse, got {universe.__class__}"
 

--- a/tradeexecutor/strategy/trading_strategy_universe.py
+++ b/tradeexecutor/strategy/trading_strategy_universe.py
@@ -1633,7 +1633,7 @@ class TradingStrategyUniverseModel(UniverseModel):
     @staticmethod
     def check_data_age(
         ts: datetime.datetime,
-        universe: TradingStrategyUniverse,
+        strategy_universe: TradingStrategyUniverse,
         best_before_duration: datetime.timedelta
     ) -> datetime.datetime:
         """Check if our data is up-to-date and we do not have issues with feeds.
@@ -1642,6 +1642,9 @@ class TradingStrategyUniverseModel(UniverseModel):
 
         :param ts:
             Current time
+
+        :param strategy_universe:
+            Strategy universe to examine.
 
         :param best_before_duration:
             Data must be not older than this duration.
@@ -1656,21 +1659,21 @@ class TradingStrategyUniverseModel(UniverseModel):
         # Avoid circular import
         from tradeexecutor.analysis.pair import display_strategy_universe
 
-        assert isinstance(universe, TradingStrategyUniverse), f"Expected TradingStrategyUniverse, got {universe.__class__}"
+        assert isinstance(strategy_universe, TradingStrategyUniverse), f"Expected TradingStrategyUniverse, got {strategy_universe.__class__}"
 
         max_age = ts - best_before_duration
-        universe = universe.data_universe
+        data_universe = strategy_universe.data_universe
         candle_end = None
 
-        if universe.candles is not None:
+        if data_universe.candles is not None:
             # Convert pandas.Timestamp to executor internal datetime format
-            candle_start, candle_end = universe.candles.get_timestamp_range(
+            candle_start, candle_end = data_universe.candles.get_timestamp_range(
                 exclude_forward_fill=True,
             )
             candle_start = candle_start.to_pydatetime().replace(tzinfo=None)
             candle_end = candle_end.to_pydatetime().replace(tzinfo=None)
 
-            no_ff_candle_start, no_ff_candle_end = universe.candles.get_timestamp_range(
+            no_ff_candle_start, no_ff_candle_end = data_universe.candles.get_timestamp_range(
                 exclude_forward_fill=True,
             )
 
@@ -1678,7 +1681,7 @@ class TradingStrategyUniverseModel(UniverseModel):
                 diff = max_age - candle_end
 
                 universe_dump_df = display_strategy_universe(
-                    universe,
+                    strategy_universe,
                     show_volume=False,
                     show_tax=False,
                     show_tvl=False,
@@ -1701,8 +1704,8 @@ class TradingStrategyUniverseModel(UniverseModel):
                     f"More information in logs"
                 )
 
-        if universe.liquidity is not None:
-            liquidity_start, liquidity_end = universe.liquidity.get_timestamp_range(
+        if data_universe.liquidity is not None:
+            liquidity_start, liquidity_end = data_universe.liquidity.get_timestamp_range(
                 exclude_forward_fill=True,
             )
             liquidity_start = liquidity_start.to_pydatetime().replace(tzinfo=None)

--- a/tradeexecutor/strategy/trading_strategy_universe.py
+++ b/tradeexecutor/strategy/trading_strategy_universe.py
@@ -1673,10 +1673,11 @@ class TradingStrategyUniverseModel(UniverseModel):
             candle_start = candle_start.to_pydatetime().replace(tzinfo=None)
             candle_end = candle_end.to_pydatetime().replace(tzinfo=None)
 
-            no_ff_candle_start, no_ff_candle_end = data_universe.candles.get_timestamp_range(
-                exclude_forward_fill=True,
+            ff_candle_start, ff_candle_end = data_universe.candles.get_timestamp_range(
+                exclude_forward_fill=False,
             )
 
+            # Do a very throughful logging on what went wrong with our data
             if candle_end < max_age:
                 diff = max_age - candle_end
 
@@ -1700,7 +1701,7 @@ class TradingStrategyUniverseModel(UniverseModel):
                 raise DataTooOld(
                     f"Candle data {candle_start} - {candle_end} is too old to work with\n" \
                     f"we require threshold {max_age}, diff is {diff}, asked best before duration is {best_before_duration}\n"
-                    f"Forward-filled data is {no_ff_candle_start} - {no_ff_candle_end}\n"
+                    f"Forward-filled data is {ff_candle_start} - {ff_candle_end}\n"
                     f"More information in logs"
                 )
 


### PR DESCRIPTION
- Display universe without forward filled dates for price data to diagnose issues
- After startup, check the universe age and refuse to startup on too old data