### PR TITLE
feat: Add deposits_disabled strategy tag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 
 - Breaking API changes
 
+- Add `deposits_disabled` strategy tag to disable deposit box on the website (2026-02-15)
+
 - Add `--trade-type` option to `show-positions` command to control trade display (2026-01-31)
 
 - Add `--sync-interest` option to `lagoon-settle` command to fix credit supply position valuation timestamp issues (2026-01-31)

--- a/tradeexecutor/strategy/tag.py
+++ b/tradeexecutor/strategy/tag.py
@@ -36,3 +36,6 @@ class StrategyTag(enum.Enum):
 
     #: The strategy should appear on the front page hero box showcasing strategies
     hero = "hero"
+
+    #: The deposit box should be disabled on the website for this strategy
+    deposits_disabled = "deposits_disabled"


### PR DESCRIPTION
## Summary
- Add `deposits_disabled` tag to `StrategyTag` enum to allow strategies to disable the deposit box on the website
- Usage: `tags = {StrategyTag.beta, StrategyTag.deposits_disabled}`

🤖 Generated with [Claude Code](https://claude.com/claude-code)