### PR TITLE
fix: relax Hypercore perp withdrawal verification tolerance

### DIFF
--- a/tests/hyperliquid/test_hypercore_dual_chain.py
+++ b/tests/hyperliquid/test_hypercore_dual_chain.py
@@ -305,6 +305,76 @@ def test_wait_for_spot_free_usdc_balance_accepts_follow_up_phase_tolerance():
     assert result == Decimal("1.980001")
 
 
+def test_wait_for_perp_withdrawable_balance_accepts_relative_tolerance():
+    """Accept perp withdrawable balance when the shortfall stays within relative tolerance.
+
+    1. Create a routing object and mock a large perp withdrawable balance increase with a small relative shortfall.
+    2. Wait for the perp withdrawable balance using the withdrawal verifier.
+    3. Verify the slightly short increase is still accepted.
+    """
+    routing = _make_routing()
+
+    # 1. Create a routing object and mock a large perp withdrawable balance increase with a small relative shortfall.
+    routing._fetch_safe_perp_withdrawable_balance = MagicMock(
+        side_effect=[Decimal("629.998483")],
+    )
+
+    # 2. Wait for the perp withdrawable balance using the withdrawal verifier.
+    with patch("tradeexecutor.ethereum.vault.hypercore_routing.time.sleep"):
+        with patch("tradeexecutor.ethereum.vault.hypercore_routing.time.time", side_effect=_monotonic_time()):
+            result = routing._wait_for_perp_withdrawable_balance(
+                baseline_balance=Decimal("59.559287"),
+                expected_increase_raw=570_690_753,
+                timeout=30.0,
+                poll_interval=2.0,
+            )
+
+    # 3. Verify the slightly short increase is still accepted.
+    assert result == Decimal("629.998483")
+
+
+def test_wait_for_perp_withdrawable_balance_rejects_large_shortfall():
+    """Reject perp withdrawable balance when the shortfall exceeds relative tolerance.
+
+    1. Create a routing object and mock a large perp withdrawable balance increase with a material shortfall.
+    2. Wait for the perp withdrawable balance using the withdrawal verifier.
+    3. Verify the helper times out and raises a withdrawal verification error.
+    """
+    import pytest
+    from tradeexecutor.ethereum.vault.hypercore_routing import (
+        HypercoreWithdrawalVerificationError,
+    )
+
+    routing = _make_routing()
+
+    # 1. Create a routing object and mock a large perp withdrawable balance increase with a material shortfall.
+    routing._fetch_safe_perp_withdrawable_balance = MagicMock(
+        return_value=Decimal("620.0"),
+    )
+
+    call_count = [0]
+
+    def fake_time():
+        call_count[0] += 1
+        if call_count[0] <= 2:
+            return 0.0
+        return 999.0
+
+    # 2. Wait for the perp withdrawable balance using the withdrawal verifier.
+    with patch("tradeexecutor.ethereum.vault.hypercore_routing.time.sleep"):
+        with patch("tradeexecutor.ethereum.vault.hypercore_routing.time.time", side_effect=fake_time):
+            # 3. Verify the helper times out and raises a withdrawal verification error.
+            with pytest.raises(HypercoreWithdrawalVerificationError) as exc_info:
+                routing._wait_for_perp_withdrawable_balance(
+                    baseline_balance=Decimal("59.559287"),
+                    expected_increase_raw=570_690_753,
+                    timeout=30.0,
+                    poll_interval=2.0,
+                )
+
+    assert "did not reach" in str(exc_info.value)
+
+
 @patch("tradeexecutor.ethereum.vault.hypercore_routing.get_block_timestamp")
 @patch("tradeexecutor.ethereum.vault.hypercore_routing.fetch_user_vault_equity")
 def test_withdrawal_phase3_uses_fee_adjusted_amount(

--- a/tradeexecutor/ethereum/vault/hypercore_routing.py
+++ b/tradeexecutor/ethereum/vault/hypercore_routing.py
@@ -145,6 +145,13 @@ HYPERCORE_WITHDRAWAL_SAFETY_MARGIN_RAW = 1_000_000
 # Remove this extra slack once settlement becomes amount-adaptive across phases.
 HYPERCORE_FOLLOW_UP_PHASE_TOLERANCE_RAW = 200_000
 
+# Relative tolerance for live HyperCore balance waits.
+#
+# Existing vault equity and withdrawable balances can drift during the
+# confirmation window, so larger amounts need more than a fixed-cent
+# tolerance to avoid false failures.
+HYPERCORE_RELATIVE_BALANCE_TOLERANCE = Decimal("0.01")
+
 def usdc_to_raw(amount: Decimal) -> int:
     """Convert a human-readable USDC amount to raw 6-decimal integer."""
     return int(amount * 10**USDC_DECIMALS)
@@ -652,8 +659,12 @@ class HypercoreVaultRouting(RoutingModel):
         poll_interval: float = 2.0,
     ) -> Decimal:
         """Poll HyperCore perp withdrawable USDC until the withdrawal reaches perp."""
