### PR TITLE
fix: Use correct CLI app import in tests

### DIFF
--- a/tests/cli/test_console.py
+++ b/tests/cli/test_console.py
@@ -3,7 +3,7 @@ import secrets
 
 import pytest
 
-from tradeexecutor.cli.commands.app import app
+from tradeexecutor.cli.main import app
 
 pytestmark = pytest.mark.skipif(os.environ.get("JSON_RPC_ETHEREUM") is None, reason="Set JSON_RPC_ETHEREUM environment variable torun this test")
 

--- a/tests/enzyme/test_enzyme_vault_arbitrum_fork.py
+++ b/tests/enzyme/test_enzyme_vault_arbitrum_fork.py
@@ -21,7 +21,7 @@ from eth_defi.hotwallet import HotWallet
 from eth_defi.provider.anvil import AnvilLaunch, launch_anvil
 from eth_defi.token import TokenDetails, fetch_erc20_details
 from eth_defi.trace import assert_transaction_success_with_explanation
-from tradeexecutor.cli.commands.app import app
+from tradeexecutor.cli.main import app
 
 JSON_RPC_ARBITRUM = os.environ.get("JSON_RPC_ARBITRUM")
 TRADING_STRATEGY_API_KEY = os.environ.get("TRADING_STRATEGY_API_KEY")

--- a/tests/legacy/test_repair_zero_quantity_position.py
+++ b/tests/legacy/test_repair_zero_quantity_position.py
@@ -8,7 +8,7 @@ import pytest
 from pytest import FixtureRequest
 
 from eth_defi.provider.anvil import launch_anvil, AnvilLaunch
-from tradeexecutor.cli.commands.app import app
+from tradeexecutor.cli.main import app
 from tradeexecutor.state.state import State
 
 

--- a/tests/mainnet_fork/test_check_accounts_low_value_position.py
+++ b/tests/mainnet_fork/test_check_accounts_low_value_position.py
@@ -13,7 +13,7 @@ from pytest import FixtureRequest
 
 from eth_defi.provider.anvil import AnvilLaunch, launch_anvil
 
-from tradeexecutor.cli.commands.app import app
+from tradeexecutor.cli.main import app
 from tradeexecutor.state.state import State
 from tradeexecutor.utils.dedent import dedent_any
 from tradeexecutor.utils.hex import hexbytes_to_hex_str

--- a/tests/mainnet_fork/test_correct_accouting_closed_position_has_ausdc.py
+++ b/tests/mainnet_fork/test_correct_accouting_closed_position_has_ausdc.py
@@ -15,7 +15,7 @@ from pytest import FixtureRequest
 
 from eth_defi.provider.anvil import AnvilLaunch, launch_anvil
 
-from tradeexecutor.cli.commands.app import app
+from tradeexecutor.cli.main import app
 from tradeexecutor.utils.hex import hexbytes_to_hex_str
 
 

--- a/tests/mainnet_fork/test_correct_accouting_position_should_be_open.py
+++ b/tests/mainnet_fork/test_correct_accouting_position_should_be_open.py
@@ -15,7 +15,7 @@ from pytest import FixtureRequest
 
 from eth_defi.provider.anvil import AnvilLaunch, launch_anvil
 
-from tradeexecutor.cli.commands.app import app
+from tradeexecutor.cli.main import app
 from tradeexecutor.utils.hex import hexbytes_to_hex_str
 
 

--- a/tests/mainnet_fork/test_correct_credit_position_redemption.py
+++ b/tests/mainnet_fork/test_correct_credit_position_redemption.py
@@ -15,7 +15,7 @@ from pytest import FixtureRequest
 
 from eth_defi.provider.anvil import AnvilLaunch, launch_anvil
 
-from tradeexecutor.cli.commands.app import app
+from tradeexecutor.cli.main import app
 from tradeexecutor.state.state import State
 from tradeexecutor.utils.hex import hexbytes_to_hex_str
 

--- a/tests/mainnet_fork/test_correct_interest_not_accrued.py
+++ b/tests/mainnet_fork/test_correct_interest_not_accrued.py
@@ -16,7 +16,7 @@ from pytest import FixtureRequest
 
 from eth_defi.provider.anvil import AnvilLaunch, launch_anvil
 
