### PR TITLE
fix: harden Hypercore settlement follow-ups

### DIFF
--- a/tests/hyperliquid/test_hypercore_activation_cost.py
+++ b/tests/hyperliquid/test_hypercore_activation_cost.py
@@ -296,26 +296,25 @@ def test_withdrawal_uses_live_equity_on_close():
     assert trade.other_data["hypercore_capped_withdrawal_raw"] == expected_withdrawal_raw
 
 
-def test_withdrawal_rejects_large_equity_mismatch():
-    """Abort withdrawal when live equity diverges too far from planned amount.
-
-    If the live vault equity is below HYPERCORE_LIKELY_CLOSE_TOLERANCE of the
-    planned amount, something is seriously wrong and we abort rather than
-    withdraw an unexpected amount.
+def test_withdrawal_logs_large_equity_mismatch_but_uses_live_amount(caplog):
+    """Large planned/live drift should warn loudly but still use live equity.
 
     1. Create a sell trade with planned_reserve=100 USDC.
-    2. Mock live equity at 90 USDC (90% — below the 97.5% tolerance).
-    3. Verify the withdrawal raises AssertionError.
+    2. Mock live equity at 90 USDC so the planned/live drift breaches the warning threshold.
+    3. Verify the withdrawal still uses live equity minus safety margin.
+    4. Verify the warning is logged so the operator can inspect the drift.
     """
     import datetime
-    import pytest
     from eth_defi.hyperliquid.api import UserVaultEquity
     from tradeexecutor.state.trade import TradeFlag
+    from tradeexecutor.ethereum.vault.hypercore_routing import HYPERCORE_WITHDRAWAL_SAFETY_MARGIN_RAW
 
     routing = _make_routing(simulate=False)
     trade = _make_trade(planned_reserve=Decimal("100.0"), is_buy=False)
     trade.pair.pool_address = "0x1111111111111111111111111111111111111111"
     trade.flags = {TradeFlag.close}
+    withdraw_fn = MagicMock()
+    signed_tx = MagicMock()
 
     # 1. Live equity is only 90% of planned — below the 97.5% tolerance.
     live_equity = UserVaultEquity(
@@ -323,11 +322,26 @@ def test_withdrawal_rejects_large_equity_mismatch():
         equity=Decimal("90.0"),
         locked_until=datetime.datetime(2020, 1, 1),
     )
+    expected_withdrawal_raw = 90_000_000 - HYPERCORE_WITHDRAWAL_SAFETY_MARGIN_RAW
 
-    # 2. The sanity check should reject this large mismatch.
-    with patch("tradeexecutor.ethereum.vault.hypercore_routing.fetch_user_vault_equity", return_value=live_equity):
-        with pytest.raises(AssertionError, match="too far below"):
-            routing._create_deposit_or_withdraw_txs(trade)
+    # Step 2: Mock the live equity so the drift warning path is exercised.
+    with caplog.at_level("WARNING"):
+        with patch("tradeexecutor.ethereum.vault.hypercore_routing.fetch_user_vault_equity", return_value=live_equity):
+            with patch("tradeexecutor.ethereum.vault.hypercore_routing.build_hypercore_withdraw_from_vault_call", return_value=withdraw_fn) as build_withdraw:
+                with patch.object(routing, "_sign_module_call", return_value=signed_tx):
+                    txs = routing._create_deposit_or_withdraw_txs(trade)
+
+    # Step 3: Verify the withdrawal still uses live equity minus safety margin.
+    assert txs == [signed_tx]
+    build_withdraw.assert_called_once_with(
+        routing.lagoon_vault,
+        vault_address="0x1111111111111111111111111111111111111111",
+        hypercore_usdc_amount=expected_withdrawal_raw,
+    )
+    assert trade.other_data["hypercore_capped_withdrawal_raw"] == expected_withdrawal_raw
+
+    # Step 4: Verify the warning is logged so the operator can inspect the drift.
+    assert any("planned/live drift is large" in record.message for record in caplog.records)
 
 
 @patch("tradeexecutor.ethereum.vault.hypercore_routing.report_failure")

--- a/tests/hyperliquid/test_hypercore_dual_chain.py
+++ b/tests/hyperliquid/test_hypercore_dual_chain.py
@@ -50,6 +50,7 @@ def _make_trade(planned_reserve=Decimal("50.0"), is_buy=False):
     trade.is_vault.return_value = True
     trade.get_planned_reserve.return_value = planned_reserve
     trade.trade_id = 1
+    trade.position_id = 1
     trade.blockchain_transactions = [MagicMock(tx_hash="0xabc")]
     trade.other_data = {}
     trade.pair = MagicMock()
@@ -373,6 +374,88 @@ def test_wait_for_perp_withdrawable_balance_rejects_large_shortfall():
                 )
 
     assert "did not reach" in str(exc_info.value)
+
+
+def test_withdrawal_already_reflected_in_vault_equity_is_detected():
+    """Detect a phase 1 withdrawal that already reduced vault equity.
+
+    1. Create a routing object with a state position quantity from before settlement.
+    2. Feed the helper a vault equity snapshot that matches the expected post-withdrawal residual.
+    3. Verify the helper recognises phase 1 as already applied.
+    """
+    routing = _make_routing()
+
+    # 1. Create a routing object with a state position quantity from before settlement.
+    position_quantity_before = Decimal("630.007301")
+    current_vault_equity = Decimal("77.748241")
+
+    # 2. Feed the helper a vault equity snapshot that matches the expected post-withdrawal residual.
+    result = routing._is_withdrawal_already_reflected_in_vault_equity(
+        position_quantity_before=position_quantity_before,
+        current_vault_equity=current_vault_equity,
+        expected_increase_raw=552_259_060,
+    )
+
+    # 3. Verify the helper recognises phase 1 as already applied.
+    assert result is True
+
+
+@patch("tradeexecutor.ethereum.vault.hypercore_routing.get_block_timestamp")
+@patch("tradeexecutor.ethereum.vault.hypercore_routing.fetch_user_vault_equity")
+def test_withdrawal_phase1_timeout_uses_vault_equity_fallback(
+    mock_fetch_equity,
+    mock_block_ts,
+):
+    """Continue withdrawal settlement when phase 1 already shows as residual vault equity.
+
+    1. Simulate a timeout while waiting for perp withdrawable balance after phase 1.
+    2. Return a vault equity snapshot that already matches the expected post-withdrawal residual.
+    3. Verify settlement continues to phase 2 and marks the trade successful instead of freezing it.
+    """
+    from hexbytes import HexBytes
+
+    from tradeexecutor.ethereum.vault.hypercore_routing import (
+        HypercoreWithdrawalVerificationError,
+    )
+
+    routing = _make_routing()
+    trade = _make_trade(planned_reserve=Decimal("552.259060"))
+    state = MagicMock()
+    state.portfolio.get_position_by_id.return_value.get_quantity.return_value = Decimal("630.007301")
+    mock_block_ts.return_value = datetime.datetime(2025, 1, 1)
+    mock_fetch_equity.side_effect = [
+        _make_equity(Decimal("77.748241")),
+        _make_equity(Decimal("77.748241")),
+        _make_equity(Decimal("77.748241")),
+    ]
+    receipts = {HexBytes("0xabc"): {"status": 1, "blockNumber": 100}}
+
+    phase2_tx = MagicMock(tx_hash="0xdef")
+    phase3_tx = MagicMock(tx_hash="0x123")
+
+    with patch.object(routing, "_fetch_safe_evm_usdc_balance", side_effect=[820_762_276, 1_373_021_336]):
+        with patch.object(routing, "_fetch_safe_perp_withdrawable_balance", return_value=Decimal("761.147434")):
+            with patch.object(routing, "_fetch_safe_spot_free_usdc_balance", return_value=Decimal("0.009157")):
+                with patch.object(
+                    routing,
+                    "_wait_for_perp_withdrawable_balance",
+                    side_effect=HypercoreWithdrawalVerificationError("phase 1 timed out"),
+                ):
+                    with patch.object(routing, "_wait_for_spot_free_usdc_balance", return_value=Decimal("552.268217")):
+                        with patch.object(routing, "_broadcast_withdrawal_phase2", return_value=(phase2_tx, {"status": 1, "blockNumber": 101})):
+                            with patch.object(routing, "_broadcast_withdrawal_phase3", return_value=(phase3_tx, {"status": 1, "blockNumber": 102})):
+                                with patch.object(routing, "_wait_for_usdc_arrival", return_value=552_259_060):
+                                    with patch("tradeexecutor.ethereum.vault.hypercore_routing.time.sleep"):
+                                        with patch("tradeexecutor.ethereum.vault.hypercore_routing.time.time", side_effect=_monotonic_time()):
+                                            routing._settle_withdrawal(
+                                                routing.web3,
+                                                state,
+                                                trade,
+                                                receipts,
+                                                stop_on_execution_failure=False,
+                                            )
+
+    state.mark_trade_success.assert_called_once()
 
 
 @patch("tradeexecutor.ethereum.vault.hypercore_routing.get_block_timestamp")

--- a/tests/hyperliquid/test_hypercore_escrow_robust.py
+++ b/tests/hyperliquid/test_hypercore_escrow_robust.py
@@ -1,7 +1,8 @@
 """Test P15: Robust escrow wait with spot balance verification."""
 
+import itertools
 from decimal import Decimal
-from unittest.mock import MagicMock, patch, call
+from unittest.mock import MagicMock, patch
 
 from eth_defi.hyperliquid.api import SpotBalance, SpotClearinghouseState, EvmEscrow
 from eth_defi.hyperliquid.evm_escrow import _get_usdc_spot_balance, wait_for_evm_escrow_clear
@@ -11,6 +12,12 @@ def _make_state(usdc_balance: Decimal, escrows: list[EvmEscrow] | None = None) -
     """Helper to build a SpotClearinghouseState with a USDC balance."""
     balances = [SpotBalance(coin="USDC", token=0, total=usdc_balance, hold=Decimal(0))]
     return SpotClearinghouseState(balances=balances, evm_escrows=escrows or [])
+
+
+def _monotonic_time():
+    """Return a callable that yields steadily increasing timestamps for tests."""
+    counter = itertools.count()
+    return lambda: float(next(counter))
 
 
 def test_get_usdc_spot_balance_found():
@@ -45,12 +52,7 @@ def test_escrow_wait_with_expected_usdc_succeeds(monkeypatch):
         "eth_defi.hyperliquid.evm_escrow.fetch_spot_clearinghouse_state",
         side_effect=[baseline, pending, cleared],
     ), patch("eth_defi.hyperliquid.evm_escrow.time") as mock_time:
-        mock_time.time.side_effect = [
-            0,    # deadline = 0 + 60
-            0.5,  # after initial sleep: baseline capture is before this
-            2,    # first poll remaining check
-            4,    # second poll remaining check
-        ]
+        mock_time.time.side_effect = _monotonic_time()
         mock_time.sleep = MagicMock()
 
         wait_for_evm_escrow_clear(
@@ -62,26 +64,33 @@ def test_escrow_wait_with_expected_usdc_succeeds(monkeypatch):
         )
 
 
-def test_escrow_wait_with_expected_usdc_warns_on_shortfall(monkeypatch, caplog):
-    """Escrow clears but spot USDC increase is less than expected — logs warning."""
+def test_escrow_wait_with_expected_usdc_keeps_polling_after_shortfall(caplog):
+    """Escrow clear should keep polling until the expected spot USDC increase arrives.
+
+    1. Build a baseline with escrow and then return a cleared state with too little spot USDC.
+    2. Return a later cleared state where the expected spot increase has finally arrived.
+    3. Verify the helper logs the shortfall warning but still succeeds once spot catches up.
+    """
     import logging
+
     session = MagicMock()
 
     escrow_entry = EvmEscrow(coin="USDC", token=0, total=Decimal("50"))
 
-    # Baseline: 100 USDC
+    # Step 1: Build a baseline with escrow and then return a cleared state with too little spot USDC.
     baseline = _make_state(Decimal("100"), [escrow_entry])
-    # Cleared but only +20 instead of +50
-    cleared = _make_state(Decimal("120"))
+    shortfall = _make_state(Decimal("120"))
+    reached = _make_state(Decimal("150"))
 
     with patch(
         "eth_defi.hyperliquid.evm_escrow.fetch_spot_clearinghouse_state",
-        side_effect=[baseline, cleared],
+        side_effect=[baseline, shortfall, reached],
     ), patch("eth_defi.hyperliquid.evm_escrow.time") as mock_time:
-        mock_time.time.side_effect = [0, 2]
+        mock_time.time.side_effect = _monotonic_time()
         mock_time.sleep = MagicMock()
 
         with caplog.at_level(logging.WARNING):
+            # Step 2: Return a later cleared state where the expected spot increase has finally arrived.
             wait_for_evm_escrow_clear(
                 session,
                 user="0xABC",
@@ -90,7 +99,8 @@ def test_escrow_wait_with_expected_usdc_warns_on_shortfall(monkeypatch, caplog):
                 expected_usdc=Decimal("50"),
             )
 
-        assert "Possible silent bridge failure" in caplog.text
+        # Step 3: Verify the helper logs the shortfall warning but still succeeds once spot catches up.
+        assert "Waiting for the actual spot balance update instead of returning success yet." in caplog.text
 
 
 def test_escrow_wait_without_expected_usdc_backward_compatible():
@@ -103,7 +113,7 @@ def test_escrow_wait_without_expected_usdc_backward_compatible():
         "eth_defi.hyperliquid.evm_escrow.fetch_spot_clearinghouse_state",
         return_value=cleared,
     ), patch("eth_defi.hyperliquid.evm_escrow.time") as mock_time:
-        mock_time.time.side_effect = [0, 2]
+        mock_time.time.side_effect = _monotonic_time()
         mock_time.sleep = MagicMock()
 
         # Should work fine without expected_usdc

--- a/tests/hyperliquid/test_hyperliquid_cleanup.py
+++ b/tests/hyperliquid/test_hyperliquid_cleanup.py
@@ -437,3 +437,68 @@ def test_hyperliquid_cleanup_allows_live_vault_rows_when_stranded_recovery_exist
     ]
     assert actions[0].amount == Decimal("4177.73")
     assert actions[1].amount == Decimal("4177.739252")
+
+
+def test_wait_for_spot_free_balance_accepts_threshold_instead_of_exact_match(
+    monkeypatch,
+):
+    """Cleanup spot wait should accept threshold arrival instead of exact final balance.
+
+    1. Mock HyperCore spot balance slightly above the threshold implied by the expected increase.
+    2. Wait for the cleanup helper to confirm the spot balance increase.
+    3. Verify the helper accepts the observed balance without requiring an exact final match.
+    """
+
+    # Step 1: Mock HyperCore spot balance slightly above the threshold implied by the expected increase.
+    monkeypatch.setattr(
+        hyperliquid_cleanup,
+        "fetch_spot_clearinghouse_state",
+        lambda _session, user: SimpleNamespace(
+            balances=[
+                SimpleNamespace(
+                    coin="USDC",
+                    total=Decimal("11.497"),
+                    hold=Decimal("0"),
+                )
+            ]
+        ),
+    )
+
+    # Step 2: Wait for the cleanup helper to confirm the spot balance increase.
+    result = hyperliquid_cleanup._wait_for_spot_free_balance(
+        session=object(),
+        user="0x123",
+        baseline_balance=Decimal("10.0"),
+        expected_increase=Decimal("1.5"),
+        timeout=0.1,
+        poll_interval=0.01,
+    )
+
+    # Step 3: Verify the helper accepts the observed balance without requiring an exact final match.
+    assert result == Decimal("11.497")
+
+
+def test_wait_for_evm_usdc_balance_accepts_threshold_instead_of_exact_match():
+    """Cleanup EVM wait should accept threshold arrival instead of exact final balance.
+
+    1. Mock a token balance slightly above the threshold implied by the expected bridged increase.
+    2. Wait for the cleanup helper to confirm the EVM USDC balance increase.
+    3. Verify the helper accepts the observed balance without requiring an exact final match.
+    """
+    token = MagicMock()
+
+    # Step 1: Mock a token balance slightly above the threshold implied by the expected bridged increase.
+    token.fetch_balance_of.return_value = Decimal("108.992")
+
+    # Step 2: Wait for the cleanup helper to confirm the EVM USDC balance increase.
+    result = hyperliquid_cleanup._wait_for_evm_usdc_balance(
+        token=token,
+        address="0x123",
+        baseline_balance=Decimal("100.0"),
+        expected_increase=Decimal("9.0"),
+        timeout=0.1,
+        poll_interval=0.01,
+    )
+
+    # Step 3: Verify the helper accepts the observed balance without requiring an exact final match.
+    assert result == Decimal("108.992")

--- a/tradeexecutor/ethereum/vault/hypercore_routing.py
+++ b/tradeexecutor/ethereum/vault/hypercore_routing.py
@@ -431,9 +431,10 @@ class HypercoreVaultRouting(RoutingModel):
         at trade-creation time can drift from actual vault equity due to fees,
         PnL, or NAV changes.  This method fetches the **live** equity from the
         ``userVaultEquities`` API and uses it directly as the withdrawal amount.
-        The planned value serves only as a sanity reference — if the two
+        The planned value serves only as a stale reference — if the two
         disagree by more than :py:data:`HYPERCORE_LIKELY_CLOSE_TOLERANCE`, we
-        abort because something is seriously wrong.
+        log a loud warning but still trust the live equity because aborting
+        here can freeze a legitimate close on ordinary NAV drift alone.
 
         The live amount is stored in ``trade.other_data`` so that settlement
         phases 2-3 use the same value that phase 1's ``vaultTransfer`` was
@@ -448,8 +449,7 @@ class HypercoreVaultRouting(RoutingModel):
         :return:
             Raw USDC amount to withdraw (the live vault equity).
         :raises AssertionError:
-            If the vault has no position or the live equity diverges from
-            the planned amount by more than the tolerance.
+            If the vault has no position.
         """
         session = self._get_session()
 
