### PR TITLE
fix: allow Hyperliquid cleanup with mixed live vaults

### DIFF
--- a/tests/hyperliquid/test_hyperliquid_cleanup.py
+++ b/tests/hyperliquid/test_hyperliquid_cleanup.py
@@ -373,3 +373,67 @@ def test_hyperliquid_cleanup_raises_on_dust_spot_balance(monkeypatch):
         RuntimeError, match="too small to cover the HyperCore bridge fee margin"
     ):
         hyperliquid_cleanup._execute_spot_to_evm(context, dust_balance)
+
+
+def test_hyperliquid_cleanup_allows_live_vault_rows_when_stranded_recovery_exists():
+    """Mixed live-vault and stranded-balance rows should still plan Safe-side recovery.
+
+    1. Build one genuinely live vault row and one closed-in-reality stranded row.
+    2. Run the clean-up action planner for a Safe with stranded HyperCore perp USDC.
+    3. Assert the planner ignores the live vault row and keeps the stranded recovery actions.
+    """
+    comparison_rows = [
+        hyperliquid_cleanup.HyperliquidCleanupComparisonRow(
+            position_id=34,
+            state_status="frozen",
+            vault_name="Still live vault",
+            vault_address="0x0000000000000000000000000000000000000034",
+            state_quantity=Decimal("591.373"),
+            live_vault_equity=Decimal("0.47309"),
+            reserve_quantity=Decimal("110.635"),
+            spot_free_usdc=Decimal("0.009252"),
+            perp_withdrawable=Decimal("4177.73"),
+            perp_position_count=0,
+            failed_trade_ids=[65],
+            classification="live_vault_open_no_action",
+        ),
+        hyperliquid_cleanup.HyperliquidCleanupComparisonRow(
+            position_id=33,
+            state_status="frozen",
+            vault_name="Closed in reality",
+            vault_address="0x0000000000000000000000000000000000000033",
+            state_quantity=Decimal("591.373"),
+            live_vault_equity=Decimal("0.099999"),
+            reserve_quantity=Decimal("110.635"),
+            spot_free_usdc=Decimal("0.009252"),
+            perp_withdrawable=Decimal("4177.73"),
+            perp_position_count=0,
+            failed_trade_ids=[64],
+            classification="closed_in_reality_perp_stranded",
+        ),
+    ]
+    live_snapshot = hyperliquid_cleanup.HyperliquidCleanupSnapshot(
+        safe_address="0xB136581dFB3efA76Ae71293C1A70942f0726E8fD",
+        evm_usdc_balance=Decimal("110.635"),
+        spot_total_usdc=Decimal("0.009252"),
+        spot_free_usdc=Decimal("0.009252"),
+        perp_withdrawable=Decimal("4177.73"),
+        perp_account_value=Decimal("4177.73"),
+        perp_position_count=0,
+        vault_equities={
+            "0x0000000000000000000000000000000000000034": Decimal("0.47309"),
+            "0x0000000000000000000000000000000000000033": Decimal("0.099999"),
+        },
+    )
+
+    # Step 1: Build a mixed live-vault and stranded-balance comparison.
+    # Step 2: Plan the clean-up actions from the Safe-level balances.
+    actions = hyperliquid_cleanup._plan_cleanup_actions(comparison_rows, live_snapshot)
+
+    # Step 3: Confirm we still recover the stranded Safe balances.
+    assert [action.action_kind for action in actions] == [
+        "perp_to_spot",
+        "spot_to_evm",
+    ]
+    assert actions[0].amount == Decimal("4177.73")
+    assert actions[1].amount == Decimal("4177.739252")

--- a/tradeexecutor/ethereum/vault/hyperliquid_cleanup.py
+++ b/tradeexecutor/ethereum/vault/hyperliquid_cleanup.py
@@ -24,9 +24,9 @@ The clean-up flow therefore only ever performs these actions:
 
 It never performs ``vaultTransfer(vault -> perp)``.
 
-If the failed close candidate still has meaningful live vault equity on
-Hyperliquid, this module aborts and tells the operator to review the
-position manually.
+If some Hyperliquid vault positions are still genuinely live, this
+module leaves them untouched. It only aborts when the Safe still has
+active perp positions, because that requires manual review.
 """
 
 import datetime
@@ -375,12 +375,6 @@ def _plan_cleanup_actions(
 ) -> list[HyperliquidCleanupAction]:
     """Create a safe action plan from current live balances."""
     for row in comparison_rows:
-        if row.classification == "live_vault_open_no_action":
-            raise RuntimeError(
-                f"Refusing clean-up for position {row.position_id}: live vault equity is still "
-                f"{row.live_vault_equity}, which is above the residual threshold "
-                f"{RESIDUAL_VAULT_EQUITY_THRESHOLD}. This looks like a genuinely open real vault position."
-            )
         if row.classification == "manual_review_required_active_perp_positions":
             raise RuntimeError(
                 f"Refusing clean-up for position {row.position_id}: manual review required because "


### PR DESCRIPTION
## Why

Hyperliquid clean-up currently aborts on mixed portfolios where some vaults are still live even though other frozen positions have already closed in reality and only need Safe-side stranded USDC recovery. This blocks the intended repair flow for the Hypercore incident class.

## Lessons learnt

The clean-up helper only performs Safe-side `perp -> spot` and `spot -> EVM` recovery, so genuinely live vault rows do not need to be fatal as long as there are no active perp positions. Mixed live and stranded vault states need explicit test coverage.

## Summary

- removed the fatal `live_vault_open_no_action` planner guard so the helper can proceed when recoverable stranded balances exist alongside unrelated live vaults
- updated the module wording to reflect that live vaults are left untouched and only active perp positions force manual review
- added a regression test covering the mixed live-vault plus stranded-balance scenario
