### PR TITLE
Fix webhook test port binding flakiness

### DIFF
--- a/tests/web/test_webhook_api.py
+++ b/tests/web/test_webhook_api.py
@@ -7,7 +7,6 @@ from queue import Queue
 import flaky
 import pytest
 import requests
-from eth_defi.utils import find_free_port
 
 from tradeexecutor.cli.log import (get_ring_buffer_handler,
                                    setup_in_memory_logging)
@@ -15,10 +14,10 @@ from tradeexecutor.state.metadata import Metadata
 from tradeexecutor.state.portfolio import Portfolio
 from tradeexecutor.state.state import State
 from tradeexecutor.state.store import JSONFileStore
+from tradeexecutor.testing.webhook import create_webhook_server_with_retries, get_webhook_test_url
 from tradeexecutor.strategy.run_state import RunState
 from tradeexecutor.strategy.tag import StrategyTag
 from tradeexecutor.webhook.api import web_notify
-from tradeexecutor.webhook.server import create_webhook_server
 from eth_defi.compat import native_datetime_utc_now
 
 
@@ -70,9 +69,8 @@ def server_url(store):
     metadata.backtest_notebook = notebook_result
     metadata.backtest_html = html_result
 
-    port = find_free_port(20_000, 40_000, 20)
-    server = create_webhook_server("127.0.0.1", port, "test", "test", queue, store, metadata, execution_state)
-    server_url = f"http://test:test@127.0.0.1:{port}"
+    server = create_webhook_server_with_retries("127.0.0.1", "test", "test", queue, store, metadata, execution_state)
+    server_url = get_webhook_test_url(server, "test", "test")
     yield server_url
     server.shutdown()
 
@@ -202,9 +200,8 @@ def test_source_closed_source(logger, store):
         tags={StrategyTag.closed_source},
     )
 
-    port = find_free_port(20_000, 40_000, 20)
-    server = create_webhook_server("127.0.0.1", port, "test", "test", queue, store, metadata, execution_state)
-    url = f"http://test:test@127.0.0.1:{port}"
+    server = create_webhook_server_with_retries("127.0.0.1", "test", "test", queue, store, metadata, execution_state)
+    url = get_webhook_test_url(server, "test", "test")
 
     try:
         resp = requests.get(f"{url}/source")

--- a/tests/web/test_webhook_auth.py
+++ b/tests/web/test_webhook_auth.py
@@ -4,12 +4,10 @@ from queue import Queue
 import requests
 import flaky
 
-from eth_defi.utils import find_free_port
-
 from tradeexecutor.state.metadata import Metadata
 from tradeexecutor.state.store import NoneStore
 from tradeexecutor.strategy.run_state import RunState
-from tradeexecutor.webhook.server import create_webhook_server
+from tradeexecutor.testing.webhook import create_webhook_server_with_retries, get_webhook_test_url
 
 
 #  OSError: [Errno 98] Address already in use
@@ -17,9 +15,8 @@ from tradeexecutor.webhook.server import create_webhook_server
 def test_auth_ok(logger):
     """Username and password allow to access the webhook"""
     queue = Queue()
-    port = find_free_port(20_000, 40_000, 20)
-    server = create_webhook_server("127.0.0.1", port, "test", "test", queue, NoneStore(), Metadata.create_dummy(), RunState())
-    server_url = f"http://test:test@127.0.0.1:{port}"
+    server = create_webhook_server_with_retries("127.0.0.1", "test", "test", queue, NoneStore(), Metadata.create_dummy(), RunState())
+    server_url = get_webhook_test_url(server, "test", "test")
     # Test home view
     try:
         resp = requests.get(server_url)
@@ -31,9 +28,8 @@ def test_auth_ok(logger):
 def test_auth_failed(logger):
     """Wrong password denies the access to the webhook"""
     queue = Queue()