@@ -473,18 +473,27 @@ class HypercoreVaultRouting(RoutingModel):
 
         live_raw = usdc_to_raw(equity.equity)
 
-        # 3. Sanity check: the planned and live values must agree within
-        #    HYPERCORE_LIKELY_CLOSE_TOLERANCE (default 97.5%).  A larger
-        #    divergence signals a wrong vault address, corrupted state, or a
-        #    major vault event — abort rather than withdraw an unexpected amount.
-        assert live_raw >= planned_raw * HYPERCORE_LIKELY_CLOSE_TOLERANCE, (
-            f"Live vault equity ({equity.equity} USDC, {live_raw} raw) is too far "
-            f"below planned withdrawal ({raw_to_usdc(planned_raw)} USDC, {planned_raw} raw) "
-            f"for Safe {self.safe_address} in vault {vault_address}. "
-            f"Ratio: {live_raw / planned_raw:.4f}, "
-            f"tolerance: {HYPERCORE_LIKELY_CLOSE_TOLERANCE}. "
-            f"Aborting withdrawal to avoid unexpected behaviour."
-        )
+        # 3. WARNING: Do not abort a live close just because planned_reserve
+        #    drifted too far from current vault equity.
+        #    Planned reserve is created earlier in the cycle and can become
+        #    stale on real HyperCore vaults.  The live API read is the
+        #    authoritative amount for phase 1.  We keep the ratio check only
+        #    as a loud operator signal in logs so unexpected drift is visible.
+        if planned_raw > 0 and live_raw < planned_raw * HYPERCORE_LIKELY_CLOSE_TOLERANCE:
+            logger.warning(
+                "Full close planned/live drift is large for Safe %s in vault %s: "
+                "planned %s USDC (%d raw), live %s USDC (%d raw), ratio %.4f, "
+                "warning threshold %.4f. Continuing with live equity because "
+                "aborting here can freeze a legitimate close on NAV drift alone.",
+                self.safe_address,
+                vault_address,
+                raw_to_usdc(planned_raw),
+                planned_raw,
+                equity.equity,
+                live_raw,
+                live_raw / planned_raw,
+                HYPERCORE_LIKELY_CLOSE_TOLERANCE,
+            )
 
         # 4. Subtract a safety margin from the live equity to account for
         #    NAV drift between the API read and HyperCore action execution.
