### PR TITLE
Generalise redemption diagnostics and audits

### DIFF
--- a/scripts/audit-hypercore-redemption-state.py
+++ b/scripts/audit-hypercore-redemption-state.py
@@ -1,0 +1,20 @@
+"""Backwards-compatible wrapper for the generic redemption audit CLI."""
+
+from importlib.util import module_from_spec, spec_from_file_location
+from pathlib import Path
+import sys
+
+
+def main() -> int:
+    """Forward the legacy script entry point to the generic audit CLI."""
+    target = Path(__file__).with_name("audit-redemption-state.py")
+    spec = spec_from_file_location("audit_redemption_state_cli", target)
+    assert spec is not None
+    assert spec.loader is not None
+    module = module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module.main()
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/audit-redemption-state.py
+++ b/scripts/audit-redemption-state.py
@@ -1,0 +1,57 @@
+"""Audit blocked redemption diagnostics from a strategy state dump."""
+
+import argparse
+import datetime
+import json
+import sys
+import urllib.request
+from pathlib import Path
+
+from eth_defi.compat import native_datetime_utc_now
+
+from tradeexecutor.analysis.redemption_audit import audit_redemption_state
+from tradeexecutor.state.state import State
+
+
+def _load_state(source: str) -> State:
+    """Load state from a local JSON file or an HTTP endpoint."""
+    if source.startswith(("http://", "https://")):
+        with urllib.request.urlopen(source) as response:
+            payload = json.loads(response.read().decode("utf-8"))
+        return State.read_json_blob(json.dumps(payload))
+
+    return State.read_json_file(Path(source))
+
+
+def main() -> int:
+    """Run the state audit and print a compact tabular report."""
+    parser = argparse.ArgumentParser()
+    parser.add_argument("source", help="Local state JSON path or HTTP(S) URL")
+    parser.add_argument("--now", help="Naive UTC timestamp in ISO format", default=None)
+    args = parser.parse_args()
+
+    now = datetime.datetime.fromisoformat(args.now) if args.now else native_datetime_utc_now()
+    state = _load_state(args.source)
+    rows, mismatch_count = audit_redemption_state(state, now=now)
+
+    print("pair_ticker\tvault_address\tstage\treason_code\trecorded_lockup_expired\tposition_lockup_expires_at\tuser_lockup_expires_at")
+    for row in rows:
+        print(
+            "\t".join(
+                [
+                    row.pair_ticker or "",
+                    row.vault_address or "",
+                    row.stage or "",
+                    row.reason_code or "",
+                    "yes" if row.recorded_lockup_expired else "no",
+                    row.position_recorded_lockup_expires_at.isoformat() if row.position_recorded_lockup_expires_at else "",
+                    row.user_lockup_expires_at.isoformat() if row.user_lockup_expires_at else "",
+                ]
+            )
+        )
+
+    return 1 if mismatch_count > 0 else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/strategies/hyper-ai.py
+++ b/strategies/hyper-ai.py
@@ -36,7 +36,6 @@ Calmar                            11.62      -1.12   -0.98
 import datetime
 import logging
 import re
-from collections import Counter
 
 import pandas as pd
 from eth_defi.token import USDC_NATIVE_TOKEN
