### PR TITLE
fix: Pass user address to Hyperliquid vaultDetails for correct maxWithdrawable

### DIFF
--- a/tests/hyperliquid/test_hypercore_tradeability.py
+++ b/tests/hyperliquid/test_hypercore_tradeability.py
@@ -79,7 +79,7 @@ def test_hypercore_deposit_closed_when_vault_closed(
     monkeypatch: pytest.MonkeyPatch,
 ):
     pair = _make_pair()
-    monkeypatch.setattr(pricing, "_get_vault_info", lambda pair: _make_info(is_closed=True))
+    monkeypatch.setattr(pricing, "_get_vault_info", lambda pair, user=None: _make_info(is_closed=True))
 
     assert pricing.get_max_deposit(None, pair) == 0
     assert pricing.can_deposit(None, pair) is False
@@ -90,7 +90,7 @@ def test_hypercore_deposit_closed_when_leader_disables_deposits(
     monkeypatch: pytest.MonkeyPatch,
 ):
     pair = _make_pair()
-    monkeypatch.setattr(pricing, "_get_vault_info", lambda pair: _make_info(allow_deposits=False))
+    monkeypatch.setattr(pricing, "_get_vault_info", lambda pair, user=None: _make_info(allow_deposits=False))
 
     assert pricing.get_max_deposit(None, pair) == 0
     assert pricing.can_deposit(None, pair) is False
@@ -101,7 +101,7 @@ def test_hypercore_deposit_closed_when_leader_fraction_too_low(
     monkeypatch: pytest.MonkeyPatch,
 ):
     pair = _make_pair()
-    monkeypatch.setattr(pricing, "_get_vault_info", lambda pair: _make_info(leader_fraction=0.04))
+    monkeypatch.setattr(pricing, "_get_vault_info", lambda pair, user=None: _make_info(leader_fraction=0.04))
 
     assert pricing.get_max_deposit(None, pair) == 0
     assert pricing.can_deposit(None, pair) is False