@@ -704,6 +713,31 @@ class HypercoreVaultRouting(RoutingModel):
                 attempt,
             )
             time.sleep(min(poll_interval, remaining))
+
+    def _is_withdrawal_already_reflected_in_vault_equity(
+        self,
+        position_quantity_before: Decimal,
+        current_vault_equity: Decimal,
+        expected_increase_raw: int,
+    ) -> bool:
+        """Check whether a withdrawal already appears as reduced vault equity.
+
+        HyperCore phase 1 (``vaultTransfer(vault->perp)``) can settle quickly
+        enough that by the time we start polling, the vault equity has already
+        dropped and the perp withdrawable balance baseline is effectively
+        post-withdrawal. In that case, waiting for another increase in perp
+        withdrawable would be a false failure.
+        """
+        expected_increase = raw_to_usdc(expected_increase_raw)
+        accepted_tolerance = max(
+            Decimal("0.10"),
+            expected_increase * HYPERCORE_RELATIVE_BALANCE_TOLERANCE,
+        )
+        inferred_decrease = max(
+            position_quantity_before - current_vault_equity,
+            Decimal(0),
+        )
+        return inferred_decrease >= expected_increase - accepted_tolerance
 
     def _wait_for_spot_free_usdc_balance(
         self,
@@ -1397,6 +1431,25 @@ class HypercoreVaultRouting(RoutingModel):
         if not self.simulate:
             baseline_balance_raw = self._fetch_safe_evm_usdc_balance()
             expected_raw = self._get_raw_usdc_amount(trade)
+            position_quantity_before: Decimal | None = None
+            try:
+                candidate_position_quantity = state.portfolio.get_position_by_id(
+                    trade.position_id
+                ).get_quantity()
+                if isinstance(candidate_position_quantity, Decimal):
+                    position_quantity_before = candidate_position_quantity
+                else:
+                    logger.warning(
+                        "Could not use state position quantity for withdrawal verification: "
+                        "position %s returned non-Decimal value %r",
+                        trade.position_id,
+                        candidate_position_quantity,
+                    )
+            except Exception as e:
+                logger.warning(
+                    "Could not read state position quantity for withdrawal verification: %s",
+                    e,
+                )
 
             # If the withdrawal amount was adjusted during phase 1 build
             # (full close trades that use live vault equity), use that amount
@@ -1418,7 +1471,7 @@ class HypercoreVaultRouting(RoutingModel):
                 "expected increase = %d raw",
                 self.safe_address, baseline_balance_raw, expected_raw,
             )
