### PR TITLE
fix: preserve pre-phase hypercore spot baselines

### DIFF
--- a/tests/hyperliquid/test_hypercore_activation_cost.py
+++ b/tests/hyperliquid/test_hypercore_activation_cost.py
@@ -54,7 +54,12 @@ def _make_routing_state():
 
 
 def test_activation_cost_only_deducted_from_first_buy():
-    """Two buy trades in the same cycle: only the first bears activation cost."""
+    """Two buy trades in the same cycle: only the first bears activation cost.
+
+    1. Create two buy trades in the same cycle.
+    2. Mock activation, pre-phase-1 spot baseline reads, and transaction creation.
+    3. Verify only the first trade bears the activation cost while both trades persist a spot baseline.
+    """
     routing = _make_routing(simulate=False)
     state = MagicMock()
     trade1 = _make_trade(planned_reserve=Decimal("100.0"))
@@ -66,14 +71,15 @@ def test_activation_cost_only_deducted_from_first_buy():
         costs_seen.append(activation_cost_raw)
         return [MagicMock()]
 
-    # 1. Build two buy trades in the same cycle.
-    # 2. Simulate activation followed by transaction creation.
-    # 3. Verify only the first trade carries the activation cost.
+    # 1. Create two buy trades in the same cycle.
+    # 2. Mock activation, pre-phase-1 spot baseline reads, and transaction creation.
+    # 3. Verify only the first trade carries the activation cost while both trades persist a spot baseline.
     with patch.object(routing, "_create_deposit_or_withdraw_txs", side_effect=capture_cost):
-        with patch("tradeexecutor.ethereum.vault.hypercore_routing.is_account_activated", return_value=False):
-            with patch("tradeexecutor.ethereum.vault.hypercore_routing.activate_account"):
-                with patch("tradeexecutor.ethereum.vault.hypercore_routing.fetch_user_abstraction_mode", return_value="standard"):
-                    routing.setup_trades(state, _make_routing_state(), [trade1, trade2])
+        with patch.object(routing, "_fetch_safe_spot_free_usdc_balance", side_effect=[Decimal("0"), Decimal("0")]):
+            with patch("tradeexecutor.ethereum.vault.hypercore_routing.is_account_activated", return_value=False):
+                with patch("tradeexecutor.ethereum.vault.hypercore_routing.activate_account"):
+                    with patch("tradeexecutor.ethereum.vault.hypercore_routing.fetch_user_abstraction_mode", return_value="standard"):
+                        routing.setup_trades(state, _make_routing_state(), [trade1, trade2])
 
     # First buy gets the activation cost, second does not
     assert costs_seen[0] == 2_000_000
@@ -82,6 +88,8 @@ def test_activation_cost_only_deducted_from_first_buy():
     # Only the first trade has activation cost persisted
     assert trade1.other_data.get("hypercore_activation_cost_raw") == 2_000_000
     assert "hypercore_activation_cost_raw" not in trade2.other_data
+    assert trade1.other_data.get("hypercore_phase1_spot_baseline_usdc") == "0"
+    assert trade2.other_data.get("hypercore_phase1_spot_baseline_usdc") == "0"
 
 
 def test_activation_cost_not_applied_to_sell():
@@ -125,9 +133,10 @@ def test_setup_trades_logs_account_mode_without_blocking(caplog):
     # 3. Verify transaction creation still proceeds and the mode is logged.
     with caplog.at_level(logging.INFO):
         with patch.object(routing, "_create_deposit_or_withdraw_txs", return_value=[MagicMock()]) as create_txs:
-            with patch("tradeexecutor.ethereum.vault.hypercore_routing.is_account_activated", return_value=True):
-                with patch("tradeexecutor.ethereum.vault.hypercore_routing.fetch_user_abstraction_mode", return_value="unifiedAccount"):
-                    routing.setup_trades(state, _make_routing_state(), [trade])
+            with patch.object(routing, "_fetch_safe_spot_free_usdc_balance", return_value=Decimal("0")):
+                with patch("tradeexecutor.ethereum.vault.hypercore_routing.is_account_activated", return_value=True):
+                    with patch("tradeexecutor.ethereum.vault.hypercore_routing.fetch_user_abstraction_mode", return_value="unifiedAccount"):
+                        routing.setup_trades(state, _make_routing_state(), [trade])
 
     create_txs.assert_called_once()
     assert any("unifiedAccount" in r.message for r in caplog.records)