-    port = find_free_port(20_000, 40_000, 20)
-    server = create_webhook_server("127.0.0.1", port, "test", "test", queue, NoneStore(), Metadata.create_dummy(), RunState())
-    server_url = f"http://test:wrong@127.0.0.1:{port}"
+    server = create_webhook_server_with_retries("127.0.0.1", "test", "test", queue, NoneStore(), Metadata.create_dummy(), RunState())
+    server_url = get_webhook_test_url(server, "test", "wrong")
     # Test home view
     try:
         resp = requests.get(server_url)

--- a/tests/web/test_webhook_position_chart.py
+++ b/tests/web/test_webhook_position_chart.py
@@ -11,7 +11,6 @@ from queue import Queue
 import pytest
 import requests
 from eth_defi.compat import native_datetime_utc_now
-from eth_defi.utils import find_free_port
 
 from tradeexecutor.state.identifier import AssetIdentifier, TradingPairIdentifier
 from tradeexecutor.state.metadata import Metadata
@@ -24,12 +23,13 @@ from tradeexecutor.strategy.pandas_trader.indicator import IndicatorSet
 from tradeexecutor.strategy.pandas_trader.strategy_input import StrategyInputIndicators
 from tradeexecutor.strategy.run_state import RunState
 from tradeexecutor.strategy.tag import StrategyTag
+from tradeexecutor.testing.webhook import create_webhook_server_with_retries, get_webhook_test_url
 from tradeexecutor.strategy.trading_strategy_universe import TradingStrategyUniverse
 from tradeexecutor.testing.synthetic_ethereum_data import generate_random_ethereum_address
 from tradeexecutor.testing.synthetic_exchange_data import generate_exchange
 from tradeexecutor.testing.synthetic_price_data import generate_ohlcv_candles
 from tradeexecutor.testing.synthetic_universe_data import create_synthetic_single_pair_universe
-from tradeexecutor.webhook.server import WebhookServer, create_webhook_server
+from tradeexecutor.webhook.server import WebhookServer
 from tradingstrategy.chain import ChainId
 from tradingstrategy.timebucket import TimeBucket
 