@@ -90,9 +89,9 @@ from tradeexecutor.strategy.pandas_trader.trading_universe_input import \
     CreateTradingUniverseInput
 from tradeexecutor.strategy.parameters import StrategyParameters
 from tradeexecutor.strategy.redemption import (
-    BlockedRedemptionSummary,
-    RedemptionCheckResult,
-    RedemptionCycleDiagnostics,
+    collect_blocked_redemption_results,
+    create_redemption_cycle_diagnostics,
+    group_blocked_redemption_reasons,
 )
 from tradeexecutor.strategy.tag import StrategyTag
 from tradeexecutor.strategy.trading_strategy_universe import (
@@ -322,52 +321,6 @@ def _get_available_supporting_pair_ids(
             continue
     return pair_ids
 
-
-def _get_blocked_redemption_results(alpha_model: AlphaModel) -> list[RedemptionCheckResult]:
-    """Collect blocked redemption checks from the current alpha model."""
-    results = []
-    for signal in alpha_model.signals.values():
-        for result in signal.redemption_check_results:
-            if not result.can_redeem:
-                results.append(result)
-    return results
-
-
-def _format_decimal(value) -> str | None:
-    """Format Decimal-like diagnostics without widening state payloads."""
-    if value is None:
-        return None
-    return str(value)
-
-
-def _make_blocked_redemption_summary(
-    result: RedemptionCheckResult,
-) -> BlockedRedemptionSummary:
-    """Convert one rich redemption result to a compact persisted summary."""
-    return BlockedRedemptionSummary(
-        pair_ticker=result.pair_ticker,
-        vault_address=result.vault_address,
-        stage=result.stage.value,
-        reason_code=result.reason_code.value if result.reason_code else None,
-        message=result.message,
-        safe_address=result.safe_address,
-        position_recorded_lockup_expires_at=result.position_recorded_lockup_expires_at,
-        user_lockup_expires_at=result.user_lockup_expires_at,
-        max_withdrawable=_format_decimal(result.max_withdrawable),
-        max_redemption=_format_decimal(result.max_redemption),
-    )
-
-
-def _group_blocked_redemption_reasons(
-    blocked_results: list[RedemptionCheckResult],
-) -> dict[str, int]:
-    """Group blocked redemption diagnostics by stable reason code."""
-    counts = Counter()
-    for result in blocked_results:
-        counts[result.reason_code.value if result.reason_code else "unknown"] += 1
-    return dict(counts)
-
-
 #
 # Strategy logic
 #
@@ -459,8 +412,8 @@ def decide_trades(input: StrategyInput) -> list[TradeExecution]:
     )
 
     if input.is_visualisation_enabled():
-        blocked_redemption_results = _get_blocked_redemption_results(alpha_model)
-        blocked_redemption_reason_counts = _group_blocked_redemption_reasons(blocked_redemption_results)
+        blocked_redemption_results = collect_blocked_redemption_results(alpha_model.signals)
+        blocked_redemption_reason_counts = group_blocked_redemption_reasons(blocked_redemption_results)
 
         try:
             top_signal = next(iter(alpha_model.get_signals_sorted_by_weight()))
@@ -522,20 +475,11 @@ def decide_trades(input: StrategyInput) -> list[TradeExecution]:
         state.visualisation.add_message(timestamp, report)
         state.visualisation.set_discardable_data("alpha_model", alpha_model)
         if input.execution_context.live_trading and blocked_redemption_results:
-            blocked_signal_count = len({
-                (result.pair_ticker, result.vault_address)
-                for result in blocked_redemption_results
-            })
-            cycle_diagnostics = RedemptionCycleDiagnostics(
+            cycle_diagnostics = create_redemption_cycle_diagnostics(
                 cycle=input.cycle,
                 redeemable_capital=float(redeemable_capital),
                 locked_capital_carried_forward=float(locked_position_value),
-                blocked_signal_count=blocked_signal_count,
-                reason_counts=blocked_redemption_reason_counts,
-                blocked_redemptions=[
-                    _make_blocked_redemption_summary(result)
-                    for result in blocked_redemption_results
-                ],
+                blocked_results=blocked_redemption_results,
             )
             state.visualisation.add_calculations(
                 timestamp,

--- a/strategies/hyper-ai.py
+++ b/strategies/hyper-ai.py
@@ -36,6 +36,7 @@ Calmar                            11.62      -1.12   -0.98
 import datetime
 import logging
 import re
+from collections import Counter
 
 import pandas as pd
 from eth_defi.token import USDC_NATIVE_TOKEN
@@ -88,6 +89,11 @@ from tradeexecutor.strategy.pandas_trader.strategy_input import StrategyInput
 from tradeexecutor.strategy.pandas_trader.trading_universe_input import \
     CreateTradingUniverseInput
 from tradeexecutor.strategy.parameters import StrategyParameters
+from tradeexecutor.strategy.redemption import (
+    BlockedRedemptionSummary,
+    RedemptionCheckResult,
+    RedemptionCycleDiagnostics,
+)
 from tradeexecutor.strategy.tag import StrategyTag
 from tradeexecutor.strategy.trading_strategy_universe import (
     TradingStrategyUniverse, load_partial_data,
@@ -317,6 +323,51 @@ def _get_available_supporting_pair_ids(
     return pair_ids
 
 
+def _get_blocked_redemption_results(alpha_model: AlphaModel) -> list[RedemptionCheckResult]:
+    """Collect blocked redemption checks from the current alpha model."""
+    results = []
+    for signal in alpha_model.signals.values():
+        for result in signal.redemption_check_results:
+            if not result.can_redeem:
+                results.append(result)
+    return results
+
+
+def _format_decimal(value) -> str | None:
+    """Format Decimal-like diagnostics without widening state payloads."""
+    if value is None:
+        return None
+    return str(value)
+
+
+def _make_blocked_redemption_summary(
+    result: RedemptionCheckResult,
+) -> BlockedRedemptionSummary:
+    """Convert one rich redemption result to a compact persisted summary."""
+    return BlockedRedemptionSummary(
+        pair_ticker=result.pair_ticker,
+        vault_address=result.vault_address,
+        stage=result.stage.value,
+        reason_code=result.reason_code.value if result.reason_code else None,
+        message=result.message,
+        safe_address=result.safe_address,
+        position_recorded_lockup_expires_at=result.position_recorded_lockup_expires_at,
+        user_lockup_expires_at=result.user_lockup_expires_at,
+        max_withdrawable=_format_decimal(result.max_withdrawable),
+        max_redemption=_format_decimal(result.max_redemption),
+    )
+
+
+def _group_blocked_redemption_reasons(
+    blocked_results: list[RedemptionCheckResult],
+) -> dict[str, int]:
+    """Group blocked redemption diagnostics by stable reason code."""
+    counts = Counter()
+    for result in blocked_results:
+        counts[result.reason_code.value if result.reason_code else "unknown"] += 1
+    return dict(counts)
+
+
 #
 # Strategy logic
 #
@@ -408,6 +459,9 @@ def decide_trades(input: StrategyInput) -> list[TradeExecution]:
     )
 
     if input.is_visualisation_enabled():
+        blocked_redemption_results = _get_blocked_redemption_results(alpha_model)
+        blocked_redemption_reason_counts = _group_blocked_redemption_reasons(blocked_redemption_results)
+
         try:
             top_signal = next(iter(alpha_model.get_signals_sorted_by_weight()))
             if top_signal.normalised_weight == 0:
@@ -443,6 +497,14 @@ def decide_trades(input: StrategyInput) -> list[TradeExecution]:
             """
         )
 
+        if blocked_redemption_results:
+            report += dedent_any(
+                f"""
+                Blocked redemption checks: {len(blocked_redemption_results)}
+                Blocked redemption reasons: {blocked_redemption_reason_counts}
+                """
+            )
+
         if top_signal:
             assert top_signal.position_size_risk
             report += dedent_any(
@@ -459,6 +521,26 @@ def decide_trades(input: StrategyInput) -> list[TradeExecution]:
 
         state.visualisation.add_message(timestamp, report)
         state.visualisation.set_discardable_data("alpha_model", alpha_model)
+        if input.execution_context.live_trading and blocked_redemption_results:
+            blocked_signal_count = len({
+                (result.pair_ticker, result.vault_address)
+                for result in blocked_redemption_results
+            })
+            cycle_diagnostics = RedemptionCycleDiagnostics(
+                cycle=input.cycle,
+                redeemable_capital=float(redeemable_capital),
+                locked_capital_carried_forward=float(locked_position_value),
+                blocked_signal_count=blocked_signal_count,
+                reason_counts=blocked_redemption_reason_counts,
+                blocked_redemptions=[
+                    _make_blocked_redemption_summary(result)
+                    for result in blocked_redemption_results
+                ],
+            )
+            state.visualisation.add_calculations(
+                timestamp,
+                cycle_diagnostics.to_dict(),
+            )
 
     return trades
 

--- a/strategies/hyper-ai.py
+++ b/strategies/hyper-ai.py
@@ -483,7 +483,7 @@ def decide_trades(input: StrategyInput) -> list[TradeExecution]:
             )
             state.visualisation.add_calculations(
                 timestamp,
-                cycle_diagnostics.to_dict(),
+                cycle_diagnostics.to_dict(encode_json=True),
             )
 
     return trades

--- a/strategies/test_only/hyper-ai-test.py
+++ b/strategies/test_only/hyper-ai-test.py
@@ -40,7 +40,6 @@ Win month                         87.5%      25.0%    25.0%
 
 import datetime
 import logging
-from collections import Counter
 
 import pandas as pd
 from eth_defi.token import USDC_NATIVE_TOKEN
@@ -94,9 +93,9 @@ from tradeexecutor.strategy.pandas_trader.trading_universe_input import \
     CreateTradingUniverseInput
 from tradeexecutor.strategy.parameters import StrategyParameters
 from tradeexecutor.strategy.redemption import (
-    BlockedRedemptionSummary,
-    RedemptionCheckResult,
-    RedemptionCycleDiagnostics,
+    collect_blocked_redemption_results,
+    create_redemption_cycle_diagnostics,
+    group_blocked_redemption_reasons,
 )
 from tradeexecutor.strategy.tag import StrategyTag
 from tradeexecutor.strategy.trading_strategy_universe import (
@@ -108,51 +107,6 @@ from tradeexecutor.strategy.weighting import weight_equal
 from tradeexecutor.utils.dedent import dedent_any
 
 logger = logging.getLogger(__name__)
-
-
-def _get_blocked_redemption_results(alpha_model: AlphaModel) -> list[RedemptionCheckResult]:
-    """Collect blocked redemption checks from the current alpha model."""
-    results = []
-    for signal in alpha_model.signals.values():
-        for result in signal.redemption_check_results:
-            if not result.can_redeem:
-                results.append(result)
-    return results
-
-
-def _format_decimal(value) -> str | None:
-    """Format Decimal-like diagnostics without widening state payloads."""
-    if value is None:
-        return None
-    return str(value)
-
-
-def _make_blocked_redemption_summary(
-    result: RedemptionCheckResult,
-) -> BlockedRedemptionSummary:
-    """Convert one rich redemption result to a compact persisted summary."""
-    return BlockedRedemptionSummary(
-        pair_ticker=result.pair_ticker,
-        vault_address=result.vault_address,
-        stage=result.stage.value,
-        reason_code=result.reason_code.value if result.reason_code else None,
-        message=result.message,
-        safe_address=result.safe_address,
-        position_recorded_lockup_expires_at=result.position_recorded_lockup_expires_at,
-        user_lockup_expires_at=result.user_lockup_expires_at,
-        max_withdrawable=_format_decimal(result.max_withdrawable),
-        max_redemption=_format_decimal(result.max_redemption),
-    )
-
-
-def _group_blocked_redemption_reasons(
-    blocked_results: list[RedemptionCheckResult],
-) -> dict[str, int]:
-    """Group blocked redemption diagnostics by stable reason code."""
-    counts = Counter()
-    for result in blocked_results:
-        counts[result.reason_code.value if result.reason_code else "unknown"] += 1
-    return dict(counts)
 
 #
 # Trading universe constants
@@ -439,8 +393,8 @@ def decide_trades(
     )
 
     if input.is_visualisation_enabled():
-        blocked_redemption_results = _get_blocked_redemption_results(alpha_model)
-        blocked_redemption_reason_counts = _group_blocked_redemption_reasons(blocked_redemption_results)
+        blocked_redemption_results = collect_blocked_redemption_results(alpha_model.signals)
+        blocked_redemption_reason_counts = group_blocked_redemption_reasons(blocked_redemption_results)
 
         try:
             top_signal = next(iter(alpha_model.get_signals_sorted_by_weight()))
@@ -499,20 +453,11 @@ def decide_trades(
         )
         state.visualisation.set_discardable_data("alpha_model", alpha_model)
         if input.execution_context.live_trading and blocked_redemption_results:
-            blocked_signal_count = len({
-                (result.pair_ticker, result.vault_address)
-                for result in blocked_redemption_results
-            })
-            cycle_diagnostics = RedemptionCycleDiagnostics(
+            cycle_diagnostics = create_redemption_cycle_diagnostics(
                 cycle=input.cycle,
                 redeemable_capital=float(redeemable_capital),
                 locked_capital_carried_forward=float(locked_position_value),
-                blocked_signal_count=blocked_signal_count,
-                reason_counts=blocked_redemption_reason_counts,
-                blocked_redemptions=[
-                    _make_blocked_redemption_summary(result)
-                    for result in blocked_redemption_results
-                ],
+                blocked_results=blocked_redemption_results,
             )
             state.visualisation.add_calculations(
                 timestamp,

--- a/strategies/test_only/hyper-ai-test.py
+++ b/strategies/test_only/hyper-ai-test.py
@@ -461,7 +461,7 @@ def decide_trades(
             )
             state.visualisation.add_calculations(
                 timestamp,
-                cycle_diagnostics.to_dict(),
+                cycle_diagnostics.to_dict(encode_json=True),
             )
 
     return trades

--- a/strategies/test_only/hyper-ai-test.py
+++ b/strategies/test_only/hyper-ai-test.py
@@ -40,6 +40,7 @@ Win month                         87.5%      25.0%    25.0%
 
 import datetime
 import logging
+from collections import Counter
 
 import pandas as pd
 from eth_defi.token import USDC_NATIVE_TOKEN
@@ -92,6 +93,11 @@ from tradeexecutor.strategy.pandas_trader.strategy_input import StrategyInput
 from tradeexecutor.strategy.pandas_trader.trading_universe_input import \
     CreateTradingUniverseInput
 from tradeexecutor.strategy.parameters import StrategyParameters
+from tradeexecutor.strategy.redemption import (
+    BlockedRedemptionSummary,
+    RedemptionCheckResult,
+    RedemptionCycleDiagnostics,
+)
 from tradeexecutor.strategy.tag import StrategyTag
 from tradeexecutor.strategy.trading_strategy_universe import (
     TradingStrategyUniverse, load_partial_data,
@@ -102,6 +108,51 @@ from tradeexecutor.strategy.weighting import weight_equal
 from tradeexecutor.utils.dedent import dedent_any
 
 logger = logging.getLogger(__name__)
+
+
+def _get_blocked_redemption_results(alpha_model: AlphaModel) -> list[RedemptionCheckResult]:
+    """Collect blocked redemption checks from the current alpha model."""
+    results = []
+    for signal in alpha_model.signals.values():
+        for result in signal.redemption_check_results:
+            if not result.can_redeem:
+                results.append(result)
+    return results
+
+
+def _format_decimal(value) -> str | None:
+    """Format Decimal-like diagnostics without widening state payloads."""
+    if value is None:
+        return None
+    return str(value)
+
+
+def _make_blocked_redemption_summary(
+    result: RedemptionCheckResult,
+) -> BlockedRedemptionSummary:
+    """Convert one rich redemption result to a compact persisted summary."""
+    return BlockedRedemptionSummary(
+        pair_ticker=result.pair_ticker,
+        vault_address=result.vault_address,
+        stage=result.stage.value,
+        reason_code=result.reason_code.value if result.reason_code else None,
+        message=result.message,
+        safe_address=result.safe_address,
+        position_recorded_lockup_expires_at=result.position_recorded_lockup_expires_at,
+        user_lockup_expires_at=result.user_lockup_expires_at,
+        max_withdrawable=_format_decimal(result.max_withdrawable),
+        max_redemption=_format_decimal(result.max_redemption),
+    )
+
+
+def _group_blocked_redemption_reasons(
+    blocked_results: list[RedemptionCheckResult],
+) -> dict[str, int]:
+    """Group blocked redemption diagnostics by stable reason code."""
+    counts = Counter()
+    for result in blocked_results:
+        counts[result.reason_code.value if result.reason_code else "unknown"] += 1
+    return dict(counts)
 
 #
 # Trading universe constants
@@ -388,6 +439,9 @@ def decide_trades(
     )
 
     if input.is_visualisation_enabled():
+        blocked_redemption_results = _get_blocked_redemption_results(alpha_model)
+        blocked_redemption_reason_counts = _group_blocked_redemption_reasons(blocked_redemption_results)
+
         try:
             top_signal = next(iter(alpha_model.get_signals_sorted_by_weight()))
             if top_signal.normalised_weight == 0:
@@ -421,6 +475,12 @@ def decide_trades(
         Rebalance volume: {rebalance_volume:,.2f} USD
         """)
 
+        if blocked_redemption_results:
+            report += dedent_any(f"""
+            Blocked redemption checks: {len(blocked_redemption_results)}
+            Blocked redemption reasons: {blocked_redemption_reason_counts}
+            """)
+
         if top_signal:
             assert top_signal.position_size_risk
             report += dedent_any(f"""
@@ -438,6 +498,26 @@ def decide_trades(
             report,
         )
         state.visualisation.set_discardable_data("alpha_model", alpha_model)
+        if input.execution_context.live_trading and blocked_redemption_results:
+            blocked_signal_count = len({
+                (result.pair_ticker, result.vault_address)
+                for result in blocked_redemption_results
+            })
+            cycle_diagnostics = RedemptionCycleDiagnostics(
+                cycle=input.cycle,
+                redeemable_capital=float(redeemable_capital),
+                locked_capital_carried_forward=float(locked_position_value),
+                blocked_signal_count=blocked_signal_count,
+                reason_counts=blocked_redemption_reason_counts,
+                blocked_redemptions=[
+                    _make_blocked_redemption_summary(result)
+                    for result in blocked_redemption_results
+                ],
+            )
+            state.visualisation.add_calculations(
+                timestamp,
+                cycle_diagnostics.to_dict(),
+            )
 
     return trades
 

--- a/tests/backtest/test_hyper_ai_allocation_lockup_backtest.py
+++ b/tests/backtest/test_hyper_ai_allocation_lockup_backtest.py
@@ -22,6 +22,7 @@ from tradeexecutor.strategy.default_routing_options import TradeRouting
 from tradeexecutor.strategy.execution_context import ExecutionContext, ExecutionMode
 from tradeexecutor.strategy.pandas_trader.indicator import IndicatorSet
 from tradeexecutor.strategy.pandas_trader.strategy_input import StrategyInput
+from tradeexecutor.strategy.redemption import RedemptionCheckResult, RedemptionCheckStage
 from tradeexecutor.strategy.reserve_currency import ReserveCurrency
 from tradeexecutor.strategy.strategy_module import StrategyParameters
 from tradeexecutor.strategy.trading_strategy_universe import TradingStrategyUniverse, create_pair_universe_from_code
@@ -120,13 +121,24 @@ def decide_trades(input: StrategyInput) -> list[TradeExecution]:
     }
 
     # 2. Carry any non-redeemable Hypercore positions forward at their current marked value.
-    locked_position_value = alpha_model.carry_forward_non_redeemable_positions(
-        position_manager,
-        can_redeem=lambda position: get_redeemable_capital(
+    def _check_redemption(ts, pair, *, stage=RedemptionCheckStage.unknown, position=None):
+        del pair
+        assert position is not None
+        redeemable_capital = get_redeemable_capital(
             position,
             timestamp=input.timestamp,
-        ) > 0,
-    )
+        )
+        return RedemptionCheckResult(
+            timestamp=ts,
+            stage=stage,
+            can_redeem=redeemable_capital > 0,
+            pair_ticker=position.pair.get_ticker(),
+            vault_address=position.pair.pool_address,
+            max_redemption=redeemable_capital,
+        )
+
+    input.pricing_model.check_redemption = _check_redemption
+    locked_position_value = alpha_model.carry_forward_non_redeemable_positions(position_manager)
 
     portfolio_target_value = calculate_portfolio_target_value(
         position_manager,

--- a/tests/erc_4626/test_vault_pricing.py
+++ b/tests/erc_4626/test_vault_pricing.py
@@ -12,6 +12,7 @@ from tradeexecutor.state.trade import TradeExecution, TradeType
 from tradeexecutor.state.valuation import ValuationUpdate
 from tradeexecutor.strategy.generic.generic_pricing_model import GenericPricing
 from tradeexecutor.state.identifier import TradingPairIdentifier
+from tradeexecutor.strategy.redemption import RedemptionCheckStage
 from eth_defi.compat import native_datetime_utc_now
 
 
@@ -137,8 +138,16 @@ def test_vault_redemption_closed_when_max_redeem_zero(
     monkeypatch.setattr(vault_pricing, "get_vault", lambda pair: fake_vault)
 
     max_redemption = vault_pricing.get_max_redemption(None, ipor_usdc)
+    redemption_check = vault_pricing.check_redemption(
+        None,
+        ipor_usdc,
+        stage=RedemptionCheckStage.sell_rebalance,
+    )
     assert max_redemption == 0
     assert vault_pricing.can_redeem(None, ipor_usdc) is False
+    assert redemption_check.can_redeem is False
+    assert redemption_check.stage == RedemptionCheckStage.sell_rebalance
+    assert redemption_check.max_redemption == 0
 
 
 def test_vault_tradeability_defaults_to_open_when_owner_unknown(
@@ -152,6 +161,7 @@ def test_vault_tradeability_defaults_to_open_when_owner_unknown(
 
     assert vault_pricing.get_max_deposit(None, ipor_usdc) is None
     assert vault_pricing.get_max_redemption(None, ipor_usdc) is None
+    assert vault_pricing.check_redemption(None, ipor_usdc).can_redeem is True
     assert vault_pricing.can_deposit(None, ipor_usdc) is True
     assert vault_pricing.can_redeem(None, ipor_usdc) is True
     assert vault_pricing.is_tradeable(None, ipor_usdc) is True

--- a/tests/hypercore_writer/test_hyper_ai_live_loop.py
+++ b/tests/hypercore_writer/test_hyper_ai_live_loop.py
@@ -413,7 +413,7 @@ def test_hyper_ai_live_cycle_persists_blocked_redemption_diagnostics(
             position_recorded_lockup_expires_at=datetime.datetime(2026, 2, 1),
             user_lockup_expires_at=datetime.datetime(2026, 2, 1),
             message="Vault user lockup has not expired yet",
-            max_redemption=Decimal(0),
+            max_redemption=0.0,
         )],
     )
     monkeypatch.setattr(
@@ -435,7 +435,7 @@ def test_hyper_ai_live_cycle_persists_blocked_redemption_diagnostics(
             position_recorded_lockup_expires_at=datetime.datetime(2026, 2, 1),
             user_lockup_expires_at=datetime.datetime(2026, 2, 1),
             message="Hypercore user lockup has not expired yet",
-            max_redemption=Decimal(0),
+            max_redemption=0.0,
         ),
     )
     blocked_input = make_hyper_ai_strategy_input(

--- a/tests/hypercore_writer/test_hyper_ai_live_loop.py
+++ b/tests/hypercore_writer/test_hyper_ai_live_loop.py
@@ -401,9 +401,9 @@ def test_hyper_ai_live_cycle_persists_blocked_redemption_diagnostics(
     # 2. Run a second live-style cycle with a deterministic blocked redemption result and the vault excluded from inclusion criteria.
     monkeypatch.setattr(
         hyper_ai_strategy_module,
-        "_get_blocked_redemption_results",
-        lambda alpha_model: [RedemptionCheckResult(
-            timestamp=alpha_model.timestamp,
+        "collect_blocked_redemption_results",
+        lambda signals: [RedemptionCheckResult(
+            timestamp=datetime.datetime(2026, 1, 28),
             stage=RedemptionCheckStage.carry_forward,
             can_redeem=False,
             reason_code=RedemptionBlockReason.user_lockup_not_expired,
@@ -418,7 +418,7 @@ def test_hyper_ai_live_cycle_persists_blocked_redemption_diagnostics(
     )
     monkeypatch.setattr(
         hyper_ai_strategy_module,
-        "_group_blocked_redemption_reasons",
+        "group_blocked_redemption_reasons",
         lambda blocked_results: {"user_lockup_not_expired": len(blocked_results)},
     )
     monkeypatch.setattr(

--- a/tests/hypercore_writer/test_hyper_ai_live_loop.py
+++ b/tests/hypercore_writer/test_hyper_ai_live_loop.py
@@ -23,6 +23,11 @@ from tradeexecutor.strategy.generic.generic_valuation import GenericValuation
 from tradeexecutor.strategy.pandas_trader.position_manager import \
     PositionManager
 from tradeexecutor.strategy.pandas_trader.strategy_input import StrategyInput
+from tradeexecutor.strategy.redemption import (
+    RedemptionBlockReason,
+    RedemptionCheckResult,
+    RedemptionCheckStage,
+)
 from tradeexecutor.strategy.trading_strategy_universe import \
     TradingStrategyUniverse
 from tradeexecutor.testing.hypercore import (
@@ -325,6 +330,149 @@ def test_hyper_ai_hypercore_open_cycle(
 
     assert_single_multicall_trade(trade, note_substring="Hypercore deposit (simulate)")
     assert len(state.portfolio.open_positions) == 1
+
+
+@pytest.mark.timeout(300)
+def test_hyper_ai_live_cycle_persists_blocked_redemption_diagnostics(
+    monkeypatch: pytest.MonkeyPatch,
+    hyper_ai_strategy_module: ModuleType,
+    make_fake_indicators: IndicatorFactory,
+    deposited_hypercore_vault_state: tuple[LagoonVault, State],
+    hypercore_execution_model: LagoonExecution,
+    hypercore_pricing_model: GenericPricing,
+    hypercore_routing_model: GenericRouting,
+    hypercore_strategy_universe: TradingStrategyUniverse,
+    hypercore_sync_model: LagoonVaultSyncModel,
+    hypercore_valuation_model: GenericValuation,
+    hypercore_vault_pair: TradingPairIdentifier,
+) -> None:
+    """Persist blocked redemption diagnostics only for live-style blocked cycles.
+
+    1. Run one live-style open cycle before any lockup block is expected and verify no noisy calculations are stored.
+    2. Run a second live-style decision cycle with a deterministic blocked redemption result and the vault excluded from inclusion criteria.
+    3. Verify the blocked cycle stores compact calculations and still persists the latest alpha-model snapshot.
+    """
+    # 1. Run one live-style open cycle before any lockup block is expected and verify no noisy calculations are stored.
+    install_hypercore_wait_failures(monkeypatch)
+    monkeypatch.setattr(hyper_ai_strategy_module, "is_quarantined", lambda pool_address, timestamp: False)
+
+    vault, state = deposited_hypercore_vault_state
+    del vault
+    pair = hypercore_strategy_universe.get_pair_by_id(hypercore_vault_pair.internal_id)
+    parameters = create_hyper_ai_test_parameters(
+        hyper_ai_strategy_module,
+        initial_cash=100.0,
+        allocation=0.50,
+    )
+
+    hypercore_execution_model.initialize()
+    routing_state = hypercore_routing_model.create_routing_state(
+        hypercore_strategy_universe,
+        hypercore_execution_model.get_routing_state_details(),
+    )
+    ensure_hypercore_routing_state(
+        hypercore_routing_model,
+        routing_state,
+        pair,
+    )
+
+    open_cycle = run_hyper_ai_cycle(
+        hyper_ai_strategy_module=hyper_ai_strategy_module,
+        make_fake_indicators=make_fake_indicators,
+        cycle=1,
+        timestamp=datetime.datetime(2026, 1, 21),
+        include_pair=True,
+        state=state,
+        strategy_universe=hypercore_strategy_universe,
+        sync_model=hypercore_sync_model,
+        execution_model=hypercore_execution_model,
+        pricing_model=hypercore_pricing_model,
+        routing_model=hypercore_routing_model,
+        routing_state=routing_state,
+        valuation_model=hypercore_valuation_model,
+        pair=pair,
+        parameters=parameters,
+        execution_mode=ExecutionMode.unit_testing_trading,
+    )
+
+    assert len(open_cycle.trades) == 1
+    assert state.visualisation.calculations == {}
+
+    # 2. Run a second live-style cycle with a deterministic blocked redemption result and the vault excluded from inclusion criteria.
+    monkeypatch.setattr(
+        hyper_ai_strategy_module,
+        "_get_blocked_redemption_results",
+        lambda alpha_model: [RedemptionCheckResult(
+            timestamp=alpha_model.timestamp,
+            stage=RedemptionCheckStage.carry_forward,
+            can_redeem=False,
+            reason_code=RedemptionBlockReason.user_lockup_not_expired,
+            pair_ticker=pair.get_ticker(),
+            vault_address=pair.pool_address,
+            safe_address="0x0000000000000000000000000000000000000abc",
+            position_recorded_lockup_expires_at=datetime.datetime(2026, 2, 1),
+            user_lockup_expires_at=datetime.datetime(2026, 2, 1),
+            message="Vault user lockup has not expired yet",
+            max_redemption=Decimal(0),
+        )],
+    )
+    monkeypatch.setattr(
+        hyper_ai_strategy_module,
+        "_group_blocked_redemption_reasons",
+        lambda blocked_results: {"user_lockup_not_expired": len(blocked_results)},
+    )
+    monkeypatch.setattr(
+        hypercore_pricing_model,
+        "check_redemption",
+        lambda ts, checked_pair, **kwargs: RedemptionCheckResult(
+            timestamp=ts,
+            stage=kwargs["stage"],
+            can_redeem=False,
+            reason_code=RedemptionBlockReason.user_lockup_not_expired,
+            pair_ticker=checked_pair.get_ticker(),
+            vault_address=checked_pair.pool_address,
+            safe_address="0x0000000000000000000000000000000000000abc",
+            position_recorded_lockup_expires_at=datetime.datetime(2026, 2, 1),
+            user_lockup_expires_at=datetime.datetime(2026, 2, 1),
+            message="Hypercore user lockup has not expired yet",
+            max_redemption=Decimal(0),
+        ),
+    )
+    blocked_input = make_hyper_ai_strategy_input(
+        hyper_ai_strategy_module=hyper_ai_strategy_module,
+        make_fake_indicators=make_fake_indicators,
+        state=state,
+        strategy_universe=hypercore_strategy_universe,
+        pricing_model=hypercore_pricing_model,
+        routing_model=hypercore_routing_model,
+        routing_state=routing_state,
+        pair=pair,
+        timestamp=datetime.datetime(2026, 1, 28),
+        cycle=2,
+        include_pair=False,
+        parameters=parameters,
+        execution_mode=ExecutionMode.unit_testing_trading,
+    )
+    blocked_trades = hyper_ai_strategy_module.decide_trades(blocked_input)
+
+    assert blocked_trades == []
+    assert len(state.visualisation.calculations) == 1
+
+    # 3. Verify the blocked cycle stores compact calculations and the latest alpha-model snapshot still persists.
+    calculations = next(iter(state.visualisation.calculations.values()))
+    assert calculations["blocked_signal_count"] == 1
+    assert calculations["reason_counts"]["user_lockup_not_expired"] == 1
+    assert calculations["blocked_redemptions"][0]["reason_code"] == "user_lockup_not_expired"
+    assert "lockup" in calculations["blocked_redemptions"][0]["message"].lower()
+
+    alpha_model = state.visualisation.discardable_data["alpha_model"]
+    assert alpha_model is not None
+
+    restored_state = State.read_json_blob(state.to_json_safe())
+    restored_calculations = next(iter(restored_state.visualisation.calculations.values()))
+    assert restored_calculations["blocked_redemptions"][0]["reason_code"] == "user_lockup_not_expired"
+    restored_alpha_model = restored_state.visualisation.discardable_data["alpha_model"]
+    assert restored_alpha_model is not None
 
 
 @pytest.mark.timeout(300)

--- a/tests/hyperliquid/test_close_dust_hypercore.py
+++ b/tests/hyperliquid/test_close_dust_hypercore.py
@@ -24,6 +24,7 @@ from eth_defi.compat import native_datetime_utc_now
 from eth_defi.hyperliquid.api import UserVaultEquity
 
 from tradeexecutor.cli.close_position import close_single_or_all_positions
+from tradeexecutor.analysis.redemption_audit import audit_redemption_state
 from tradeexecutor.state.state import State
 from tradeexecutor.state.trade import TradeType
 from tradeexecutor.strategy.account_correction import _build_hypercore_vault_account_checks
@@ -222,3 +223,26 @@ def test_close_dust_hypercore_and_account_correction(
     for p in remaining_vault_positions:
         assert p.position_id in checked_position_ids, \
             f"Open position #{p.position_id} should appear in account corrections"
+
+
+def test_sample_state_audit_reports_blocked_redemption_rows() -> None:
+    """Audit the sample Hyper AI state for blocked redemption rows.
+
+    1. Load the sample Hyper AI state fixture that already contains cannot_redeem signals.
+    2. Run the read-only audit helper against a far-future timestamp so expired recorded lockups are easy to detect.
+    3. Verify the helper returns blocked rows with readable identifiers and at least one mismatch candidate.
+    """
+    # 1. Load the sample Hyper AI state fixture that already contains cannot_redeem signals.
+    state = State.read_json_file(SAMPLE_STATE_FILE)
+
+    # 2. Run the read-only audit helper against a far-future timestamp so expired recorded lockups are easy to detect.
+    rows, mismatch_count = audit_redemption_state(
+        state,
+        now=datetime.datetime(2026, 12, 31),
+    )
+
+    # 3. Verify the helper returns blocked rows with readable identifiers and at least one mismatch candidate.
+    assert rows, "Expected at least one blocked redemption row from the sample state"
+    assert mismatch_count >= 1
+    assert rows[0].pair_ticker is not None
+    assert rows[0].vault_address is not None

--- a/tests/hyperliquid/test_hypercore_tradeability.py
+++ b/tests/hyperliquid/test_hypercore_tradeability.py
@@ -18,6 +18,11 @@ from tradeexecutor.ethereum.vault.hypercore_vault import (
     create_hypercore_vault_pair,
 )
 from tradeexecutor.state.identifier import AssetIdentifier
+from tradeexecutor.strategy.redemption import (
+    RedemptionBlockReason,
+    RedemptionCheckResult,
+    RedemptionCheckStage,
+)
 
 
 def _make_pair() -> object:
@@ -136,6 +141,12 @@ def test_hypercore_redemption_closed_during_lockup(
     pricing: HypercoreVaultPricing,
     monkeypatch: pytest.MonkeyPatch,
 ):
+    """Check Hypercore lockup diagnostics report a blocked user lockup.
+
+    1. Mock a vault with withdrawable liquidity but a user lockup still in force.
+    2. Run both the legacy and structured redemption checks.
+    3. Verify the structured result records the user-lockup reason and stage.
+    """
     pair = _make_pair()
     monkeypatch.setattr(pricing, "_get_vault_info", lambda pair: _make_info())
     monkeypatch.setattr(
@@ -147,14 +158,31 @@ def test_hypercore_redemption_closed_during_lockup(
         ),
     )
 
+    # 1. Mock a vault with withdrawable liquidity but a user lockup still in force.
+    result = pricing.check_redemption(None, pair, stage=RedemptionCheckStage.carry_forward)
+
+    # 2. Run both the legacy and structured redemption checks.
     assert pricing.get_max_redemption(None, pair) == 0
     assert pricing.can_redeem(None, pair) is False
+    assert result.can_redeem is False
+
+    # 3. Verify the structured result records the user-lockup reason and stage.
+    assert result.reason_code == RedemptionBlockReason.user_lockup_not_expired
+    assert result.stage == RedemptionCheckStage.carry_forward
+    assert result.user_lockup_expires_at is not None
+    assert result.max_redemption == 0
 
 
 def test_hypercore_redemption_closed_when_vault_has_no_withdrawable_liquidity(
     pricing: HypercoreVaultPricing,
     monkeypatch: pytest.MonkeyPatch,
 ):
+    """Check Hypercore diagnostics report a zero-withdrawable vault block.
+
+    1. Mock a vault whose user lockup is expired but whose max withdrawable value is zero.
+    2. Run both the legacy and structured redemption checks.
+    3. Verify the structured result records the vault-liquidity block reason.
+    """
     pair = _make_pair()
     monkeypatch.setattr(pricing, "_get_vault_info", lambda pair: _make_info(max_withdrawable=Decimal("0")))
     monkeypatch.setattr(
@@ -166,14 +194,31 @@ def test_hypercore_redemption_closed_when_vault_has_no_withdrawable_liquidity(
         ),
     )
 
+    # 1. Mock a vault whose user lockup is expired but whose max withdrawable value is zero.
+    result = pricing.check_redemption(None, pair, stage=RedemptionCheckStage.sell_rebalance)
+
+    # 2. Run both the legacy and structured redemption checks.
     assert pricing.get_max_redemption(None, pair) == 0
     assert pricing.can_redeem(None, pair) is False
+    assert result.can_redeem is False
+
+    # 3. Verify the structured result records the vault-liquidity block reason.
+    assert result.reason_code == RedemptionBlockReason.vault_max_withdrawable_zero
+    assert result.stage == RedemptionCheckStage.sell_rebalance
+    assert result.max_withdrawable == 0
+    assert result.max_redemption == 0
 
 
 def test_hypercore_redemption_allowed_when_lockup_expired(
     pricing: HypercoreVaultPricing,
     monkeypatch: pytest.MonkeyPatch,
 ):
+    """Check Hypercore diagnostics report an allowed redemption and round-trip cleanly.
+
+    1. Mock a vault with an expired user lockup and positive withdrawable liquidity.
+    2. Run both the legacy and structured redemption checks.
+    3. Verify the structured result round-trips through dataclasses-json intact.
+    """
     pair = _make_pair()
     monkeypatch.setattr(pricing, "_get_vault_info", lambda pair: _make_info(max_withdrawable=Decimal("40")))
     monkeypatch.setattr(
@@ -185,10 +230,27 @@ def test_hypercore_redemption_allowed_when_lockup_expired(
         ),
     )
 
+    # 1. Mock a vault with an expired user lockup and positive withdrawable liquidity.
+    result = pricing.check_redemption(None, pair, stage=RedemptionCheckStage.sell_rebalance)
+
+    # 2. Run both the legacy and structured redemption checks.
     assert pricing.get_max_redemption(None, pair) == Decimal("40")
     assert pricing.can_redeem(None, pair) is True
     assert pricing.is_tradeable(None, pair) is True
+    assert result.can_redeem is True
+    assert result.reason_code is None
+    assert result.max_redemption == Decimal("40")
+    assert result.raw_api_data is not None
+    assert result.raw_api_data.vault_info is not None
+    assert result.raw_api_data.user_equity is not None
 
+    # 3. Verify the structured result round-trips through dataclasses-json intact.
+    restored = RedemptionCheckResult.from_json(result.to_json())
+    assert restored.can_redeem is True
+    assert restored.stage == RedemptionCheckStage.sell_rebalance
+    assert restored.max_redemption == Decimal("40")
+    assert restored.raw_api_data is not None
+    assert restored.raw_api_data.user_equity is not None
 
 def test_hypercore_redemption_defaults_to_open_when_safe_unknown(
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/hyperliquid/test_hypercore_tradeability.py
+++ b/tests/hyperliquid/test_hypercore_tradeability.py
@@ -170,7 +170,7 @@ def test_hypercore_redemption_closed_during_lockup(
     assert result.reason_code == RedemptionBlockReason.user_lockup_not_expired
     assert result.stage == RedemptionCheckStage.carry_forward
     assert result.user_lockup_expires_at is not None
-    assert result.max_redemption == 0
+    assert result.max_redemption == pytest.approx(0.0)
 
 
 def test_hypercore_redemption_closed_when_vault_has_no_withdrawable_liquidity(
@@ -205,8 +205,8 @@ def test_hypercore_redemption_closed_when_vault_has_no_withdrawable_liquidity(
     # 3. Verify the structured result records the vault-liquidity block reason.
     assert result.reason_code == RedemptionBlockReason.vault_max_withdrawable_zero
     assert result.stage == RedemptionCheckStage.sell_rebalance
-    assert result.max_withdrawable == 0
-    assert result.max_redemption == 0
+    assert result.max_withdrawable == pytest.approx(0.0)
+    assert result.max_redemption == pytest.approx(0.0)
 
 
 def test_hypercore_redemption_allowed_when_lockup_expired(
@@ -239,7 +239,7 @@ def test_hypercore_redemption_allowed_when_lockup_expired(
     assert pricing.is_tradeable(None, pair) is True
     assert result.can_redeem is True
     assert result.reason_code is None
-    assert result.max_redemption == Decimal("40")
+    assert result.max_redemption == pytest.approx(40.0)
     assert result.raw_api_data is not None
     assert result.raw_api_data.vault_info is not None
     assert result.raw_api_data.user_equity is not None
@@ -248,7 +248,7 @@ def test_hypercore_redemption_allowed_when_lockup_expired(
     restored = RedemptionCheckResult.from_json(result.to_json())
     assert restored.can_redeem is True
     assert restored.stage == RedemptionCheckStage.sell_rebalance
-    assert restored.max_redemption == Decimal("40")
+    assert restored.max_redemption == pytest.approx(40.0)
     assert restored.raw_api_data is not None
     assert restored.raw_api_data.user_equity is not None
 

--- a/tests/test_rebalance.py
+++ b/tests/test_rebalance.py
@@ -32,6 +32,11 @@ from tradeexecutor.strategy.fixed_size_risk import FixedSizeRiskModel
 from tradeexecutor.strategy.pandas_trader.position_manager import PositionManager
 from tradeexecutor.strategy.pandas_trader.rebalance import get_existing_portfolio_weights, rebalance_portfolio_old, \
     get_weight_diffs
+from tradeexecutor.strategy.redemption import (
+    RedemptionBlockReason,
+    RedemptionCheckResult,
+    RedemptionCheckStage,
+)
 from tradeexecutor.strategy.weighting import BadWeightsException, clip_to_normalised, weight_passthrouh
 from tradeexecutor.strategy.trading_strategy_universe import TradingStrategyUniverse, create_pair_universe_from_code
 from tradeexecutor.testing.synthetic_ethereum_data import generate_random_ethereum_address
@@ -1615,6 +1620,7 @@ def test_alpha_model_carries_forward_locked_hypercore_vault(
         reserve_currency=usdc,
     )
     locked_position.trades[1] = locked_trade
+    locked_position.other_data["vault_lockup_expires_at"] = "2022-01-03T00:00:00"
     state.portfolio.open_positions = {1: locked_position}
 
     position_manager = PositionManager(
@@ -1623,11 +1629,45 @@ def test_alpha_model_carries_forward_locked_hypercore_vault(
         state,
         pricing_model,
     )
+    original_get_mid_price = pricing_model.get_mid_price
+    monkeypatch.setattr(
+        pricing_model,
+        "get_mid_price",
+        lambda ts, pair: 1.0 if pair == hypercore_vault_pair else original_get_mid_price(ts, pair),
+    )
 
     monkeypatch.setattr(
         pricing_model,
-        "can_redeem",
-        lambda ts, pair: pair != hypercore_vault_pair,
+        "check_redemption",
+        lambda ts, pair, **kwargs: RedemptionCheckResult(
+            timestamp=ts,
+            stage=kwargs["stage"],
+            can_redeem=pair != hypercore_vault_pair,
+            reason_code=(
+                RedemptionBlockReason.user_lockup_not_expired
+                if pair == hypercore_vault_pair
+                else None
+            ),
+            pair_ticker=pair.get_ticker(),
+            vault_address=pair.pool_address,
+            safe_address="0x0000000000000000000000000000000000000abc",
+            position_recorded_lockup_expires_at=(
+                datetime.datetime(2022, 1, 3)
+                if pair == hypercore_vault_pair
+                else None
+            ),
+            user_lockup_expires_at=(
+                datetime.datetime(2022, 1, 3)
+                if pair == hypercore_vault_pair
+                else None
+            ),
+            message=(
+                "Hypercore user lockup has not expired yet"
+                if pair == hypercore_vault_pair
+                else None
+            ),
+            max_redemption=Decimal(0) if pair == hypercore_vault_pair else None,
+        ),
     )
 
     alpha_model = AlphaModel(timestamp=position_manager.timestamp)
@@ -1657,11 +1697,134 @@ def test_alpha_model_carries_forward_locked_hypercore_vault(
     # 3. Verify the locked vault stays pinned with zero adjustment and only the free cash becomes a buy trade.
     assert locked_signal.position_adjust_usd == pytest.approx(0.0)
     assert TradingPairSignalFlags.cannot_redeem in locked_signal.flags
+    assert len(locked_signal.redemption_check_results) == 1
+    assert locked_signal.redemption_check_results[0].stage == RedemptionCheckStage.carry_forward
+    assert locked_signal.redemption_check_results[0].reason_code == RedemptionBlockReason.user_lockup_not_expired
+
+    restored_signal = locked_signal.__class__.from_json(locked_signal.to_json())
+    assert len(restored_signal.redemption_check_results) == 1
+    assert restored_signal.redemption_check_results[0].stage == RedemptionCheckStage.carry_forward
+
     assert all(trade.pair != hypercore_vault_pair for trade in trades)
     assert len(trades) == 1
     assert trades[0].is_buy()
     assert trades[0].pair == aave_usdc
     assert trades[0].get_planned_value() == pytest.approx(2500.0)
+
+
+def test_alpha_model_skips_sell_rebalance_for_non_redeemable_position(
+    start_ts: datetime.datetime,
+    strategy_universe: TradingStrategyUniverse,
+    pricing_model: BacktestPricing,
+    usdc: AssetIdentifier,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Check AlphaModel stores sell-side redemption diagnostics when a reduction is blocked.
+
+    1. Build a portfolio with one open Hypercore vault position and no carry-forward pinning.
+    2. Ask the alpha model to shrink that position while the pricing model reports it as non-redeemable.
+    3. Verify the sell rebalance is skipped and the signal stores the sell-stage diagnostics.
+    """
+    state = State()
+    hypercore_vault_pair = TradingPairIdentifier(
+        base=AssetIdentifier(1, "0x1234567890123456789012345678901234567890", "pmalt", 18),
+        quote=usdc,
+        pool_address="0x1234567890123456789012345678901234567891",
+        exchange_address="0x1234567890123456789012345678901234567892",
+        internal_id=101,
+        kind=TradingPairKind.vault,
+        fee=0,
+    )
+    hypercore_vault_pair.other_data["vault_protocol"] = "hypercore"
+
+    locked_position = TradingPosition(
+        position_id=1,
+        opened_at=start_ts,
+        pair=hypercore_vault_pair,
+        last_pricing_at=start_ts,
+        last_token_price=USDollarPrice(1.0),
+        last_reserve_price=USDollarPrice(1.0),
+        reserve_currency=usdc,
+    )
+    locked_position.other_data["vault_lockup_expires_at"] = "2022-01-03T00:00:00"
+    locked_trade = TradeExecution(
+        trade_id=1,
+        position_id=1,
+        trade_type=TradeType.rebalance,
+        pair=hypercore_vault_pair,
+        opened_at=start_ts,
+        planned_quantity=Decimal(5000),
+        executed_quantity=Decimal(5000),
+        planned_price=USDollarPrice(1.0),
+        executed_price=USDollarPrice(1.0),
+        lp_fees_estimated=USDollarAmount(0),
+        planned_reserve=USDollarAmount(5000),
+        executed_reserve=USDollarAmount(5000),
+        executed_at=start_ts,
+        reserve_currency=usdc,
+    )
+    locked_position.trades[1] = locked_trade
+    state.portfolio.open_positions = {1: locked_position}
+
+    position_manager = PositionManager(
+        start_ts + datetime.timedelta(days=1),
+        strategy_universe.data_universe,
+        state,
+        pricing_model,
+    )
+    original_get_mid_price = pricing_model.get_mid_price
+    monkeypatch.setattr(
+        pricing_model,
+        "get_mid_price",
+        lambda ts, pair: 1.0 if pair == hypercore_vault_pair else original_get_mid_price(ts, pair),
+    )
+
+    monkeypatch.setattr(
+        pricing_model,
+        "check_redemption",
+        lambda ts, pair, **kwargs: RedemptionCheckResult(
+            timestamp=ts,
+            stage=kwargs["stage"],
+            can_redeem=False,
+            reason_code=RedemptionBlockReason.user_lockup_not_expired,
+            pair_ticker=pair.get_ticker(),
+            vault_address=pair.pool_address,
+            safe_address="0x0000000000000000000000000000000000000abc",
+            position_recorded_lockup_expires_at=datetime.datetime(2022, 1, 3),
+            user_lockup_expires_at=datetime.datetime(2022, 1, 3),
+            message="Hypercore user lockup has not expired yet",
+            max_redemption=Decimal(0),
+        ),
+    )
+
+    alpha_model = AlphaModel(timestamp=position_manager.timestamp)
+    alpha_model.set_signal(hypercore_vault_pair, 1.0)
+
+    # 1. Build a portfolio with one open Hypercore vault position and no carry-forward pinning.
+    alpha_model.select_top_signals(count=5)
+    alpha_model.assign_weights(method=weight_passthrouh)
+    alpha_model.normalise_weights(max_weight=1.0)
+    alpha_model.update_old_weights(state.portfolio, ignore_credit=False)
+    alpha_model.calculate_target_positions(position_manager, investable_equity=1000.0)
+
+    # 2. Ask the alpha model to shrink that position while the pricing model reports it as non-redeemable.
+    trades = alpha_model.generate_rebalance_trades_and_triggers(
+        position_manager,
+        min_trade_threshold=0.01,
+        individual_rebalance_min_threshold=0.01,
+        sell_rebalance_min_threshold=0.01,
+    )
+
+    signal = alpha_model.get_signal_by_pair(hypercore_vault_pair)
+    assert signal is not None
+
+    # 3. Verify the sell rebalance is skipped and the signal stores the sell-stage diagnostics.
+    assert trades == []
+    assert signal.position_adjust_ignored is True
+    assert TradingPairSignalFlags.cannot_redeem in signal.flags
+    assert len(signal.redemption_check_results) == 1
+    assert signal.redemption_check_results[0].stage == RedemptionCheckStage.sell_rebalance
+    assert signal.redemption_check_results[0].reason_code == RedemptionBlockReason.user_lockup_not_expired
 
 
 def test_update_old_weights_reads_position_value_once(

--- a/tests/test_rebalance.py
+++ b/tests/test_rebalance.py
@@ -1666,7 +1666,7 @@ def test_alpha_model_carries_forward_locked_hypercore_vault(
                 if pair == hypercore_vault_pair
                 else None
             ),
-            max_redemption=Decimal(0) if pair == hypercore_vault_pair else None,
+            max_redemption=0.0 if pair == hypercore_vault_pair else None,
         ),
     )
 
@@ -1793,7 +1793,7 @@ def test_alpha_model_skips_sell_rebalance_for_non_redeemable_position(
             position_recorded_lockup_expires_at=datetime.datetime(2022, 1, 3),
             user_lockup_expires_at=datetime.datetime(2022, 1, 3),
             message="Hypercore user lockup has not expired yet",
-            max_redemption=Decimal(0),
+            max_redemption=0.0,
         ),
     )
 

--- a/tradeexecutor/analysis/hypercore_redemption_audit.py
+++ b/tradeexecutor/analysis/hypercore_redemption_audit.py
@@ -1,0 +1,6 @@
+"""Backwards-compatible aliases for generic redemption audit helpers."""
+
+from tradeexecutor.analysis.redemption_audit import (
+    RedemptionAuditRow as HypercoreRedemptionAuditRow,
+    audit_redemption_state as audit_hypercore_redemption_state,
+)

--- a/tradeexecutor/analysis/redemption_audit.py
+++ b/tradeexecutor/analysis/redemption_audit.py
@@ -1,0 +1,146 @@
+"""Read-only helpers for auditing redemption diagnostics from state."""
+
+import datetime
+from dataclasses import dataclass
+
+from tradeexecutor.state.state import State
+from tradeexecutor.strategy.redemption import parse_recorded_lockup_expires_at
+
+
+@dataclass(frozen=True, slots=True)
+class RedemptionAuditRow:
+    """One blocked-redemption audit row derived from saved state."""
+
+    #: Pair ticker for the blocked signal.
+    pair_ticker: str | None
+    #: Vault address for the blocked signal.
+    vault_address: str | None
+    #: Latest recorded redemption-check stage.
+    stage: str | None
+    #: Latest recorded redemption-check reason code.
+    reason_code: str | None
+    #: Human-readable explanation from the latest recorded result.
+    message: str | None
+    #: Safe address used in the latest recorded live lookup, if any.
+    safe_address: str | None
+    #: Lockup expiry stored on the position state.
+    position_recorded_lockup_expires_at: datetime.datetime | None
+    #: Lockup expiry returned by the latest live user equity lookup, if any.
+    user_lockup_expires_at: datetime.datetime | None
+    #: Whether the recorded position lockup expiry is already in the past.
+    recorded_lockup_expired: bool
+
+
+def _read_attr_or_key(value: object, key: str, default=None):
+    """Read a field from either a dataclass-like object or a plain dict."""
+    if value is None:
+        return default
+
+    if isinstance(value, dict):
+        return value.get(key, default)
+
+    return getattr(value, key, default)
+
+
+def _extract_stage_value(value: object) -> str | None:
+    """Normalise enum-like or plain-string values."""
+    if value is None:
+        return None
+
+    enum_value = getattr(value, "value", None)
+    if enum_value is not None:
+        return enum_value
+
+    return str(value)
+
+
+def _extract_latest_result(signal: object) -> object | None:
+    """Get the latest redemption result from a serialised or live signal."""
+    results = _read_attr_or_key(signal, "redemption_check_results", [])
+    if not results:
+        return None
+    return results[-1]
+
+
+def _extract_pair_ticker(pair: object) -> str | None:
+    """Resolve a readable ticker from a live or serialised pair object."""
+    ticker = _read_attr_or_key(pair, "ticker")
+    if ticker:
+        return ticker
+
+    base = _read_attr_or_key(pair, "base")
+    return _read_attr_or_key(base, "token_symbol")
+
+
+def audit_redemption_state(
+    state: State,
+    *,
+    now: datetime.datetime,
+) -> tuple[list[RedemptionAuditRow], int]:
+    """Inspect the latest alpha-model snapshot for blocked redemptions.
+
+    1. Read the latest ``discardable_data["alpha_model"]`` snapshot.
+    2. Find signals still marked with ``cannot_redeem``.
+    3. Compare their stored position lockup expiry against ``now``.
+    """
+    alpha_model = state.visualisation.discardable_data.get("alpha_model")
+    if alpha_model is None:
+        return [], 0
+
+    signals = _read_attr_or_key(alpha_model, "signals", {})
+    if not signals:
+        return [], 0
+
+    positions_by_pair_id = {
+        position.pair.internal_id: position
+        for position in state.portfolio.open_positions.values()
+    }
+
+    rows = []
+    for signal in signals.values():
+        flags = _read_attr_or_key(signal, "flags", [])
+        flag_values = {getattr(flag, "value", flag) for flag in flags}
+        if "cannot_redeem" not in flag_values:
+            continue
+
+        pair = _read_attr_or_key(signal, "pair")
+        pair_internal_id = _read_attr_or_key(pair, "internal_id")
+        position = positions_by_pair_id.get(pair_internal_id)
+
+        latest_result = _extract_latest_result(signal)
+        position_recorded_lockup_expires_at = None
+        if position is not None:
+            position_recorded_lockup_expires_at = parse_recorded_lockup_expires_at(
+                position.other_data.get("vault_lockup_expires_at"),
+            )
+        elif latest_result is not None:
+            position_recorded_lockup_expires_at = parse_recorded_lockup_expires_at(
+                _read_attr_or_key(
+                    latest_result,
+                    "position_recorded_lockup_expires_at",
+                )
+            )
+
+        recorded_lockup_expired = (
+            position_recorded_lockup_expires_at is not None
+            and position_recorded_lockup_expires_at <= now
+        )
+
+        rows.append(
+            RedemptionAuditRow(
+                pair_ticker=_extract_pair_ticker(pair),
+                vault_address=_read_attr_or_key(pair, "pool_address"),
+                stage=_extract_stage_value(_read_attr_or_key(latest_result, "stage")),
+                reason_code=_extract_stage_value(_read_attr_or_key(latest_result, "reason_code")),
+                message=_read_attr_or_key(latest_result, "message"),
+                safe_address=_read_attr_or_key(latest_result, "safe_address"),
+                position_recorded_lockup_expires_at=position_recorded_lockup_expires_at,
+                user_lockup_expires_at=parse_recorded_lockup_expires_at(
+                    _read_attr_or_key(latest_result, "user_lockup_expires_at"),
+                ),
+                recorded_lockup_expired=recorded_lockup_expired,
+            )
+        )
+
+    mismatch_count = sum(1 for row in rows if row.recorded_lockup_expired)
+    return rows, mismatch_count

--- a/tradeexecutor/ethereum/vault/hypercore_valuation.py
+++ b/tradeexecutor/ethereum/vault/hypercore_valuation.py
@@ -39,6 +39,16 @@ from tradeexecutor.state.identifier import TradingPairIdentifier
 from tradeexecutor.state.position import TradingPosition
 from tradeexecutor.state.valuation import ValuationUpdate
 from tradeexecutor.strategy.pricing_model import PricingModel
+from tradeexecutor.strategy.redemption import (
+    RedemptionApiSnapshot,
+    RedemptionBlockReason,
+    RedemptionCheckResult,
+    RedemptionCheckStage,
+    VaultInfoSnapshot,
+    VaultMetadataSnapshot,
+    VaultUserEquitySnapshot,
+    parse_recorded_lockup_expires_at,
+)
 from tradeexecutor.strategy.trade_pricing import TradePricing
 from tradeexecutor.strategy.valuation import ValuationModel
 from tradeexecutor.testing.hypercore_replay import (
@@ -337,11 +347,76 @@ class HypercoreVaultPricing(PricingModel):
             return Decimal(0)
         return None
 
-    def get_max_redemption(
+    def _build_metadata_snapshot(
+        self,
+        pair: TradingPairIdentifier,
+        position: TradingPosition | None = None,
+    ) -> VaultMetadataSnapshot:
+        """Capture the pair and position metadata used for diagnostics."""
+        pair_other_data = pair.other_data or {}
+        position_lockup_expires_at = None
+        if position is not None:
+            position_lockup_expires_at = parse_recorded_lockup_expires_at(
+                position.other_data.get("vault_lockup_expires_at"),
+            )
+
+        return VaultMetadataSnapshot(
+            vault_protocol=pair_other_data.get("vault_protocol"),
+            vault_name=pair_other_data.get("vault_name"),
+            deposit_closed_reason=pair_other_data.get("deposit_closed_reason"),
+            redemption_closed_reason=pair_other_data.get("redemption_closed_reason"),
+            redemption_next_open=pair_other_data.get("redemption_next_open"),
+            exchange_is_testnet=pair_other_data.get("exchange_is_testnet"),
+            position_recorded_lockup_expires_at=position_lockup_expires_at,
+        )
+
+    @staticmethod
+    def _build_vault_info_snapshot(info: VaultInfo) -> VaultInfoSnapshot:
+        """Capture the decision-relevant subset of ``vaultDetails``."""
+        return VaultInfoSnapshot(
+            name=info.name,
+            vault_address=info.vault_address,
+            max_withdrawable=info.max_withdrawable,
+            max_distributable=info.max_distributable,
+            is_closed=info.is_closed,
+            allow_deposits=info.allow_deposits,
+            relationship_type=info.relationship_type,
+            leader_fraction=float(info.leader_fraction) if info.leader_fraction is not None else None,
+            follower_count=len(info.followers),
+            parent=info.parent,
+        )
+
+    @staticmethod
+    def _build_user_equity_snapshot(eq) -> VaultUserEquitySnapshot:
+        """Capture the decision-relevant subset of ``fetch_user_vault_equity()``."""
+        return VaultUserEquitySnapshot(
+            vault_address=eq.vault_address,
+            equity=eq.equity,
+            locked_until=eq.locked_until,
+            is_lockup_expired=eq.is_lockup_expired,
+        )
+
+    def check_redemption(
         self,
         ts: datetime.datetime | None,
         pair: TradingPairIdentifier,
-    ) -> Decimal | None:
+        *,
+        stage: RedemptionCheckStage = RedemptionCheckStage.unknown,
+        position: TradingPosition | None = None,
+    ) -> RedemptionCheckResult:
+        metadata_snapshot = self._build_metadata_snapshot(pair, position)
+        result = RedemptionCheckResult(
+            timestamp=ts,
+            stage=stage,
+            can_redeem=True,
+            pair_ticker=pair.get_ticker(),
+            vault_address=pair.pool_address,
+            configured_redeem_delay_seconds=None,
+            configured_redeem_delay_source=None,
+            position_recorded_lockup_expires_at=metadata_snapshot.position_recorded_lockup_expires_at,
+            used_vault_metadata=metadata_snapshot,
+        )
+
         if self.market_data_source is not None:
             current_equity_usd = None
             if self.value_func is not None and not self.simulate:
@@ -352,26 +427,57 @@ class HypercoreVaultPricing(PricingModel):
                 pair,
                 current_equity_usd=current_equity_usd,
             )
+            result.max_withdrawable = snapshot.max_withdrawable_usd
 
             if not snapshot.lockup_expired:
-                return Decimal(0)
+                result.can_redeem = False
+                result.reason_code = RedemptionBlockReason.user_lockup_not_expired
+                result.max_redemption = Decimal(0)
+                result.message = "Replay snapshot reports that the user lockup has not expired yet"
+                return result
 
             if snapshot.max_withdrawable_usd is None:
-                return None
+                result.max_redemption = None
+                result.message = "Replay snapshot allows redemption but does not expose a hard cap"
+                return result
 
-            return snapshot.max_withdrawable_usd
+            if snapshot.max_withdrawable_usd <= 0:
+                result.can_redeem = False
+                result.reason_code = RedemptionBlockReason.vault_max_withdrawable_zero
+                result.max_redemption = Decimal(0)
+                result.message = "Replay snapshot reports zero max_withdrawable liquidity"
+                return result
+
+            result.max_redemption = snapshot.max_withdrawable_usd
+            result.message = "Replay snapshot allows redemption and caps it by max_withdrawable"
+            return result
 
         if self.simulate:
-            return None
+            result.max_redemption = None
+            result.message = "Simulate mode assumes redemption is available"
+            return result
 
         safe_address = self._get_safe_address(pair)
+        result.safe_address = safe_address
         if safe_address is None:
             logger.warning("Cannot resolve safe address for Hypercore redemption check: %s", pair)
-            return None
+            result.reason_code = RedemptionBlockReason.safe_address_unavailable
+            result.max_redemption = None
+            result.message = "Cannot resolve safe address for Hypercore redemption check"
+            return result
 
         info = self._get_vault_info(pair)
+        result.max_withdrawable = info.max_withdrawable
+        result.raw_api_data = RedemptionApiSnapshot(
+            vault_info=self._build_vault_info_snapshot(info),
+        )
+
         if info.max_withdrawable <= 0:
-            return Decimal(0)
+            result.can_redeem = False
+            result.reason_code = RedemptionBlockReason.vault_max_withdrawable_zero
+            result.max_redemption = Decimal(0)
+            result.message = "Hypercore vault reports zero max_withdrawable liquidity"
+            return result
 
         vault_address = pair.pool_address
         assert vault_address, f"No pool_address set for Hypercore vault pair: {pair}"
@@ -382,12 +488,32 @@ class HypercoreVaultPricing(PricingModel):
             bypass_cache=True,
         )
         if eq is None:
-            return Decimal(0)
+            result.can_redeem = False
+            result.reason_code = RedemptionBlockReason.user_equity_fetch_failed
+            result.max_redemption = Decimal(0)
+            result.message = "Hypercore user equity lookup returned no position data"
+            return result
+
+        result.raw_api_data.user_equity = self._build_user_equity_snapshot(eq)
+        result.user_lockup_expires_at = eq.locked_until
 
         if not eq.is_lockup_expired:
-            return Decimal(0)
+            result.can_redeem = False
+            result.reason_code = RedemptionBlockReason.user_lockup_not_expired
+            result.max_redemption = Decimal(0)
+            result.message = "Hypercore user lockup has not expired yet"
+            return result
 
-        return min(eq.equity, info.max_withdrawable)
+        result.max_redemption = min(eq.equity, info.max_withdrawable)
+        result.message = "Redemption allowed and capped by Hypercore max_withdrawable"
+        return result
+
+    def get_max_redemption(
+        self,
+        ts: datetime.datetime | None,
+        pair: TradingPairIdentifier,
+    ) -> Decimal | None:
+        return self.check_redemption(ts, pair).max_redemption
 
     def can_deposit(
         self,
@@ -408,29 +534,6 @@ class HypercoreVaultPricing(PricingModel):
 
         info = self._get_vault_info(pair)
         return get_hypercore_deposit_closed_reason(info) is None
-
-    def can_redeem(
-        self,
-        ts: datetime.datetime | None,
-        pair: TradingPairIdentifier,
-    ) -> bool:
-        if self.market_data_source is not None:
-            snapshot = self._get_market_snapshot(ts, pair)
-            if not snapshot.lockup_expired:
-                return False
-
-            if snapshot.max_withdrawable_usd is None:
-                return True
-
-            return snapshot.max_withdrawable_usd > 0
-
-        if self.simulate:
-            return True
-
-        max_redemption = self.get_max_redemption(ts, pair)
-        if max_redemption is None:
-            return True
-        return max_redemption > 0
 
 
 class HypercoreVaultValuator(ValuationModel):

--- a/tradeexecutor/ethereum/vault/hypercore_valuation.py
+++ b/tradeexecutor/ethereum/vault/hypercore_valuation.py
@@ -376,8 +376,8 @@ class HypercoreVaultPricing(PricingModel):
         return VaultInfoSnapshot(
             name=info.name,
             vault_address=info.vault_address,
-            max_withdrawable=info.max_withdrawable,
-            max_distributable=info.max_distributable,
+            max_withdrawable=float(info.max_withdrawable) if info.max_withdrawable is not None else None,
+            max_distributable=float(info.max_distributable) if info.max_distributable is not None else None,
             is_closed=info.is_closed,
             allow_deposits=info.allow_deposits,
             relationship_type=info.relationship_type,
@@ -391,7 +391,7 @@ class HypercoreVaultPricing(PricingModel):
         """Capture the decision-relevant subset of ``fetch_user_vault_equity()``."""
         return VaultUserEquitySnapshot(
             vault_address=eq.vault_address,
-            equity=eq.equity,
+            equity=float(eq.equity) if eq.equity is not None else None,
             locked_until=eq.locked_until,
             is_lockup_expired=eq.is_lockup_expired,
         )
@@ -427,12 +427,12 @@ class HypercoreVaultPricing(PricingModel):
                 pair,
                 current_equity_usd=current_equity_usd,
             )
-            result.max_withdrawable = snapshot.max_withdrawable_usd
+            result.max_withdrawable = float(snapshot.max_withdrawable_usd) if snapshot.max_withdrawable_usd is not None else None
 
             if not snapshot.lockup_expired:
                 result.can_redeem = False
                 result.reason_code = RedemptionBlockReason.user_lockup_not_expired
-                result.max_redemption = Decimal(0)
+                result.max_redemption = 0.0
                 result.message = "Replay snapshot reports that the user lockup has not expired yet"
                 return result
 
@@ -444,11 +444,11 @@ class HypercoreVaultPricing(PricingModel):
             if snapshot.max_withdrawable_usd <= 0:
                 result.can_redeem = False
                 result.reason_code = RedemptionBlockReason.vault_max_withdrawable_zero
-                result.max_redemption = Decimal(0)
+                result.max_redemption = 0.0
                 result.message = "Replay snapshot reports zero max_withdrawable liquidity"
                 return result
 
-            result.max_redemption = snapshot.max_withdrawable_usd
+            result.max_redemption = float(snapshot.max_withdrawable_usd)
             result.message = "Replay snapshot allows redemption and caps it by max_withdrawable"
             return result
 
@@ -467,7 +467,7 @@ class HypercoreVaultPricing(PricingModel):
             return result
 
         info = self._get_vault_info(pair)
-        result.max_withdrawable = info.max_withdrawable
+        result.max_withdrawable = float(info.max_withdrawable)
         result.raw_api_data = RedemptionApiSnapshot(
             vault_info=self._build_vault_info_snapshot(info),
         )
@@ -475,7 +475,7 @@ class HypercoreVaultPricing(PricingModel):
         if info.max_withdrawable <= 0:
             result.can_redeem = False
             result.reason_code = RedemptionBlockReason.vault_max_withdrawable_zero
-            result.max_redemption = Decimal(0)
+            result.max_redemption = 0.0
             result.message = "Hypercore vault reports zero max_withdrawable liquidity"
             return result
 
@@ -490,7 +490,7 @@ class HypercoreVaultPricing(PricingModel):
         if eq is None:
             result.can_redeem = False
             result.reason_code = RedemptionBlockReason.user_equity_fetch_failed
-            result.max_redemption = Decimal(0)
+            result.max_redemption = 0.0
             result.message = "Hypercore user equity lookup returned no position data"
             return result
 
@@ -500,11 +500,11 @@ class HypercoreVaultPricing(PricingModel):
         if not eq.is_lockup_expired:
             result.can_redeem = False
             result.reason_code = RedemptionBlockReason.user_lockup_not_expired
-            result.max_redemption = Decimal(0)
+            result.max_redemption = 0.0
             result.message = "Hypercore user lockup has not expired yet"
             return result
 
-        result.max_redemption = min(eq.equity, info.max_withdrawable)
+        result.max_redemption = float(min(eq.equity, info.max_withdrawable))
         result.message = "Redemption allowed and capped by Hypercore max_withdrawable"
         return result
 

--- a/tradeexecutor/ethereum/vault/vault_live_pricing.py
+++ b/tradeexecutor/ethereum/vault/vault_live_pricing.py
@@ -214,13 +214,3 @@ class VaultPricing(PricingModel):
         if max_deposit is None:
             return True
         return max_deposit > 0
-
-    def can_redeem(
-        self,
-        ts: datetime.datetime | None,
-        pair: TradingPairIdentifier,
-    ) -> bool:
-        max_redemption = self.get_max_redemption(ts, pair)
-        if max_redemption is None:
-            return True
-        return max_redemption > 0

--- a/tradeexecutor/strategy/alpha_model.py
+++ b/tradeexecutor/strategy/alpha_model.py
@@ -22,6 +22,10 @@ from tradeexecutor.state.types import (LeverageMultiplier, PairInternalId,
 from tradeexecutor.strategy.execution_context import ExecutionContext
 from tradeexecutor.strategy.pandas_trader.position_manager import \
     PositionManager
+from tradeexecutor.strategy.redemption import (
+    RedemptionCheckResult,
+    RedemptionCheckStage,
+)
 from tradeexecutor.strategy.size_risk_model import SizeRiskModel
 from tradeexecutor.strategy.weighting import (Signal, check_normalised_weights,
                                               clip_to_normalised,
@@ -313,6 +317,9 @@ class TradingPairSignal:
     #: Debug flags for this signal, see :py:fuc:`format_signals`
     flags: set[TradingPairSignalFlags] = field(default_factory=set)
 
+    #: Structured redemption diagnostics collected for this cycle.
+    redemption_check_results: list[RedemptionCheckResult] = field(default_factory=list)
+
     def __post_init__(self):
         assert isinstance(self.pair, TradingPairIdentifier)
         if type(self.signal) != float:
@@ -327,6 +334,15 @@ class TradingPairSignal:
 
     def __repr__(self):
         return f"Signal #{self.signal_id} pair:{self.pair.get_ticker()} old weight:{self.old_weight:.4f} old value:{self.old_value:,} raw signal:{self.signal:.4f} normalised weight:{self.normalised_weight:.4f} new value:{self.position_target or 0:,} adjust:{self.position_adjust_usd:,}"
+
+    def set_redemption_check_result(self, result: RedemptionCheckResult) -> None:
+        """Store the latest redemption check result for a stage."""
+        for idx, existing in enumerate(self.redemption_check_results):
+            if existing.stage == result.stage:
+                self.redemption_check_results[idx] = result
+                return
+
+        self.redemption_check_results.append(result)
 
     def has_trades(self) -> bool:
         """Did/should this signal cause any trades to be executed.
@@ -785,17 +801,28 @@ class AlphaModel:
         can_redeem: Callable[[TradingPosition], bool] | None = None,
     ) -> USDollarAmount:
         """Pin current non-redeemable positions at their marked value for this cycle."""
-        if can_redeem is None:
-            can_redeem = lambda position: position_manager.pricing_model.can_redeem(  # noqa: E731
-                self.timestamp,
-                position.pair,
-            )
-
         locked_position_value = 0.0
 
         for position in position_manager.get_current_portfolio().open_positions.values():
-            if can_redeem(position):
-                continue
+            if can_redeem is None:
+                redemption_result = self._check_redemption_for_position(
+                    position_manager,
+                    position,
+                    stage=RedemptionCheckStage.carry_forward,
+                )
+                if redemption_result.can_redeem:
+                    continue
+            else:
+                if can_redeem(position):
+                    continue
+                redemption_result = RedemptionCheckResult(
+                    timestamp=self.timestamp,
+                    stage=RedemptionCheckStage.carry_forward,
+                    can_redeem=False,
+                    pair_ticker=position.pair.get_ticker(),
+                    vault_address=position.pair.pool_address,
+                    message="Position cannot be redeemed according to the strategy callback",
+                )
 
             current_value = position.get_value()
             signal = self.raw_signals.get(position.pair.internal_id)
@@ -807,10 +834,55 @@ class AlphaModel:
 
             signal.carry_forward_position = True
             signal.position_target = current_value
-            signal.flags.add(TradingPairSignalFlags.cannot_redeem)
+            self._mark_signal_cannot_redeem(
+                signal,
+                redemption_result,
+                current_value=current_value,
+            )
             locked_position_value += current_value
 
         return locked_position_value
+
+    def _check_redemption_for_position(
+        self,
+        position_manager: PositionManager,
+        position: TradingPosition,
+        *,
+        stage: RedemptionCheckStage,
+    ) -> RedemptionCheckResult:
+        """Run the pricing-model redemption check for a position."""
+        return position_manager.pricing_model.check_redemption(
+            self.timestamp,
+            position.pair,
+            stage=stage,
+            position=position,
+        )
+
+    def _mark_signal_cannot_redeem(
+        self,
+        signal: TradingPairSignal,
+        redemption_result: RedemptionCheckResult,
+        *,
+        current_value: USDollarAmount | None,
+    ) -> None:
+        """Attach diagnostics and emit one searchable blocked-redemption log line."""
+        signal.flags.add(TradingPairSignalFlags.cannot_redeem)
+        signal.set_redemption_check_result(redemption_result)
+
+        logger.info(
+            "HYPERCORE_REDEMPTION_DIAGNOSTIC stage=%s pair_ticker=%s vault_address=%s safe_address=%s reason_code=%s current_value=%s position_recorded_lockup_expires_at=%s user_lockup_expires_at=%s max_withdrawable=%s max_redemption=%s message=%s",
+            redemption_result.stage.value,
+            redemption_result.pair_ticker,
+            redemption_result.vault_address,
+            redemption_result.safe_address,
+            redemption_result.reason_code.value if redemption_result.reason_code else None,
+            current_value,
+            redemption_result.position_recorded_lockup_expires_at,
+            redemption_result.user_lockup_expires_at,
+            redemption_result.max_withdrawable,
+            redemption_result.max_redemption,
+            redemption_result.message,
+        )
 
     def _normalise_weights_simple(
         self,
@@ -1638,14 +1710,6 @@ class AlphaModel:
                 signal.profit_before_trades = 0
         return current_position
 
-    def _can_redeem_position(
-        self,
-        position_manager: PositionManager,
-        position: TradingPosition,
-    ) -> bool:
-        """Check whether a current position can be reduced on this cycle."""
-        return position_manager.pricing_model.can_redeem(self.timestamp, position.pair)
-
     def _should_skip_signal_rebalance(
         self,
         signal: TradingPairSignal,
@@ -1692,13 +1756,25 @@ class AlphaModel:
         underlying = signal.pair
         synthetic = signal.synthetic_pair
 
-        if current_position and dollar_diff < 0 and not self._can_redeem_position(position_manager, current_position):
+        redemption_result = None
+        if current_position and dollar_diff < 0:
+            redemption_result = self._check_redemption_for_position(
+                position_manager,
+                current_position,
+                stage=RedemptionCheckStage.sell_rebalance,
+            )
+
+        if current_position and dollar_diff < 0 and redemption_result and not redemption_result.can_redeem:
             logger.info(
                 "Skipping sell-side rebalance for %s because the position is not redeemable yet",
                 current_position.pair,
             )
             signal.position_adjust_ignored = True
-            signal.flags.add(TradingPairSignalFlags.cannot_redeem)
+            self._mark_signal_cannot_redeem(
+                signal,
+                redemption_result,
+                current_value=current_position.get_value(),
+            )
             return position_rebalance_trades
 
         if signal.normalised_weight < self.close_position_weight_epsilon:

--- a/tradeexecutor/strategy/alpha_model.py
+++ b/tradeexecutor/strategy/alpha_model.py
@@ -798,31 +798,18 @@ class AlphaModel:
     def carry_forward_non_redeemable_positions(
         self,
         position_manager: PositionManager,
-        can_redeem: Callable[[TradingPosition], bool] | None = None,
     ) -> USDollarAmount:
         """Pin current non-redeemable positions at their marked value for this cycle."""
         locked_position_value = 0.0
 
         for position in position_manager.get_current_portfolio().open_positions.values():
-            if can_redeem is None:
-                redemption_result = self._check_redemption_for_position(
-                    position_manager,
-                    position,
-                    stage=RedemptionCheckStage.carry_forward,
-                )
-                if redemption_result.can_redeem:
-                    continue
-            else:
-                if can_redeem(position):
-                    continue
-                redemption_result = RedemptionCheckResult(
-                    timestamp=self.timestamp,
-                    stage=RedemptionCheckStage.carry_forward,
-                    can_redeem=False,
-                    pair_ticker=position.pair.get_ticker(),
-                    vault_address=position.pair.pool_address,
-                    message="Position cannot be redeemed according to the strategy callback",
-                )
+            redemption_result = self._check_redemption_for_position(
+                position_manager,
+                position,
+                stage=RedemptionCheckStage.carry_forward,
+            )
+            if redemption_result.can_redeem:
+                continue
 
             current_value = position.get_value()
             signal = self.raw_signals.get(position.pair.internal_id)
@@ -870,7 +857,7 @@ class AlphaModel:
         signal.set_redemption_check_result(redemption_result)
 
         logger.info(
-            "HYPERCORE_REDEMPTION_DIAGNOSTIC stage=%s pair_ticker=%s vault_address=%s safe_address=%s reason_code=%s current_value=%s position_recorded_lockup_expires_at=%s user_lockup_expires_at=%s max_withdrawable=%s max_redemption=%s message=%s",
+            "REDEMPTION_DIAGNOSTIC stage=%s pair_ticker=%s vault_address=%s safe_address=%s reason_code=%s current_value=%s position_recorded_lockup_expires_at=%s user_lockup_expires_at=%s max_withdrawable=%s max_redemption=%s message=%s",
             redemption_result.stage.value,
             redemption_result.pair_ticker,
             redemption_result.vault_address,

--- a/tradeexecutor/strategy/pricing_model.py
+++ b/tradeexecutor/strategy/pricing_model.py
@@ -265,7 +265,7 @@ class PricingModel(abc.ABC):
             can_redeem=can_redeem,
             pair_ticker=pair.get_ticker(),
             vault_address=pair.pool_address,
-            max_redemption=max_redemption,
+            max_redemption=float(max_redemption) if max_redemption is not None else None,
         )
 
     def is_tradeable(

--- a/tradeexecutor/strategy/pricing_model.py
+++ b/tradeexecutor/strategy/pricing_model.py
@@ -1,14 +1,17 @@
-"""Asset pricing model."""
-
-import logging
 import abc
 import datetime
+import logging
 from decimal import Decimal, ROUND_DOWN
-from typing import Callable, Optional, Literal, Protocol
+from typing import Callable, Literal, Optional, Protocol
 
 from tradeexecutor.state.identifier import TradingPairIdentifier
+from tradeexecutor.state.position import TradingPosition
 from tradeexecutor.state.types import USDollarPrice, Percent, USDollarAmount, TokenAmount
 from tradeexecutor.strategy.execution_model import ExecutionModel
+from tradeexecutor.strategy.redemption import (
+    RedemptionCheckResult,
+    RedemptionCheckStage,
+)
 from tradeexecutor.strategy.routing import RoutingModel
 from tradeexecutor.strategy.universe_model import StrategyExecutionUniverse
 from tradeexecutor.strategy.trade_pricing import TradePricing
@@ -236,7 +239,34 @@ class PricingModel(abc.ABC):
         The base implementation treats unknown venue-specific limits as allowed.
         Pricing models with live gating should override this method.
         """
-        return True
+        return self.check_redemption(ts, pair).can_redeem
+
+    def check_redemption(
+        self,
+        ts: datetime.datetime | None,
+        pair: TradingPairIdentifier,
+        *,
+        stage: RedemptionCheckStage = RedemptionCheckStage.unknown,
+        position: TradingPosition | None = None,
+    ) -> RedemptionCheckResult:
+        """Return a structured redemption check result.
+
+        The base implementation preserves the old behaviour by deriving the
+        boolean result from :py:meth:`get_max_redemption`.
+        """
+        del position
+
+        max_redemption = self.get_max_redemption(ts, pair)
+        can_redeem = True if max_redemption is None else max_redemption > 0
+
+        return RedemptionCheckResult(
+            timestamp=ts,
+            stage=stage,
+            can_redeem=can_redeem,
+            pair_ticker=pair.get_ticker(),
+            vault_address=pair.pool_address,
+            max_redemption=max_redemption,
+        )
 
     def is_tradeable(
         self,

--- a/tradeexecutor/strategy/redemption.py
+++ b/tradeexecutor/strategy/redemption.py
@@ -1,0 +1,202 @@
+"""Structured redemption diagnostics for pricing and alpha-model decisions."""
+
+import datetime
+import enum
+from dataclasses import dataclass
+from decimal import Decimal
+
+from dataclasses_json import dataclass_json
+from eth_defi.compat import native_datetime_utc_fromtimestamp
+
+
+class RedemptionCheckStage(enum.Enum):
+    """Where the strategy asked whether a position can be redeemed."""
+
+    unknown = "unknown"
+    carry_forward = "carry_forward"
+    sell_rebalance = "sell_rebalance"
+
+
+class RedemptionBlockReason(enum.Enum):
+    """Stable reason codes for redemption diagnostics."""
+
+    safe_address_unavailable = "safe_address_unavailable"
+    user_equity_fetch_failed = "user_equity_fetch_failed"
+    user_lockup_not_expired = "user_lockup_not_expired"
+    vault_max_withdrawable_zero = "vault_max_withdrawable_zero"
+
+
+@dataclass_json
+@dataclass(slots=True)
+class VaultUserEquitySnapshot:
+    """Compact vault user equity payload used in diagnostics."""
+
+    #: Vault address used in the user equity lookup.
+    vault_address: str | None = None
+    #: Current equity reported by Hyperliquid for this user and vault.
+    equity: Decimal | None = None
+    #: Naive UTC timestamp when the user lockup expires.
+    locked_until: datetime.datetime | None = None
+    #: Whether Hyperliquid reports the user lockup as already expired.
+    is_lockup_expired: bool | None = None
+
+
+@dataclass_json
+@dataclass(slots=True)
+class VaultInfoSnapshot:
+    """Compact vault info payload used in diagnostics."""
+
+    #: Human-readable vault name from ``vaultDetails``.
+    name: str | None = None
+    #: Vault address returned by the Hyperliquid API.
+    vault_address: str | None = None
+    #: Maximum currently withdrawable amount reported by the vault.
+    max_withdrawable: Decimal | None = None
+    #: Maximum currently distributable amount reported by the vault.
+    max_distributable: Decimal | None = None
+    #: Whether the vault is permanently closed.
+    is_closed: bool | None = None
+    #: Whether the leader currently allows deposits.
+    allow_deposits: bool | None = None
+    #: Relationship type reported by Hyperliquid for the vault.
+    relationship_type: str | None = None
+    #: Leader share of the vault capital as a float ratio.
+    leader_fraction: float | None = None
+    #: Number of followers returned in the API payload.
+    follower_count: int | None = None
+    #: Optional parent vault address for parent-child vault layouts.
+    parent: str | None = None
+
+
+@dataclass_json
+@dataclass(slots=True)
+class VaultMetadataSnapshot:
+    """Vault pair and position metadata used in redemption checks."""
+
+    #: Protocol slug stored on the trading pair metadata.
+    vault_protocol: str | None = None
+    #: Human-readable vault name stored on the trading pair metadata.
+    vault_name: str | None = None
+    #: Human-readable reason why deposits are closed, if known.
+    deposit_closed_reason: str | None = None
+    #: Human-readable reason why redemptions are closed, if known.
+    redemption_closed_reason: str | None = None
+    #: Next known redemption-open timestamp from the pair metadata.
+    redemption_next_open: datetime.datetime | None = None
+    #: Whether this pair targets the Hyperliquid testnet API.
+    exchange_is_testnet: bool | None = None
+    #: Lockup expiry recorded earlier on the open position state.
+    position_recorded_lockup_expires_at: datetime.datetime | None = None
+
+
+@dataclass_json
+@dataclass(slots=True)
+class RedemptionApiSnapshot:
+    """Decision-relevant vault API payloads."""
+
+    #: Compact snapshot of ``vaultDetails``.
+    vault_info: VaultInfoSnapshot | None = None
+    #: Compact snapshot of ``fetch_user_vault_equity()``.
+    user_equity: VaultUserEquitySnapshot | None = None
+
+
+@dataclass_json
+@dataclass(slots=True)
+class RedemptionCheckResult:
+    """Serialisable result of a redemption check."""
+
+    #: Strategy-cycle timestamp when the check ran.
+    timestamp: datetime.datetime | None = None
+    #: Where in the alpha-model flow the check was requested.
+    stage: RedemptionCheckStage = RedemptionCheckStage.unknown
+    #: Final boolean decision used by the caller.
+    can_redeem: bool = True
+    #: Stable reason code for the decision, when available.
+    reason_code: RedemptionBlockReason | None = None
+    #: Human-readable explanation of the decision.
+    message: str | None = None
+    #: Pair ticker shown in logs and diagnostics.
+    pair_ticker: str | None = None
+    #: Vault address for the checked position.
+    vault_address: str | None = None
+    #: Safe address used for the lookup, when available.
+    safe_address: str | None = None
+    #: Configured redeem delay in seconds, if known.
+    configured_redeem_delay_seconds: int | None = None
+    #: Origin of the configured redeem delay field, if known.
+    configured_redeem_delay_source: str | None = None
+    #: Lockup expiry recorded earlier on the position state.
+    position_recorded_lockup_expires_at: datetime.datetime | None = None
+    #: Latest lockup expiry returned by the live user equity lookup.
+    user_lockup_expires_at: datetime.datetime | None = None
+    #: Raw vault-side max withdrawable amount used in the decision.
+    max_withdrawable: Decimal | None = None
+    #: Final max redeemable amount exposed to callers.
+    max_redemption: Decimal | None = None
+    #: Compact raw API payloads used for the decision.
+    raw_api_data: RedemptionApiSnapshot | None = None
+    #: Pair and position metadata used for the decision.
+    used_vault_metadata: VaultMetadataSnapshot | None = None
+
+
+@dataclass_json
+@dataclass(slots=True)
+class BlockedRedemptionSummary:
+    """Compact blocked-redemption entry persisted in cycle calculations."""
+
+    #: Pair ticker for the blocked position.
+    pair_ticker: str | None
+    #: Vault address for the blocked position.
+    vault_address: str | None
+    #: Stage where the block happened.
+    stage: str
+    #: Stable reason code for the block.
+    reason_code: str | None
+    #: Human-readable explanation of the block.
+    message: str | None
+    #: Safe address used for the live lookup, if available.
+    safe_address: str | None
+    #: Lockup expiry previously recorded on the position state.
+    position_recorded_lockup_expires_at: datetime.datetime | None
+    #: Lockup expiry returned by the latest user equity lookup.
+    user_lockup_expires_at: datetime.datetime | None
+    #: Vault max withdrawable amount formatted for compact storage.
+    max_withdrawable: str | None
+    #: Final max redemption amount formatted for compact storage.
+    max_redemption: str | None
+
+
+@dataclass_json
+@dataclass(slots=True)
+class RedemptionCycleDiagnostics:
+    """Compact per-cycle blocked-redemption diagnostics."""
+
+    #: Strategy cycle number that produced these diagnostics.
+    cycle: int
+    #: Capital that the allocator considered redeemable this cycle.
+    redeemable_capital: float
+    #: Capital pinned because blocked positions had to be carried forward.
+    locked_capital_carried_forward: float
+    #: Count of distinct signals blocked by redemption checks.
+    blocked_signal_count: int
+    #: Grouped blocked reason counts keyed by reason code value.
+    reason_counts: dict[str, int]
+    #: Compact blocked-redemption entries for this cycle.
+    blocked_redemptions: list[BlockedRedemptionSummary]
+
+
+def parse_recorded_lockup_expires_at(value: object) -> datetime.datetime | None:
+    """Parse a stored ISO timestamp from ``position.other_data`` if present."""
+    if value is None:
+        return None
+
+    if isinstance(value, datetime.datetime):
+        return value
+
+    if isinstance(value, str):
+        return datetime.datetime.fromisoformat(value)
+
+    if isinstance(value, (int, float)):
+        return native_datetime_utc_fromtimestamp(value)
+
+    raise TypeError(f"Unsupported lockup expiry value: {value!r}")

--- a/tradeexecutor/strategy/redemption.py
+++ b/tradeexecutor/strategy/redemption.py
@@ -4,6 +4,7 @@ import datetime
 import enum
 from dataclasses import dataclass
 from decimal import Decimal
+from collections.abc import Mapping
 
 from dataclasses_json import dataclass_json
 from eth_defi.compat import native_datetime_utc_fromtimestamp
@@ -183,6 +184,87 @@ class RedemptionCycleDiagnostics:
     reason_counts: dict[str, int]
     #: Compact blocked-redemption entries for this cycle.
     blocked_redemptions: list[BlockedRedemptionSummary]
+
+
+def collect_blocked_redemption_results(
+    signals: Mapping[object, object],
+) -> list[RedemptionCheckResult]:
+    """Collect the latest blocked redemption check for each signal."""
+    results = []
+    for signal in signals.values():
+        latest_blocked_result = None
+        for result in signal.redemption_check_results:
+            if not result.can_redeem:
+                latest_blocked_result = result
+        if latest_blocked_result is not None:
+            results.append(latest_blocked_result)
+    return results
+
+
+def format_redemption_decimal(value: Decimal | None) -> str | None:
+    """Format Decimal-like diagnostics without widening state payloads."""
+    if value is None:
+        return None
+    return str(value)
+
+
+def make_blocked_redemption_summary(
+    result: RedemptionCheckResult,
+) -> BlockedRedemptionSummary:
+    """Convert one rich redemption result to a compact persisted summary."""
+    return BlockedRedemptionSummary(
+        pair_ticker=result.pair_ticker,
+        vault_address=result.vault_address,
+        stage=result.stage.value,
+        reason_code=result.reason_code.value if result.reason_code else None,
+        message=result.message,
+        safe_address=result.safe_address,
+        position_recorded_lockup_expires_at=result.position_recorded_lockup_expires_at,
+        user_lockup_expires_at=result.user_lockup_expires_at,
+        max_withdrawable=format_redemption_decimal(result.max_withdrawable),
+        max_redemption=format_redemption_decimal(result.max_redemption),
+    )
+
+
+def group_blocked_redemption_reasons(
+    blocked_results: list[RedemptionCheckResult],
+) -> dict[str, int]:
+    """Group blocked redemption diagnostics by stable reason code per signal."""
+    counts: dict[str, int] = {}
+    for result in blocked_results:
+        reason_code = result.reason_code.value if result.reason_code else "unknown"
+        counts[reason_code] = counts.get(reason_code, 0) + 1
+    return counts
+
+
+def count_blocked_redemption_signals(
+    blocked_results: list[RedemptionCheckResult],
+) -> int:
+    """Count distinct blocked signals in a blocked-result list."""
+    return len({
+        (result.pair_ticker, result.vault_address)
+        for result in blocked_results
+    })
+
+
+def create_redemption_cycle_diagnostics(
+    cycle: int,
+    redeemable_capital: float,
+    locked_capital_carried_forward: float,
+    blocked_results: list[RedemptionCheckResult],
+) -> RedemptionCycleDiagnostics:
+    """Create compact per-cycle blocked-redemption diagnostics."""
+    return RedemptionCycleDiagnostics(
+        cycle=cycle,
+        redeemable_capital=redeemable_capital,
+        locked_capital_carried_forward=locked_capital_carried_forward,
+        blocked_signal_count=count_blocked_redemption_signals(blocked_results),
+        reason_counts=group_blocked_redemption_reasons(blocked_results),
+        blocked_redemptions=[
+            make_blocked_redemption_summary(result)
+            for result in blocked_results
+        ],
+    )
 
 
 def parse_recorded_lockup_expires_at(value: object) -> datetime.datetime | None:

--- a/tradeexecutor/strategy/redemption.py
+++ b/tradeexecutor/strategy/redemption.py
@@ -2,12 +2,13 @@
 
 import datetime
 import enum
-from dataclasses import dataclass
-from decimal import Decimal
 from collections.abc import Mapping
+from dataclasses import dataclass
 
 from dataclasses_json import dataclass_json
 from eth_defi.compat import native_datetime_utc_fromtimestamp
+
+from tradeexecutor.state.types import JSONHexAddress, Percent, USDollarAmount
 
 
 class RedemptionCheckStage(enum.Enum):
@@ -33,9 +34,9 @@ class VaultUserEquitySnapshot:
     """Compact vault user equity payload used in diagnostics."""
 
     #: Vault address used in the user equity lookup.
-    vault_address: str | None = None
+    vault_address: JSONHexAddress | None = None
     #: Current equity reported by Hyperliquid for this user and vault.
-    equity: Decimal | None = None
+    equity: USDollarAmount | None = None
     #: Naive UTC timestamp when the user lockup expires.
     locked_until: datetime.datetime | None = None
     #: Whether Hyperliquid reports the user lockup as already expired.
@@ -50,11 +51,11 @@ class VaultInfoSnapshot:
     #: Human-readable vault name from ``vaultDetails``.
     name: str | None = None
     #: Vault address returned by the Hyperliquid API.
-    vault_address: str | None = None
+    vault_address: JSONHexAddress | None = None
     #: Maximum currently withdrawable amount reported by the vault.
-    max_withdrawable: Decimal | None = None
+    max_withdrawable: USDollarAmount | None = None
     #: Maximum currently distributable amount reported by the vault.
-    max_distributable: Decimal | None = None
+    max_distributable: USDollarAmount | None = None
     #: Whether the vault is permanently closed.
     is_closed: bool | None = None
     #: Whether the leader currently allows deposits.
@@ -62,11 +63,11 @@ class VaultInfoSnapshot:
     #: Relationship type reported by Hyperliquid for the vault.
     relationship_type: str | None = None
     #: Leader share of the vault capital as a float ratio.
-    leader_fraction: float | None = None
+    leader_fraction: Percent | None = None
     #: Number of followers returned in the API payload.
     follower_count: int | None = None
     #: Optional parent vault address for parent-child vault layouts.
-    parent: str | None = None
+    parent: JSONHexAddress | None = None
 
 
 @dataclass_json
@@ -119,9 +120,9 @@ class RedemptionCheckResult:
     #: Pair ticker shown in logs and diagnostics.
     pair_ticker: str | None = None
     #: Vault address for the checked position.
-    vault_address: str | None = None
+    vault_address: JSONHexAddress | None = None
     #: Safe address used for the lookup, when available.
-    safe_address: str | None = None
+    safe_address: JSONHexAddress | None = None
     #: Configured redeem delay in seconds, if known.
     configured_redeem_delay_seconds: int | None = None
     #: Origin of the configured redeem delay field, if known.
@@ -131,9 +132,9 @@ class RedemptionCheckResult:
     #: Latest lockup expiry returned by the live user equity lookup.
     user_lockup_expires_at: datetime.datetime | None = None
     #: Raw vault-side max withdrawable amount used in the decision.
-    max_withdrawable: Decimal | None = None
+    max_withdrawable: USDollarAmount | None = None
     #: Final max redeemable amount exposed to callers.
-    max_redemption: Decimal | None = None
+    max_redemption: USDollarAmount | None = None
     #: Compact raw API payloads used for the decision.
     raw_api_data: RedemptionApiSnapshot | None = None
     #: Pair and position metadata used for the decision.
@@ -148,23 +149,23 @@ class BlockedRedemptionSummary:
     #: Pair ticker for the blocked position.
     pair_ticker: str | None
     #: Vault address for the blocked position.
-    vault_address: str | None
+    vault_address: JSONHexAddress | None
     #: Stage where the block happened.
-    stage: str
+    stage: RedemptionCheckStage
     #: Stable reason code for the block.
-    reason_code: str | None
+    reason_code: RedemptionBlockReason | None
     #: Human-readable explanation of the block.
     message: str | None
     #: Safe address used for the live lookup, if available.
-    safe_address: str | None
+    safe_address: JSONHexAddress | None
     #: Lockup expiry previously recorded on the position state.
     position_recorded_lockup_expires_at: datetime.datetime | None
     #: Lockup expiry returned by the latest user equity lookup.
     user_lockup_expires_at: datetime.datetime | None
-    #: Vault max withdrawable amount formatted for compact storage.
-    max_withdrawable: str | None
-    #: Final max redemption amount formatted for compact storage.
-    max_redemption: str | None
+    #: Vault max withdrawable amount stored as an approximate USD float.
+    max_withdrawable: USDollarAmount | None
+    #: Final max redemption amount stored as an approximate USD float.
+    max_redemption: USDollarAmount | None
 
 
 @dataclass_json
@@ -175,9 +176,9 @@ class RedemptionCycleDiagnostics:
     #: Strategy cycle number that produced these diagnostics.
     cycle: int
     #: Capital that the allocator considered redeemable this cycle.
-    redeemable_capital: float
+    redeemable_capital: USDollarAmount
     #: Capital pinned because blocked positions had to be carried forward.
-    locked_capital_carried_forward: float
+    locked_capital_carried_forward: USDollarAmount
     #: Count of distinct signals blocked by redemption checks.
     blocked_signal_count: int
     #: Grouped blocked reason counts keyed by reason code value.
@@ -201,11 +202,11 @@ def collect_blocked_redemption_results(
     return results
 
 
-def format_redemption_decimal(value: Decimal | None) -> str | None:
-    """Format Decimal-like diagnostics without widening state payloads."""
+def format_redemption_amount(value: object) -> USDollarAmount | None:
+    """Convert diagnostic money values to approximate USD floats."""
     if value is None:
         return None
-    return str(value)
+    return float(value)
 
 
 def make_blocked_redemption_summary(
@@ -215,14 +216,14 @@ def make_blocked_redemption_summary(
     return BlockedRedemptionSummary(
         pair_ticker=result.pair_ticker,
         vault_address=result.vault_address,
-        stage=result.stage.value,
-        reason_code=result.reason_code.value if result.reason_code else None,
+        stage=result.stage,
+        reason_code=result.reason_code,
         message=result.message,
         safe_address=result.safe_address,
         position_recorded_lockup_expires_at=result.position_recorded_lockup_expires_at,
         user_lockup_expires_at=result.user_lockup_expires_at,
-        max_withdrawable=format_redemption_decimal(result.max_withdrawable),
-        max_redemption=format_redemption_decimal(result.max_redemption),
+        max_withdrawable=format_redemption_amount(result.max_withdrawable),
+        max_redemption=format_redemption_amount(result.max_redemption),
     )
 
 

--- a/tradeexecutor/testing/hypercore.py
+++ b/tradeexecutor/testing/hypercore.py
@@ -235,11 +235,12 @@ def make_hyper_ai_strategy_input(
     cycle: int,
     include_pair: bool,
     parameters: StrategyParameters,
+    execution_mode: ExecutionMode = ExecutionMode.unit_testing,
 ) -> StrategyInput:
     """Build one Hyper AI strategy input payload for a deterministic cycle."""
 
     execution_context = ExecutionContext(
-        mode=ExecutionMode.unit_testing,
+        mode=execution_mode,
         parameters=parameters,
     )
 
@@ -338,6 +339,7 @@ def run_hyper_ai_cycle(
     valuation_model: GenericValuation,
     pair: TradingPairIdentifier,
     parameters: StrategyParameters,
+    execution_mode: ExecutionMode = ExecutionMode.unit_testing,
 ) -> HyperAiCycleResult:
     """Run one revalue + treasury-sync + Hyper AI rebalance cycle."""
 
@@ -367,6 +369,7 @@ def run_hyper_ai_cycle(
         cycle=cycle,
         include_pair=include_pair,
         parameters=parameters,
+        execution_mode=execution_mode,
     )
     trades = hyper_ai_strategy_module.decide_trades(strategy_input)
 


### PR DESCRIPTION
## Why

We need structured redemption diagnostics that work across vault implementations instead of being tied to Hypercore-specific names and payloads. This also gives Hyper AI a reusable way to persist blocked redemption state, while keeping serialisation consistent with the existing `dataclasses-json` approach.

## Lessons learnt

Moving the shared redemption types into the `tradeexecutor` namespace made it much easier to reuse the same contract across Hypercore and ERC-4626 pricing paths. Keeping the audit and persistence helpers generic also avoids duplicating strategy-specific logic in scripts and tests.

## Summary

- add shared `tradeexecutor.strategy.redemption` dataclasses, enums, and parsing helpers for redemption checks
- route `PricingModel.can_redeem()` through structured `check_redemption()` results and update the Hypercore pricing model to use that single source of truth
- persist compact blocked-redemption diagnostics from Hyper AI and the test-only Hyper AI strategy, while keeping the latest rich alpha-model snapshot in discardable state
- add generic redemption audit helpers and CLI scripts, with thin backwards-compatible Hypercore aliases
- extend the existing Hypercore, rebalance, Hyper AI live-loop, sample-state audit, and ERC-4626 pricing tests to cover the new shared behaviour