@@ -148,9 +157,10 @@ def test_setup_trades_tolerates_account_mode_lookup_failure():
     # 2. Simulate an account-mode lookup failure.
     # 3. Verify transaction creation still proceeds.
     with patch.object(routing, "_create_deposit_or_withdraw_txs", return_value=[MagicMock()]) as create_txs:
-        with patch("tradeexecutor.ethereum.vault.hypercore_routing.is_account_activated", return_value=True):
-            with patch("tradeexecutor.ethereum.vault.hypercore_routing.fetch_user_abstraction_mode", side_effect=RuntimeError("boom")):
-                routing.setup_trades(state, _make_routing_state(), [trade])
+        with patch.object(routing, "_fetch_safe_spot_free_usdc_balance", return_value=Decimal("0")):
+            with patch("tradeexecutor.ethereum.vault.hypercore_routing.is_account_activated", return_value=True):
+                with patch("tradeexecutor.ethereum.vault.hypercore_routing.fetch_user_abstraction_mode", side_effect=RuntimeError("boom")):
+                    routing.setup_trades(state, _make_routing_state(), [trade])
 
     create_txs.assert_called_once()
 
@@ -170,14 +180,38 @@ def test_setup_trades_checks_mode_after_activation():
     # 2. Simulate successful activation and a unified mode read.
     # 3. Verify the trade is built only after activation completes.
     with patch.object(routing, "_create_deposit_or_withdraw_txs", return_value=[MagicMock()]) as create_txs:
-        with patch("tradeexecutor.ethereum.vault.hypercore_routing.is_account_activated", return_value=False):
-            with patch("tradeexecutor.ethereum.vault.hypercore_routing.activate_account") as activate:
-                with patch("tradeexecutor.ethereum.vault.hypercore_routing.fetch_user_abstraction_mode", return_value="unifiedAccount") as fetch_mode:
-                    routing.setup_trades(state, _make_routing_state(), [trade])
+        with patch.object(routing, "_fetch_safe_spot_free_usdc_balance", return_value=Decimal("0")):
+            with patch("tradeexecutor.ethereum.vault.hypercore_routing.is_account_activated", return_value=False):
+                with patch("tradeexecutor.ethereum.vault.hypercore_routing.activate_account") as activate:
+                    with patch("tradeexecutor.ethereum.vault.hypercore_routing.fetch_user_abstraction_mode", return_value="unifiedAccount") as fetch_mode:
+                        routing.setup_trades(state, _make_routing_state(), [trade])
 
     activate.assert_called_once()
     fetch_mode.assert_called_once()
     create_txs.assert_called_once()
+
+
+def test_setup_trades_stores_pre_phase1_spot_baseline_for_buy():
+    """Persist the pre-phase-1 HyperCore spot baseline for later settlement checks.
+
+    1. Create one live buy trade for an already activated Safe.
+    2. Mock the pre-phase-1 HyperCore spot read before transaction creation.
+    3. Verify setup stores the captured spot baseline in ``trade.other_data``.
+    """
+    routing = _make_routing(simulate=False)
+    state = MagicMock()
+    trade = _make_trade(planned_reserve=Decimal("25.0"))
+
+    # 1. Create one live buy trade for an already activated Safe.
+    # 2. Mock the pre-phase-1 HyperCore spot read before transaction creation.
+    # 3. Verify setup stores the captured spot baseline in trade.other_data.
+    with patch.object(routing, "_create_deposit_or_withdraw_txs", return_value=[MagicMock()]):
+        with patch.object(routing, "_fetch_safe_spot_free_usdc_balance", return_value=Decimal("12.345678")):
+            with patch("tradeexecutor.ethereum.vault.hypercore_routing.is_account_activated", return_value=True):
+                with patch("tradeexecutor.ethereum.vault.hypercore_routing.fetch_user_abstraction_mode", return_value="standard"):
+                    routing.setup_trades(state, _make_routing_state(), [trade])
+
+    assert trade.other_data["hypercore_phase1_spot_baseline_usdc"] == "12.345678"
 
 
 def test_create_buy_transactions_split_approve_and_deposit():
