### PR TITLE
Improve Hyper AI startup compatibility and vault diagnostics

### DIFF
--- a/tests/backtest/test_hyper_ai_stale_data_indicators.py
+++ b/tests/backtest/test_hyper_ai_stale_data_indicators.py
@@ -751,6 +751,44 @@ def test_get_vault_data_freshness_includes_universe_level_history_diagnostics(
     assert (df["Vault history parquet max timestamp"] == datetime.datetime(2026, 4, 11, 13, 0, 0)).all()
 
 
+def test_clone_preserves_vault_history_diagnostics(
+    stale_universe: TradingStrategyUniverse,
+) -> None:
+    """Verify TradingStrategyUniverse.clone preserves vault history diagnostics.
+
+    1. Attach synthetic vault history startup diagnostics to the original universe.
+    2. Clone the universe.
+    3. Assert the clone still exposes the same diagnostics through get_vault_data_freshness.
+    """
+    # 1. Attach synthetic vault history startup diagnostics to the original universe.
+    stale_universe.vault_history_diagnostics = VaultHistoryDiagnostics(
+        cache_path=Path("/tmp/vault-price-history.parquet"),
+        local_cache_mtime=datetime.datetime(2026, 4, 11, 10, 0, 0),
+        local_cache_age=datetime.timedelta(hours=4),
+        remote_last_modified=datetime.datetime(2026, 4, 11, 12, 30, 0),
+        remote_last_modified_age=datetime.timedelta(hours=1, minutes=30),
+        remote_etag='"abc123"',
+        remote_content_length=12345,
+        remote_head_error=None,
+        parquet_max_timestamp=datetime.datetime(2026, 4, 11, 13, 0, 0),
+        parquet_data_age=datetime.timedelta(hours=1),
+        filtered_max_timestamp=datetime.datetime(2026, 4, 11, 12, 0, 0),
+        filtered_data_age=datetime.timedelta(hours=2),
+        resampled_max_timestamp=datetime.datetime(2026, 4, 11, 0, 0, 0),
+        resampled_data_age=datetime.timedelta(hours=14),
+        parquet_to_filtered_delta=datetime.timedelta(hours=1),
+        filtered_to_resampled_delta=datetime.timedelta(hours=12),
+    )
+
+    # 2. Clone the universe.
+    cloned_universe = stale_universe.clone()
+
+    # 3. Assert the clone still exposes the same diagnostics through get_vault_data_freshness.
+    df = get_vault_data_freshness(cloned_universe)
+    assert "Vault history cache age" in df.columns
+    assert (df["Vault history cache age"] == datetime.timedelta(hours=4)).all()
+
+
 def test_vault_data_freshness_chart_renders(
     stale_universe: TradingStrategyUniverse,
     vault_a_pair: TradingPairIdentifier,

--- a/tests/backtest/test_hyper_ai_stale_data_indicators.py
+++ b/tests/backtest/test_hyper_ai_stale_data_indicators.py
@@ -106,7 +106,12 @@ from pathlib import Path
 import pandas as pd
 import pytest
 
-from tradeexecutor.ethereum.vault.checks import StaleVaultData, check_stale_vault_data, get_vault_data_freshness
+from tradeexecutor.ethereum.vault.checks import (
+    StaleVaultData,
+    VaultHistoryDiagnostics,
+    check_stale_vault_data,
+    get_vault_data_freshness,
+)
 from tradeexecutor.ethereum.vault.hypercore_valuation import HypercoreVaultPricing
 from tradeexecutor.state.identifier import AssetIdentifier, TradingPairIdentifier, TradingPairKind
 from tradeexecutor.strategy.execution_context import (
@@ -704,6 +709,46 @@ def test_get_vault_data_freshness(
     assert pd.notna(row_a["Latest candle"])
     assert pd.notna(row_b["Last real candle"])
     assert pd.notna(row_b["Latest candle"])
+
+
+def test_get_vault_data_freshness_includes_universe_level_history_diagnostics(
+    stale_universe: TradingStrategyUniverse,
+) -> None:
+    """Verify get_vault_data_freshness surfaces universe-level vault history diagnostics.
+
+    1. Attach synthetic vault history startup diagnostics to the trading universe.
+    2. Call get_vault_data_freshness on the same universe.
+    3. Assert the returned DataFrame includes the shared cache and source freshness columns.
+    """
+    # 1. Attach synthetic vault history startup diagnostics to the trading universe.
+    stale_universe.vault_history_diagnostics = VaultHistoryDiagnostics(
+        cache_path=Path("/tmp/vault-price-history.parquet"),
+        local_cache_mtime=datetime.datetime(2026, 4, 11, 10, 0, 0),
+        local_cache_age=datetime.timedelta(hours=4),
+        remote_last_modified=datetime.datetime(2026, 4, 11, 12, 30, 0),
+        remote_last_modified_age=datetime.timedelta(hours=1, minutes=30),
+        remote_etag='"abc123"',
+        remote_content_length=12345,
+        remote_head_error=None,
+        parquet_max_timestamp=datetime.datetime(2026, 4, 11, 13, 0, 0),
+        parquet_data_age=datetime.timedelta(hours=1),
+        filtered_max_timestamp=datetime.datetime(2026, 4, 11, 12, 0, 0),
+        filtered_data_age=datetime.timedelta(hours=2),
+        resampled_max_timestamp=datetime.datetime(2026, 4, 11, 0, 0, 0),
+        resampled_data_age=datetime.timedelta(hours=14),
+        parquet_to_filtered_delta=datetime.timedelta(hours=1),
+        filtered_to_resampled_delta=datetime.timedelta(hours=12),
+    )
+
+    # 2. Call get_vault_data_freshness on the same universe.
+    df = get_vault_data_freshness(stale_universe)
+
+    # 3. Assert the returned DataFrame includes the shared cache and source freshness columns.
+    assert "Vault history cache age" in df.columns
+    assert "Vault history parquet max timestamp" in df.columns
+    assert "Vault history filtered->resampled delta" in df.columns
+    assert (df["Vault history cache age"] == datetime.timedelta(hours=4)).all()
+    assert (df["Vault history parquet max timestamp"] == datetime.datetime(2026, 4, 11, 13, 0, 0)).all()
 
 
 def test_vault_data_freshness_chart_renders(

--- a/tests/ethereum/test_vault_history_diagnostics.py
+++ b/tests/ethereum/test_vault_history_diagnostics.py
@@ -1,0 +1,311 @@
+"""Test vault history startup diagnostics for cache, source and resample freshness."""
+
+import datetime
+import os
+from pathlib import Path
+from types import SimpleNamespace
+
+import pandas as pd
+import pytest
+import requests
+
+from tradeexecutor.ethereum.vault.checks import (
+    build_vault_history_diagnostics,
+    log_stale_vault_candle_data,
+    log_vault_history_diagnostics,
+)
+from tradingstrategy.alternative_data.vault import convert_vault_prices_to_candles
+
+
+pytestmark = pytest.mark.timeout(300)
+
+
+class _MockResponse:
+    """Minimal response stub for HEAD metadata tests."""
+
+    def __init__(self, headers: dict[str, str]):
+        self.headers = headers
+
+    def raise_for_status(self) -> None:
+        """Pretend the response succeeded."""
+
+
+class _MockSession:
+    """Minimal session stub with configurable HEAD behaviour."""
+
+    def __init__(
+        self,
+        response: _MockResponse | None = None,
+        error: Exception | None = None,
+    ):
+        self.response = response
+        self.error = error
+
+    def head(self, url: str, allow_redirects: bool = True, timeout: int = 30) -> _MockResponse:
+        """Return the configured response or raise the configured error."""
+        del url
+        del allow_redirects
+        del timeout
+
+        if self.error is not None:
+            raise self.error
+
+        assert self.response is not None
+        return self.response
+
+
+def _build_vault_price_history_df(
+    address: str,
+    timestamps: list[datetime.datetime],
+    share_price: float = 1.02,
+    total_assets: float = 100_000.0,
+) -> pd.DataFrame:
+    """Build a minimal vault history DataFrame for diagnostics tests."""
+    rows = []
+    for timestamp in timestamps:
+        rows.append(
+            {
+                "timestamp": pd.Timestamp(timestamp),
+                "chain": 8453,
+                "address": address,
+                "share_price": share_price,
+                "total_assets": total_assets,
+            }
+        )
+    return pd.DataFrame(rows)
+
+
+def test_build_vault_history_diagnostics_includes_cache_and_remote_metadata(
+    tmp_path: Path,
+) -> None:
+    """Verify diagnostics capture cache mtime, remote headers and freshness timestamps.
+
+    1. Create a temporary cached parquet placeholder with a fixed mtime.
+    2. Build diagnostics with mocked remote HEAD metadata and explicit timestamps.
+    3. Assert cache, remote and parquet freshness fields are populated correctly.
+    """
+    # 1. Create a temporary cached parquet placeholder with a fixed mtime.
+    cache_path = tmp_path / "vault-price-history.parquet"
+    cache_path.write_bytes(b"vault-history")
+    cache_mtime = datetime.datetime(2026, 4, 11, 10, 0, 0)
+    cache_path.touch()
+    os_mtime = datetime.datetime(2026, 4, 11, 10, 0, 0, tzinfo=datetime.timezone.utc).timestamp()
+    cache_path.chmod(0o644)
+    os.utime(cache_path, (os_mtime, os_mtime))
+
+    now = datetime.datetime(2026, 4, 11, 14, 0, 0)
+    raw_df = _build_vault_price_history_df(
+        "0x1234000000000000000000000000000000000000",
+        [datetime.datetime(2026, 4, 11, 13, 0, 0)],
+    )
+    filtered_df = raw_df.copy()
+    resampled_df = pd.DataFrame(
+        {
+            "timestamp": [pd.Timestamp(datetime.datetime(2026, 4, 11, 0, 0, 0))],
+            "pair_id": [1],
+        }
+    )
+    session = _MockSession(
+        response=_MockResponse(
+            {
+                "Last-Modified": "Fri, 11 Apr 2026 12:30:00 GMT",
+                "ETag": '"abc123"',
+                "Content-Length": "12345",
+            }
+        )
+    )
+
+    # 2. Build diagnostics with mocked remote HEAD metadata and explicit timestamps.
+    diagnostics = build_vault_history_diagnostics(
+        raw_vault_price_df=raw_df,
+        filtered_vault_price_df=filtered_df,
+        resampled_vault_candle_df=resampled_df,
+        cache_path=cache_path,
+        http_session=session,
+        now=now,
+    )
+
+    # 3. Assert cache, remote and parquet freshness fields are populated correctly.
+    assert diagnostics.cache_path == cache_path
+    assert diagnostics.local_cache_mtime == cache_mtime
+    assert diagnostics.local_cache_age == datetime.timedelta(hours=4)
+    assert diagnostics.remote_last_modified == datetime.datetime(2026, 4, 11, 12, 30, 0)
+    assert diagnostics.remote_last_modified_age == datetime.timedelta(hours=1, minutes=30)
+    assert diagnostics.remote_etag == '"abc123"'
+    assert diagnostics.remote_content_length == 12345
+    assert diagnostics.parquet_max_timestamp == datetime.datetime(2026, 4, 11, 13, 0, 0)
+    assert diagnostics.filtered_max_timestamp == datetime.datetime(2026, 4, 11, 13, 0, 0)
+    assert diagnostics.resampled_max_timestamp == datetime.datetime(2026, 4, 11, 0, 0, 0)
+    assert diagnostics.parquet_data_age == datetime.timedelta(hours=1)
+
+
+def test_build_vault_history_diagnostics_detects_daily_resample_floor_gap() -> None:
+    """Verify diagnostics separate fresh parquet data from older daily candle timestamps.
+
+    1. Build raw vault history whose latest source sample is still under 24 hours old.
+    2. Convert the same history to daily candles so the visible candle is floored to midnight.
+    3. Assert source data is still fresh while the resampled candle looks older than 24 hours.
+    """
+    # 1. Build raw vault history whose latest source sample is still under 24 hours old.
+    address = "0xabcd000000000000000000000000000000000000"
+    now = datetime.datetime(2026, 4, 11, 13, 59, 0)
+    raw_df = _build_vault_price_history_df(
+        address,
+        [datetime.datetime(2026, 4, 10, 23, 59, 0)],
+    )
+
+    # 2. Convert the same history to daily candles so the visible candle is floored to midnight.
+    resampled_df, _ = convert_vault_prices_to_candles(raw_df.copy(), "1d")
+
+    # 3. Assert source data is still fresh while the resampled candle looks older than 24 hours.
+    diagnostics = build_vault_history_diagnostics(
+        raw_vault_price_df=raw_df,
+        filtered_vault_price_df=raw_df.copy(),
+        resampled_vault_candle_df=resampled_df,
+        cache_path=None,
+        http_session=_MockSession(response=_MockResponse({})),
+        now=now,
+    )
+
+    assert diagnostics.parquet_data_age == datetime.timedelta(hours=14)
+    assert diagnostics.resampled_data_age == datetime.timedelta(days=1, hours=13, minutes=59)
+    assert diagnostics.filtered_to_resampled_delta == datetime.timedelta(hours=23, minutes=59)
+
+
+def test_log_vault_history_diagnostics_warns_when_source_data_is_stale(caplog: pytest.LogCaptureFixture) -> None:
+    """Verify stale parquet data escalates the summary log level to warning.
+
+    1. Build diagnostics with a parquet max timestamp older than the 24-hour tolerance.
+    2. Emit the startup summary log.
+    3. Assert the summary is logged at warning level and mentions the parquet age.
+    """
+    # 1. Build diagnostics with a parquet max timestamp older than the 24-hour tolerance.
+    diagnostics = build_vault_history_diagnostics(
+        raw_vault_price_df=_build_vault_price_history_df(
+            "0xdead000000000000000000000000000000000000",
+            [datetime.datetime(2026, 4, 8, 12, 0, 0)],
+        ),
+        filtered_vault_price_df=_build_vault_price_history_df(
+            "0xdead000000000000000000000000000000000000",
+            [datetime.datetime(2026, 4, 8, 12, 0, 0)],
+        ),
+        resampled_vault_candle_df=pd.DataFrame(
+            {
+                "timestamp": [pd.Timestamp(datetime.datetime(2026, 4, 8, 0, 0, 0))],
+                "pair_id": [1],
+            }
+        ),
+        cache_path=None,
+        http_session=_MockSession(response=_MockResponse({})),
+        now=datetime.datetime(2026, 4, 11, 13, 59, 0),
+    )
+
+    # 2. Emit the startup summary log.
+    with caplog.at_level("INFO"):
+        log_vault_history_diagnostics(diagnostics)
+
+    # 3. Assert the summary is logged at warning level and mentions the parquet age.
+    summary_record = next(record for record in caplog.records if "Vault history freshness summary" in record.message)
+    assert summary_record.levelname == "WARNING"
+    assert "parquet_data_age=3 days, 1:59:00" in summary_record.message
+
+
+def test_log_vault_history_diagnostics_warns_when_remote_head_fails(caplog: pytest.LogCaptureFixture) -> None:
+    """Verify remote HEAD failure is recorded without aborting startup.
+
+    1. Build diagnostics with a mocked HEAD failure but otherwise fresh parquet data.
+    2. Emit the startup summary log.
+    3. Assert the summary is logged at warning level and includes the HEAD error.
+    """
+    # 1. Build diagnostics with a mocked HEAD failure but otherwise fresh parquet data.
+    diagnostics = build_vault_history_diagnostics(
+        raw_vault_price_df=_build_vault_price_history_df(
+            "0xbeef000000000000000000000000000000000000",
+            [datetime.datetime(2026, 4, 11, 12, 0, 0)],
+        ),
+        filtered_vault_price_df=_build_vault_price_history_df(
+            "0xbeef000000000000000000000000000000000000",
+            [datetime.datetime(2026, 4, 11, 12, 0, 0)],
+        ),
+        resampled_vault_candle_df=pd.DataFrame(
+            {
+                "timestamp": [pd.Timestamp(datetime.datetime(2026, 4, 11, 0, 0, 0))],
+                "pair_id": [1],
+            }
+        ),
+        cache_path=None,
+        http_session=_MockSession(error=requests.RequestException("boom")),
+        now=datetime.datetime(2026, 4, 11, 13, 59, 0),
+    )
+
+    # 2. Emit the startup summary log.
+    with caplog.at_level("INFO"):
+        log_vault_history_diagnostics(diagnostics)
+
+    # 3. Assert the summary is logged at warning level and includes the HEAD error.
+    summary_record = next(record for record in caplog.records if "Vault history freshness summary" in record.message)
+    assert summary_record.levelname == "WARNING"
+    assert "RequestException: boom" in summary_record.message
+
+
+def test_vault_history_logging_keeps_summary_before_per_vault_stale_entries(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Verify the startup summary is logged before per-vault stale entries.
+
+    1. Build fresh summary diagnostics and a stale per-vault candle snapshot.
+    2. Emit the summary log and then the per-vault stale log.
+    3. Assert the summary message appears before the per-vault stale entry.
+    """
+    # 1. Build fresh summary diagnostics and a stale per-vault candle snapshot.
+    diagnostics = build_vault_history_diagnostics(
+        raw_vault_price_df=_build_vault_price_history_df(
+            "0xcafe000000000000000000000000000000000000",
+            [datetime.datetime(2026, 4, 10, 23, 59, 0)],
+        ),
+        filtered_vault_price_df=_build_vault_price_history_df(
+            "0xcafe000000000000000000000000000000000000",
+            [datetime.datetime(2026, 4, 10, 23, 59, 0)],
+        ),
+        resampled_vault_candle_df=pd.DataFrame(
+            {
+                "timestamp": [pd.Timestamp(datetime.datetime(2026, 4, 10, 0, 0, 0))],
+                "pair_id": [272079929],
+            }
+        ),
+        cache_path=None,
+        http_session=_MockSession(response=_MockResponse({})),
+        now=datetime.datetime(2026, 4, 11, 13, 59, 0),
+    )
+    vault_candle_df = pd.DataFrame(
+        {
+            "pair_id": [272079929],
+            "timestamp": [pd.Timestamp(datetime.datetime(2026, 4, 10, 0, 0, 0))],
+        }
+    )
+    vault_pairs_df = pd.DataFrame(
+        {
+            "pair_id": [272079929],
+            "exchange_name": ["MirVault"],
+            "address": ["0x10aa8b767d0742de206bfafe36b8556634379c39"],
+            "token_metadata": [SimpleNamespace(tvl=80_107.73)],
+        }
+    )
+
+    # 2. Emit the summary log and then the per-vault stale log.
+    with caplog.at_level("INFO"):
+        log_vault_history_diagnostics(diagnostics)
+        log_stale_vault_candle_data(
+            vault_candle_df=vault_candle_df,
+            vault_pairs_df=vault_pairs_df,
+            now=datetime.datetime(2026, 4, 11, 13, 59, 0),
+        )
+
+    # 3. Assert the summary message appears before the per-vault stale entry.
+    relevant_messages = [
+        record.message
+        for record in caplog.records
+        if "Vault history freshness summary" in record.message or "Vault candle data is stale" in record.message
+    ]
+    assert "Vault history freshness summary" in relevant_messages[0]
+    assert "Vault candle data is stale (>24h after 1d resampling floor)" in relevant_messages[1]

--- a/tests/ethereum/test_vault_history_diagnostics.py
+++ b/tests/ethereum/test_vault_history_diagnostics.py
@@ -251,11 +251,11 @@ def test_log_vault_history_diagnostics_warns_when_remote_head_fails(caplog: pyte
 def test_vault_history_logging_keeps_summary_before_per_vault_stale_entries(
     caplog: pytest.LogCaptureFixture,
 ) -> None:
-    """Verify the startup summary is logged before per-vault stale entries.
+    """Verify the startup summary is logged before the aggregated stale-vault warning.
 
     1. Build fresh summary diagnostics and a stale per-vault candle snapshot.
-    2. Emit the summary log and then the per-vault stale log.
-    3. Assert the summary message appears before the per-vault stale entry.
+    2. Emit the summary log and then the aggregated stale-vault warning.
+    3. Assert the summary message appears before the stale-vault warning and the stale warning is at warning level.
     """
     # 1. Build fresh summary diagnostics and a stale per-vault candle snapshot.
     diagnostics = build_vault_history_diagnostics(
@@ -292,7 +292,7 @@ def test_vault_history_logging_keeps_summary_before_per_vault_stale_entries(
         }
     )
 
-    # 2. Emit the summary log and then the per-vault stale log.
+    # 2. Emit the summary log and then the aggregated stale-vault warning.
     with caplog.at_level("INFO"):
         log_vault_history_diagnostics(diagnostics)
         log_stale_vault_candle_data(
@@ -301,11 +301,13 @@ def test_vault_history_logging_keeps_summary_before_per_vault_stale_entries(
             now=datetime.datetime(2026, 4, 11, 13, 59, 0),
         )
 
-    # 3. Assert the summary message appears before the per-vault stale entry.
-    relevant_messages = [
-        record.message
+    # 3. Assert the summary message appears before the stale-vault warning and the stale warning is at warning level.
+    relevant_records = [
+        record
         for record in caplog.records
         if "Vault history freshness summary" in record.message or "Vault candle data is stale" in record.message
     ]
-    assert "Vault history freshness summary" in relevant_messages[0]
-    assert "Vault candle data is stale (>24h after 1d resampling floor)" in relevant_messages[1]
+    assert "Vault history freshness summary" in relevant_records[0].message
+    assert relevant_records[1].levelname == "WARNING"
+    assert "Vault candle data is stale (>24h after 1d resampling floor) for 1 vault(s)" in relevant_records[1].message
+    assert "MirVault" in relevant_records[1].message

--- a/tests/lagoon/test_lagoon_arbitrum.py
+++ b/tests/lagoon/test_lagoon_arbitrum.py
@@ -22,6 +22,7 @@ from eth_defi.vault.base import VaultSpec
 from tradeexecutor.cli.main import app
 from tradeexecutor.cli.log import setup_pytest_logging
 from tradeexecutor.state.state import State
+from tradeexecutor.strategy.trading_strategy_universe import TradingStrategyUniverseModel
 
 from eth_typing import HexAddress
 
@@ -204,6 +205,8 @@ def test_cli_lagoon_deploy_arbitrum_vault(
     cli.main(args=["perform-test-trade", "--pair", "(arbitrum, 0x4b6f1c9e5d470b97181786b26da0d0945a7cf027)"], standalone_mode=False)
 
     # 4. Start executor and run 1s cycle
+    # This test exercises Lagoon deploy/start wiring, not remote market-data freshness.
+    mocker.patch.object(TradingStrategyUniverseModel, "check_data_age", return_value=None)
     cli.main(args=["start"], standalone_mode=False)
 
     # 4.b Check the 1s cycle has been run by inspecting the saved state

--- a/tradeexecutor/cli/slippage.py
+++ b/tradeexecutor/cli/slippage.py
@@ -31,14 +31,18 @@ def configure_max_slippage_tolerance(
         # Read max slippage from the strategy parameters if available
         parameters = mod.parameters
         if parameters:
-            # Legacy Parameters lack slippage tolerance
+            # Accept both the legacy and the newer parameter name so
+            # existing strategies do not silently fall back to defaults.
             slippage_tolerance = parameters.get("slippage_tolerance")
-            if slippage_tolerance:
+            if slippage_tolerance is None:
+                slippage_tolerance = parameters.get("slippage_tolerance_pct")
+
+            if slippage_tolerance is not None:
                 assert type(slippage_tolerance) == float
                 assert 0.0005 <= slippage_tolerance < 0.08, f"Slippage tolerance is {slippage_tolerance * 100} % - check if the value is sane"
                 max_slippage = slippage_tolerance
             else:
-                logger.warning("Parameters.slippage_tolerance missing - needed for live trading. Please add.")
+                logger.warning("Parameters.slippage_tolerance or Parameters.slippage_tolerance_pct missing - needed for live trading. Please add.")
 
     if not max_slippage:
         logger.info("Slippage tolerance not configured, using default %f", default_max_slippage)

--- a/tradeexecutor/ethereum/vault/checks.py
+++ b/tradeexecutor/ethereum/vault/checks.py
@@ -237,11 +237,12 @@ def log_stale_vault_candle_data(
     now: datetime.datetime | None = None,
     stale_tolerance: datetime.timedelta = datetime.timedelta(hours=24),
 ) -> None:
-    """Log per-vault stale candle entries for live startup diagnostics."""
+    """Log stale vault candle data as a single warning for live startup diagnostics."""
     if vault_candle_df is None or len(vault_candle_df) == 0:
         return
 
     reference_now = pd.Timestamp(now or native_datetime_utc_now())
+    stale_entries = []
 
     for pair_id in vault_candle_df["pair_id"].unique():
         pair_candles = vault_candle_df[vault_candle_df["pair_id"] == pair_id]
@@ -262,14 +263,15 @@ def log_stale_vault_candle_data(
             if metadata is not None:
                 vault_tvl = metadata.tvl
 
-        logger.info(
-            "Vault candle data is stale (>24h after 1d resampling floor): %s, address=%s, TVL=%s, pair_id=%d, last_candle=%s, age=%s",
-            vault_name,
-            vault_address,
-            vault_tvl,
-            pair_id,
-            last_ts,
-            age,
+        stale_entries.append(
+            f"{vault_name}, address={vault_address}, TVL={vault_tvl}, pair_id={pair_id}, last_candle={last_ts}, age={age}"
+        )
+
+    if stale_entries:
+        logger.warning(
+            "Vault candle data is stale (>24h after 1d resampling floor) for %d vault(s): %s",
+            len(stale_entries),
+            " | ".join(stale_entries),
         )
 
 

--- a/tradeexecutor/ethereum/vault/checks.py
+++ b/tradeexecutor/ethereum/vault/checks.py
@@ -23,12 +23,19 @@ dashboards and strategy chart registries.
 
 import datetime
 import logging
+from dataclasses import dataclass
+from email.utils import parsedate_to_datetime
+from pathlib import Path
 
 import pandas as pd
+import requests
 
+from eth_defi.compat import native_datetime_utc_fromtimestamp, native_datetime_utc_now
+from tradingstrategy.alternative_data.vault import CLEANED_VAULT_PRICE_PARQUET_URL
+
+from tradeexecutor.state.types import USDollarAmount
 from tradeexecutor.strategy.execution_context import ExecutionMode
 from tradeexecutor.strategy.trading_strategy_universe import TradingStrategyUniverse
-from tradeexecutor.state.types import USDollarAmount
 
 logger = logging.getLogger(__name__)
 
@@ -36,6 +43,234 @@ logger = logging.getLogger(__name__)
 class StaleVaultData(Exception):
     """Raised when one or more vaults have data older than the tolerance."""
     pass
+
+
+@dataclass(slots=True)
+class VaultHistoryDiagnostics:
+    """Summarise vault history freshness across cache, source, filter and resample stages."""
+
+    cache_path: Path | None
+    local_cache_mtime: datetime.datetime | None
+    local_cache_age: datetime.timedelta | None
+    remote_last_modified: datetime.datetime | None
+    remote_last_modified_age: datetime.timedelta | None
+    remote_etag: str | None
+    remote_content_length: int | None
+    remote_head_error: str | None
+    parquet_max_timestamp: datetime.datetime | None
+    parquet_data_age: datetime.timedelta | None
+    filtered_max_timestamp: datetime.datetime | None
+    filtered_data_age: datetime.timedelta | None
+    resampled_max_timestamp: datetime.datetime | None
+    resampled_data_age: datetime.timedelta | None
+    parquet_to_filtered_delta: datetime.timedelta | None
+    filtered_to_resampled_delta: datetime.timedelta | None
+
+
+def _coerce_naive_utc_datetime(value: pd.Timestamp | datetime.datetime | None) -> datetime.datetime | None:
+    """Convert pandas and aware datetimes to naive UTC datetimes."""
+    if value is None:
+        return None
+
+    if isinstance(value, pd.Timestamp):
+        if pd.isna(value):
+            return None
+        value = value.to_pydatetime()
+
+    if value.tzinfo is not None:
+        value = value.astimezone(datetime.timezone.utc).replace(tzinfo=None)
+
+    return value
+
+
+def _get_max_timestamp(df: pd.DataFrame | None) -> datetime.datetime | None:
+    """Get the maximum timestamp from a DataFrame if available."""
+    if df is None or len(df) == 0:
+        return None
+
+    if "timestamp" in df.columns:
+        return _coerce_naive_utc_datetime(pd.Timestamp(df["timestamp"].max()))
+
+    if df.index.name == "timestamp" and len(df.index) > 0:
+        return _coerce_naive_utc_datetime(pd.Timestamp(df.index.max()))
+
+    return None
+
+
+def _calculate_age(
+    timestamp: datetime.datetime | None,
+    reference_now: datetime.datetime,
+) -> datetime.timedelta | None:
+    """Calculate age from a timestamp to the reference time."""
+    if timestamp is None:
+        return None
+    return reference_now - timestamp
+
+
+def _calculate_delta(
+    older: datetime.datetime | None,
+    newer: datetime.datetime | None,
+) -> datetime.timedelta | None:
+    """Calculate the gap between two timestamps when both are present."""
+    if older is None or newer is None:
+        return None
+    return older - newer
+
+
+def _parse_last_modified_header(header_value: str | None) -> datetime.datetime | None:
+    """Parse an HTTP Last-Modified header to a naive UTC datetime."""
+    if not header_value:
+        return None
+
+    parsed = parsedate_to_datetime(header_value)
+    return _coerce_naive_utc_datetime(parsed)
+
+
+def _fetch_remote_vault_history_metadata(
+    http_session: requests.Session | None,
+    remote_url: str,
+) -> tuple[datetime.datetime | None, str | None, int | None, str | None]:
+    """Fetch remote vault parquet metadata with a lightweight HEAD request."""
+    if http_session is None:
+        return None, None, None, "No HTTP session available for remote vault metadata HEAD request"
+
+    try:
+        response = http_session.head(remote_url, allow_redirects=True, timeout=30)
+        response.raise_for_status()
+        last_modified = _parse_last_modified_header(response.headers.get("Last-Modified"))
+        etag = response.headers.get("ETag")
+        content_length_header = response.headers.get("Content-Length")
+        content_length = int(content_length_header) if content_length_header is not None else None
+        return last_modified, etag, content_length, None
+    except Exception as exc:
+        return None, None, None, f"{exc.__class__.__name__}: {exc}"
+
+
+def build_vault_history_diagnostics(
+    raw_vault_price_df: pd.DataFrame,
+    filtered_vault_price_df: pd.DataFrame,
+    resampled_vault_candle_df: pd.DataFrame | None,
+    cache_path: Path | None,
+    http_session: requests.Session | None,
+    remote_url: str = CLEANED_VAULT_PRICE_PARQUET_URL,
+    now: datetime.datetime | None = None,
+) -> VaultHistoryDiagnostics:
+    """Build startup diagnostics for vault history freshness."""
+    reference_now = now or native_datetime_utc_now()
+
+    local_cache_mtime = None
+    local_cache_age = None
+    if cache_path is not None and cache_path.exists():
+        local_cache_mtime = native_datetime_utc_fromtimestamp(cache_path.stat().st_mtime)
+        local_cache_age = reference_now - local_cache_mtime
+
+    remote_last_modified, remote_etag, remote_content_length, remote_head_error = _fetch_remote_vault_history_metadata(
+        http_session=http_session,
+        remote_url=remote_url,
+    )
+
+    parquet_max_timestamp = _get_max_timestamp(raw_vault_price_df)
+    filtered_max_timestamp = _get_max_timestamp(filtered_vault_price_df)
+    resampled_max_timestamp = _get_max_timestamp(resampled_vault_candle_df)
+
+    return VaultHistoryDiagnostics(
+        cache_path=cache_path,
+        local_cache_mtime=local_cache_mtime,
+        local_cache_age=local_cache_age,
+        remote_last_modified=remote_last_modified,
+        remote_last_modified_age=_calculate_age(remote_last_modified, reference_now),
+        remote_etag=remote_etag,
+        remote_content_length=remote_content_length,
+        remote_head_error=remote_head_error,
+        parquet_max_timestamp=parquet_max_timestamp,
+        parquet_data_age=_calculate_age(parquet_max_timestamp, reference_now),
+        filtered_max_timestamp=filtered_max_timestamp,
+        filtered_data_age=_calculate_age(filtered_max_timestamp, reference_now),
+        resampled_max_timestamp=resampled_max_timestamp,
+        resampled_data_age=_calculate_age(resampled_max_timestamp, reference_now),
+        parquet_to_filtered_delta=_calculate_delta(parquet_max_timestamp, filtered_max_timestamp),
+        filtered_to_resampled_delta=_calculate_delta(filtered_max_timestamp, resampled_max_timestamp),
+    )
+
+
+def log_vault_history_diagnostics(
+    diagnostics: VaultHistoryDiagnostics,
+    stale_tolerance: datetime.timedelta = datetime.timedelta(hours=24),
+) -> None:
+    """Log a one-line startup summary for vault history freshness."""
+    level = logging.INFO
+    if diagnostics.remote_head_error:
+        level = logging.WARNING
+    elif diagnostics.parquet_data_age is not None and diagnostics.parquet_data_age > stale_tolerance:
+        level = logging.WARNING
+
+    logger.log(
+        level,
+        "Vault history freshness summary: cache_path=%s, local_cache_mtime=%s, local_cache_age=%s, "
+        "remote_last_modified=%s, remote_last_modified_age=%s, remote_etag=%s, remote_content_length=%s, "
+        "parquet_max_timestamp=%s, parquet_data_age=%s, filtered_max_timestamp=%s, filtered_data_age=%s, "
+        "resampled_max_timestamp=%s, resampled_data_age=%s, parquet_to_filtered_delta=%s, "
+        "filtered_to_resampled_delta=%s, remote_head_error=%s. When using 1d resampling, the latest candle "
+        "is floored to 00:00 UTC, so a candle timestamp can still reflect materially newer source data.",
+        diagnostics.cache_path,
+        diagnostics.local_cache_mtime,
+        diagnostics.local_cache_age,
+        diagnostics.remote_last_modified,
+        diagnostics.remote_last_modified_age,
+        diagnostics.remote_etag,
+        diagnostics.remote_content_length,
+        diagnostics.parquet_max_timestamp,
+        diagnostics.parquet_data_age,
+        diagnostics.filtered_max_timestamp,
+        diagnostics.filtered_data_age,
+        diagnostics.resampled_max_timestamp,
+        diagnostics.resampled_data_age,
+        diagnostics.parquet_to_filtered_delta,
+        diagnostics.filtered_to_resampled_delta,
+        diagnostics.remote_head_error,
+    )
+
+
+def log_stale_vault_candle_data(
+    vault_candle_df: pd.DataFrame | None,
+    vault_pairs_df: pd.DataFrame,
+    now: datetime.datetime | None = None,
+    stale_tolerance: datetime.timedelta = datetime.timedelta(hours=24),
+) -> None:
+    """Log per-vault stale candle entries for live startup diagnostics."""
+    if vault_candle_df is None or len(vault_candle_df) == 0:
+        return
+
+    reference_now = pd.Timestamp(now or native_datetime_utc_now())
+
+    for pair_id in vault_candle_df["pair_id"].unique():
+        pair_candles = vault_candle_df[vault_candle_df["pair_id"] == pair_id]
+        if len(pair_candles) == 0:
+            continue
+
+        last_ts = pair_candles["timestamp"].max()
+        age = reference_now - last_ts
+        if age <= pd.Timedelta(stale_tolerance):
+            continue
+
+        vault_row = vault_pairs_df[vault_pairs_df["pair_id"] == pair_id]
+        vault_name = vault_row["exchange_name"].iloc[0] if len(vault_row) > 0 else "unknown"
+        vault_address = vault_row["address"].iloc[0] if len(vault_row) > 0 else "unknown"
+        vault_tvl = None
+        if len(vault_row) > 0:
+            metadata = vault_row["token_metadata"].iloc[0]
+            if metadata is not None:
+                vault_tvl = metadata.tvl
+
+        logger.info(
+            "Vault candle data is stale (>24h after 1d resampling floor): %s, address=%s, TVL=%s, pair_id=%d, last_candle=%s, age=%s",
+            vault_name,
+            vault_address,
+            vault_tvl,
+            pair_id,
+            last_ts,
+            age,
+        )
 
 
 def check_stale_vault_data(
@@ -318,5 +553,25 @@ def get_vault_data_freshness(
     df["_sort_key"] = df[["Candle data age", "TVL data age"]].max(axis=1)
     df = df.sort_values("_sort_key", ascending=False, na_position="first")
     df = df.drop(columns=["_sort_key"])
+
+    diagnostics = getattr(strategy_universe, "vault_history_diagnostics", None)
+    if diagnostics is not None:
+        df["Vault history cache path"] = str(diagnostics.cache_path) if diagnostics.cache_path is not None else None
+        df["Vault history cache mtime"] = diagnostics.local_cache_mtime
+        df["Vault history cache age"] = diagnostics.local_cache_age
+        df["Vault history remote last modified"] = diagnostics.remote_last_modified
+        df["Vault history remote last modified age"] = diagnostics.remote_last_modified_age
+        df["Vault history remote ETag"] = diagnostics.remote_etag
+        df["Vault history remote Content-Length"] = diagnostics.remote_content_length
+        df["Vault history remote HEAD error"] = diagnostics.remote_head_error
+        df["Vault history parquet max timestamp"] = diagnostics.parquet_max_timestamp
+        df["Vault history parquet data age"] = diagnostics.parquet_data_age
+        df["Vault history filtered max timestamp"] = diagnostics.filtered_max_timestamp
+        df["Vault history filtered data age"] = diagnostics.filtered_data_age
+        df["Vault history resampled max timestamp"] = diagnostics.resampled_max_timestamp
+        df["Vault history resampled data age"] = diagnostics.resampled_data_age
+        df["Vault history parquet->filtered delta"] = diagnostics.parquet_to_filtered_delta
+        df["Vault history filtered->resampled delta"] = diagnostics.filtered_to_resampled_delta
+
     df = df.reset_index(drop=True)
     return df

--- a/tradeexecutor/state/identifier.py
+++ b/tradeexecutor/state/identifier.py
@@ -519,6 +519,8 @@ class TradingPairIdentifier:
     #: Uniswap v2 likes are identified by their factor address.
     #:
     #: Legacy state files may have this as ``null``.
+    #: Keep this optional only for state deserialisation compatibility; live runtime code should still populate
+    #: a real exchange address because routing, reverse-universe lookups, and exchange matching assume a string.
     exchange_address: str | None
 
     #: How this asset is referred in the internal database
@@ -1471,5 +1473,4 @@ class AssetWithTrackedValue:
         self.quantity = quantity
         self.interest_rate_at_open = None
         self.last_interest_rate = None
-
 

--- a/tradeexecutor/state/identifier.py
+++ b/tradeexecutor/state/identifier.py
@@ -517,7 +517,9 @@ class TradingPairIdentifier:
     #: Exchange address.
     #: Identifies a decentralised exchange.
     #: Uniswap v2 likes are identified by their factor address.
-    exchange_address: str
+    #:
+    #: Legacy state files may have this as ``null``.
+    exchange_address: str | None
 
     #: How this asset is referred in the internal database
     #:
@@ -607,7 +609,7 @@ class TradingPairIdentifier:
     def __repr__(self):
         fee = self.fee or 0
         type_name = self.kind.name if self.kind else "spot"
-        exchange_name = self.exchange_name if self.exchange_name else f"{self.exchange_address}"
+        exchange_name = self.exchange_name or self.exchange_address or "<unknown exchange>"
 
         if self.is_vault():
             return f"<Pair for vault {self.get_vault_name()} on {self.get_vault_protocol()},  {self.base.token_symbol}-{self.quote.token_symbol} {exchange_name}, id #{self.internal_id}>"
@@ -1469,6 +1471,5 @@ class AssetWithTrackedValue:
         self.quantity = quantity
         self.interest_rate_at_open = None
         self.last_interest_rate = None
-
 
 

--- a/tradeexecutor/strategy/chart/standard/vault.py
+++ b/tradeexecutor/strategy/chart/standard/vault.py
@@ -154,8 +154,11 @@ def vault_data_freshness(input: ChartInput) -> pd.DataFrame:
     """Data freshness timestamps for all vault pairs showing candle and TVL staleness.
 
     Reports the last real (non-forward-filled) timestamp and the latest
-    timestamp for both candle and TVL data per vault. Vaults with no
-    real data at all appear at the top, followed by stalest-first ordering.
+    timestamp for both candle and TVL data per vault. When available, also
+    includes universe-level vault history startup diagnostics such as cache
+    age, remote metadata, and pre-filter / post-filter / post-resample
+    freshness markers. Vaults with no real data at all appear at the top,
+    followed by stalest-first ordering.
     """
     from tradeexecutor.ethereum.vault.checks import get_vault_data_freshness
     return get_vault_data_freshness(input.strategy_universe)

--- a/tradeexecutor/strategy/pricing_model.py
+++ b/tradeexecutor/strategy/pricing_model.py
@@ -232,7 +232,7 @@ class PricingModel(abc.ABC):
     def can_redeem(
         self,
         ts: datetime.datetime | None,
-        pair: TradingPairIdentifier,
+        pair: TradingPairIdentifier | None,
     ) -> bool:
         """Check whether a redemption or position reduction is currently possible.
 
@@ -244,7 +244,7 @@ class PricingModel(abc.ABC):
     def check_redemption(
         self,
         ts: datetime.datetime | None,
-        pair: TradingPairIdentifier,
+        pair: TradingPairIdentifier | None,
         *,
         stage: RedemptionCheckStage = RedemptionCheckStage.unknown,
         position: TradingPosition | None = None,
@@ -263,15 +263,15 @@ class PricingModel(abc.ABC):
             timestamp=ts,
             stage=stage,
             can_redeem=can_redeem,
-            pair_ticker=pair.get_ticker(),
-            vault_address=pair.pool_address,
+            pair_ticker=pair.get_ticker() if pair else None,
+            vault_address=pair.pool_address if pair else None,
             max_redemption=float(max_redemption) if max_redemption is not None else None,
         )
 
     def is_tradeable(
         self,
         ts: datetime.datetime | None,
-        pair: TradingPairIdentifier,
+        pair: TradingPairIdentifier | None,
     ) -> bool:
         """Check whether both deposit and redemption are currently possible."""
         return self.can_deposit(ts, pair) and self.can_redeem(ts, pair)

--- a/tradeexecutor/strategy/trading_strategy_universe.py
+++ b/tradeexecutor/strategy/trading_strategy_universe.py
@@ -21,6 +21,7 @@ from typing import TYPE_CHECKING, List, Optional, Callable, Tuple, Set, Dict, It
 import pandas as pd
 from tabulate import tabulate
 
+from eth_defi.compat import native_datetime_utc_now
 from tradingstrategy.lending import LendingReserveUniverse, LendingReserveDescription, LendingCandleType, LendingCandleUniverse, UnknownLendingReserve, LendingProtocolType, LendingReserve
 from tradingstrategy.token import Token
 from tradingstrategy.candle import GroupedCandleUniverse

--- a/tradeexecutor/strategy/trading_strategy_universe.py
+++ b/tradeexecutor/strategy/trading_strategy_universe.py
@@ -116,6 +116,9 @@ class Dataset:
     #: List of vaults we loaded
     vault_specs: VaultUniverse | list[tuple[ChainId, JSONHexAddress]] | None = None
 
+    #: Optional vault history startup diagnostics gathered during loading.
+    vault_history_diagnostics: object | None = None
+
     def __repr__(self):
         return f"<Dataset pairs:{len(self.pairs)} candles:{len(self.candles)} start:{self.start_at} end:{self.end_at} live history period:{self.history_period}>"
 
@@ -222,6 +225,9 @@ class TradingStrategyUniverse(StrategyExecutionUniverse):
 
     #: Allow backtest to skip routing checks to trade pairs for which we have not configured routes yet.
     ignore_routing: bool = False
+
+    #: Optional vault history startup diagnostics propagated from the dataset loader.
+    vault_history_diagnostics: object | None = None
 
     def __repr__(self):
         pair_count = self.data_universe.pairs.get_count()
@@ -1254,6 +1260,7 @@ class TradingStrategyUniverse(StrategyExecutionUniverse):
             reserve_assets=reserve_assets,
             backtest_stop_loss_time_bucket=backtest_stop_loss_time_bucket,
             backtest_stop_loss_candles=backtest_stop_loss_candles,
+            vault_history_diagnostics=dataset.vault_history_diagnostics,
         )
 
     @staticmethod
@@ -1470,6 +1477,7 @@ class TradingStrategyUniverse(StrategyExecutionUniverse):
             backtest_stop_loss_time_bucket=dataset.backtest_stop_loss_time_bucket,
             backtest_stop_loss_candles=stop_loss_candle_universe,
             primary_chain=primary_chain,
+            vault_history_diagnostics=dataset.vault_history_diagnostics,
         )
 
     @staticmethod
@@ -2004,7 +2012,8 @@ class TradingStrategyUniverseModel(UniverseModel):
             data_universe=universe,
             reserve_assets=reserve_assets,
             backtest_stop_loss_candles=backtest_stop_loss_candles,
-            backtest_stop_loss_time_bucket=dataset.backtest_stop_loss_time_bucket)
+            backtest_stop_loss_time_bucket=dataset.backtest_stop_loss_time_bucket,
+            vault_history_diagnostics=dataset.vault_history_diagnostics)
 
     @abstractmethod
     def construct_universe(
@@ -2811,6 +2820,7 @@ def load_partial_data(
 
         # Include vault data for designed vaults if asked
         vault_pairs_df = None
+        vault_history_diagnostics = None
         if vaults is not None:
             logger.info("Including vaults: %s", vaults)
             vault_exchanges, vault_pairs_df = load_multiple_vaults(vaults, check_all_vaults_found=check_all_vaults_found)
@@ -2842,11 +2852,11 @@ def load_partial_data(
             assert vaults, "Vaults must be given to load Trading Strategy website vault price history"
             assert vault_pairs_df is not None, "Vault pairs must be materialised before loading Trading Strategy website vault history"
 
-            website_vault_prices_df = client.fetch_vault_price_history(
+            raw_website_vault_prices_df = client.fetch_vault_price_history(
                 download_root=vault_history_download_root,
             )
-            website_vault_prices_df = filter_vault_price_history(
-                website_vault_prices_df,
+            filtered_website_vault_prices_df = filter_vault_price_history(
+                raw_website_vault_prices_df,
                 vault_pairs_df,
                 data_load_start_at,
                 end_at,
@@ -2854,39 +2864,34 @@ def load_partial_data(
 
             offset = time_bucket.to_frequency()
             freq_string = f"{offset.n}{offset.name.lower()}"
-            vault_candle_df, vault_liquidity_df = convert_vault_prices_to_candles(website_vault_prices_df, freq_string)
+            vault_candle_df, vault_liquidity_df = convert_vault_prices_to_candles(filtered_website_vault_prices_df, freq_string)
             candles_df = _concat_optional_dataframe(candles_df, vault_candle_df)
             if liquidity_df is not None:
                 liquidity_df = _concat_optional_dataframe(liquidity_df, vault_liquidity_df)
 
-            # Log per-vault candle data freshness so stale data is visible
-            # in the logs. Warn if any vault's latest candle is more than 24h old.
-            if execution_context.mode.is_live_trading() and vault_candle_df is not None:
-                now = pd.Timestamp(native_datetime_utc_now())
-                for pair_id in vault_candle_df["pair_id"].unique():
-                    pair_candles = vault_candle_df[vault_candle_df["pair_id"] == pair_id]
-                    if len(pair_candles) > 0:
-                        last_ts = pair_candles["timestamp"].max()
-                        age = now - last_ts
-                        if age > pd.Timedelta(hours=24):
-                            # Look up vault name, address and TVL from the pairs dataframe
-                            vault_row = vault_pairs_df[vault_pairs_df["pair_id"] == pair_id]
-                            vault_name = vault_row["exchange_name"].iloc[0] if len(vault_row) > 0 else "unknown"
-                            vault_address = vault_row["address"].iloc[0] if len(vault_row) > 0 else "unknown"
-                            vault_tvl = None
-                            if len(vault_row) > 0:
-                                metadata = vault_row["token_metadata"].iloc[0]
-                                if metadata is not None:
-                                    vault_tvl = metadata.tvl
-                            logger.warning(
-                                "Vault candle data is stale (>24h): %s, address=%s, TVL=%s, pair_id=%d, last_candle=%s, age=%s",
-                                vault_name,
-                                vault_address,
-                                vault_tvl,
-                                pair_id,
-                                last_ts,
-                                age,
-                            )
+            if execution_context.mode.is_live_trading():
+                from tradeexecutor.ethereum.vault.checks import (
+                    build_vault_history_diagnostics,
+                    log_stale_vault_candle_data,
+                    log_vault_history_diagnostics,
+                )
+
+                vault_history_cache_path = client.transport.fetch_vault_price_history(
+                    download_root=vault_history_download_root,
+                )
+                vault_history_diagnostics = build_vault_history_diagnostics(
+                    raw_vault_price_df=raw_website_vault_prices_df,
+                    filtered_vault_price_df=filtered_website_vault_prices_df,
+                    resampled_vault_candle_df=vault_candle_df,
+                    cache_path=vault_history_cache_path,
+                    http_session=client.transport.requests,
+                    now=native_datetime_utc_now(),
+                )
+                log_vault_history_diagnostics(vault_history_diagnostics)
+                log_stale_vault_candle_data(
+                    vault_candle_df=vault_candle_df,
+                    vault_pairs_df=vault_pairs_df,
+                )
 
         # Collect some debug data for the first 5 pairs
         # to diagnose data loding problems
@@ -2925,6 +2930,7 @@ def load_partial_data(
             end_at=end_at,
             history_period=required_history_period,
             vault_specs=vaults,
+            vault_history_diagnostics=vault_history_diagnostics,
         )
 
 

--- a/tradeexecutor/strategy/trading_strategy_universe.py
+++ b/tradeexecutor/strategy/trading_strategy_universe.py
@@ -16,12 +16,11 @@ from dataclasses import dataclass, field
 import logging
 from math import isnan
 from pathlib import Path
-from typing import List, Optional, Callable, Tuple, Set, Dict, Iterable, Collection, TypeAlias, Literal
+from typing import TYPE_CHECKING, List, Optional, Callable, Tuple, Set, Dict, Iterable, Collection, TypeAlias, Literal
 
 import pandas as pd
 from tabulate import tabulate
 
-from eth_defi.compat import native_datetime_utc_now
 from tradingstrategy.lending import LendingReserveUniverse, LendingReserveDescription, LendingCandleType, LendingCandleUniverse, UnknownLendingReserve, LendingProtocolType, LendingReserve
 from tradingstrategy.token import Token
 from tradingstrategy.candle import GroupedCandleUniverse
@@ -41,7 +40,7 @@ from tradingstrategy.utils.groupeduniverse import filter_for_pairs, NoDataAvaila
 from tradingstrategy.utils.token_extra_data import load_extra_metadata
 from tradingstrategy.utils.token_filter import add_base_quote_address_columns
 from tradingstrategy.vault import VaultMetadata, VaultUniverse
-from tradingstrategy.alternative_data.vault import load_multiple_vaults, load_vault_price_data, convert_vault_prices_to_candles, DEFAULT_VAULT_PRICE_BUNDLE, filter_vault_price_history
+from tradingstrategy.alternative_data.vault import load_multiple_vaults, load_vault_price_data, convert_vault_prices_to_candles, DEFAULT_VAULT_DOWNLOAD_ROOT, DEFAULT_VAULT_PRICE_BUNDLE, filter_vault_price_history
 
 from tradeexecutor.strategy.execution_context import ExecutionMode, ExecutionContext
 from tradeexecutor.ethereum.cctp.bridge_universe import generate_primary_to_satellite_cctp_bridge_universe
@@ -52,10 +51,10 @@ from tradeexecutor.strategy.pandas_trader.create_universe_wrapper import call_cr
 from tradeexecutor.strategy.parameters import StrategyParameters
 
 from tradeexecutor.strategy.dex_data_translation import translate_trading_pair, translate_credit_reserve, translate_token
-from eth_defi.compat import native_datetime_utc_now
-
-
 logger = logging.getLogger(__name__)
+
+if TYPE_CHECKING:
+    from tradeexecutor.ethereum.vault.checks import VaultHistoryDiagnostics
 
 
 #: Unique hash string for each universe.
@@ -117,7 +116,7 @@ class Dataset:
     vault_specs: VaultUniverse | list[tuple[ChainId, JSONHexAddress]] | None = None
 
     #: Optional vault history startup diagnostics gathered during loading.
-    vault_history_diagnostics: object | None = None
+    vault_history_diagnostics: "VaultHistoryDiagnostics | None" = None
 
     def __repr__(self):
         return f"<Dataset pairs:{len(self.pairs)} candles:{len(self.candles)} start:{self.start_at} end:{self.end_at} live history period:{self.history_period}>"
@@ -227,7 +226,7 @@ class TradingStrategyUniverse(StrategyExecutionUniverse):
     ignore_routing: bool = False
 
     #: Optional vault history startup diagnostics propagated from the dataset loader.
-    vault_history_diagnostics: object | None = None
+    vault_history_diagnostics: "VaultHistoryDiagnostics | None" = None
 
     def __repr__(self):
         pair_count = self.data_universe.pairs.get_count()
@@ -622,6 +621,7 @@ class TradingStrategyUniverse(StrategyExecutionUniverse):
             backtest_stop_loss_candles=self.backtest_stop_loss_candles,
             reserve_assets=self.reserve_assets,
             required_history_period=self.required_history_period,
+            vault_history_diagnostics=self.vault_history_diagnostics,
         )
 
     def write_pickle(self, path: Path):
@@ -910,6 +910,7 @@ class TradingStrategyUniverse(StrategyExecutionUniverse):
             reserve_assets=reserve_assets,
             backtest_stop_loss_time_bucket=dataset.backtest_stop_loss_time_bucket,
             backtest_stop_loss_candles=stop_loss_candle_universe,
+            vault_history_diagnostics=dataset.vault_history_diagnostics,
         )
 
     @staticmethod
@@ -1028,6 +1029,7 @@ class TradingStrategyUniverse(StrategyExecutionUniverse):
             reserve_assets=reserve_assets,
             backtest_stop_loss_time_bucket=dataset.backtest_stop_loss_time_bucket,
             backtest_stop_loss_candles=stop_loss_candle_universe,
+            vault_history_diagnostics=dataset.vault_history_diagnostics,
         )
 
     def get_pair_by_address(self, address: str) -> Optional[TradingPairIdentifier]:
@@ -1563,6 +1565,7 @@ class TradingStrategyUniverse(StrategyExecutionUniverse):
             reserve_assets=reserve_assets,
             backtest_stop_loss_time_bucket=dataset.backtest_stop_loss_time_bucket,
             backtest_stop_loss_candles=stop_loss_candle_universe,
+            vault_history_diagnostics=dataset.vault_history_diagnostics,
         )
 
     def get_credit_supply_pair(self) -> TradingPairIdentifier:
@@ -2876,8 +2879,12 @@ def load_partial_data(
                     log_vault_history_diagnostics,
                 )
 
-                vault_history_cache_path = client.transport.fetch_vault_price_history(
-                    download_root=vault_history_download_root,
+                vault_history_cache_root = vault_history_download_root or DEFAULT_VAULT_DOWNLOAD_ROOT
+                vault_history_cache_path = Path(
+                    client.transport.get_cached_file_path(
+                        "vault-price-history.parquet",
+                        cache_path=vault_history_cache_root,
+                    )
                 )
                 vault_history_diagnostics = build_vault_history_diagnostics(
                     raw_vault_price_df=raw_website_vault_prices_df,


### PR DESCRIPTION
## Why

Hyper AI live startup was producing noisy compatibility warnings and stale vault logs that were hard to interpret. We needed to preserve the existing warning-first behaviour while making it clearer whether the issue was old source data, filtering, or daily resampling, and also restore compatibility with older state files and the newer strategy parameter naming used by `hyper-ai.py`.

## Lessons learnt

The vault history path already had the right home for structured diagnostics in `tradeexecutor.ethereum.vault.checks`, so extending that path kept logs and charts aligned instead of creating a second diagnostics track. Also, using a lightweight `HEAD` request kept the remote metadata check local to `trade-executor` and avoided pushing new API surface into the `trading-strategy` submodule.

## Summary

- added vault history startup diagnostics covering local cache age, remote object metadata, parquet freshness before filtering, freshness after filtering, and freshness after daily resampling
- logged the new vault freshness summary before the stale-vault warning, clarified that `1d` resampling floors candle timestamps to `00:00 UTC`, and collapsed per-vault stale entries into a single warning to avoid log spam
- propagated vault history diagnostics through all relevant `TradingStrategyUniverse` construction paths, including `clone()`, so charts and copied universes keep the same diagnostics context
- derived the cached vault-history parquet path directly instead of refetching it through the client transport fetch path
- accepted both `slippage_tolerance` and `slippage_tolerance_pct` during live startup parameter resolution
- kept `TradingPairIdentifier.exchange_address` optional for older state JSON compatibility, documented the intended runtime behaviour, and improved its fallback string representation
- added focused tests for cache-hit, stale-source, remote-HEAD-failure, resample-boundary, and diagnostics-propagation cases
