### PR TITLE
Fix wrong days in year for CAGR calculation

### DIFF
--- a/tradeexecutor/statistics/key_metric.py
+++ b/tradeexecutor/statistics/key_metric.py
@@ -172,7 +172,7 @@ def calculate_cagr(returns: pd.Series) -> Percent:
         return 0
 
     try:
-        return cagr(returns)
+        return cagr(returns, periods=365)
     except ZeroDivisionError:
         return 0
 


### PR DESCRIPTION
- Change CAGR year from 250 days (wrong) to 365 days, which was quantstats default
