### PR TITLE
fix: resolve pytest deprecation and future warnings

### DIFF
--- a/tests/backtest/test_backtest_inline_synthetic_data.py
+++ b/tests/backtest/test_backtest_inline_synthetic_data.py
@@ -650,7 +650,7 @@ def test_benchmark_synthetic_trading_portfolio(
     # Visualise performance
     fig = visualise_equity_curve_benchmark(
         state.name,
-        portfolio_statistics=state.stats.portfolio,
+        state=state,
         all_cash=100_000,
         buy_and_hold_asset_name="ETH",
         buy_and_hold_price_series=strategy_universe.data_universe.candles.get_single_pair_data()["close"],

--- a/tests/backtest/test_backtest_open_position.py
+++ b/tests/backtest/test_backtest_open_position.py
@@ -326,7 +326,7 @@ def test_benchmark_synthetic_trading_portfolio(
     # Visualise performance
     fig = visualise_equity_curve_benchmark(
         state.name,
-        portfolio_statistics=state.stats.portfolio,
+        state=state,
         all_cash=100_000,
         buy_and_hold_asset_name="ETH",
         buy_and_hold_price_series=strategy_universe.data_universe.candles.get_single_pair_data()["close"],

--- a/tests/backtest/test_backtest_profit_calculation.py
+++ b/tests/backtest/test_backtest_profit_calculation.py
@@ -266,7 +266,7 @@ def test_calculate_realised_trading_profitability(backtest_result: State):
     assert isinstance(profitability.index, pd.DatetimeIndex)
 
     sized_profitability = calculate_size_relative_realised_trading_returns(state)
-    assert sized_profitability[0] == pytest.approx(profitability[0] / 10, rel=0.01)  # 10% position size is used
+    assert sized_profitability.iloc[0] == pytest.approx(profitability.iloc[0] / 10, rel=0.01)  # 10% position size is used
 
     compounded_profitability = calculate_compounding_realised_trading_profitability(state)
     assert isinstance(compounded_profitability, pd.Series)

--- a/tests/backtest/test_backtest_report.py
+++ b/tests/backtest/test_backtest_report.py
@@ -189,7 +189,8 @@ def test_generate_html_report(html_report: Path):
     assert os.path.exists(html_report), f"Did not create: {html_report}"
 
     # Check we injected CSS correctly
-    html_content = html_report.open("rt").read()
+    with html_report.open("rt") as f:
+        html_content = f.read()
     assert "/* trade-executor backtest report generator custom CSS */" in html_content
 
 

--- a/tests/backtest/test_grid_search.py
+++ b/tests/backtest/test_grid_search.py
@@ -249,7 +249,7 @@ def test_perform_grid_search_single_thread(
 
     sample = pick_best_grid_search_result(
         results,
-        key=lambda r: r.metrics.loc["Max Drawdown"][0])
+        key=lambda r: r.metrics.loc["Max Drawdown"].iloc[0])
     assert sample is not None
 
     sample = pick_best_grid_search_result(results)
@@ -339,7 +339,7 @@ def test_perform_grid_search_threaded(
 
     # Check we got results back
     for r in results:
-        assert r.metrics.loc["Sharpe"][0] != 0
+        assert r.metrics.loc["Sharpe"].iloc[0] != 0
 
 
 def test_perform_grid_search_multiprocess(
@@ -368,7 +368,7 @@ def test_perform_grid_search_multiprocess(
 
     # Check we got results back
     for r in results:
-        assert r.metrics.loc["Sharpe"][0] != 0
+        assert r.metrics.loc["Sharpe"].iloc[0] != 0
         assert r.process_id > 1
 
 
@@ -430,7 +430,7 @@ def test_perform_grid_search_engine_v4(
 
     # Check we got results back
     for r in results:
-        assert r.metrics.loc["Sharpe"][0] != 0
+        assert r.metrics.loc["Sharpe"].iloc[0] != 0
         assert r.process_id > 1
 
     # See we can render the results
@@ -605,7 +605,7 @@ def test_perform_grid_search_engine_v5(
 
     # Check we got results back
     for r in results_2:
-        assert r.metrics.loc["Sharpe"][0] != 0
+        assert r.metrics.loc["Sharpe"].iloc[0] != 0
         assert r.process_id > 1
 
     # Single thread

--- a/tradeexecutor/analysis/grid_search.py
+++ b/tradeexecutor/analysis/grid_search.py
@@ -317,9 +317,9 @@ def visualise_heatmap_2d(
 
     # Format percents inside the cells and mouse hovers
     if metric in PERCENT_COLS:
-        text = df.applymap(lambda x: f"{x * 100:,.2f}%")
+        text = df.map(lambda x: f"{x * 100:,.2f}%")
     else:
-        text = df.applymap(lambda x: f"{x:,.2f}")
+        text = df.map(lambda x: f"{x:,.2f}")
 
     fig = px.imshow(
         df,

--- a/tradeexecutor/analysis/trade_analyser.py
+++ b/tradeexecutor/analysis/trade_analyser.py
@@ -1526,7 +1526,8 @@ def expand_timeline(
 
     # Get rid of NaN labels
     # https://stackoverflow.com/a/28390992/315168
-    applied_df.fillna('', inplace=True)
+    str_cols = applied_df.select_dtypes(include=["object"]).columns
+    applied_df[str_cols] = applied_df[str_cols].fillna('')
 
     styling = TimelineStyler(
         row_styling=row_styling_mode,
@@ -1588,7 +1589,8 @@ def expand_timeline_raw(
 
     # Get rid of NaN labels
     # https://stackoverflow.com/a/28390992/315168
-    applied_df.fillna('', inplace=True)
+    str_cols = applied_df.select_dtypes(include=["object"]).columns
+    applied_df[str_cols] = applied_df[str_cols].fillna('')
 
     return applied_df
 

--- a/tradeexecutor/statistics/key_metric.py
+++ b/tradeexecutor/statistics/key_metric.py
@@ -145,7 +145,7 @@ def calculate_profitability(returns: pd.Series) -> Percent:
 
     """
     compounded = returns.add(1).cumprod().sub(1)
-    return compounded[-1]
+    return compounded.iloc[-1]
 
 
 def calculate_cagr(returns: pd.Series) -> Percent:

--- a/tradeexecutor/strategy/pandas_trader/alternative_market_data.py
+++ b/tradeexecutor/strategy/pandas_trader/alternative_market_data.py
@@ -122,7 +122,7 @@ def _fix_nans(df: pd.DataFrame) -> pd.DataFrame:
     
     for column in df.columns:
         if column not in exclude_columns:
-            df[column].fillna(method='ffill', inplace=True)
+            df[column] = df[column].ffill()
 
     # TODO: Add NaN fixing logic here
     # https://stackoverflow.com/a/29530303/315168

--- a/tradeexecutor/strategy/trading_strategy_universe.py
+++ b/tradeexecutor/strategy/trading_strategy_universe.py
@@ -929,10 +929,10 @@ class TradingStrategyUniverse(StrategyExecutionUniverse):
         assert exchange, f"No exchange {exchange_slug} found on chain {chain_id.name}"
 
         # Create trading pair database
-        pair_universe = PandasPairUniverse.create_limited_pair_universe(
+        pair_descriptions = [(chain_id, exchange_slug, base, quote) for base, quote in pairs]
+        pair_universe = PandasPairUniverse.create_pair_universe(
             dataset.pairs,
-            exchange,
-            pairs,
+            pair_descriptions,
         )
 
         # Get daily candles as Pandas DataFrame

--- a/tradeexecutor/testing/unit_test_trader.py
+++ b/tradeexecutor/testing/unit_test_trader.py
@@ -162,11 +162,11 @@ class UnitTestTrader:
         return self.create_and_execute(pair, -quantity, price)
 
     def buy_with_price_data(self, pair, quantity, candle_universe: GroupedCandleUniverse) -> Tuple[TradingPosition, TradeExecution]:
-        price = candle_universe.get_closest_price(pair.internal_id, pd.Timestamp(self.ts))
+        price, _ = candle_universe.get_price_with_tolerance(pair.internal_id, pd.Timestamp(self.ts), tolerance=pd.Timedelta(days=7))
         return self.create_and_execute(pair, quantity, float(price))
 
     def sell_with_price_data(self, pair, quantity, candle_universe: GroupedCandleUniverse) -> Tuple[TradingPosition, TradeExecution]:
-        price = candle_universe.get_closest_price(pair.internal_id, pd.Timestamp(self.ts))
+        price, _ = candle_universe.get_price_with_tolerance(pair.internal_id, pd.Timestamp(self.ts), tolerance=pd.Timedelta(days=7))
         return self.create_and_execute(pair, -quantity, float(price))
 
     def open_short(self, pair, quantity, price, leverage=1) -> tuple[TradingPosition, TradeExecution]:

--- a/tradeexecutor/utils/binance.py
+++ b/tradeexecutor/utils/binance.py
@@ -107,7 +107,7 @@ def fetch_binance_dataset(
         df, {symbol: pair for symbol, pair in zip(symbols, pairs)}
     )
 
-    candle_df["pair_id"] = candle_df["pair_id"].replace(spot_symbol_map)
+    candle_df["pair_id"] = candle_df["pair_id"].map(spot_symbol_map).fillna(candle_df["pair_id"])
 
     candle_universe, stop_loss_candle_universe = load_candle_universe_from_dataframe(
         df=candle_df,
@@ -118,7 +118,7 @@ def fetch_binance_dataset(
     exchange_universe = generate_exchange_universe_for_binance(pair_count=len(pairs))
 
     pairs_df = DEXPair.convert_to_dataframe(pairs)
-    pairs_df["pair_id"].replace(spot_symbol_map, inplace=True)
+    pairs_df["pair_id"] = pairs_df["pair_id"].map(spot_symbol_map).fillna(pairs_df["pair_id"])
 
     if include_lending:
         reserves = []


### PR DESCRIPTION
## Summary

- Fix 41 deprecation/future warnings across the backtest test suite (reduced to 0 warnings from our code)
- Update deprecated pandas APIs: `fillna(method='ffill')` → `.ffill()`, `applymap` → `.map`, `Series[int]` → `.iloc[int]`, chained inplace assignment → direct assignment
- Replace deprecated `get_closest_price()` with `get_price_with_tolerance()` in unit test trader
- Replace deprecated `create_limited_pair_universe()` with `create_pair_universe()` in trading strategy universe
- Use `state=` parameter instead of deprecated `portfolio_statistics=` in benchmark visualisation calls
- Fix unclosed file handle in test_backtest_report


🤖 Generated with [Claude Code](https://claude.ai/code)
via [Happy](https://happy.engineering)