### PR TITLE
Fix Hypercore trade execution sequencing

### DIFF
--- a/tests/test_execution_sequencing.py
+++ b/tests/test_execution_sequencing.py
@@ -104,7 +104,7 @@ def test_execute_trades_runs_sequential_router_one_trade_at_a_time(
 
     1. Build an execution model and a routing model that declares sequential settlement.
     2. Execute two trades and verify start/setup/broadcast happen per trade, not per batch.
-    3. Verify freeze handling and final outcome logging also happen per trade.
+    3. Verify slippage, freeze handling, and final outcome logging also happen per trade.
     """
     # 1. Build an execution model and a routing model that declares sequential settlement.
     execution = RecordingExecution()
@@ -137,10 +137,11 @@ def test_execute_trades_runs_sequential_router_one_trade_at_a_time(
         check_balances=True,
     )
 
-    # 3. Verify freeze handling and final outcome logging also happen per trade.
+    # 3. Verify slippage, freeze handling, and final outcome logging also happen per trade.
     state.start_execution_all.assert_not_called()
     assert [call.args[1].trade_id for call in state.start_execution.call_args_list] == [1, 2]
     assert all(call.kwargs["underflow_check"] is True for call in state.start_execution.call_args_list)
+    assert [trade.planned_max_slippage for trade in trades] == [execution.max_slippage, execution.max_slippage]
     assert [call.kwargs["trades"][0].trade_id for call in routing_model.setup_trades.call_args_list] == [1, 2]
     assert execution.executed_batches == [[1], [2]]
     assert frozen_batches == [[1], [2]]

--- a/tests/test_execution_sequencing.py
+++ b/tests/test_execution_sequencing.py
@@ -1,0 +1,300 @@
+"""Tests for sequential trade execution orchestration.
+
+The Hypercore regression happened because some routes need each trade to be
+fully settled before the next trade is prepared and broadcast.
+"""
+
+import datetime
+from decimal import Decimal
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+from tradeexecutor.ethereum.execution import EthereumExecution
+from tradeexecutor.ethereum.tx import TransactionBuilder
+from tradeexecutor.strategy.execution_model import ExecutionHaltableIssue
+from tradeexecutor.strategy.generic.generic_router import GenericRouting
+
+
+class DummyTransactionBuilder(TransactionBuilder):
+    """Tiny transaction builder for executor orchestration tests."""
+
+    def init(self):
+        """Initialise the builder."""
+
+    def sign_transaction(
+        self,
+        contract,
+        args_bound_func,
+        gas_limit: int | None = None,
+        gas_price_suggestion=None,
+        asset_deltas=None,
+        notes: str = "",
+    ):
+        """Unused in these tests."""
+        raise NotImplementedError()
+
+    def get_token_delivery_address(self) -> str:
+        """Return a dummy token delivery address."""
+        return "0x0000000000000000000000000000000000000001"
+
+    def get_erc_20_balance_address(self) -> str:
+        """Return a dummy ERC-20 balance address."""
+        return "0x0000000000000000000000000000000000000002"
+
+    def get_gas_wallet_address(self) -> str:
+        """Return a dummy gas wallet address."""
+        return "0x0000000000000000000000000000000000000003"
+
+    def get_gas_wallet_balance(self) -> Decimal:
+        """Return a dummy gas balance."""
+        return Decimal("10")
+
+
+class RecordingExecution(EthereumExecution):
+    """Execution model that records orchestration instead of broadcasting."""
+
+    def __init__(self):
+        web3 = SimpleNamespace(
+            eth=SimpleNamespace(chain_id=31337),
+            provider=SimpleNamespace(),
+        )
+        super().__init__(
+            DummyTransactionBuilder(web3),
+            confirmation_block_count=1,
+        )
+        self.executed_batches: list[list[int]] = []
+        self.logged_outcomes: list[int] = []
+
+    def _execute_trade_batch(self, routing_model, state, trades, rebroadcast: bool) -> None:
+        """Record the batch and mark each trade as succeeded."""
+        del routing_model
+        del state
+        del rebroadcast
+
+        self.executed_batches.append([trade.trade_id for trade in trades])
+        for trade in trades:
+            trade.get_status.return_value = SimpleNamespace(value="success")
+
+    def _log_trade_outcome(self, trade) -> None:
+        """Record the trade ids whose outcomes were logged."""
+        self.logged_outcomes.append(trade.trade_id)
+
+
+def _make_trade(trade_id: int) -> MagicMock:
+    """Create a tiny trade stub for execution orchestration tests."""
+    trade = MagicMock()
+    trade.trade_id = trade_id
+    trade.route = None
+    trade.pair = MagicMock()
+    trade.pair.is_exchange_account.return_value = False
+    trade.pair.get_ticker.return_value = f"PAIR-{trade_id}"
+    trade.get_planned_value.return_value = float(trade_id)
+    trade.get_status.return_value = SimpleNamespace(value="planned")
+    trade.is_failed.return_value = False
+    trade.get_revert_reason.return_value = None
+    return trade
+
+
+def test_execute_trades_runs_sequential_router_one_trade_at_a_time(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Run sequential routes one trade at a time.
+
+    1. Build an execution model and a routing model that declares sequential settlement.
+    2. Execute two trades and verify start/setup/broadcast happen per trade, not per batch.
+    3. Verify freeze handling and final outcome logging also happen per trade.
+    """
+    # 1. Build an execution model and a routing model that declares sequential settlement.
+    execution = RecordingExecution()
+    state = MagicMock()
+    routing_model = MagicMock()
+    routing_model.needs_sequential_trade_execution.return_value = True
+    routing_model.get_sequential_trade_execution_reason.return_value = "router needs settlement sequencing"
+    routing_state = SimpleNamespace()
+    trades = [_make_trade(1), _make_trade(2)]
+
+    frozen_batches: list[list[int]] = []
+
+    def record_freeze(ts, state_arg, trade_batch):
+        del ts
+        del state_arg
+        frozen_batches.append([trade.trade_id for trade in trade_batch])
+
+    monkeypatch.setattr(
+        "tradeexecutor.ethereum.execution.freeze_position_on_failed_trade",
+        record_freeze,
+    )
+
+    # 2. Execute two trades and verify start/setup/broadcast happen per trade, not per batch.
+    execution.execute_trades(
+        ts=datetime.datetime(2026, 4, 13, 12, 0, 0),
+        state=state,
+        trades=trades,
+        routing_model=routing_model,
+        routing_state=routing_state,
+        check_balances=True,
+    )
+
+    # 3. Verify freeze handling and final outcome logging also happen per trade.
+    state.start_execution_all.assert_not_called()
+    assert [call.args[1].trade_id for call in state.start_execution.call_args_list] == [1, 2]
+    assert all(call.kwargs["underflow_check"] is True for call in state.start_execution.call_args_list)
+    assert [call.kwargs["trades"][0].trade_id for call in routing_model.setup_trades.call_args_list] == [1, 2]
+    assert execution.executed_batches == [[1], [2]]
+    assert frozen_batches == [[1], [2]]
+    assert execution.logged_outcomes == [1, 2]
+
+
+def test_execute_trades_keeps_batch_mode_for_normal_routes(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Keep the existing batch behaviour for normal routes.
+
+    1. Build an execution model and a routing model that does not need sequential settlement.
+    2. Execute two trades and verify setup and broadcast still happen as a single batch.
+    3. Verify freeze handling and outcome logging also stay batched.
+    """
+    # 1. Build an execution model and a routing model that does not need sequential settlement.
+    execution = RecordingExecution()
+    state = MagicMock()
+    routing_model = MagicMock()
+    routing_model.needs_sequential_trade_execution.return_value = False
+    routing_state = SimpleNamespace()
+    trades = [_make_trade(10), _make_trade(11)]
+
+    frozen_batches: list[list[int]] = []
+
+    def record_freeze(ts, state_arg, trade_batch):
+        del ts
+        del state_arg
+        frozen_batches.append([trade.trade_id for trade in trade_batch])
+
+    monkeypatch.setattr(
+        "tradeexecutor.ethereum.execution.freeze_position_on_failed_trade",
+        record_freeze,
+    )
+
+    # 2. Execute two trades and verify setup and broadcast still happen as a single batch.
+    execution.execute_trades(
+        ts=datetime.datetime(2026, 4, 13, 12, 5, 0),
+        state=state,
+        trades=trades,
+        routing_model=routing_model,
+        routing_state=routing_state,
+    )
+
+    # 3. Verify freeze handling and outcome logging also stay batched.
+    state.start_execution_all.assert_called_once()
+    state.start_execution.assert_not_called()
+    assert len(routing_model.setup_trades.call_args_list) == 1
+    assert routing_model.setup_trades.call_args.kwargs["trades"] == trades
+    assert execution.executed_batches == [[10, 11]]
+    assert frozen_batches == [[10, 11]]
+    assert execution.logged_outcomes == [10, 11]
+
+
+def test_execute_trades_stops_sequential_batch_after_failed_trade(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Stop the remaining sequential batch after a failed trade.
+
+    1. Build a sequential execution run where the first trade resolves as failed.
+    2. Execute the batch and verify the executor raises a haltable issue immediately.
+    3. Verify the second trade is never started or prepared.
+    """
+    # 1. Build a sequential execution run where the first trade resolves as failed.
+    execution = RecordingExecution()
+    state = MagicMock()
+    routing_model = MagicMock()
+    routing_model.needs_sequential_trade_execution.return_value = True
+    routing_model.get_sequential_trade_execution_reason.return_value = "router needs settlement sequencing"
+    routing_state = SimpleNamespace()
+    trades = [_make_trade(21), _make_trade(22)]
+
+    frozen_batches: list[list[int]] = []
+
+    def record_freeze(ts, state_arg, trade_batch):
+        del ts
+        del state_arg
+        frozen_batches.append([trade.trade_id for trade in trade_batch])
+
+    monkeypatch.setattr(
+        "tradeexecutor.ethereum.execution.freeze_position_on_failed_trade",
+        record_freeze,
+    )
+
+    def fail_first_trade(routing_model_arg, state_arg, trade_batch, rebroadcast: bool) -> None:
+        del routing_model_arg
+        del state_arg
+        del rebroadcast
+
+        execution.executed_batches.append([trade.trade_id for trade in trade_batch])
+        trade = trade_batch[0]
+        trade.get_status.return_value = SimpleNamespace(value="failed")
+        trade.is_failed.return_value = True
+        trade.get_revert_reason.return_value = "insufficient settled capital"
+
+    execution._execute_trade_batch = fail_first_trade
+
+    # 2. Execute the batch and verify the executor raises a haltable issue immediately.
+    with pytest.raises(ExecutionHaltableIssue, match="Failed trade_id=21"):
+        execution.execute_trades(
+            ts=datetime.datetime(2026, 4, 13, 12, 10, 0),
+            state=state,
+            trades=trades,
+            routing_model=routing_model,
+            routing_state=routing_state,
+        )
+
+    # 3. Verify the second trade is never started or prepared.
+    assert [call.args[1].trade_id for call in state.start_execution.call_args_list] == [21]
+    assert [call.kwargs["trades"][0].trade_id for call in routing_model.setup_trades.call_args_list] == [21]
+    assert execution.executed_batches == [[21]]
+    assert frozen_batches == [[21]]
+    assert execution.logged_outcomes == [21]
+
+
+def test_generic_routing_detects_underlying_sequential_router() -> None:
+    """Surface sequential requirements from the matched underlying router.
+
+    1. Build a GenericRouting with one normal router and one sequential router.
+    2. Ask GenericRouting about a mixed batch of trades.
+    3. Verify it reports sequential execution and forwards the underlying reason.
+    """
+    # 1. Build a GenericRouting with one normal router and one sequential router.
+    sequential_router = MagicMock()
+    sequential_router.needs_sequential_trade_execution.return_value = True
+    sequential_router.get_sequential_trade_execution_reason.return_value = "hypercore settlement appends follow-up txs"
+
+    normal_router = MagicMock()
+    normal_router.needs_sequential_trade_execution.return_value = False
+    normal_router.get_sequential_trade_execution_reason.return_value = None
+
+    pair_a = object()
+    pair_b = object()
+    routing_id_a = object()
+    routing_id_b = object()
+    configs = {
+        routing_id_a: SimpleNamespace(routing_model=normal_router),
+        routing_id_b: SimpleNamespace(routing_model=sequential_router),
+    }
+    pair_configurator = SimpleNamespace(
+        match_router=lambda pair: routing_id_a if pair is pair_a else routing_id_b,
+        get_config=lambda routing_id, three_leg_resolution=True: configs[routing_id],
+    )
+    routing = GenericRouting(pair_configurator)
+
+    trades = [
+        SimpleNamespace(pair=pair_a),
+        SimpleNamespace(pair=pair_b),
+    ]
+
+    # 2. Ask GenericRouting about a mixed batch of trades.
+    needs_sequential = routing.needs_sequential_trade_execution(trades)
+    reason = routing.get_sequential_trade_execution_reason(trades)
+
+    # 3. Verify it reports sequential execution and forwards the underlying reason.
+    assert needs_sequential is True
+    assert reason == "hypercore settlement appends follow-up txs"

--- a/tradeexecutor/ethereum/execution.py
+++ b/tradeexecutor/ethereum/execution.py
@@ -661,6 +661,8 @@ class EthereumExecution(ExecutionModel):
                     underflow_check=check_balances,
                     triggered=triggered,
                 )
+                if self.max_slippage is not None:
+                    trade.planned_max_slippage = self.max_slippage
 
             routing_model.setup_trades(
                 state=state,

--- a/tradeexecutor/ethereum/execution.py
+++ b/tradeexecutor/ethereum/execution.py
@@ -573,6 +573,122 @@ class EthereumExecution(ExecutionModel):
             stop_on_execution_failure=stop_on_execution_failure
         )
 
+    def _execute_trade_batch(
+        self,
+        routing_model: RoutingModel,
+        state: State,
+        trades: List[TradeExecution],
+        rebroadcast: bool,
+    ) -> None:
+        """Broadcast and settle one prepared trade batch."""
+        force_sequential_broadcast = self.force_sequential_broadcast
+
+        if isinstance(self.web3.provider, MEVBlockerProvider) or force_sequential_broadcast:
+            self.broadcast_and_resolve_mev_blocker(
+                routing_model,
+                state,
+                trades,
+                # Explicitly set to False here to keep execution going
+                stop_on_execution_failure=False,
+            )
+        elif isinstance(self.web3.provider, (FallbackProvider)):
+            self.broadcast_and_resolve_multiple_nodes(
+                routing_model,
+                state,
+                trades,
+                confirmation_timeout=self.confirmation_timeout,
+                confirmation_block_count=self.confirmation_block_count,
+                rebroadcast=rebroadcast,
+            )
+        else:
+            self.broadcast_and_resolve_old(
+                state,
+                trades,
+                routing_model,
+                confirmation_timeout=self.confirmation_timeout,
+                confirmation_block_count=self.confirmation_block_count,
+            )
+
+    @staticmethod
+    def _log_trade_outcome(trade: TradeExecution) -> None:
+        """Log the final trade status after settlement and freeze handling."""
+        status = trade.get_status().value
+        route = trade.route or "-"
+        revert_reason = trade.get_revert_reason()
+        logger.info(
+            "Trade outcome resolved: trade_id=%s status=%s route=%s tx_count=%d failed=%s revert_reason=%s",
+            trade.trade_id,
+            status,
+            route,
+            len(trade.blockchain_transactions),
+            trade.is_failed(),
+            revert_reason,
+        )
+
+    def _execute_trades_sequentially(
+        self,
+        ts: datetime.datetime,
+        state: State,
+        trades: List[TradeExecution],
+        routing_model: RoutingModel,
+        routing_state: RoutingState,
+        check_balances: bool,
+        rebroadcast: bool,
+        triggered: bool,
+    ) -> None:
+        """Prepare, broadcast, settle, and freeze one trade at a time."""
+        reason = routing_model.get_sequential_trade_execution_reason(trades)
+        logger.warning(
+            "Sequential trade execution enabled for %d trade(s)%s",
+            len(trades),
+            f": {reason}" if reason else "",
+        )
+
+        for idx, trade in enumerate(trades, start=1):
+            logger.info(
+                "Sequential trade execution %d/%d: preparing trade_id=%s planned_value=%.6f pair=%s",
+                idx,
+                len(trades),
+                trade.trade_id,
+                trade.get_planned_value(),
+                trade.pair.get_ticker(),
+            )
+
+            if not rebroadcast:
+                state.start_execution(
+                    native_datetime_utc_now(),
+                    trade,
+                    underflow_check=check_balances,
+                    triggered=triggered,
+                )
+
+            routing_model.setup_trades(
+                state=state,
+                routing_state=routing_state,
+                trades=[trade],
+                check_balances=check_balances,
+                rebroadcast=rebroadcast,
+            )
+
+            self._execute_trade_batch(
+                routing_model,
+                state,
+                [trade],
+                rebroadcast=rebroadcast,
+            )
+
+            freeze_position_on_failed_trade(ts, state, [trade])
+            self._log_trade_outcome(trade)
+
+            if trade.is_failed():
+                remaining_trade_ids = [remaining.trade_id for remaining in trades[idx:]]
+                raise ExecutionHaltableIssue(
+                    "Sequential trade execution stopped after trade failure. "
+                    f"Failed trade_id={trade.trade_id}, route={trade.route or '-'}, "
+                    f"pair={trade.pair.get_ticker()}, revert_reason={trade.get_revert_reason()}, "
+                    f"remaining_trade_ids={remaining_trade_ids}"
+                )
+
     def execute_trades(
         self,
         ts: datetime.datetime,
@@ -595,6 +711,19 @@ class EthereumExecution(ExecutionModel):
             if not self.mainnet_fork:
                 assert self.confirmation_block_count > 0, f"confirmation_block_count set to {self.confirmation_block_count} "
 
+        if routing_model.needs_sequential_trade_execution(trades) and not rebroadcast:
+            self._execute_trades_sequentially(
+                ts=ts,
+                state=state,
+                trades=trades,
+                routing_model=routing_model,
+                routing_state=routing_state,
+                check_balances=check_balances,
+                rebroadcast=rebroadcast,
+                triggered=triggered,
+            )
+            return
+
         if not rebroadcast:
             state.start_execution_all(
                 native_datetime_utc_now(),
@@ -611,39 +740,17 @@ class EthereumExecution(ExecutionModel):
             rebroadcast=rebroadcast,
         )
 
-        force_sequential_broadcast = self.force_sequential_broadcast
-
-        if isinstance(self.web3.provider, MEVBlockerProvider) or force_sequential_broadcast:
-            self.broadcast_and_resolve_mev_blocker(
-                routing_model,
-                state,
-                trades,
-                # explicitly set to False here to keep execution going
-                stop_on_execution_failure=False,
-            )
-        elif isinstance(self.web3.provider, (FallbackProvider)):
-            # Multi node broadcast
-            self.broadcast_and_resolve_multiple_nodes(
-                routing_model,
-                state,
-                trades,
-                confirmation_timeout=self.confirmation_timeout,
-                confirmation_block_count=self.confirmation_block_count,
-                rebroadcast=rebroadcast,
-            )
-
-        else:
-            # Rebroadcast not supported for the old code path
-            self.broadcast_and_resolve_old(
-                state,
-                trades,
-                routing_model,
-                confirmation_timeout=self.confirmation_timeout,
-                confirmation_block_count=self.confirmation_block_count,
-            )
+        self._execute_trade_batch(
+            routing_model,
+            state,
+            trades,
+            rebroadcast=rebroadcast,
+        )
 
         # Clean up failed trades
         freeze_position_on_failed_trade(ts, state, trades)
+        for trade in trades:
+            self._log_trade_outcome(trade)
 
     def get_routing_state_details(self) -> RoutingStateDetails:
         return {
@@ -744,14 +851,16 @@ def update_confirmation_status(
             status = receipt["status"] == 1
             block_number = receipt["blockNumber"]
             logger.info(
-                f"Resolved as %s tx nonce: %d, hash: %s, function: %s(), contract %s, gas limit %s, block {block_number:,} for trade %s",
+                "Resolved tx receipt as %s tx nonce: %d, hash: %s, function: %s(), contract %s, gas limit %s, block %s for trade %s; final trade outcome pending settlement",
                 "success" if status else "reverted",
                 tx.nonce,
                 tx_hash.hex(),
                 tx.function_selector,
                 tx.contract_address,
                 tx.get_gas_limit(),
-                trade)
+                f"{block_number:,}",
+                trade,
+            )
 
             reason = None
             stack_trace = None

--- a/tradeexecutor/ethereum/vault/hypercore_routing.py
+++ b/tradeexecutor/ethereum/vault/hypercore_routing.py
@@ -306,6 +306,33 @@ class HypercoreVaultRouting(RoutingModel):
         logger.info("Hypercore vault routing details")
         self.reserve_asset_logging(pair_universe)
 
+    def needs_sequential_trade_execution(
+        self,
+        trades: list[TradeExecution],
+    ) -> bool:
+        """Hypercore trades must settle before the next trade is prepared.
+
+        Hypercore deposits and withdrawals can:
+
+        - release spendable capital only during settlement, not at phase 1 receipt
+        - append extra follow-up transactions during settlement
+
+        Because of this, batching multiple Hypercore trades before settling the
+        earlier ones can mis-sequence capital reuse and nonce allocation.
+        """
+        return len(trades) > 0
+
+    def get_sequential_trade_execution_reason(
+        self,
+        trades: list[TradeExecution],
+    ) -> str | None:
+        if not trades:
+            return None
+        return (
+            "Hypercore vault trades release spendable capital only after settlement "
+            "and may create follow-up settlement transactions"
+        )
+
     # ------------------------------------------------------------------
     # Transaction building helpers
     # ------------------------------------------------------------------

--- a/tradeexecutor/strategy/generic/generic_router.py
+++ b/tradeexecutor/strategy/generic/generic_router.py
@@ -230,6 +230,29 @@ class GenericRouting(RoutingModel):
             if original_web3 is not None:
                 router_state.web3 = original_web3
 
+    def needs_sequential_trade_execution(
+        self,
+        trades: List[TradeExecution],
+    ) -> bool:
+        """Return ``True`` if any underlying router needs per-trade settlement."""
+        for trade in trades:
+            router, _ = self.get_router(trade.pair)
+            if router.needs_sequential_trade_execution([trade]):
+                return True
+        return False
+
+    def get_sequential_trade_execution_reason(
+        self,
+        trades: List[TradeExecution],
+    ) -> str | None:
+        """Return the first underlying router reason, if any."""
+        for trade in trades:
+            router, _ = self.get_router(trade.pair)
+            reason = router.get_sequential_trade_execution_reason([trade])
+            if reason:
+                return reason
+        return None
+
     def settle_trade(
         self,
         web3: Web3,

--- a/tradeexecutor/strategy/routing.py
+++ b/tradeexecutor/strategy/routing.py
@@ -267,6 +267,26 @@ class RoutingModel(abc.ABC):
             If a trade cannot be executed, e.g. due to an unsupported pair or an exchange,
         """
 
+    def needs_sequential_trade_execution(
+        self,
+        trades: List[TradeExecution],
+    ) -> bool:
+        """Does this router require trade-by-trade execution for the batch.
+
+        Some routers only release spendable capital during settlement and may
+        also create extra follow-up transactions while settling a trade.
+        Those routers must be executed one trade at a time so later trades are
+        prepared against the up-to-date on-chain and portfolio state.
+        """
+        return False
+
+    def get_sequential_trade_execution_reason(
+        self,
+        trades: List[TradeExecution],
+    ) -> str | None:
+        """Return a human-readable reason for sequential execution, if any."""
+        return None
+
     def settle_trade(
         self,
         web3,


### PR DESCRIPTION
## Why

Hypercore vault routes can only release reusable capital during settlement, so batching a full rebalance before earlier trades settle can cascade one failed withdrawal into multiple frozen buys. The sequential execution path also needed to preserve the configured per-trade slippage cap instead of dropping it when switching away from the batch path.

## Lessons learnt

The executor needs to distinguish transaction receipt success from final trade success when a route has multi-phase settlement. When a dependency compatibility fix is needed upstream, it is safer to land it in the dependency repo without automatically advancing the vendored pointer in an unrelated executor PR.

## Summary

- execute Hypercore-style routes one trade at a time, halting the remaining batch after the first failed trade
- preserve `planned_max_slippage` in the sequential execution path
- add clearer settlement and final-outcome logging for sequential execution paths
- add focused regression coverage for sequential router orchestration