-            equity_before: Decimal | None = None
+            vault_equity_after_phase1_snapshot: Decimal | None = None
             vault_address = self._get_vault_address(trade)
             session = self._get_session()
             baseline_perp_withdrawable = self._fetch_safe_perp_withdrawable_balance()
@@ -1438,13 +1491,14 @@ class HypercoreVaultRouting(RoutingModel):
                     bypass_cache=True,
                 )
                 if eq_before is not None:
-                    equity_before = eq_before.equity
+                    vault_equity_after_phase1_snapshot = eq_before.equity
                     logger.info(
-                        "Vault equity before withdrawal: %s", equity_before,
+                        "Vault equity snapshot after phase 1 tx: %s",
+                        vault_equity_after_phase1_snapshot,
                     )
             except Exception as e:
                 logger.warning(
-                    "Could not snapshot vault equity before withdrawal: %s", e,
+                    "Could not snapshot vault equity after phase 1 tx: %s", e,
                 )
 
         withdraw_tx = trade.blockchain_transactions[-1]
@@ -1487,13 +1541,46 @@ class HypercoreVaultRouting(RoutingModel):
                     poll_interval=2.0,
                 )
             except HypercoreWithdrawalVerificationError as e:
-                logger.error(
-                    "Withdrawal phase 1 verification failed for trade %s: %s",
-                    trade.trade_id, e,
-                )
-                self._mark_stranded_usdc(trade, expected_raw, "hypercore_perp")
-                report_failure(ts, state, trade, stop_on_execution_failure)
-                return
+                current_vault_equity = vault_equity_after_phase1_snapshot
+                try:
+                    eq_after_phase1 = fetch_user_vault_equity(
+                        session,
+                        user=self.safe_address,
+                        vault_address=vault_address,
+                        bypass_cache=True,
+                    )
+                    current_vault_equity = (
+                        eq_after_phase1.equity if eq_after_phase1 is not None else Decimal(0)
+                    )
+                except Exception as snapshot_error:
+                    logger.warning(
+                        "Could not refresh vault equity after phase 1 timeout: %s",
+                        snapshot_error,
+                    )
+
+                if position_quantity_before is not None and current_vault_equity is not None and self._is_withdrawal_already_reflected_in_vault_equity(
+                    position_quantity_before=position_quantity_before,
+                    current_vault_equity=current_vault_equity,
+                    expected_increase_raw=expected_raw,
+                ):
+                    perp_balance = self._fetch_safe_perp_withdrawable_balance()
+                    logger.info(
+                        "Withdrawal phase 1 already reflected in vault equity for trade %s: "
+                        "state position quantity %s USDC, current vault equity %s USDC, "
+                        "current perp withdrawable %s USDC. Continuing with phase 2.",
+                        trade.trade_id,
+                        position_quantity_before,
+                        current_vault_equity,
+                        perp_balance,
+                    )
+                else:
+                    logger.error(
+                        "Withdrawal phase 1 verification failed for trade %s: %s",
+                        trade.trade_id, e,
+                    )
+                    self._mark_stranded_usdc(trade, expected_raw, "hypercore_perp")
+                    report_failure(ts, state, trade, stop_on_execution_failure)
+                    return
 
             logger.info(
                 "Before transferUsdClass(perp->spot), Safe %s perp withdrawable balance is %s USDC",
@@ -1691,8 +1778,10 @@ class HypercoreVaultRouting(RoutingModel):
                 )
                 remaining_equity = eq_after.equity if eq_after else Decimal(0)
 
