### PR TITLE
Vault share token price was calculated wrong way

### DIFF
--- a/tradeexecutor/ethereum/vault/vault_valuation.py
+++ b/tradeexecutor/ethereum/vault/vault_valuation.py
@@ -63,6 +63,7 @@ class VaultValuator(ValuationModel):
             new_price=new_price,
             quantity=shares_amount,
         )
+        logger.info("Vault position %s, valuation updated: %s", position, evt)
         position.last_token_price = new_price
         return evt
 

--- a/tradeexecutor/state/valuation.py
+++ b/tradeexecutor/state/valuation.py
@@ -27,7 +27,6 @@ class ValuationUpdate:
     #:
     created_at: datetime.datetime
 
-
     #: The block timestamp this valuation is based on.
     #:
     #: If not available then wall clock time of the valuation.
@@ -39,6 +38,7 @@ class ValuationUpdate:
     #:
     valued_at: datetime.datetime
 
+    #: The value after the price update
     new_value: USDollarAmount
 
     #: The new price of the base asset of the position.
@@ -72,4 +72,7 @@ class ValuationUpdate:
 
     #: What was the quantity of the position at the time of valuation
     quantity: Decimal | None = None
+
+    def __repr__(self) -> str:
+        return f"<ValuationUpdate position_id={self.position_id} new_value={self.new_value} new_price={self.new_price} old_price={self.old_price} block_number={self.block_number}>"
 

--- a/tradeexecutor/strategy/pandas_trader/yield_manager.py
+++ b/tradeexecutor/strategy/pandas_trader/yield_manager.py
@@ -316,11 +316,12 @@ class YieldManager:
 
             dollar_delta = desired_amount - existing_amount
             if existing_position:
-                quantity_delta = dollar_delta * existing_position.get_current_price()
+                quantity_delta = dollar_delta / existing_position.get_current_price()
                 quantity_delta = Decimal(quantity_delta)
             else:
                 quantity_delta = None
 
+            # Check for almost zero (positive or negative)
             if quantity_delta is not None:
                 if abs(quantity_delta) < dollar_epsilon:
                     quantity_delta = 0.0


### PR DESCRIPTION
- When converting to sell quantity, the vault share token price was inverted, leading to too high quantity number