-        # Allow $0.10 tolerance for Hypercore API rounding and vault NAV drift
-        expected_balance = baseline_balance + raw_to_usdc(expected_increase_raw) - Decimal("0.10")
+        expected_increase = raw_to_usdc(expected_increase_raw)
+        accepted_tolerance = max(
+            Decimal("0.10"),
+            expected_increase * HYPERCORE_RELATIVE_BALANCE_TOLERANCE,
+        )
+        expected_balance = baseline_balance + expected_increase - accepted_tolerance
         deadline = time.time() + timeout
         attempt = 0
 
@@ -664,11 +675,12 @@ class HypercoreVaultRouting(RoutingModel):
             if current_balance >= expected_balance:
                 logger.info(
                     "Perp withdrawable balance is ready for Safe %s after %d poll(s): "
-                    "%s USDC (expected at least %s USDC)",
+                    "%s USDC (expected at least %s USDC, tolerance %s USDC)",
                     self.safe_address,
                     attempt,
                     current_balance,
                     expected_balance,
+                    accepted_tolerance,
                 )
                 return current_balance
 
@@ -676,16 +688,18 @@ class HypercoreVaultRouting(RoutingModel):
             if remaining <= 0:
                 raise HypercoreWithdrawalVerificationError(
                     f"Perp withdrawable USDC did not reach {expected_balance} for Safe {self.safe_address} "
-                    f"within {timeout}s. Current balance: {current_balance} after {attempt} poll(s). "
+                    f"within {timeout}s. Current balance: {current_balance}, tolerance: {accepted_tolerance} "
+                    f"after {attempt} poll(s). "
                     f"The vaultTransfer action may have failed silently on HyperCore."
                 )
 
             logger.info(
                 "Waiting for perp withdrawable USDC in Safe %s: %s/%s USDC "
-                "(%.0fs remaining, poll #%d)",
+                "(tolerance %s USDC, %.0fs remaining, poll #%d)",
                 self.safe_address,
                 current_balance,
                 expected_balance,
+                accepted_tolerance,
                 remaining,
                 attempt,
             )


### PR DESCRIPTION
## Why

HyperCore withdrawal settlement still used a fixed 0.10 USDC tolerance when waiting for perp withdrawable balance after `vaultTransfer`. For larger live vault withdrawals this is too strict, because withdrawable balance can drift during the confirmation window and cause false trade failures.

## Lessons learnt

Live HyperCore verification should use relative tolerance once amounts get large. A fixed-cent threshold is fine for dust, but existing live balances can move enough during polling that larger withdrawals need the same kind of relative slack we already use in other HyperCore verification paths.

## Summary

- changed `_wait_for_perp_withdrawable_balance()` to accept the larger of 0.10 USDC or 1 percent of the expected increase
- improved logging and timeout messages to show the accepted tolerance explicitly
- added focused tests covering both the accepted relative-shortfall case and the still-failing large-shortfall case