-                if equity_before is not None:
-                    equity_decrease = equity_before - remaining_equity
+                if vault_equity_after_phase1_snapshot is not None:
+                    equity_decrease = (
+                        vault_equity_after_phase1_snapshot - remaining_equity
+                    )
                     expected_decrease = executed_reserve
                     tolerance = expected_decrease * Decimal("0.01")
                     if equity_decrease < expected_decrease - tolerance:
@@ -1701,14 +1790,14 @@ class HypercoreVaultRouting(RoutingModel):
                             "but HyperCore equity decreased by only %s (expected ~%s). "
                             "Before: %s, after: %s",
                             executed_reserve, equity_decrease, expected_decrease,
-                            equity_before, remaining_equity,
+                            vault_equity_after_phase1_snapshot, remaining_equity,
                         )
                     else:
                         logger.info(
                             "Withdrawal dual-chain verified: EVM USDC arrived (+%s), "
                             "HyperCore equity decreased by %s. Before: %s, after: %s",
                             executed_reserve, equity_decrease,
-                            equity_before, remaining_equity,
+                            vault_equity_after_phase1_snapshot, remaining_equity,
                         )
                 else:
                     logger.info(

--- a/tradeexecutor/ethereum/vault/hyperliquid_cleanup.py
+++ b/tradeexecutor/ethereum/vault/hyperliquid_cleanup.py
@@ -86,6 +86,7 @@ from tradeexecutor.strategy.universe_model import UniverseOptions
 logger = logging.getLogger(__name__)
 
 BALANCE_TOLERANCE = Decimal("0.02")
+CLEANUP_WAIT_RELATIVE_TOLERANCE = Decimal("0.001")
 RESIDUAL_VAULT_EQUITY_THRESHOLD = Decimal("0.10")
 POLL_INTERVAL = 2.0
 BALANCE_TIMEOUT = 60.0
@@ -201,6 +202,18 @@ class HyperliquidAccountingContext:
 def _is_within_tolerance(left: Decimal, right: Decimal) -> bool:
     """Check whether two balances are close enough."""
     return abs(left - right) <= BALANCE_TOLERANCE
+
+
+def _get_cleanup_wait_threshold(
+    baseline_balance: Decimal,
+    expected_increase: Decimal,
+) -> tuple[Decimal, Decimal]:
+    """Calculate the minimum balance increase that cleanup waits should accept."""
+    accepted_tolerance = max(
+        BALANCE_TOLERANCE,
+        expected_increase * CLEANUP_WAIT_RELATIVE_TOLERANCE,
+    )
+    return baseline_balance + expected_increase - accepted_tolerance, accepted_tolerance
 
 
 def _position_vault_address(position) -> str:
@@ -524,20 +537,31 @@ def _confirm_cleanup(auto_approve: bool) -> None:
 def _wait_for_spot_free_balance(
     session: HyperliquidSession,
     user: str,
-    expected_balance: Decimal,
+    baseline_balance: Decimal,
+    expected_increase: Decimal,
     timeout: float = BALANCE_TIMEOUT,
     poll_interval: float = POLL_INTERVAL,
 ) -> Decimal:
     """Wait until free spot USDC reaches the expected balance."""
+    # WARNING: Do not wait for an exact final spot balance here.
+    # Cleanup is an operator recovery flow and the Safe can already have spot
+    # dust or receive nearby balance changes while we are polling.  We only
+    # need to prove that the expected recovery amount arrived within a modest
+    # tolerance, not that the final balance matches one exact snapshot.
+    expected_balance, accepted_tolerance = _get_cleanup_wait_threshold(
+        baseline_balance=baseline_balance,
+        expected_increase=expected_increase,
+    )
     deadline = time.time() + timeout
     while True:
         spot_state = fetch_spot_clearinghouse_state(session, user=user)
         _spot_total, spot_free = _get_spot_usdc_balances(spot_state)
-        if _is_within_tolerance(spot_free, expected_balance):
+        if spot_free >= expected_balance:
             return spot_free
         if time.time() >= deadline:
             raise AssertionError(
-                f"Timed out waiting for HyperCore free spot USDC {expected_balance} for {user}, "
+                f"Timed out waiting for HyperCore free spot USDC threshold {expected_balance} "
+                f"for {user} (expected increase {expected_increase}, tolerance {accepted_tolerance}), "
                 f"last observed balance was {spot_free}"
             )
         time.sleep(poll_interval)
@@ -546,19 +570,30 @@ def _wait_for_spot_free_balance(
 def _wait_for_evm_usdc_balance(
     token: TokenDetails,
     address: str,
-    expected_balance: Decimal,
+    baseline_balance: Decimal,
+    expected_increase: Decimal,
     timeout: float = BALANCE_TIMEOUT,
     poll_interval: float = POLL_INTERVAL,
 ) -> Decimal:
     """Wait until EVM USDC reaches the expected balance."""
+    # WARNING: Do not wait for one exact final EVM balance here.
+    # The cleanup bridge confirmation only needs to prove that the expected
+    # increase arrived.  Requiring an exact final balance causes false
+    # failures when the Safe balance is slightly higher than the snapshot we
+    # started from or when minor bridge-side rounding drifts occur.
+    expected_balance, accepted_tolerance = _get_cleanup_wait_threshold(
+        baseline_balance=baseline_balance,
+        expected_increase=expected_increase,
+    )
     deadline = time.time() + timeout
     while True:
         balance = token.fetch_balance_of(address)
-        if _is_within_tolerance(balance, expected_balance):
+        if balance >= expected_balance:
             return balance
         if time.time() >= deadline:
             raise AssertionError(
-                f"Timed out waiting for HyperEVM USDC {expected_balance} for {address}, "
+                f"Timed out waiting for HyperEVM USDC threshold {expected_balance} "
+                f"for {address} (expected increase {expected_increase}, tolerance {accepted_tolerance}), "
                 f"last observed balance was {balance}"
             )
         time.sleep(poll_interval)
@@ -590,14 +625,19 @@ def _execute_perp_to_spot(
         f"{live_snapshot.perp_withdrawable}, expected at least {amount}"
     )
 
-    expected_spot_free = live_snapshot.spot_free_usdc + amount
+    baseline_spot_free = live_snapshot.spot_free_usdc
     fn = build_hypercore_transfer_usd_class_call(
         context.lagoon_vault,
         hypercore_usdc_amount=context.reserve_token.convert_to_raw(amount),
         to_perp=False,
     )
     tx_hash = _broadcast_bound_call(context.web3, context.hot_wallet, fn)
-    _wait_for_spot_free_balance(context.session, safe_address, expected_spot_free)
+    _wait_for_spot_free_balance(
+        context.session,
+        safe_address,
+        baseline_balance=baseline_spot_free,
+        expected_increase=amount,
+    )
     return tx_hash
 
 
@@ -627,14 +667,17 @@ def _execute_spot_to_evm(
             f"({HYPERCORE_BRIDGE_FEE_MARGIN} USDC); cannot withdraw to EVM"
         )
 
-    expected_evm_balance = live_snapshot.evm_usdc_balance + withdraw_amount
+    baseline_evm_balance = live_snapshot.evm_usdc_balance
     fn = build_hypercore_send_asset_to_evm_call(
         context.lagoon_vault,
         evm_usdc_amount=context.reserve_token.convert_to_raw(withdraw_amount),
     )
     tx_hash = _broadcast_bound_call(context.web3, context.hot_wallet, fn)
     _wait_for_evm_usdc_balance(
-        context.reserve_token, safe_address, expected_evm_balance
+        context.reserve_token,
+        safe_address,
+        baseline_balance=baseline_evm_balance,
+        expected_increase=withdraw_amount,
     )
     return tx_hash
 


### PR DESCRIPTION
## Why

Recent HyperCore failures exposed a few related follow-up issues after the initial tolerance fix. A legitimate close could still be frozen when phase 1 had already reduced vault equity before our baseline poll, the cleanup tooling still waited for exact final balances instead of the expected increase, and full-close routing could still abort on planned-versus-live drift even though the live vault equity is the authoritative amount.

This PR also updates the vendored `web3-ethereum-defi` pointer to the merged upstream deposit-confirmation hardening so the executor consumes the escrow/deposit verification fixes that were split into the separate dependency PR.

## Lessons learnt

HyperCore settlement checks need to verify the state transition we actually care about, not a stale snapshot or an exact final balance. Planned reserve is advisory for live closes, and follow-up waits should prove that enough balance moved instead of insisting the destination account ended at one precise number.

## Summary

- continue withdrawal settlement when phase 1 is already visible as reduced vault equity instead of freezing the trade on a false timeout
- warn loudly on large planned/live close drift but still use live vault equity minus the safety margin for the withdrawal amount
- change Hyperliquid cleanup balance waits to accept threshold-based balance increases rather than exact final-balance matches
- add focused regression tests for the phase-1 vault-equity fallback, the live-close drift warning path, and the cleanup wait thresholds
- update the vendored `web3-ethereum-defi` pointer to the merged upstream deposit/escrow confirmation hardening