### PR TITLE
Fix live vault cutoff and warning semantics

### DIFF
--- a/tests/backtest/test_hyper_ai_stale_data_indicators.py
+++ b/tests/backtest/test_hyper_ai_stale_data_indicators.py
@@ -738,6 +738,8 @@ def test_get_vault_data_freshness_includes_universe_level_history_diagnostics(
         resampled_data_age=datetime.timedelta(hours=14),
         parquet_to_filtered_delta=datetime.timedelta(hours=1),
         filtered_to_resampled_delta=datetime.timedelta(hours=12),
+        vault_history_filter_end_at=datetime.datetime(2026, 4, 11, 14, 0, 0),
+        expected_daily_flooring_reason="Expected 1d floor artefact: the resampled candle timestamp is floored to 00:00 UTC",
     )
 
     # 2. Call get_vault_data_freshness on the same universe.
@@ -778,6 +780,8 @@ def test_clone_preserves_vault_history_diagnostics(
         resampled_data_age=datetime.timedelta(hours=14),
         parquet_to_filtered_delta=datetime.timedelta(hours=1),
         filtered_to_resampled_delta=datetime.timedelta(hours=12),
+        vault_history_filter_end_at=datetime.datetime(2026, 4, 11, 14, 0, 0),
+        expected_daily_flooring_reason="Expected 1d floor artefact: the resampled candle timestamp is floored to 00:00 UTC",
     )
 
     # 2. Clone the universe.

--- a/tests/ethereum/test_vault_history_diagnostics.py
+++ b/tests/ethereum/test_vault_history_diagnostics.py
@@ -170,6 +170,7 @@ def test_build_vault_history_diagnostics_detects_daily_resample_floor_gap() -> N
     assert diagnostics.parquet_data_age == datetime.timedelta(hours=14)
     assert diagnostics.resampled_data_age == datetime.timedelta(days=1, hours=13, minutes=59)
     assert diagnostics.filtered_to_resampled_delta == datetime.timedelta(hours=23, minutes=59)
+    assert diagnostics.expected_daily_flooring_reason is not None
 
 
 def test_log_vault_history_diagnostics_warns_when_source_data_is_stale(caplog: pytest.LogCaptureFixture) -> None:
@@ -248,14 +249,14 @@ def test_log_vault_history_diagnostics_warns_when_remote_head_fails(caplog: pyte
     assert "RequestException: boom" in summary_record.message
 
 
-def test_log_vault_history_diagnostics_warns_for_suspicious_resample_values(
+def test_log_vault_history_diagnostics_does_not_warn_for_expected_d1_floor(
     caplog: pytest.LogCaptureFixture,
 ) -> None:
-    """Verify suspicious 1d-resample values are highlighted in a follow-up warning.
+    """Verify expected 1d floor artefacts stay informational instead of warning.
 
     1. Build diagnostics where the parquet is still fresh but the 1d candle looks stale.
     2. Emit the startup summary log.
-    3. Assert a follow-up warning highlights the suspicious resample-only fields in a table.
+    3. Assert the summary carries the daily-floor explanation and no suspicious-values warning is emitted.
     """
     # 1. Build diagnostics where the parquet is still fresh but the 1d candle looks stale.
     diagnostics = build_vault_history_diagnostics(
@@ -281,6 +282,7 @@ def test_log_vault_history_diagnostics_warns_for_suspicious_resample_values(
                 }
             )
         ),
+        vault_history_filter_end_at=datetime.datetime(2026, 4, 11, 16, 43, 33),
         now=datetime.datetime(2026, 4, 11, 16, 43, 33),
     )
 
@@ -288,13 +290,53 @@ def test_log_vault_history_diagnostics_warns_for_suspicious_resample_values(
     with caplog.at_level("INFO"):
         log_vault_history_diagnostics(diagnostics)
 
-    # 3. Assert a follow-up warning highlights the suspicious resample-only fields in a table.
+    # 3. Assert the summary carries the explanation and no suspicious-values warning is emitted.
+    summary_record = next(record for record in caplog.records if "Vault history freshness summary" in record.message)
+    assert summary_record.levelname == "INFO"
+    assert "expected_daily_flooring_reason=Expected 1d floor artefact" in summary_record.message
+    assert not any("Vault history freshness has suspicious values" in record.message for record in caplog.records)
+
+
+def test_log_vault_history_diagnostics_warns_for_unexpected_parquet_to_filtered_gap(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Verify fresh source rows lost before filtering still trigger a warning.
+
+    1. Build diagnostics where the source parquet is fresh but the filtered max timestamp trails unexpectedly.
+    2. Emit the startup summary log.
+    3. Assert the suspicious-values warning highlights the parquet-to-filter gap.
+    """
+    # 1. Build diagnostics where the source parquet is fresh but the filtered max timestamp trails unexpectedly.
+    diagnostics = build_vault_history_diagnostics(
+        raw_vault_price_df=_build_vault_price_history_df(
+            "0xface000000000000000000000000000000000000",
+            [datetime.datetime(2026, 4, 11, 12, 0, 0)],
+        ),
+        filtered_vault_price_df=_build_vault_price_history_df(
+            "0xface000000000000000000000000000000000000",
+            [datetime.datetime(2026, 4, 11, 9, 30, 0)],
+        ),
+        resampled_vault_candle_df=pd.DataFrame(
+            {
+                "timestamp": [pd.Timestamp(datetime.datetime(2026, 4, 11, 9, 30, 0))],
+                "pair_id": [1],
+            }
+        ),
+        cache_path=None,
+        http_session=_MockSession(response=_MockResponse({})),
+        vault_history_filter_end_at=datetime.datetime(2026, 4, 11, 13, 0, 0),
+        now=datetime.datetime(2026, 4, 11, 13, 30, 0),
+    )
+
+    # 2. Emit the startup summary log.
+    with caplog.at_level("INFO"):
+        log_vault_history_diagnostics(diagnostics)
+
+    # 3. Assert the suspicious-values warning highlights the parquet-to-filter gap.
     warning_record = next(record for record in caplog.records if "Vault history freshness has suspicious values" in record.message)
     assert warning_record.levelname == "WARNING"
-    assert "\nfield" in warning_record.message
-    assert "resampled_data_age" in warning_record.message
-    assert "filtered_to_resampled_delta" in warning_record.message
-    assert "Looks stale after 1d resampling floor" in warning_record.message
+    assert "parquet_to_filtered_delta" in warning_record.message
+    assert "Selected vault history trails the freshest parquet row" in warning_record.message
 
 
 def test_vault_history_logging_keeps_summary_before_per_vault_stale_entries(

--- a/tests/test_vault_live_cutoff.py
+++ b/tests/test_vault_live_cutoff.py
@@ -1,0 +1,169 @@
+"""Tests for live vault-history cutoff handling."""
+
+import datetime
+from types import SimpleNamespace
+
+import pandas as pd
+import pytest
+from tradingstrategy.client import Client
+from tradingstrategy.exchange import ExchangeUniverse
+from tradingstrategy.timebucket import TimeBucket
+
+import tradeexecutor.ethereum.vault.checks as vault_checks
+import tradeexecutor.strategy.trading_strategy_universe as trading_strategy_universe
+from tradeexecutor.strategy.execution_context import ExecutionContext, ExecutionMode
+from tradeexecutor.strategy.trading_strategy_universe import (
+    _resolve_live_end_timestamps,
+    load_partial_data,
+)
+from tradeexecutor.strategy.universe_model import UniverseOptions
+
+
+pytestmark = pytest.mark.timeout(300)
+
+
+def test_resolve_live_end_timestamps_daily_rounding(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Verify live daily datasets keep a floored dataset end and an unfloored vault cutoff.
+
+    1. Freeze the live clock to a specific intraday timestamp.
+    2. Resolve live end timestamps for a daily bucket with rounding enabled.
+    3. Assert the dataset end is floored to midnight while the vault cutoff keeps the live timestamp.
+    """
+    fixed_now = datetime.datetime(2026, 4, 11, 17, 9, 41)
+
+    # 1. Freeze the live clock to a specific intraday timestamp.
+    monkeypatch.setattr(trading_strategy_universe, "native_datetime_utc_now", lambda: fixed_now)
+
+    # 2. Resolve live end timestamps for a daily bucket with rounding enabled.
+    dataset_end_at, vault_history_filter_end_at = _resolve_live_end_timestamps(
+        time_bucket=TimeBucket.d1,
+        explicit_end_at=None,
+        round_start_end=True,
+    )
+
+    # 3. Assert the dataset end is floored to midnight while the vault cutoff keeps the live timestamp.
+    assert dataset_end_at == datetime.datetime(2026, 4, 11, 0, 0, 0)
+    assert vault_history_filter_end_at == fixed_now
+
+
+def test_resolve_live_end_timestamps_without_rounding() -> None:
+    """Verify disabled rounding keeps identical dataset and vault end timestamps.
+
+    1. Create an explicit intraday end timestamp.
+    2. Resolve live end timestamps with rounding disabled.
+    3. Assert both returned timestamps are unchanged.
+    """
+    explicit_end_at = datetime.datetime(2026, 4, 11, 17, 9, 41)
+
+    # 1. Create an explicit intraday end timestamp.
+    # 2. Resolve live end timestamps with rounding disabled.
+    dataset_end_at, vault_history_filter_end_at = _resolve_live_end_timestamps(
+        time_bucket=TimeBucket.d1,
+        explicit_end_at=explicit_end_at,
+        round_start_end=False,
+    )
+
+    # 3. Assert both returned timestamps are unchanged.
+    assert dataset_end_at == explicit_end_at
+    assert vault_history_filter_end_at == explicit_end_at
+
+
+def test_load_partial_data_uses_unfloored_vault_history_cutoff(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Verify live website vault history filtering receives the unfloored cutoff.
+
+    1. Build a stubbed live loader path with a fixed intraday clock and local vault history rows.
+    2. Run ``load_partial_data()`` with website vault history enabled and capture the filter cutoff.
+    3. Assert the vault-history filter sees the unfloored live timestamp while the dataset end stays floored.
+    """
+    fixed_now = datetime.datetime(2026, 4, 11, 17, 9, 41)
+    captured: dict[str, object] = {}
+    transport = SimpleNamespace(
+        requests=None,
+        get_cached_file_path=lambda filename, cache_path=None: f"/tmp/{filename}",
+    )
+    client = Client(None, transport)
+    client.fetch_exchange_universe = lambda: ExchangeUniverse({})
+    client.fetch_vault_price_history = lambda download_root=None: pd.DataFrame(
+        [
+            {
+                "timestamp": pd.Timestamp("2026-04-11 04:22:29.962000"),
+                "chain": 9999,
+                "address": "0xabc",
+                "share_price": 1.01,
+                "total_assets": 1_000.0,
+            },
+            {
+                "timestamp": pd.Timestamp("2026-04-10 23:59:35.537000"),
+                "chain": 9999,
+                "address": "0xabc",
+                "share_price": 1.0,
+                "total_assets": 999.0,
+            },
+        ]
+    )
+
+    # 1. Build a stubbed live loader path with a fixed intraday clock and local vault history rows.
+    monkeypatch.setattr(trading_strategy_universe, "native_datetime_utc_now", lambda: fixed_now)
+    monkeypatch.setattr(
+        trading_strategy_universe,
+        "load_multiple_vaults",
+        lambda vaults, check_all_vaults_found=True: (
+            [],
+            pd.DataFrame(
+                [
+                    {
+                        "chain_id": 9999,
+                        "address": "0xabc",
+                        "pair_id": 1,
+                    }
+                ]
+            ),
+        ),
+    )
+
+    def _capture_filter(
+        vault_prices_df: pd.DataFrame,
+        vault_pairs_df: pd.DataFrame,
+        start_at: datetime.datetime | None = None,
+        end_at: datetime.datetime | None = None,
+    ) -> pd.DataFrame:
+        captured["end_at"] = end_at
+        del vault_pairs_df
+        if start_at is not None:
+            vault_prices_df = vault_prices_df.loc[vault_prices_df["timestamp"] >= pd.Timestamp(start_at)]
+        if end_at is not None:
+            vault_prices_df = vault_prices_df.loc[vault_prices_df["timestamp"] <= pd.Timestamp(end_at)]
+        return vault_prices_df.copy()
+
+    monkeypatch.setattr(trading_strategy_universe, "filter_vault_price_history", _capture_filter)
+    monkeypatch.setattr(
+        trading_strategy_universe,
+        "convert_vault_prices_to_candles",
+        lambda df, frequency: (
+            pd.DataFrame({"timestamp": [pd.Timestamp("2026-04-11 00:00:00")], "pair_id": [1]}),
+            pd.DataFrame(),
+        ),
+    )
+    monkeypatch.setattr(vault_checks, "build_vault_history_diagnostics", lambda *args, **kwargs: None)
+    monkeypatch.setattr(vault_checks, "log_vault_history_diagnostics", lambda *args, **kwargs: None)
+    monkeypatch.setattr(vault_checks, "log_stale_vault_candle_data", lambda *args, **kwargs: None)
+
+    # 2. Run ``load_partial_data()`` with website vault history enabled and capture the filter cutoff.
+    dataset = load_partial_data(
+        client=client,
+        execution_context=ExecutionContext(ExecutionMode.unit_testing_trading),
+        time_bucket=TimeBucket.d1,
+        pairs=pd.DataFrame(columns=["dex_type", "exchange_id", "pair_id"]),
+        universe_options=UniverseOptions(history_period=datetime.timedelta(days=30)),
+        liquidity=False,
+        vaults=object(),
+        vault_history_source="trading-strategy-website",
+    )
+
+    # 3. Assert the vault-history filter sees the unfloored live timestamp while the dataset end stays floored.
+    assert captured["end_at"] == fixed_now
+    assert dataset.end_at == datetime.datetime(2026, 4, 11, 0, 0, 0)

--- a/tradeexecutor/ethereum/vault/checks.py
+++ b/tradeexecutor/ethereum/vault/checks.py
@@ -41,6 +41,9 @@ from tradeexecutor.strategy.trading_strategy_universe import TradingStrategyUniv
 logger = logging.getLogger(__name__)
 
 
+DEFAULT_VAULT_HISTORY_STALE_TOLERANCE = datetime.timedelta(hours=24)
+
+
 class StaleVaultData(Exception):
     """Raised when one or more vaults have data older than the tolerance."""
     pass
@@ -66,6 +69,8 @@ class VaultHistoryDiagnostics:
     resampled_data_age: datetime.timedelta | None
     parquet_to_filtered_delta: datetime.timedelta | None
     filtered_to_resampled_delta: datetime.timedelta | None
+    vault_history_filter_end_at: datetime.datetime | None
+    expected_daily_flooring_reason: str | None
 
 
 def _coerce_naive_utc_datetime(value: pd.Timestamp | datetime.datetime | None) -> datetime.datetime | None:
@@ -127,6 +132,39 @@ def _parse_last_modified_header(header_value: str | None) -> datetime.datetime |
     return _coerce_naive_utc_datetime(parsed)
 
 
+def _calculate_expected_daily_flooring_reason(
+    parquet_data_age: datetime.timedelta | None,
+    filtered_data_age: datetime.timedelta | None,
+    filtered_max_timestamp: datetime.datetime | None,
+    resampled_max_timestamp: datetime.datetime | None,
+    vault_history_filter_end_at: datetime.datetime | None,
+    stale_tolerance: datetime.timedelta = DEFAULT_VAULT_HISTORY_STALE_TOLERANCE,
+) -> str | None:
+    """Explain when a stale-looking resampled timestamp is an expected daily floor artefact."""
+    if (
+        parquet_data_age is None
+        or filtered_data_age is None
+        or parquet_data_age > stale_tolerance
+        or filtered_data_age > stale_tolerance
+        or filtered_max_timestamp is None
+        or resampled_max_timestamp is None
+        or filtered_max_timestamp <= resampled_max_timestamp
+    ):
+        return None
+
+    filtered_floor = filtered_max_timestamp.replace(hour=0, minute=0, second=0, microsecond=0)
+    if resampled_max_timestamp != filtered_floor:
+        return None
+
+    if vault_history_filter_end_at is not None:
+        return (
+            "Expected 1d floor artefact: vault history kept intraday source data until "
+            f"{vault_history_filter_end_at}, but the resampled candle timestamp is floored to 00:00 UTC"
+        )
+
+    return "Expected 1d floor artefact: the resampled candle timestamp is floored to 00:00 UTC"
+
+
 def _fetch_remote_vault_history_metadata(
     http_session: requests.Session | None,
     remote_url: str,
@@ -153,6 +191,7 @@ def build_vault_history_diagnostics(
     resampled_vault_candle_df: pd.DataFrame | None,
     cache_path: Path | None,
     http_session: requests.Session | None,
+    vault_history_filter_end_at: datetime.datetime | None = None,
     remote_url: str = CLEANED_VAULT_PRICE_PARQUET_URL,
     now: datetime.datetime | None = None,
 ) -> VaultHistoryDiagnostics:
@@ -173,6 +212,8 @@ def build_vault_history_diagnostics(
     parquet_max_timestamp = _get_max_timestamp(raw_vault_price_df)
     filtered_max_timestamp = _get_max_timestamp(filtered_vault_price_df)
     resampled_max_timestamp = _get_max_timestamp(resampled_vault_candle_df)
+    parquet_data_age = _calculate_age(parquet_max_timestamp, reference_now)
+    filtered_data_age = _calculate_age(filtered_max_timestamp, reference_now)
 
     return VaultHistoryDiagnostics(
         cache_path=cache_path,
@@ -184,19 +225,27 @@ def build_vault_history_diagnostics(
         remote_content_length=remote_content_length,
         remote_head_error=remote_head_error,
         parquet_max_timestamp=parquet_max_timestamp,
-        parquet_data_age=_calculate_age(parquet_max_timestamp, reference_now),
+        parquet_data_age=parquet_data_age,
         filtered_max_timestamp=filtered_max_timestamp,
-        filtered_data_age=_calculate_age(filtered_max_timestamp, reference_now),
+        filtered_data_age=filtered_data_age,
         resampled_max_timestamp=resampled_max_timestamp,
         resampled_data_age=_calculate_age(resampled_max_timestamp, reference_now),
         parquet_to_filtered_delta=_calculate_delta(parquet_max_timestamp, filtered_max_timestamp),
         filtered_to_resampled_delta=_calculate_delta(filtered_max_timestamp, resampled_max_timestamp),
+        vault_history_filter_end_at=vault_history_filter_end_at,
+        expected_daily_flooring_reason=_calculate_expected_daily_flooring_reason(
+            parquet_data_age=parquet_data_age,
+            filtered_data_age=filtered_data_age,
+            filtered_max_timestamp=filtered_max_timestamp,
+            resampled_max_timestamp=resampled_max_timestamp,
+            vault_history_filter_end_at=vault_history_filter_end_at,
+        ),
     )
 
 
 def log_vault_history_diagnostics(
     diagnostics: VaultHistoryDiagnostics,
-    stale_tolerance: datetime.timedelta = datetime.timedelta(hours=24),
+    stale_tolerance: datetime.timedelta = DEFAULT_VAULT_HISTORY_STALE_TOLERANCE,
 ) -> None:
     """Log a one-line startup summary for vault history freshness."""
     level = logging.INFO
@@ -211,8 +260,9 @@ def log_vault_history_diagnostics(
         "remote_last_modified=%s, remote_last_modified_age=%s, remote_etag=%s, remote_content_length=%s, "
         "parquet_max_timestamp=%s, parquet_data_age=%s, filtered_max_timestamp=%s, filtered_data_age=%s, "
         "resampled_max_timestamp=%s, resampled_data_age=%s, parquet_to_filtered_delta=%s, "
-        "filtered_to_resampled_delta=%s, remote_head_error=%s. When using 1d resampling, the latest candle "
-        "is floored to 00:00 UTC, so a candle timestamp can still reflect materially newer source data.",
+        "filtered_to_resampled_delta=%s, vault_history_filter_end_at=%s, expected_daily_flooring_reason=%s, "
+        "remote_head_error=%s. When using 1d resampling, the latest candle is floored to 00:00 UTC, "
+        "so a candle timestamp can still reflect materially newer source data.",
         diagnostics.cache_path,
         diagnostics.local_cache_mtime,
         diagnostics.local_cache_age,
@@ -228,6 +278,8 @@ def log_vault_history_diagnostics(
         diagnostics.resampled_data_age,
         diagnostics.parquet_to_filtered_delta,
         diagnostics.filtered_to_resampled_delta,
+        diagnostics.vault_history_filter_end_at,
+        diagnostics.expected_daily_flooring_reason,
         diagnostics.remote_head_error,
     )
 
@@ -301,10 +353,28 @@ def _build_vault_history_warning_rows(
         )
 
     if (
+        diagnostics.parquet_to_filtered_delta is not None
+        and diagnostics.parquet_to_filtered_delta > datetime.timedelta(hours=1)
+        and diagnostics.parquet_data_age is not None
+        and diagnostics.parquet_data_age <= stale_tolerance
+        and diagnostics.filtered_data_age is not None
+        and diagnostics.filtered_data_age <= stale_tolerance
+        and diagnostics.expected_daily_flooring_reason is None
+    ):
+        warning_rows.append(
+            {
+                "field": "parquet_to_filtered_delta",
+                "value": diagnostics.parquet_to_filtered_delta,
+                "reason": "Selected vault history trails the freshest parquet row even though the source parquet is still fresh",
+            }
+        )
+
+    if (
         diagnostics.resampled_data_age is not None
         and diagnostics.resampled_data_age > stale_tolerance
         and diagnostics.parquet_data_age is not None
         and diagnostics.parquet_data_age <= stale_tolerance
+        and diagnostics.expected_daily_flooring_reason is None
     ):
         warning_rows.append(
             {
@@ -319,6 +389,7 @@ def _build_vault_history_warning_rows(
         and diagnostics.filtered_to_resampled_delta > datetime.timedelta(hours=12)
         and diagnostics.parquet_data_age is not None
         and diagnostics.parquet_data_age <= stale_tolerance
+        and diagnostics.expected_daily_flooring_reason is None
     ):
         warning_rows.append(
             {
@@ -688,6 +759,8 @@ def get_vault_data_freshness(
         df["Vault history resampled data age"] = diagnostics.resampled_data_age
         df["Vault history parquet->filtered delta"] = diagnostics.parquet_to_filtered_delta
         df["Vault history filtered->resampled delta"] = diagnostics.filtered_to_resampled_delta
+        df["Vault history filter end timestamp"] = diagnostics.vault_history_filter_end_at
+        df["Vault history expected daily flooring reason"] = diagnostics.expected_daily_flooring_reason
 
     df = df.reset_index(drop=True)
     return df

--- a/tradeexecutor/strategy/trading_strategy_universe.py
+++ b/tradeexecutor/strategy/trading_strategy_universe.py
@@ -2363,6 +2363,27 @@ def _concat_optional_dataframe(
     return pd.concat([original_df, additional_df])
 
 
+def _resolve_live_end_timestamps(
+    time_bucket: TimeBucket,
+    explicit_end_at: datetime.datetime | None,
+    round_start_end: bool,
+) -> tuple[datetime.datetime, datetime.datetime]:
+    """Return live dataset and vault-history end timestamps."""
+    live_end_at = explicit_end_at or native_datetime_utc_now()
+
+    if not round_start_end:
+        return live_end_at, live_end_at
+
+    flooring_time_bucket = time_bucket if time_bucket < TimeBucket.d7 else TimeBucket.d1
+    dataset_end_at = flooring_time_bucket.floor_datetime(live_end_at)
+    vault_history_filter_end_at = live_end_at
+    assert vault_history_filter_end_at >= dataset_end_at, (
+        f"Vault history filter end {vault_history_filter_end_at} must be on or after "
+        f"dataset end {dataset_end_at}"
+    )
+    return dataset_end_at, vault_history_filter_end_at
+
+
 def load_partial_data(
     client: BaseClient,
     execution_context: ExecutionContext,
@@ -2629,6 +2650,8 @@ def load_partial_data(
     else:
         data_load_start_at = start_at or (native_datetime_utc_now() - required_history_period)
 
+    vault_history_filter_end_at = end_at
+
     # Generate a rounded range of the latest data
     if round_start_end and execution_context.mode.is_live_trading():
 
@@ -2644,16 +2667,20 @@ def load_partial_data(
         )
 
         start_at = data_load_start_at = floored_start
-        if not end_at:
-            end_at = native_datetime_utc_now()
-            floored_end = flooring_time_bucket.floor_datetime(end_at)
-            logger.info(
-                "Floored end timestamp %s -> %s for bucket %s",
-                end_at,
-                floored_end,
-                time_bucket.value,
-            )
-            end_at = floored_end
+        original_end_at = end_at
+        dataset_end_at, vault_history_filter_end_at = _resolve_live_end_timestamps(
+            time_bucket=time_bucket,
+            explicit_end_at=original_end_at,
+            round_start_end=round_start_end,
+        )
+        logger.info(
+            "Resolved live end timestamps %s -> dataset=%s, vault_history_filter=%s for bucket %s",
+            original_end_at,
+            dataset_end_at,
+            vault_history_filter_end_at,
+            time_bucket.value,
+        )
+        end_at = dataset_end_at
 
     logger.info(
         "load_partial_data(): data_load_start_at: %s, start_at: %s, end_at: %s, required_history_period: %s",
@@ -2863,7 +2890,7 @@ def load_partial_data(
                 raw_website_vault_prices_df,
                 vault_pairs_df,
                 data_load_start_at,
-                end_at,
+                vault_history_filter_end_at,
             )
 
             offset = time_bucket.to_frequency()
@@ -2893,6 +2920,7 @@ def load_partial_data(
                     resampled_vault_candle_df=vault_candle_df,
                     cache_path=vault_history_cache_path,
                     http_session=client.transport.requests,
+                    vault_history_filter_end_at=vault_history_filter_end_at,
                     now=native_datetime_utc_now(),
                 )
                 log_vault_history_diagnostics(vault_history_diagnostics)


### PR DESCRIPTION
# Why

Live `d1` Hypercore startup was producing large `filtered_to_resampled_delta` values and stale-looking daily ages even though the source parquet data was still fresh.

The root cause was that `load_partial_data()` reused the floored live dataset `end_at` when filtering Trading Strategy website vault history. That clipped away fresh intraday vault rows before daily resampling, and the diagnostics then treated the remaining daily-floor artefact as suspicious.

# Lessons learnt

Vault source freshness and visible daily-candle freshness are different signals.

Live loader rounding is useful for dataset caching and forward-fill behaviour, but it cannot be reused blindly for vault-history filtering without losing real intraday data.

# Summary

Split live end timestamps so the dataset keeps its floored `end_at` while Trading Strategy website vault history uses an unfloored filter cutoff.

Reclassified expected `1d` resample-floor artefacts as informational diagnostics and made unexpected `parquet_to_filtered_delta` the meaningful warning path.

Added focused regression coverage for the live cutoff helper, the vault-history filter call site, and the updated diagnostics behaviour.
