### PR TITLE
fix: increase HyperCore withdrawal safety margin

### DIFF
--- a/tradeexecutor/ethereum/vault/hypercore_routing.py
+++ b/tradeexecutor/ethereum/vault/hypercore_routing.py
@@ -130,15 +130,15 @@ HYPERCORE_LIKELY_CLOSE_TOLERANCE = 0.975
 #: action, the vault NAV can fluctuate (fees, PnL, mark-to-market).  The
 #: API may also round the equity string upward vs. the on-chain value.
 #:
-#: $0.10 (100 000 raw) covers observed drift for typical vaults.
-#: The original $0.01 margin was too tight — observed shortfalls of
-#: ~$0.02 USDC on ~$7 withdrawals due to vault share price movement
+#: $1.00 (1 000 000 raw) covers larger observed drift for volatile vaults.
+#: The original $0.01 margin was too tight, and even the later $0.10 margin
+#: proved insufficient for some live withdrawals when vault share price moved
 #: between the API read and HyperCore processing the queued action.
 #:
-#: This will leave ~$0.10 unclaimable dust in the vault (below the $5
+#: This will leave up to ~$1.00 unclaimable dust in the vault (below the $5
 #: minimum vault withdrawal threshold) that must be cleaned up in
 #: accounting later.
-HYPERCORE_WITHDRAWAL_SAFETY_MARGIN_RAW = 100_000
+HYPERCORE_WITHDRAWAL_SAFETY_MARGIN_RAW = 1_000_000
 
 # Temporary stop-gap for follow-up withdrawal verification phases.
 # Proper fix: carry the actually observed amount from one phase to the next.


### PR DESCRIPTION
## Why

HyperCore vault withdrawals can silently no-op when the requested amount is slightly above the live redeemable equity. Increasing the withdrawal safety margin reduces the chance of full-close withdrawals failing because vault equity drifts between the API read and HyperCore processing the action.

## Lessons learnt

The previous $0.10 buffer was still too tight for some live HyperCore withdrawals. A larger margin is a safer short-term guard until the withdrawal flow becomes more adaptive to live redeemable amounts.

## Summary

- increase `HYPERCORE_WITHDRAWAL_SAFETY_MARGIN_RAW` from `100_000` to `1_000_000`
- update the surrounding HyperCore withdrawal comments to reflect the new $1.00 margin and dust expectation
