### PR TITLE
Make workaround for Ipor freezing positions

### DIFF
--- a/tests/mainnet_fork/test_frozen_position_and_blacklist.py
+++ b/tests/mainnet_fork/test_frozen_position_and_blacklist.py
@@ -411,6 +411,9 @@ def test_buy_and_sell_blacklisted_asset(
     assert len(portfolio.closed_positions) == 0
 
     failed_position: TradingPosition = next(iter(portfolio.frozen_positions.values()))
+
+    assert portfolio.get_frozen_position(failed_position.pair) is not None
+
     assert failed_position.position_id == 2
     assert failed_position.frozen_at is not None
     assert failed_position.is_frozen()

--- a/tradeexecutor/state/portfolio.py
+++ b/tradeexecutor/state/portfolio.py
@@ -1214,3 +1214,14 @@ class Portfolio:
     def get_total_repaid_interest(self) -> USDollarAmount:
         """Get the total interest repaid from the positions."""
         return sum(p.get_repaid_interest() for p in self.get_all_positions())
+
+    def get_frozen_position(self, pair) -> TradingPosition | None:
+        """Get a frozen position by trading pair.
+
+        :param pair:
+            Trading pair identifier
+
+        :return:
+            Frozen position or None if not found
+        """
+        return next((p for p in self.frozen_positions.values() if p.pair == pair), None)

--- a/tradeexecutor/strategy/pandas_trader/yield_manager.py
+++ b/tradeexecutor/strategy/pandas_trader/yield_manager.py
@@ -292,6 +292,9 @@ class YieldManager:
         for pair, desired_result in desired_yield_positions.items():
             desired_amount = desired_result.amount_usd
 
+            frozen_position = self.portfolio.get_frozen_position(pair)
+            assert frozen_position is not None, f"Yield position frozen, aborting execution, as we cannot generate cash releasing trades: {frozen_position}"
+
             # Avoid rounding/epsilon issues
             if abs(desired_amount) < dollar_epsilon:
                 desired_amount = 0.0


### PR DESCRIPTION
- IPOR vault redeem takes massive amount of gas, because they use some kind of reward distribution contract
- The massive amount fo gas trips all safety checks for transactions
- Make a workaround that crashes the trade execution if any of yield management positions goes out of sync and cannot execute