@@ -368,7 +402,7 @@ def test_settlement_second_buy_no_activation_cost(
     # Second buy: no activation cost in other_data
     trade = _make_trade(planned_reserve=Decimal("50.0"))
     trade.blockchain_transactions = [MagicMock(tx_hash="0xaa")]
-    trade.other_data = {}
+    trade.other_data = {"hypercore_phase1_spot_baseline_usdc": "12.34"}
     # Crucially, NO "hypercore_activation_cost_raw" key
 
     state = MagicMock()
@@ -418,6 +452,15 @@ def test_settlement_second_buy_no_activation_cost(
     # Verify _broadcast_phase2 received the full 50 USDC raw (not 48)
     deposit_raw_passed = mock_phase2.call_args[0][2]
     assert deposit_raw_passed == 50_000_000
+
+    mock_escrow.assert_called_once_with(
+        routing._get_session(),
+        user=routing.safe_address,
+        timeout=60.0,
+        poll_interval=2.0,
+        expected_usdc=Decimal("50.0"),
+        baseline_usdc=Decimal("12.34"),
+    )
 
 
 @patch("tradeexecutor.ethereum.vault.hypercore_routing.report_failure")

--- a/tradeexecutor/ethereum/vault/hypercore_routing.py
+++ b/tradeexecutor/ethereum/vault/hypercore_routing.py
@@ -1058,6 +1058,19 @@ class HypercoreVaultRouting(RoutingModel):
         for trade in trades:
             assert trade.is_vault(), f"Not a vault trade: {trade}"
 
+            if trade.is_buy() and not self.simulate:
+                if not hasattr(trade, "other_data") or trade.other_data is None:
+                    trade.other_data = {}
+
+                # WARNING: Capture the Safe's HyperCore spot balance before
+                # phase 1 is even broadcast. The escrow settlement can finish
+                # quickly enough that taking this snapshot later, during
+                # receipt handling, would already be post-deposit and make the
+                # observed spot increase look like zero.
+                trade.other_data["hypercore_phase1_spot_baseline_usdc"] = str(
+                    self._fetch_safe_spot_free_usdc_balance()
+                )
+
             if not self.simulate and not trade.is_buy() and not activated:
                 raise AssertionError(
                     f"Cannot withdraw from Hypercore vault: Safe {self.safe_address} "
@@ -1261,6 +1274,13 @@ class HypercoreVaultRouting(RoutingModel):
         deposit_raw = self._get_raw_usdc_amount(trade) - activation_cost
         session = self._get_session()
         planned_reserve = trade.get_planned_reserve()
+        baseline_spot_usdc: Decimal | None = None
+        if hasattr(trade, "other_data") and trade.other_data:
+            baseline_spot_usdc_str = trade.other_data.get(
+                "hypercore_phase1_spot_baseline_usdc"
+            )
+            if baseline_spot_usdc_str is not None:
+                baseline_spot_usdc = Decimal(baseline_spot_usdc_str)
 
         logger.info(
             "Hypercore deposit phase 1 succeeded (tx %s). Waiting for escrow to clear...",
@@ -1270,6 +1290,9 @@ class HypercoreVaultRouting(RoutingModel):
         # --- Escrow wait ---
         # Pass expected USDC so the escrow wait also verifies that USDC
         # appeared in the HyperCore spot balance, not just that escrows cleared.
+        # WARNING: Prefer the pre-phase-1 spot baseline captured during
+        # setup_trades() when it exists. Capturing a fresh baseline here can
+        # already be too late on fast HyperCore settlements.
         expected_usdc_human = raw_to_usdc(deposit_raw)
         try:
             wait_for_evm_escrow_clear(
@@ -1278,6 +1301,7 @@ class HypercoreVaultRouting(RoutingModel):
                 timeout=60.0,
                 poll_interval=2.0,
                 expected_usdc=expected_usdc_human,
+                baseline_usdc=baseline_spot_usdc,
             )
         except TimeoutError as e:
             logger.error("EVM escrow did not clear: %s", e)


### PR DESCRIPTION
## Why

HyperCore deposit settlement was still vulnerable to the same late-baseline race we hit on withdrawal. The escrow wait was proving the spot balance increase against a snapshot taken after phase 1 receipt handling had already started, which can already be post-deposit on fast settlements.

This PR depends on the upstream `web3-ethereum-defi` change that adds explicit baseline support to `wait_for_evm_escrow_clear()`.

## Lessons learnt

For multi-phase HyperCore flows, baselines must be captured before the phase that changes the observed balance is broadcast. If we let settlement helpers discover their own baselines later, fast-chain success can look identical to a missing transfer.

## Summary

- capture the Safe's HyperCore spot baseline before deposit phase 1 is broadcast
- persist that baseline in `trade.other_data` and reuse it during settlement
- pass the explicit baseline into the escrow wait so fast-settling deposits do not false-fail
- add focused regressions for setup-time baseline capture and settlement-time baseline reuse