@@ -115,7 +115,7 @@ def test_hypercore_parent_vault_ignores_allow_deposits_flag(
     monkeypatch.setattr(
         pricing,
         "_get_vault_info",
-        lambda pair: _make_info(allow_deposits=False, relationship_type="parent"),
+        lambda pair, user=None: _make_info(allow_deposits=False, relationship_type="parent"),
     )
 
     assert pricing.get_max_deposit(None, pair) is None
@@ -127,7 +127,7 @@ def test_hypercore_redemption_closed_without_position(
     monkeypatch: pytest.MonkeyPatch,
 ):
     pair = _make_pair()
-    monkeypatch.setattr(pricing, "_get_vault_info", lambda pair: _make_info())
+    monkeypatch.setattr(pricing, "_get_vault_info", lambda pair, user=None: _make_info())
     monkeypatch.setattr(
         "tradeexecutor.ethereum.vault.hypercore_valuation.fetch_user_vault_equity",
         lambda session, user, vault_address, **kwargs: None,
@@ -148,7 +148,7 @@ def test_hypercore_redemption_closed_during_lockup(
     3. Verify the structured result records the user-lockup reason and stage.
     """
     pair = _make_pair()
-    monkeypatch.setattr(pricing, "_get_vault_info", lambda pair: _make_info())
+    monkeypatch.setattr(pricing, "_get_vault_info", lambda pair, user=None: _make_info())
     monkeypatch.setattr(
         "tradeexecutor.ethereum.vault.hypercore_valuation.fetch_user_vault_equity",
         lambda session, user, vault_address, **kwargs: UserVaultEquity(
@@ -184,7 +184,7 @@ def test_hypercore_redemption_closed_when_vault_has_no_withdrawable_liquidity(
     3. Verify the structured result records the vault-liquidity block reason.
     """
     pair = _make_pair()
-    monkeypatch.setattr(pricing, "_get_vault_info", lambda pair: _make_info(max_withdrawable=Decimal("0")))
+    monkeypatch.setattr(pricing, "_get_vault_info", lambda pair, user=None: _make_info(max_withdrawable=Decimal("0")))
     monkeypatch.setattr(
         "tradeexecutor.ethereum.vault.hypercore_valuation.fetch_user_vault_equity",
         lambda session, user, vault_address, **kwargs: UserVaultEquity(
@@ -220,7 +220,7 @@ def test_hypercore_redemption_allowed_when_lockup_expired(
     3. Verify the structured result round-trips through dataclasses-json intact.
     """
     pair = _make_pair()
-    monkeypatch.setattr(pricing, "_get_vault_info", lambda pair: _make_info(max_withdrawable=Decimal("40")))
+    monkeypatch.setattr(pricing, "_get_vault_info", lambda pair, user=None: _make_info(max_withdrawable=Decimal("40")))
     monkeypatch.setattr(
         "tradeexecutor.ethereum.vault.hypercore_valuation.fetch_user_vault_equity",
         lambda session, user, vault_address, **kwargs: UserVaultEquity(
@@ -262,7 +262,7 @@ def test_hypercore_redemption_defaults_to_open_when_safe_unknown(
         session_factory=lambda pair: MagicMock(),
     )
 
-    monkeypatch.setattr(pricing, "_get_vault_info", lambda pair: _make_info())
+    monkeypatch.setattr(pricing, "_get_vault_info", lambda pair, user=None: _make_info())
 
     assert pricing.get_max_redemption(None, pair) is None
     assert pricing.can_redeem(None, pair) is True

--- a/tests/test_rebalance.py
+++ b/tests/test_rebalance.py
@@ -1827,6 +1827,146 @@ def test_alpha_model_skips_sell_rebalance_for_non_redeemable_position(
     assert signal.redemption_check_results[0].reason_code == RedemptionBlockReason.user_lockup_not_expired
 
 
+def test_generic_pricing_delegates_check_redemption_with_diagnostics(
+    strategy_universe: TradingStrategyUniverse,
+    pricing_model: BacktestPricing,
+    start_ts: datetime.datetime,
+    usdc: AssetIdentifier,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """GenericPricing must delegate check_redemption to the route so that
+    carry-forward diagnostics propagate to collect_blocked_redemption_results.
+
+    1. Build a GenericPricing that routes vault pairs to a mock Hypercore pricing model.
+    2. Use GenericPricing in a PositionManager and run carry_forward_non_redeemable_positions.
+    3. Verify collect_blocked_redemption_results returns the rich result with reason_code intact.
+    """
+    from tradeexecutor.strategy.generic.generic_pricing_model import GenericPricing
+    from tradeexecutor.strategy.generic.pair_configurator import PairConfigurator
+    from tradeexecutor.strategy.redemption import collect_blocked_redemption_results
+
+    hypercore_vault_pair = TradingPairIdentifier(
+        base=AssetIdentifier(1, "0x1234567890123456789012345678901234567890", "pmalt", 18),
+        quote=usdc,
+        pool_address="0x1234567890123456789012345678901234567891",
+        exchange_address="0x1234567890123456789012345678901234567892",
+        internal_id=100,
+        kind=TradingPairKind.vault,
+        fee=0,
+    )
+    hypercore_vault_pair.other_data["vault_protocol"] = "hypercore"
+
+    # 1. Build a GenericPricing that routes vault pairs to a mock Hypercore pricing model.
+    class MockHypercorePricing:
+        """Mimics HypercoreVaultPricing returning a rich blocked result."""
+
+        def get_mid_price(self, ts, pair):
+            return 1.0
+
+        def check_redemption(self, ts, pair, *, stage=RedemptionCheckStage.unknown, position=None):
+            return RedemptionCheckResult(
+                timestamp=ts,
+                stage=stage,
+                can_redeem=False,
+                reason_code=RedemptionBlockReason.user_lockup_not_expired,
+                pair_ticker=pair.get_ticker(),
+                vault_address=pair.pool_address,
+                safe_address="0x0000000000000000000000000000000000000abc",
+                position_recorded_lockup_expires_at=datetime.datetime(2022, 1, 3),
+                user_lockup_expires_at=datetime.datetime(2022, 1, 3),
+                message="Hypercore user lockup has not expired yet",
+                max_redemption=0.0,
+            )
+
+    mock_hypercore = MockHypercorePricing()
+
+    class MockConfigurator(PairConfigurator):
+        """Routes vault pairs to the mock Hypercore pricing model."""
+
+        def __init__(self):
+            pass
+
+        def get_pricing(self, pair):
+            return mock_hypercore
+
+        def get_supported_routers(self):
+            return set()
+
+        def match_router(self, pair):
+            return None
+
+        def create_config(self, routing_id, **kwargs):
+            return None
+
+    generic_pricing = GenericPricing(MockConfigurator())
+
+    state = State()
+    state.portfolio.reserves = {
+        usdc: ReservePosition(
+            asset=usdc,
+            quantity=Decimal(2500),
+            last_sync_at=start_ts,
+            reserve_token_price=USDollarAmount(1.0),
+            last_pricing_at=start_ts,
+            initial_deposit=Decimal(2500),
+        )
+    }
+
+    locked_position = TradingPosition(
+        position_id=1,
+        opened_at=start_ts,
+        pair=hypercore_vault_pair,
+        last_pricing_at=start_ts,
+        last_token_price=USDollarPrice(1.0),
+        last_reserve_price=USDollarPrice(1.0),
+        reserve_currency=usdc,
+    )
+    locked_trade = TradeExecution(
+        trade_id=1,
+        position_id=1,
+        trade_type=TradeType.rebalance,
+        pair=hypercore_vault_pair,
+        opened_at=start_ts,
+        planned_quantity=Decimal(5000),
+        executed_quantity=Decimal(5000),
+        planned_price=USDollarPrice(1.0),
+        executed_price=USDollarPrice(1.0),
+        lp_fees_estimated=USDollarAmount(0),
+        planned_reserve=USDollarAmount(5000),
+        executed_reserve=USDollarAmount(5000),
+        executed_at=start_ts,
+        reserve_currency=usdc,
+    )
+    locked_position.trades[1] = locked_trade
+    state.portfolio.open_positions = {1: locked_position}
+
+    # 2. Use GenericPricing in a PositionManager and run carry_forward_non_redeemable_positions.
+    position_manager = PositionManager(
+        start_ts + datetime.timedelta(days=1),
+        strategy_universe.data_universe,
+        state,
+        generic_pricing,
+    )
+    alpha_model = AlphaModel(timestamp=position_manager.timestamp)
+    locked_value = alpha_model.carry_forward_non_redeemable_positions(position_manager)
+    alpha_model.select_top_signals(count=5)
+
+    # 3. Verify collect_blocked_redemption_results returns the rich result with reason_code.
+    assert locked_value == pytest.approx(5000.0)
+    locked_signal = alpha_model.get_signal_by_pair(hypercore_vault_pair)
+    assert locked_signal is not None
+    assert TradingPairSignalFlags.cannot_redeem in locked_signal.flags
+    assert len(locked_signal.redemption_check_results) == 1
+    assert locked_signal.redemption_check_results[0].reason_code == RedemptionBlockReason.user_lockup_not_expired
+    assert locked_signal.redemption_check_results[0].safe_address == "0x0000000000000000000000000000000000000abc"
+    assert locked_signal.redemption_check_results[0].stage == RedemptionCheckStage.carry_forward
+
+    blocked_results = collect_blocked_redemption_results(alpha_model.signals)
+    assert len(blocked_results) == 1
+    assert blocked_results[0].reason_code == RedemptionBlockReason.user_lockup_not_expired
+    assert blocked_results[0].message == "Hypercore user lockup has not expired yet"
+
+
 def test_update_old_weights_reads_position_value_once(
     single_asset_portfolio: Portfolio,
     weth_usdc: TradingPairIdentifier,

--- a/tradeexecutor/ethereum/vault/hypercore_valuation.py
+++ b/tradeexecutor/ethereum/vault/hypercore_valuation.py
@@ -281,11 +281,14 @@ class HypercoreVaultPricing(PricingModel):
             self._session_cache[api_url] = session
         return session
 
-    def _get_vault_info(self, pair: TradingPairIdentifier) -> VaultInfo:
+    def _get_vault_info(self, pair: TradingPairIdentifier, user: str | None = None) -> VaultInfo:
         vault_address = pair.pool_address
         assert vault_address, f"No pool_address set for Hypercore vault pair: {pair}"
         session = self._get_session(pair)
-        return HyperliquidVault(session=session, vault_address=vault_address).fetch_info()
+        vault = HyperliquidVault(session=session, vault_address=vault_address)
+        if user is not None:
+            return vault.fetch_info(user=user)
+        return vault.fetch_metadata()
 
     def _get_market_snapshot(
         self,
@@ -466,7 +469,7 @@ class HypercoreVaultPricing(PricingModel):
             result.message = "Cannot resolve safe address for Hypercore redemption check"
             return result
 
-        info = self._get_vault_info(pair)
+        info = self._get_vault_info(pair, user=safe_address)
         result.max_withdrawable = float(info.max_withdrawable)
         result.raw_api_data = RedemptionApiSnapshot(
             vault_info=self._build_vault_info_snapshot(info),

--- a/tradeexecutor/strategy/generic/generic_pricing_model.py
+++ b/tradeexecutor/strategy/generic/generic_pricing_model.py
@@ -11,8 +11,10 @@ from tradeexecutor.ethereum.ethereum_protocol_adapters import EthereumPairConfig
 from tradeexecutor.strategy.generic.pair_configurator import PairConfigurator
 
 from tradeexecutor.state.identifier import TradingPairIdentifier, AssetIdentifier
+from tradeexecutor.state.position import TradingPosition
 from tradeexecutor.state.types import USDollarPrice, Percent, USDollarAmount, TokenAmount
 from tradeexecutor.strategy.pricing_model import PricingModel, PricingModelFactory
+from tradeexecutor.strategy.redemption import RedemptionCheckResult, RedemptionCheckStage
 from tradeexecutor.strategy.trade_pricing import TradePricing
 
 
@@ -158,6 +160,17 @@ class GenericPricing(PricingModel):
     ) -> bool:
         route = self.route(pair)
         return route.can_deposit(ts, pair)
+
+    def check_redemption(
+        self,
+        ts: datetime.datetime | None,
+        pair: TradingPairIdentifier | None,
+        *,
+        stage: RedemptionCheckStage = RedemptionCheckStage.unknown,
+        position: TradingPosition | None = None,
+    ) -> RedemptionCheckResult:
+        route = self.route(pair)
+        return route.check_redemption(ts, pair, stage=stage, position=position)
 
     def can_redeem(
         self,


### PR DESCRIPTION
## Why

The Hyperliquid `vaultDetails` API returns `maxWithdrawable` as a **per-user** field. Without a `user` parameter the API silently returns `0`, which caused `check_redemption()` to mark every Hypercore vault position as `vault_max_withdrawable_zero`. All 18 hyper-ai positions were locked — $5,500 of capital stuck with $0 investable equity and no rebalancing possible.

## Lessons learnt

- Hyperliquid `vaultDetails` `maxWithdrawable` and `followerState` are per-user; the API does not error or warn when `user` is omitted — it just returns `0.0`
- `GenericPricing` must override `check_redemption` to delegate to the route — the base-class fallback discards `position` and `reason_code`, losing all diagnostics
- Low-level API double-checks with raw requests are essential when an upstream API returns plausible-looking zero values

## Summary

- `_get_vault_info()` now passes the Safe address (`user`) to `fetch_info()` in the redemption check path so the API returns the real per-user `maxWithdrawable`
- `GenericPricing.check_redemption()` now delegates directly to the route's `check_redemption()` instead of going through the base class via `get_max_redemption()` — preserves `reason_code`, `safe_address`, `message`, and `position` kwargs
- Updated test mocks for the new `user` kwarg on `_get_vault_info`
- Added `test_generic_pricing_delegates_check_redemption_with_diagnostics` to verify the GenericPricing delegation pipeline end-to-end
- Bumped eth_defi submodule: `fetch_info(user)` now asserts user is set; new `fetch_metadata()` for scanning/metrics without user context

🤖 Generated with [Claude Code](https://claude.com/claude-code)