-from tradeexecutor.cli.commands.app import app
+from tradeexecutor.cli.main import app
 from tradeexecutor.utils.hex import hexbytes_to_hex_str
 
 

--- a/tests/mainnet_fork/test_repair_credit_position_open_failed.py
+++ b/tests/mainnet_fork/test_repair_credit_position_open_failed.py
@@ -11,7 +11,7 @@ from pytest import FixtureRequest
 
 from eth_defi.provider.anvil import AnvilLaunch, launch_anvil
 
-from tradeexecutor.cli.commands.app import app
+from tradeexecutor.cli.main import app
 from tradeexecutor.utils.hex import hexbytes_to_hex_str
 
 

--- a/tests/mainnet_fork/test_repair_frozen_credit_position.py
+++ b/tests/mainnet_fork/test_repair_frozen_credit_position.py
@@ -11,7 +11,7 @@ from pytest import FixtureRequest
 
 from eth_defi.provider.anvil import AnvilLaunch, launch_anvil
 
-from tradeexecutor.cli.commands.app import app
+from tradeexecutor.cli.main import app
 from tradeexecutor.utils.hex import hexbytes_to_hex_str
 
 

--- a/tests/mainnet_fork/test_velvet_e2e.py
+++ b/tests/mainnet_fork/test_velvet_e2e.py
@@ -9,7 +9,7 @@ from web3 import Web3
 
 from eth_defi.provider.anvil import AnvilLaunch, launch_anvil
 from eth_defi.provider.multi_provider import create_multi_provider_web3
-from tradeexecutor.cli.commands.app import app
+from tradeexecutor.cli.main import app
 from tradeexecutor.state.state import State
 
 JSON_RPC_BASE = os.environ.get("JSON_RPC_BASE")

--- a/tests/strategy_tests/test_eth_btc_trade_size.py
+++ b/tests/strategy_tests/test_eth_btc_trade_size.py
@@ -5,7 +5,7 @@ from unittest import mock
 
 import pytest
 
-from tradeexecutor.cli.commands.app import app
+from tradeexecutor.cli.main import app
 from tradeexecutor.cli.log import setup_pytest_logging
 from tradeexecutor.state.state import State
 

--- a/tests/velvet/test_velvet_check_enter_position.py
+++ b/tests/velvet/test_velvet_check_enter_position.py
@@ -11,7 +11,7 @@ from web3 import Web3
 from eth_defi.abi import ZERO_ADDRESS_STR
 from eth_defi.provider.anvil import AnvilLaunch, launch_anvil
 from eth_defi.provider.multi_provider import create_multi_provider_web3
-from tradeexecutor.cli.commands.app import app
+from tradeexecutor.cli.main import app
 from tradeexecutor.state.state import State
 
 JSON_RPC_BINANCE = os.environ.get("JSON_RPC_BINANCE")


### PR DESCRIPTION
## Why

13 test files imported `app` from `tradeexecutor.cli.commands.app` instead of `tradeexecutor.cli.main`. The bare `app` object has no commands registered — commands only get registered when `cli/main.py` imports all the command modules (triggering their `@app.command()` decorators). This caused `RuntimeError: Could not get a command for this Typer instance` when tests called `app(["check-accounts"], ...)` or similar.

This was likely broken by the shared JSON-RPC decorator refactor (`55f87dda`).

## Lessons learnt

- `tradeexecutor.cli.commands.app` exports the bare Typer instance; `tradeexecutor.cli.main` is the correct import for tests that invoke CLI commands, since it triggers all command registrations via side-effect imports.

## Summary

- Changed `from tradeexecutor.cli.commands.app import app` → `from tradeexecutor.cli.main import app` in 13 test files
- Verified the 3 previously failing tests now pass locally:
  - `test_correct_accouting_closed_position_has_ausdc`
  - `test_correct_account_missing_open_spot_position`
  - `test_correct_interest_not_accrued`

🤖 Generated with [Claude Code](https://claude.com/claude-code)