@@ -215,19 +215,9 @@ def create_position_chart_server() -> Callable[[State, TradingStrategyUniverse |
         metadata.backtest_notebook = notebook_result
         metadata.backtest_html = html_result
 
-        port = find_free_port(20_000, 40_000, 20)
-        server = create_webhook_server(
-            "127.0.0.1",
-            port,
-            "test",
-            "test",
-            Queue(),
-            store,
-            metadata,
-            run_state,
-        )
+        server = create_webhook_server_with_retries("127.0.0.1", "test", "test", Queue(), store, metadata, run_state)
         servers.append(server)
-        return f"http://test:test@127.0.0.1:{port}"
+        return get_webhook_test_url(server, "test", "test")
 
     yield _create_server
 

--- a/tests/web/test_webhook_render_chart.py
+++ b/tests/web/test_webhook_render_chart.py
@@ -11,7 +11,6 @@ import numpy as np
 import pandas as pd
 import pytest
 import requests
-from eth_defi.utils import find_free_port
 import plotly.graph_objects as go
 
 from tradeexecutor.state.identifier import AssetIdentifier, TradingPairIdentifier
@@ -25,13 +24,13 @@ from tradeexecutor.strategy.pandas_trader.indicator import IndicatorSet
 from tradeexecutor.strategy.pandas_trader.strategy_input import StrategyInputIndicators
 from tradeexecutor.strategy.run_state import RunState
 from tradeexecutor.strategy.tag import StrategyTag
+from tradeexecutor.testing.webhook import create_webhook_server_with_retries, get_webhook_test_url
 from tradeexecutor.strategy.trading_strategy_universe import TradingStrategyUniverse
 from tradeexecutor.testing.synthetic_ethereum_data import generate_random_ethereum_address
 from tradeexecutor.testing.synthetic_exchange_data import generate_exchange
 from tradeexecutor.testing.synthetic_lending_data import generate_lending_reserve, generate_lending_universe
 from tradeexecutor.testing.synthetic_price_data import generate_ohlcv_candles
 from tradeexecutor.testing.synthetic_universe_data import create_synthetic_single_pair_universe
-from tradeexecutor.webhook.server import create_webhook_server
 from tradingstrategy.chain import ChainId
 from tradingstrategy.timebucket import TimeBucket
 from eth_defi.compat import native_datetime_utc_now
@@ -187,9 +186,8 @@ def server_url(store, chart_registry, strategy_input_indicators):
     metadata.backtest_notebook = notebook_result
     metadata.backtest_html = html_result
 
-    port = find_free_port(20_000, 40_000, 20)
-    server = create_webhook_server("127.0.0.1", port, "test", "test", queue, store, metadata, execution_state)
-    server_url = f"http://test:test@127.0.0.1:{port}"
+    server = create_webhook_server_with_retries("127.0.0.1", "test", "test", queue, store, metadata, execution_state)
+    server_url = get_webhook_test_url(server, "test", "test")
     yield server_url
     server.shutdown()
 

--- a/tradeexecutor/testing/webhook.py
+++ b/tradeexecutor/testing/webhook.py
@@ -1,0 +1,62 @@
+"""Webhook testing helpers."""
+
+import errno
+from queue import Queue
+
+from eth_defi.utils import find_free_port
+
+from tradeexecutor.state.metadata import Metadata
+from tradeexecutor.strategy.run_state import RunState
+from tradeexecutor.webhook.server import WebhookServer, create_webhook_server
+
+
+def create_webhook_server_with_retries(
+    host: str,
+    username: str,
+    password: str,
+    queue: Queue,
+    store,
+    metadata: Metadata,
+    execution_state: RunState,
+    *,
+    port_start: int = 20_000,
+    port_end: int = 40_000,
+    port_search_tries: int = 20,
+    bind_tries: int = 5,
+) -> WebhookServer:
+    """Create a webhook server while retrying transient port binding races.
+
+    The test suite runs webhook tests in parallel, so a port returned by
+    `find_free_port()` may be claimed by another worker before Waitress binds it.
+    Retry only `EADDRINUSE` errors so real server startup failures still surface.
+    """
+
+    last_exception: OSError | None = None
+
+    for _attempt in range(bind_tries):
+        port = find_free_port(port_start, port_end, port_search_tries)
+
+        try:
+            return create_webhook_server(
+                host,
+                port,
+                username,
+                password,
+                queue,
+                store,
+                metadata,
+                execution_state,
+            )
+        except OSError as exc:
+            if exc.errno != errno.EADDRINUSE:
+                raise
+
+            last_exception = exc
+
+    assert last_exception is not None
+    raise last_exception
+
+
+def get_webhook_test_url(server: WebhookServer, username: str, password: str) -> str:
+    """Build an authenticated URL for a started webhook test server."""
+    return f"http://{username}:{password}@127.0.0.1:{server.effective_port}"


### PR DESCRIPTION
# Why

Webhook tests that start an in-process Waitress server are flaky under parallel CI because they call `find_free_port()` and then bind later. Another worker can claim the chosen port in the gap, which surfaces as `OSError: [Errno 98] Address already in use` in tests like `test_auth_failed` and `test_web_chart_registry`.

# Lessons learnt

Using a pre-checked "free" port is not safe under parallel pytest workers when the actual bind happens afterwards.

For these webhook tests, a narrow retry around `EADDRINUSE` is a better fit than spreading flaky markers, because it keeps the race handling in one place and still lets real server startup failures fail fast.

# Summary

Added a shared webhook test helper that retries server creation only when Waitress loses the port race.

Updated the webhook auth, API, chart rendering, and position chart tests to use the shared helper instead of open-coding `find_free_port()` plus `create_webhook_server()`.
