### PR TITLE
Fix Hypercore dust duplicate position handling

### DIFF
--- a/tests/hyperliquid/test_hypercore_accounting.py
+++ b/tests/hyperliquid/test_hypercore_accounting.py
@@ -18,9 +18,20 @@ from tradingstrategy.chain import ChainId
 
 from tradeexecutor.ethereum.vault.hypercore_valuation import HypercoreVaultPricing, HypercoreVaultValuator
 from tradeexecutor.ethereum.vault.hypercore_vault import create_hypercore_vault_pair
+from tradeexecutor.state.balance_update import (
+    BalanceUpdate,
+    BalanceUpdateCause,
+    BalanceUpdatePositionType,
+)
 from tradeexecutor.state.identifier import TradingPairIdentifier, TradingPairKind, AssetIdentifier
 from tradeexecutor.state.position import TradingPosition
-from tradeexecutor.strategy.account_correction import _build_hypercore_vault_account_checks
+from tradeexecutor.state.repair import close_hypercore_dust_positions
+from tradeexecutor.state.state import State
+from tradeexecutor.state.trade import TradeFlag, TradeType
+from tradeexecutor.strategy.account_correction import (
+    UnexpectedAccountingCorrectionIssue,
+    _build_hypercore_vault_account_checks,
+)
 from tradeexecutor.strategy.dust import (
     get_close_epsilon_for_pair,
     get_dust_epsilon_for_pair,
@@ -369,3 +380,354 @@ def test_hypercore_account_check_compares_equity_not_quantity() -> None:
     assert correction.actual_amount == live_equity
     assert correction.usd_value == 0.0
     assert correction.mismatch is False
+
+
+def test_hypercore_dust_position_is_reused_without_planned_close() -> None:
+    """Test Hypercore dust positions are reused unless the cycle is already closing them.
+
+    1. Build a state with one open Hypercore vault position whose residual quantity is below the dust epsilon.
+    2. Create a second buy trade for the same vault without any planned closing trade on the old position.
+    3. Verify the trade reuses the existing position instead of opening a duplicate position.
+    """
+
+    # 1. Build a state with one open Hypercore vault dust position.
+    reserve_asset = AssetIdentifier(
+        chain_id=999,
+        address="0xb88339cb7199b77e23db6e890353e22632ba630f",
+        token_symbol="USDC",
+        decimals=6,
+    )
+    pair = create_hypercore_vault_pair(
+        quote=reserve_asset,
+        vault_address="0x1111111111111111111111111111111111111111",
+    )
+    state = State()
+    state.portfolio.initialise_reserves(reserve_asset, reserve_token_price=1.0)
+    state.portfolio.adjust_reserves(reserve_asset, Decimal("100"), "Initial reserve")
+
+    position, trade, created = state.create_trade(
+        strategy_cycle_at=datetime.datetime(2026, 4, 13),
+        pair=pair,
+        quantity=None,
+        reserve=Decimal("1.00"),
+        assumed_price=1.0,
+        trade_type=TradeType.rebalance,
+        reserve_currency=reserve_asset,
+        reserve_currency_price=1.0,
+        notes="Create dust Hypercore position",
+    )
+    trade.mark_success(
+        executed_at=datetime.datetime(2026, 4, 13, 0, 1),
+        executed_price=1.0,
+        executed_quantity=Decimal("1.00"),
+        executed_reserve=Decimal("1.00"),
+        lp_fees=0,
+        native_token_price=0,
+        force=True,
+    )
+    position.balance_updates[1] = BalanceUpdate(
+        balance_update_id=1,
+        cause=BalanceUpdateCause.vault_flow,
+        position_type=BalanceUpdatePositionType.open_position,
+        asset=pair.base,
+        block_mined_at=datetime.datetime(2026, 4, 13, 0, 2),
+        strategy_cycle_included_at=datetime.datetime(2026, 4, 13),
+        chain_id=pair.base.chain_id,
+        quantity=Decimal("-0.90"),
+        old_balance=Decimal("1.00"),
+        usd_value=-0.90,
+        position_id=position.position_id,
+        notes="Simulate Hypercore withdrawal dust",
+        block_number=1,
+    )
+
+    assert created is True
+    assert position.can_be_closed()
+    assert len(state.portfolio.open_positions) == 1
+
+    # 2. Create a second buy trade for the same vault.
+    position2, trade2, created2 = state.create_trade(
+        strategy_cycle_at=datetime.datetime(2026, 4, 14),
+        pair=pair,
+        quantity=None,
+        reserve=Decimal("10"),
+        assumed_price=1.0,
+        trade_type=TradeType.rebalance,
+        reserve_currency=reserve_asset,
+        reserve_currency_price=1.0,
+        notes="Increase the same Hypercore position",
+    )
+
+    # 3. Verify the existing position is reused and no duplicate is opened.
+    assert created2 is False
+    assert position2.position_id == position.position_id
+    assert trade2.position_id == position.position_id
+    assert len(state.portfolio.open_positions) == 1
+
+
+def test_hypercore_dust_position_is_not_about_to_close_without_planned_trades() -> None:
+    """Test Hypercore dust does not look like a planned close unless the cycle really has closing trades.
+
+    1. Build a Hypercore position whose live quantity is below the close epsilon.
+    2. Verify is_about_to_close() stays false while there are no planned trades.
+    3. Mock a planned closing state and verify is_about_to_close() turns true.
+    """
+
+    # 1. Build a Hypercore position whose live quantity is below the close epsilon.
+    reserve_asset = AssetIdentifier(
+        chain_id=999,
+        address="0xb88339cb7199b77e23db6e890353e22632ba630f",
+        token_symbol="USDC",
+        decimals=6,
+    )
+    pair = create_hypercore_vault_pair(
+        quote=reserve_asset,
+        vault_address="0x3333333333333333333333333333333333333333",
+    )
+    state = State()
+    state.portfolio.initialise_reserves(reserve_asset, reserve_token_price=1.0)
+    state.portfolio.adjust_reserves(reserve_asset, Decimal("100"), "Initial reserve")
+
+    position, trade, _created = state.create_trade(
+        strategy_cycle_at=datetime.datetime(2026, 4, 13),
+        pair=pair,
+        quantity=None,
+        reserve=Decimal("1.00"),
+        assumed_price=1.0,
+        trade_type=TradeType.rebalance,
+        reserve_currency=reserve_asset,
+        reserve_currency_price=1.0,
+        notes="Create dust Hypercore position",
+    )
+    trade.mark_success(
+        executed_at=datetime.datetime(2026, 4, 13, 0, 1),
+        executed_price=1.0,
+        executed_quantity=Decimal("1.00"),
+        executed_reserve=Decimal("1.00"),
+        lp_fees=0,
+        native_token_price=0,
+        force=True,
+    )
+    position.balance_updates[1] = BalanceUpdate(
+        balance_update_id=1,
+        cause=BalanceUpdateCause.vault_flow,
+        position_type=BalanceUpdatePositionType.open_position,
+        asset=pair.base,
+        block_mined_at=datetime.datetime(2026, 4, 13, 0, 2),
+        strategy_cycle_included_at=datetime.datetime(2026, 4, 13),
+        chain_id=pair.base.chain_id,
+        quantity=Decimal("-0.90"),
+        old_balance=Decimal("1.00"),
+        usd_value=-0.90,
+        position_id=position.position_id,
+        notes="Simulate Hypercore withdrawal dust",
+        block_number=1,
+    )
+
+    # 2. Verify is_about_to_close() stays false while there are no planned trades.
+    assert position.can_be_closed()
+    assert position.has_planned_trades() is False
+    assert position.is_about_to_close() is False
+
+    # 3. Mock a planned closing state and verify is_about_to_close() turns true.
+    #    We mock here because create_trade() quite rightly refuses dust-sized
+    #    execution trades. This regression targets the helper semantics only:
+    #    dust must not look "about to close" until the cycle really has a
+    #    planned closing trade against the position.
+    with patch.object(position, "has_planned_trades", return_value=True):
+        assert position.is_about_to_close() is True
+
+
+def test_hypercore_account_check_rejects_duplicate_vault_positions() -> None:
+    """Test Hypercore account checks fail early with a direct duplicate-vault diagnosis.
+
+    1. Build a state with a dusty Hypercore position and a forced second open position for the same vault.
+    2. Run the Hypercore account-check builder.
+    3. Verify it raises the targeted duplicate-Hypercore error instead of producing a misleading diff table.
+    """
+
+    # 1. Build a state with one dust position and one live duplicate position.
+    reserve_asset = AssetIdentifier(
+        chain_id=999,
+        address="0xb88339cb7199b77e23db6e890353e22632ba630f",
+        token_symbol="USDC",
+        decimals=6,
+    )
+    pair = create_hypercore_vault_pair(
+        quote=reserve_asset,
+        vault_address="0x4444444444444444444444444444444444444444",
+    )
+    state = State()
+    state.portfolio.initialise_reserves(reserve_asset, reserve_token_price=1.0)
+    state.portfolio.adjust_reserves(reserve_asset, Decimal("100"), "Initial reserve")
+
+    dust_position, dust_trade, _created = state.create_trade(
+        strategy_cycle_at=datetime.datetime(2026, 4, 13),
+        pair=pair,
+        quantity=None,
+        reserve=Decimal("1.00"),
+        assumed_price=1.0,
+        trade_type=TradeType.rebalance,
+        reserve_currency=reserve_asset,
+        reserve_currency_price=1.0,
+        notes="Create dust Hypercore position",
+    )
+    dust_trade.mark_success(
+        executed_at=datetime.datetime(2026, 4, 13, 0, 1),
+        executed_price=1.0,
+        executed_quantity=Decimal("1.00"),
+        executed_reserve=Decimal("1.00"),
+        lp_fees=0,
+        native_token_price=0,
+        force=True,
+    )
+    dust_position.balance_updates[1] = BalanceUpdate(
+        balance_update_id=1,
+        cause=BalanceUpdateCause.vault_flow,
+        position_type=BalanceUpdatePositionType.open_position,
+        asset=pair.base,
+        block_mined_at=datetime.datetime(2026, 4, 13, 0, 2),
+        strategy_cycle_included_at=datetime.datetime(2026, 4, 13),
+        chain_id=pair.base.chain_id,
+        quantity=Decimal("-0.90"),
+        old_balance=Decimal("1.00"),
+        usd_value=-0.90,
+        position_id=dust_position.position_id,
+        notes="Simulate Hypercore withdrawal dust",
+        block_number=1,
+    )
+
+    _live_position, live_trade, live_created = state.create_trade(
+        strategy_cycle_at=datetime.datetime(2026, 4, 14),
+        pair=pair,
+        quantity=None,
+        reserve=Decimal("25"),
+        assumed_price=1.0,
+        trade_type=TradeType.rebalance,
+        reserve_currency=reserve_asset,
+        reserve_currency_price=1.0,
+        notes="Force a second open Hypercore position for regression coverage",
+        flags={TradeFlag.ignore_open},
+    )
+    live_trade.mark_success(
+        executed_at=datetime.datetime(2026, 4, 14, 0, 1),
+        executed_price=1.0,
+        executed_quantity=Decimal("25"),
+        executed_reserve=Decimal("25"),
+        lp_fees=0,
+        native_token_price=0,
+        force=True,
+    )
+
+    assert live_created is True
+    assert len(state.portfolio.open_positions) == 2
+
+    sync_model = MagicMock()
+    sync_model.web3 = MagicMock()
+    sync_model.get_token_storage_address.return_value = "0xa8F8DEbb722c6174B814b432169BF569603F673F"
+
+    # 2. Run the Hypercore account-check builder.
+    # 3. Verify it raises the targeted duplicate-Hypercore error.
+    with pytest.raises(UnexpectedAccountingCorrectionIssue, match="Duplicate Hypercore vault positions detected"):
+        _build_hypercore_vault_account_checks(state, sync_model)
+
+
+def test_close_hypercore_dust_positions_closes_duplicate_residual_state() -> None:
+    """Test Hypercore dust cleanup closes the stale residual position and keeps the live one open.
+
+    1. Build a state with a dusty Hypercore position and a forced second open position for the same vault.
+    2. Run the Hypercore dust cleanup helper.
+    3. Verify the residual dust position is closed with a repair trade while the live position stays open.
+    """
+
+    # 1. Build a state with one dust position and one live duplicate position.
+    reserve_asset = AssetIdentifier(
+        chain_id=999,
+        address="0xb88339cb7199b77e23db6e890353e22632ba630f",
+        token_symbol="USDC",
+        decimals=6,
+    )
+    pair = create_hypercore_vault_pair(
+        quote=reserve_asset,
+        vault_address="0x2222222222222222222222222222222222222222",
+    )
+    state = State()
+    state.portfolio.initialise_reserves(reserve_asset, reserve_token_price=1.0)
+    state.portfolio.adjust_reserves(reserve_asset, Decimal("100"), "Initial reserve")
+
+    dust_position, dust_trade, _created = state.create_trade(
+        strategy_cycle_at=datetime.datetime(2026, 4, 13),
+        pair=pair,
+        quantity=None,
+        reserve=Decimal("1.00"),
+        assumed_price=1.0,
+        trade_type=TradeType.rebalance,
+        reserve_currency=reserve_asset,
+        reserve_currency_price=1.0,
+        notes="Create dust Hypercore position",
+    )
+    dust_trade.mark_success(
+        executed_at=datetime.datetime(2026, 4, 13, 0, 1),
+        executed_price=1.0,
+        executed_quantity=Decimal("1.00"),
+        executed_reserve=Decimal("1.00"),
+        lp_fees=0,
+        native_token_price=0,
+        force=True,
+    )
+    dust_position.balance_updates[1] = BalanceUpdate(
+        balance_update_id=1,
+        cause=BalanceUpdateCause.vault_flow,
+        position_type=BalanceUpdatePositionType.open_position,
+        asset=pair.base,
+        block_mined_at=datetime.datetime(2026, 4, 13, 0, 2),
+        strategy_cycle_included_at=datetime.datetime(2026, 4, 13),
+        chain_id=pair.base.chain_id,
+        quantity=Decimal("-0.90"),
+        old_balance=Decimal("1.00"),
+        usd_value=-0.90,
+        position_id=dust_position.position_id,
+        notes="Simulate Hypercore withdrawal dust",
+        block_number=1,
+    )
+
+    live_position, live_trade, live_created = state.create_trade(
+        strategy_cycle_at=datetime.datetime(2026, 4, 14),
+        pair=pair,
+        quantity=None,
+        reserve=Decimal("25"),
+        assumed_price=1.0,
+        trade_type=TradeType.rebalance,
+        reserve_currency=reserve_asset,
+        reserve_currency_price=1.0,
+        notes="Force a second open Hypercore position for regression coverage",
+        flags={TradeFlag.ignore_open},
+    )
+    live_trade.mark_success(
+        executed_at=datetime.datetime(2026, 4, 14, 0, 1),
+        executed_price=1.0,
+        executed_quantity=Decimal("25"),
+        executed_reserve=Decimal("25"),
+        lp_fees=0,
+        native_token_price=0,
+        force=True,
+    )
+
+    assert live_created is True
+    assert len(state.portfolio.open_positions) == 2
+    assert dust_position.can_be_closed()
+    assert not live_position.can_be_closed()
+
+    # 2. Run the Hypercore dust cleanup helper.
+    created_trades = close_hypercore_dust_positions(
+        state.portfolio,
+        now=datetime.datetime(2026, 4, 15),
+    )
+
+    # 3. Verify only the dust position is closed and the live one remains open.
+    assert len(created_trades) == 1
+    assert dust_position.position_id in state.portfolio.closed_positions
+    assert dust_position.position_id not in state.portfolio.open_positions
+    assert live_position.position_id in state.portfolio.open_positions
+    assert live_position.position_id not in state.portfolio.closed_positions
+    assert created_trades[0].trade_type == TradeType.repair

--- a/tests/hyperliquid/test_hypercore_accounting.py
+++ b/tests/hyperliquid/test_hypercore_accounting.py
@@ -18,6 +18,7 @@ from tradingstrategy.chain import ChainId
 
 from tradeexecutor.ethereum.vault.hypercore_valuation import HypercoreVaultPricing, HypercoreVaultValuator
 from tradeexecutor.ethereum.vault.hypercore_vault import create_hypercore_vault_pair
+from tradeexecutor.cli.double_position import check_double_position
 from tradeexecutor.state.balance_update import (
     BalanceUpdate,
     BalanceUpdateCause,
@@ -536,6 +537,65 @@ def test_hypercore_dust_position_is_not_about_to_close_without_planned_trades() 
     #    planned closing trade against the position.
     with patch.object(position, "has_planned_trades", return_value=True):
         assert position.is_about_to_close() is True
+
+
+def test_check_double_position_distinguishes_different_hypercore_vaults() -> None:
+    """Test duplicate-position checks do not merge distinct Hypercore vaults.
+
+    1. Build two open Hypercore positions with the same synthetic pair metadata but different vault addresses.
+    2. Verify Hypercore pair equality still reproduces the broad identifier semantics.
+    3. Verify the duplicate-position tripwire does not report a duplicate because the vault addresses differ.
+    """
+
+    # 1. Build two open Hypercore positions with different vault addresses.
+    reserve_asset = AssetIdentifier(
+        chain_id=999,
+        address="0xb88339cb7199b77e23db6e890353e22632ba630f",
+        token_symbol="USDC",
+        decimals=6,
+    )
+    pair_1 = create_hypercore_vault_pair(
+        quote=reserve_asset,
+        vault_address="0x5555555555555555555555555555555555555555",
+    )
+    pair_2 = create_hypercore_vault_pair(
+        quote=reserve_asset,
+        vault_address="0x6666666666666666666666666666666666666666",
+    )
+
+    state = State()
+    state.portfolio.initialise_reserves(reserve_asset, reserve_token_price=1.0)
+    state.portfolio.adjust_reserves(reserve_asset, Decimal("100"), "Initial reserve")
+
+    for idx, pair in enumerate((pair_1, pair_2), start=1):
+        _position, trade, _created = state.create_trade(
+            strategy_cycle_at=datetime.datetime(2026, 4, 13, idx),
+            pair=pair,
+            quantity=None,
+            reserve=Decimal("10"),
+            assumed_price=1.0,
+            trade_type=TradeType.rebalance,
+            reserve_currency=reserve_asset,
+            reserve_currency_price=1.0,
+            notes=f"Create Hypercore position {idx}",
+            flags={TradeFlag.ignore_open},
+        )
+        trade.mark_success(
+            executed_at=datetime.datetime(2026, 4, 13, idx, 1),
+            executed_price=1.0,
+            executed_quantity=Decimal("10"),
+            executed_reserve=Decimal("10"),
+            lp_fees=0,
+            native_token_price=0,
+            force=True,
+        )
+
+    # 2. Verify Hypercore pair equality still reproduces the broad identifier semantics.
+    assert pair_1 == pair_2
+    assert pair_1.get_identifier() != pair_2.get_identifier()
+
+    # 3. Verify the duplicate-position tripwire does not report a duplicate.
+    assert check_double_position(state, crash=True) is False
 
 
 def test_hypercore_account_check_rejects_duplicate_vault_positions() -> None:

--- a/tradeexecutor/cli/commands/correct_accounts.py
+++ b/tradeexecutor/cli/commands/correct_accounts.py
@@ -27,6 +27,7 @@ from ...ethereum.enzyme.tx import EnzymeTransactionBuilder
 from ...ethereum.enzyme.vault import EnzymeVaultSyncModel
 from ...ethereum.hot_wallet_sync_model import HotWalletSyncModel
 from ...ethereum.tx import HotWalletTransactionBuilder
+from ...state.repair import close_hypercore_dust_positions
 from ...state.state import UncleanState
 from ...strategy.bootstrap import make_factory_from_strategy_mod
 from ...strategy.account_correction import calculate_account_corrections
@@ -524,6 +525,13 @@ def correct_accounts(
         state=state,
     )
 
+    closed_dust_trades = close_hypercore_dust_positions(state.portfolio)
+    if closed_dust_trades:
+        logger.info(
+            "Auto-closed %d Hypercore dust position(s) before duplicate and accounting checks",
+            len(closed_dust_trades),
+        )
+
     block_number = get_almost_latest_block_number(web3)
     logger.info(f"Correcting accounts at block {block_number:,}")
 
@@ -614,6 +622,13 @@ def correct_accounts(
     )
     balance_updates = list(balance_updates)  # Side effect: this will force execution of all actions stuck in the iterator
     logger.info(f"We did {len(corrections)} accounting corrections, of which {len(balance_updates)} internal state balance updates, new block height is {block_number:,} at {block_timestamp}")
+
+    closed_dust_trades = close_hypercore_dust_positions(state.portfolio)
+    if closed_dust_trades:
+        logger.info(
+            "Auto-closed %d Hypercore dust position(s) after accounting corrections",
+            len(closed_dust_trades),
+        )
 
     if not skip_save:
         logger.info("Saving state to %s", store.path)

--- a/tradeexecutor/cli/double_position.py
+++ b/tradeexecutor/cli/double_position.py
@@ -2,6 +2,25 @@
 from tradeexecutor.state.state import State
 
 
+def _format_position_diagnostics(position) -> str:
+    """Format one position for duplicate-position diagnostics."""
+    pair = position.pair
+    status = "frozen" if position.is_frozen() else "open"
+    details = [
+        f"position_id={position.position_id}",
+        f"status={status}",
+        f"quantity={position.get_quantity(planned=False)}",
+        f"planned_quantity={position.get_quantity(planned=True)}",
+        f"has_planned_trades={position.has_planned_trades()}",
+        f"is_about_to_close={position.is_about_to_close()}",
+        f"can_be_closed={position.can_be_closed()}",
+    ]
+    if pair.is_hyperliquid_vault():
+        details.append(f"vault_name={pair.get_vault_name() or pair.get_ticker()}")
+        details.append(f"vault_address={pair.pool_address or pair.base.address}")
+    return ", ".join(details)
+
+
 def check_double_position(state: State, printer=print, crash=False) -> bool:
     """Check that we do not have multiple positions open for the same trading pair.
 
@@ -20,20 +39,43 @@ def check_double_position(state: State, printer=print, crash=False) -> bool:
     for pair in pairs:
 
         positions = [p for p in state.portfolio.get_open_and_frozen_positions() if p.pair == pair]
+        if len(positions) < 2:
+            continue
 
-        about_to_close = [p for p in positions if p.is_about_to_close()]
         not_about_to_close = [p for p in positions if not p.is_about_to_close()]
+        hypercore_duplicate = pair.is_hyperliquid_vault()
+        generic_duplicate = len(not_about_to_close) >= 2
 
-        if len(not_about_to_close) >= 2:
-            printer(f"Warning: pair {pair} has multiple open positions: {len(positions)}")
+        if generic_duplicate or hypercore_duplicate:
+            if hypercore_duplicate:
+                printer(
+                    "Warning: Hypercore vault pair "
+                    f"{pair} has multiple open/frozen positions: {len(positions)}. "
+                    "This usually means a residual dust position stayed open and a later cycle "
+                    "opened a second live position for the same vault."
+                )
+            else:
+                printer(f"Warning: pair {pair} has multiple open positions: {len(positions)}")
 
             for p in positions:
-                printer(f"Position {p}, quantity {p.get_quantity(planned=False)}, planned quantity: {p.get_quantity(planned=True)}")
+                printer(f"Position {p}: {_format_position_diagnostics(p)}")
 
             double_positions = True
 
             if crash:
-                raise AssertionError(f"Double positions detected for pair {pair} - crashing for safety reasons.\nPositions: {positions}\nDiagnose what is causing the double position creation and manually clean up with close-position CLI command.\nSee logs for more details.")
+                if hypercore_duplicate:
+                    raise AssertionError(
+                        f"Duplicate Hypercore vault positions detected for pair {pair}. "
+                        "This usually means a stale Hypercore dust residual was left open and a later cycle "
+                        "opened a second live position for the same vault. "
+                        "Diagnose the duplicate positions from the logs and repair or close the residual state "
+                        "before continuing."
+                    )
+                raise AssertionError(
+                    f"Double positions detected for pair {pair} - crashing for safety reasons.\n"
+                    f"Positions: {positions}\n"
+                    "Diagnose what is causing the double position creation and manually clean up with close-position CLI command.\n"
+                    "See logs for more details."
+                )
 
     return double_positions
-

--- a/tradeexecutor/cli/double_position.py
+++ b/tradeexecutor/cli/double_position.py
@@ -2,6 +2,19 @@
 from tradeexecutor.state.state import State
 
 
+def _get_position_grouping_key(position):
+    """Get the duplicate-detection grouping key for a position."""
+    pair = position.pair
+
+    # Hypercore vault pair equality intentionally ignores ``pool_address``,
+    # but duplicate-position diagnostics must distinguish different vaults.
+    # Group these positions by their actual vault address instead.
+    if pair.is_hyperliquid_vault():
+        return ("hyperliquid_vault", (pair.pool_address or pair.base.address).lower())
+
+    return pair
+
+
 def _format_position_diagnostics(position) -> str:
     """Format one position for duplicate-position diagnostics."""
     pair = position.pair
@@ -35,13 +48,16 @@ def check_double_position(state: State, printer=print, crash=False) -> bool:
     """
     # Warn about pairs appearing twice in the portfolio
     double_positions = False
-    pairs = {p.pair for p in state.portfolio.get_open_and_frozen_positions()}
-    for pair in pairs:
+    grouped_positions = {}
+    for position in state.portfolio.get_open_and_frozen_positions():
+        grouping_key = _get_position_grouping_key(position)
+        grouped_positions.setdefault(grouping_key, []).append(position)
 
-        positions = [p for p in state.portfolio.get_open_and_frozen_positions() if p.pair == pair]
+    for positions in grouped_positions.values():
         if len(positions) < 2:
             continue
 
+        pair = positions[0].pair
         not_about_to_close = [p for p in positions if not p.is_about_to_close()]
         hypercore_duplicate = pair.is_hyperliquid_vault()
         generic_duplicate = len(not_about_to_close) >= 2

--- a/tradeexecutor/ethereum/vault/hyperliquid_cleanup.py
+++ b/tradeexecutor/ethereum/vault/hyperliquid_cleanup.py
@@ -65,7 +65,7 @@ from tradeexecutor.cli.bootstrap import (backup_state, create_client,
                                          prepare_executor_id)
 from tradeexecutor.cli.log import setup_logging
 from tradeexecutor.ethereum.lagoon.vault import LagoonVaultSyncModel
-from tradeexecutor.state.repair import repair_trades
+from tradeexecutor.state.repair import close_hypercore_dust_positions, repair_trades
 from tradeexecutor.state.state import State
 from tradeexecutor.state.store import JSONFileStore
 from tradeexecutor.strategy.account_correction import (
@@ -821,6 +821,12 @@ def _repair_and_correct_state(
         attempt_repair=True,
         interactive=False,
     )
+    closed_dust_trades = close_hypercore_dust_positions(state.portfolio)
+    if closed_dust_trades:
+        logger.info(
+            "Auto-closed %d Hypercore dust position(s) before cleanup account correction",
+            len(closed_dust_trades),
+        )
 
     accounting_context = _build_accounting_correction_context(context)
     block_identifier = get_almost_latest_block_number(
@@ -853,6 +859,13 @@ def _repair_and_correct_state(
             pricing_model=accounting_context.pricing_model,
         )
     )
+
+    closed_dust_trades = close_hypercore_dust_positions(state.portfolio)
+    if closed_dust_trades:
+        logger.info(
+            "Auto-closed %d Hypercore dust position(s) after cleanup account correction",
+            len(closed_dust_trades),
+        )
 
     check_state_internal_coherence(state)
     accounts_clean, dataframe = check_accounts(

--- a/tradeexecutor/state/portfolio.py
+++ b/tradeexecutor/state/portfolio.py
@@ -550,7 +550,26 @@ class Portfolio:
             # and the first trade closes the position.
             # 1. Recall credit
             # 2. Supply credit
-            if position:
+            #
+            # Only planned closing trades may make the old position replaceable.
+            # Hypercore vault withdrawals intentionally leave a small residual
+            # dust balance, and that dust can stay open across cycles with no
+            # planned trades at all. Treating the residual as "already
+            # closing" would create a second live position for the same vault
+            # and later confuse accounting checks.
+            if (
+                position
+                and pair.is_hyperliquid_vault()
+                and not position.has_planned_trades()
+                and abs(position.get_quantity()) <= dust_epsilon
+            ):
+                logger.info(
+                    "Reusing Hypercore dust position #%d for %s because there is no planned closing trade. "
+                    "Opening a new position here would create a duplicate vault entry.",
+                    position.position_id,
+                    pair.get_human_description(),
+                )
+            if position and position.has_planned_trades():
                 planned_quantity_this_cycle =  position.get_quantity(planned=True)
                 if abs(planned_quantity_this_cycle) < dust_epsilon:
                     # We cannot trade against the old position as it is goint to be closed

--- a/tradeexecutor/state/position.py
+++ b/tradeexecutor/state/position.py
@@ -1278,7 +1278,14 @@ class TradingPosition(GenericPosition):
         - It has planned trades taking the position to zero
         """
         epsilon = get_close_epsilon_for_pair(self.pair)
-        return self.get_quantity(planned=True) < epsilon
+        # A small live residual alone is not enough here. Hypercore vaults in
+        # particular can keep dust in the position because the protocol refuses
+        # exact full withdrawals when NAV moves between planning and execution.
+        # Only treat the position as "about to close" when this cycle has
+        # actually planned trades that take the planned quantity to zero.
+        if not self.has_planned_trades():
+            return False
+        return abs(self.get_quantity(planned=True)) <= epsilon
 
     def can_be_closed(self) -> bool:
         """There are no tied tokens in this position.

--- a/tradeexecutor/state/repair.py
+++ b/tradeexecutor/state/repair.py
@@ -239,6 +239,61 @@ def close_position_with_empty_trade(portfolio: Portfolio, p: TradingPosition) ->
     return c
 
 
+def close_hypercore_dust_positions(
+    portfolio: Portfolio,
+    now: datetime.datetime | None = None,
+) -> List[TradeExecution]:
+    """Close Hypercore vault dust positions with repair trades.
+
+    Hypercore full withdrawals intentionally leave a small residual balance
+    because the protocol rejects exact full redemptions when vault NAV drifts
+    between quote and execution.  These dust leftovers should not stay open in
+    the state because later cycles may try to trade around them as if they were
+    still meaningful live positions.
+
+    1. Scan open and frozen positions for Hypercore vault entries.
+    2. Identify positions that are already within the close epsilon.
+    3. Close each dust position locally with a zero-quantity repair trade.
+
+    :return:
+        Repair trades created for the auto-closed dust positions.
+    """
+
+    now = now or native_datetime_utc_now()
+    created_trades: List[TradeExecution] = []
+
+    positions = list(chain(
+        portfolio.open_positions.values(),
+        portfolio.frozen_positions.values(),
+    ))
+
+    for position in positions:
+        if not position.pair.is_hyperliquid_vault():
+            continue
+
+        if not position.can_be_closed():
+            continue
+
+        if position.is_frozen():
+            del portfolio.frozen_positions[position.position_id]
+            portfolio.open_positions[position.position_id] = position
+            position.unfrozen_at = now
+
+        trade = close_position_with_empty_trade(portfolio, position)
+        position.add_notes_message(
+            "Auto-closed Hypercore dust position because Hypercore vault "
+            f"withdrawals cannot fully redeem the final residual balance ({now.isoformat()})"
+        )
+        logger.info(
+            "Auto-closed Hypercore dust position %s with repair trade %s",
+            position,
+            trade,
+        )
+        created_trades.append(trade)
+
+    return created_trades
+
+
 def find_trades_to_be_repaired(state: State) -> List[TradeExecution]:
     trades_to_be_repaired = []
     # Closed trades do not need attention

--- a/tradeexecutor/strategy/account_correction.py
+++ b/tradeexecutor/strategy/account_correction.py
@@ -1328,6 +1328,11 @@ def _build_hypercore_vault_account_checks(
     path. Reuse the pair-aware multichain balance helper to fetch live
     equity for the vault pairs already present in state.
 
+    Duplicate open positions for the same Hypercore vault must be rejected
+    here. One live vault equity reading cannot be mapped to multiple state
+    positions, and allowing that would produce a misleading accounting
+    mismatch table instead of pointing at the real state corruption.
+
     Hypercore positions keep ``quantity`` as deposited USDC and
     ``last_token_price`` as the latest share price multiplier, so the
     account check must compare live equity against the position's
@@ -1343,6 +1348,51 @@ def _build_hypercore_vault_account_checks(
 
     if not vault_positions:
         return []
+
+    positions_by_vault: dict[str, list[TradingPosition]] = {}
+    for position in vault_positions:
+        vault_address = Web3.to_checksum_address(
+            position.pair.pool_address or position.pair.base.address
+        )
+        positions_by_vault.setdefault(vault_address, []).append(position)
+
+    duplicate_vault_positions = {
+        vault_address: positions
+        for vault_address, positions in positions_by_vault.items()
+        if len(positions) > 1
+    }
+    if duplicate_vault_positions:
+        logger.error(
+            "Duplicate Hypercore vault positions detected before account checks. "
+            "Hypercore full withdrawals can leave residual dust, so this usually means a stale dust "
+            "position stayed open and a later cycle opened a second live position for the same vault."
+        )
+        for vault_address, positions in duplicate_vault_positions.items():
+            sample_pair = positions[0].pair
+            logger.error(
+                "Hypercore vault %s at %s has %d open/frozen positions",
+                sample_pair.get_vault_name() or sample_pair.get_ticker(),
+                vault_address,
+                len(positions),
+            )
+            for position in positions:
+                logger.error(
+                    "Position #%s: quantity=%s, planned_quantity=%s, has_planned_trades=%s, "
+                    "is_about_to_close=%s, can_be_closed=%s",
+                    position.position_id,
+                    position.get_quantity(),
+                    position.get_quantity(planned=True),
+                    position.has_planned_trades(),
+                    position.is_about_to_close(),
+                    position.can_be_closed(),
+                )
+
+        raise UnexpectedAccountingCorrectionIssue(
+            "Duplicate Hypercore vault positions detected in state. "
+            "This usually means a stale Hypercore dust residual stayed open and a later cycle opened "
+            "a second live position for the same vault. Repair or close the residual state before "
+            "running account checks."
+        )
 
     balances = list(fetch_onchain_balances_multichain(
         sync_model.web3,

--- a/tradeexecutor/strategy/runner.py
+++ b/tradeexecutor/strategy/runner.py
@@ -51,6 +51,7 @@ from tradeexecutor.state.state import State
 from tradeexecutor.state.position import TradingPosition
 from tradeexecutor.state.trade import TradeExecution, TradeFlag
 from tradeexecutor.state.reserve import ReservePosition
+from tradeexecutor.state.repair import close_hypercore_dust_positions
 from tradeexecutor.strategy.valuation import ValuationModelFactory, ValuationModel, revalue_state
 
 logger = logging.getLogger(__name__)
@@ -696,6 +697,12 @@ class StrategyRunner(abc.ABC):
             else:
                 end_block = self.execution_model.get_safe_latest_block()
             logger.info("Post-trade accounts balance check for block %s, cycle %d", end_block, cycle)
+            closed_dust_trades = close_hypercore_dust_positions(state.portfolio)
+            if closed_dust_trades:
+                logger.info(
+                    "Auto-closed %d Hypercore dust position(s) before post-trade account checks",
+                    len(closed_dust_trades),
+                )
             self.check_accounts(
                 universe,
                 state,
@@ -794,6 +801,13 @@ class StrategyRunner(abc.ABC):
                     end_block,
                     long_short_metrics_latest=long_short_metrics_latest,
                     post_valuation=True,
+                )
+
+            closed_dust_trades = close_hypercore_dust_positions(state.portfolio)
+            if closed_dust_trades:
+                logger.info(
+                    "Auto-closed %d Hypercore dust position(s) before pre-trade account checks",
+                    len(closed_dust_trades),
                 )
 
             # Double check we handled deposits correctly
@@ -1178,6 +1192,16 @@ class StrategyRunner(abc.ABC):
             return
 
         if self.accounting_checks:
+            logger.info("Double open position tripwire check before account checks")
+            try:
+                check_double_position(
+                    state,
+                    printer=logger.error,
+                    crash=True,
+                )
+            except AssertionError as e:
+                raise UnexpectedAccountingCorrectionIssue(str(e)) from e
+
             clean, df = check_accounts(
                 universe.data_universe.pairs,
                 [universe.get_reserve_asset()],


### PR DESCRIPTION
## Why

Hypercore vault full withdrawals intentionally leave a small residual dust balance, but our state and accounting flow could still misread that residue as a fully replaceable position. That allowed later cycles to create duplicate open positions for the same vault and only fail much later during post-trade accounting.

This PR makes that failure mode easier to diagnose and safer to recover from, while keeping `hyper-ai` compatible with the fact that Hypercore vaults cannot be fully withdrawn to exact zero.

## Lessons learnt

Hypercore dust is not the same thing as a planned close. Treating a residual balance as "about to close" without any planned closing trade lets duplicate vault positions slip through and turns the real problem into a confusing downstream accounting mismatch.

For Hypercore vaults we need two layers of defence:
- reuse residual dust positions unless the cycle is genuinely closing them
- fail early with vault-specific diagnostics if duplicate state still appears

## Summary

- fix Hypercore position reuse so residual dust without planned closing trades is kept on the existing position instead of opening a duplicate
- tighten `is_about_to_close()` semantics so dust alone does not look like an in-flight close
- add Hypercore-specific duplicate-position diagnostics to the tripwire and account-check paths, including vault address and per-position state details
- auto-close residual Hypercore dust positions before pre-trade and post-trade account checks
- add focused regression tests for dust reuse, `is_about_to_close()` semantics, duplicate-vault rejection, and dust auto-close behaviour
