### PR TITLE
Add Hypercore dust repair CLI command

### DIFF
--- a/tests/hyperliquid/test_cli_repair_hypercore_dust.py
+++ b/tests/hyperliquid/test_cli_repair_hypercore_dust.py
@@ -1,0 +1,190 @@
+"""Test CLI repair flow for Hypercore dust positions and duplicates."""
+
+import datetime
+from decimal import Decimal
+from pathlib import Path
+
+import pytest
+from typer.testing import CliRunner
+
+from tradeexecutor.cli.main import app
+from tradeexecutor.ethereum.vault.hypercore_vault import create_hypercore_vault_pair
+from tradeexecutor.state.balance_update import (
+    BalanceUpdate,
+    BalanceUpdateCause,
+    BalanceUpdatePositionType,
+)
+from tradeexecutor.state.state import State
+from tradeexecutor.state.store import JSONFileStore
+from tradeexecutor.state.trade import TradeFlag, TradeType
+from tradeexecutor.state.identifier import AssetIdentifier
+
+
+pytestmark = pytest.mark.timeout(60)
+
+
+def _build_hypercore_duplicate_state(
+    *,
+    dust_quantity: Decimal | None,
+) -> tuple[State, int, int]:
+    """Build a Hypercore state with one original position and one duplicate."""
+
+    reserve_asset = AssetIdentifier(
+        chain_id=999,
+        address="0xb88339cb7199b77e23db6e890353e22632ba630f",
+        token_symbol="USDC",
+        decimals=6,
+    )
+    pair = create_hypercore_vault_pair(
+        quote=reserve_asset,
+        vault_address="0x2222222222222222222222222222222222222222",
+    )
+
+    state = State()
+    state.portfolio.initialise_reserves(reserve_asset, reserve_token_price=1.0)
+    state.portfolio.adjust_reserves(reserve_asset, Decimal("100"), "Initial reserve")
+
+    dust_position, dust_trade, _created = state.create_trade(
+        strategy_cycle_at=datetime.datetime(2026, 4, 13),
+        pair=pair,
+        quantity=None,
+        reserve=Decimal("1.00"),
+        assumed_price=1.0,
+        trade_type=TradeType.rebalance,
+        reserve_currency=reserve_asset,
+        reserve_currency_price=1.0,
+        notes="Create initial Hypercore position",
+    )
+    dust_trade.mark_success(
+        executed_at=datetime.datetime(2026, 4, 13, 0, 1),
+        executed_price=1.0,
+        executed_quantity=Decimal("1.00"),
+        executed_reserve=Decimal("1.00"),
+        lp_fees=0,
+        native_token_price=0,
+        force=True,
+    )
+
+    if dust_quantity is not None:
+        dust_position.balance_updates[1] = BalanceUpdate(
+            balance_update_id=1,
+            cause=BalanceUpdateCause.vault_flow,
+            position_type=BalanceUpdatePositionType.open_position,
+            asset=pair.base,
+            block_mined_at=datetime.datetime(2026, 4, 13, 0, 2),
+            strategy_cycle_included_at=datetime.datetime(2026, 4, 13),
+            chain_id=pair.base.chain_id,
+            quantity=-(Decimal("1.00") - dust_quantity),
+            old_balance=Decimal("1.00"),
+            usd_value=float(-(Decimal("1.00") - dust_quantity)),
+            position_id=dust_position.position_id,
+            notes="Simulate Hypercore withdrawal dust",
+            block_number=1,
+        )
+
+    duplicate_position, duplicate_trade, _duplicate_created = state.create_trade(
+        strategy_cycle_at=datetime.datetime(2026, 4, 14),
+        pair=pair,
+        quantity=None,
+        reserve=Decimal("25"),
+        assumed_price=1.0,
+        trade_type=TradeType.rebalance,
+        reserve_currency=reserve_asset,
+        reserve_currency_price=1.0,
+        notes="Force duplicate Hypercore position",
+        flags={TradeFlag.ignore_open},
+    )
+    duplicate_trade.mark_success(
+        executed_at=datetime.datetime(2026, 4, 14, 0, 1),
+        executed_price=1.0,
+        executed_quantity=Decimal("25"),
+        executed_reserve=Decimal("25"),
+        lp_fees=0,
+        native_token_price=0,
+        force=True,
+    )
+
+    return state, dust_position.position_id, duplicate_position.position_id
+
+
+def test_repair_hypercore_dust_cli_closes_duplicate_residual_position(
+    tmp_path: Path,
+) -> None:
+    """Test the CLI closes stale Hypercore dust duplicates and leaves the live position open.
+
+    1. Create a state file with one dusty Hypercore position and one duplicate live position for the same vault.
+    2. Run the CLI repair command with auto approval.
+    3. Verify the dusty duplicate is closed, the live position remains open, and the command exits cleanly.
+    """
+
+    # 1. Create a state file with one dusty Hypercore position and one duplicate live position for the same vault.
+    state, dust_position_id, live_position_id = _build_hypercore_duplicate_state(
+        dust_quantity=Decimal("0.10"),
+    )
+    state_file = tmp_path / "hypercore-duplicate-state.json"
+    JSONFileStore(state_file).sync(state)
+
+    # 2. Run the CLI repair command with auto approval.
+    runner = CliRunner()
+    result = runner.invoke(
+        app,
+        [
+            "repair-hypercore-dust",
+            "--state-file",
+            str(state_file),
+            "--auto-approve",
+            "--unit-testing",
+            "--log-level",
+            "disabled",
+        ],
+    )
+
+    # 3. Verify the dusty duplicate is closed, the live position remains open, and the command exits cleanly.
+    assert result.exit_code == 0, result.stdout
+
+    repaired_state = State.read_json_file(state_file)
+    assert dust_position_id in repaired_state.portfolio.closed_positions
+    assert dust_position_id not in repaired_state.portfolio.open_positions
+    assert live_position_id in repaired_state.portfolio.open_positions
+    assert live_position_id not in repaired_state.portfolio.closed_positions
+
+
+def test_repair_hypercore_dust_cli_warns_for_non_dust_duplicates(
+    tmp_path: Path,
+) -> None:
+    """Test the CLI warns and fails when Hypercore duplicates are not closeable dust.
+
+    1. Create a state file with two non-dust Hypercore positions for the same vault.
+    2. Run the CLI repair command with auto approval.
+    3. Verify the command fails with a duplicate warning and leaves both positions open.
+    """
+
+    # 1. Create a state file with two non-dust Hypercore positions for the same vault.
+    state, first_position_id, second_position_id = _build_hypercore_duplicate_state(
+        dust_quantity=None,
+    )
+    state_file = tmp_path / "hypercore-non-dust-duplicate-state.json"
+    JSONFileStore(state_file).sync(state)
+
+    # 2. Run the CLI repair command with auto approval.
+    runner = CliRunner()
+    result = runner.invoke(
+        app,
+        [
+            "repair-hypercore-dust",
+            "--state-file",
+            str(state_file),
+            "--auto-approve",
+            "--unit-testing",
+            "--log-level",
+            "disabled",
+        ],
+    )
+
+    # 3. Verify the command fails with a duplicate warning and leaves both positions open.
+    assert result.exit_code != 0
+    assert "Hypercore duplicate positions still remain after dust cleanup" in str(result.exception)
+
+    repaired_state = State.read_json_file(state_file)
+    assert first_position_id in repaired_state.portfolio.open_positions
+    assert second_position_id in repaired_state.portfolio.open_positions

--- a/tradeexecutor/cli/commands/repair_hypercore_dust.py
+++ b/tradeexecutor/cli/commands/repair_hypercore_dust.py
@@ -1,0 +1,101 @@
+"""Repair Hypercore dust positions from a state file."""
+
+from pathlib import Path
+
+import typer
+from typer import Option
+
+from . import shared_options
+from .app import app
+from ..bootstrap import create_state_store
+from ..double_position import check_double_position, get_duplicate_position_groups
+from ..log import setup_logging
+from ...state.repair import close_hypercore_dust_positions
+from ...state.store import JSONFileStore
+
+
+def _count_duplicate_hypercore_groups(state) -> int:
+    """Count Hypercore duplicate-position groups in the current state."""
+    return sum(
+        1
+        for positions in get_duplicate_position_groups(state)
+        if positions[0].pair.is_hyperliquid_vault()
+    )
+
+
+@app.command()
+def repair_hypercore_dust(
+    state_file: Path = Option(
+        ...,
+        envvar="STATE_FILE",
+        help=shared_options.state_file.help,
+    ),
+    log_level: str = shared_options.log_level,
+    unit_testing: bool = shared_options.unit_testing,
+    auto_approve: bool = Option(
+        False,
+        envvar="AUTO_APPROVE",
+        help="Approve Hypercore dust cleanup without asking for confirmation.",
+    ),
+):
+    """Close Hypercore dust positions and warn about duplicate vault entries.
+
+    This command is intentionally local-state only. It does not attempt any
+    on-chain execution; instead it creates repair trades for Hypercore vault
+    positions that are already within the configured close epsilon.
+
+    Duplicate Hypercore positions are diagnosed before and after cleanup so
+    operators can see whether stale dust residuals were removed or whether a
+    deeper manual repair is still needed.
+    """
+
+    logger = setup_logging(log_level=log_level)
+
+    store = create_state_store(Path(state_file))
+    assert isinstance(store, JSONFileStore)
+    assert not store.is_pristine(), f"State file does not exist: {state_file}"
+
+    state = store.load()
+
+    duplicate_group_count_before = _count_duplicate_hypercore_groups(state)
+    if duplicate_group_count_before:
+        logger.warning(
+            "Detected %d Hypercore duplicate position group(s) before dust cleanup",
+            duplicate_group_count_before,
+        )
+        check_double_position(state, printer=logger.warning, crash=False)
+    else:
+        logger.info("No Hypercore duplicate position groups detected before dust cleanup")
+
+    if not auto_approve and not unit_testing:
+        confirmation = typer.confirm(
+            "Create repair trades for all closeable Hypercore dust positions in this state file?"
+        )
+        if not confirmation:
+            raise RuntimeError("Operator aborted Hypercore dust cleanup")
+
+    created_trades = close_hypercore_dust_positions(state.portfolio)
+    if created_trades:
+        logger.info(
+            "Auto-closed %d Hypercore dust position(s) with repair trades",
+            len(created_trades),
+        )
+        for trade in created_trades:
+            logger.info("Created repair trade %s for position %s", trade.trade_id, trade.position_id)
+        store.sync(state)
+    else:
+        logger.info("No closeable Hypercore dust positions were found")
+
+    duplicate_group_count_after = _count_duplicate_hypercore_groups(state)
+    if duplicate_group_count_after:
+        logger.warning(
+            "Hypercore duplicate position groups remaining after dust cleanup: %d",
+            duplicate_group_count_after,
+        )
+        check_double_position(state, printer=logger.warning, crash=False)
+        raise RuntimeError(
+            "Hypercore duplicate positions still remain after dust cleanup. "
+            "Any remaining duplicates are not closeable dust and require manual repair."
+        )
+
+    logger.info("No Hypercore duplicate position groups remain after dust cleanup")

--- a/tradeexecutor/cli/double_position.py
+++ b/tradeexecutor/cli/double_position.py
@@ -34,6 +34,52 @@ def _format_position_diagnostics(position) -> str:
     return ", ".join(details)
 
 
+def get_duplicate_position_groups(state: State) -> list[list]:
+    """Get position groups that are considered duplicates.
+
+    Hypercore vaults are stricter than generic pairs: any repeated open/frozen
+    position for the same vault address is treated as a duplicate, because even
+    one stale residual can break later accounting and execution paths.
+    """
+
+    grouped_positions = {}
+    for position in state.portfolio.get_open_and_frozen_positions():
+        grouping_key = _get_position_grouping_key(position)
+        grouped_positions.setdefault(grouping_key, []).append(position)
+
+    duplicate_groups = []
+    for positions in grouped_positions.values():
+        if len(positions) < 2:
+            continue
+
+        pair = positions[0].pair
+        not_about_to_close = [p for p in positions if not p.is_about_to_close()]
+        hypercore_duplicate = pair.is_hyperliquid_vault()
+        generic_duplicate = len(not_about_to_close) >= 2
+        if generic_duplicate or hypercore_duplicate:
+            duplicate_groups.append(positions)
+
+    return duplicate_groups
+
+
+def _print_duplicate_position_group(positions: list, printer=print) -> None:
+    """Print diagnostics for one duplicate-position group."""
+    pair = positions[0].pair
+
+    if pair.is_hyperliquid_vault():
+        printer(
+            "Warning: Hypercore vault pair "
+            f"{pair} has multiple open/frozen positions: {len(positions)}. "
+            "This usually means a residual dust position stayed open and a later cycle "
+            "opened a second live position for the same vault."
+        )
+    else:
+        printer(f"Warning: pair {pair} has multiple open positions: {len(positions)}")
+
+    for position in positions:
+        printer(f"Position {position}: {_format_position_diagnostics(position)}")
+
+
 def check_double_position(state: State, printer=print, crash=False) -> bool:
     """Check that we do not have multiple positions open for the same trading pair.
 
@@ -46,52 +92,28 @@ def check_double_position(state: State, printer=print, crash=False) -> bool:
     :return:
         True if there are double positions
     """
-    # Warn about pairs appearing twice in the portfolio
     double_positions = False
-    grouped_positions = {}
-    for position in state.portfolio.get_open_and_frozen_positions():
-        grouping_key = _get_position_grouping_key(position)
-        grouped_positions.setdefault(grouping_key, []).append(position)
+    duplicate_groups = get_duplicate_position_groups(state)
 
-    for positions in grouped_positions.values():
-        if len(positions) < 2:
-            continue
-
+    for positions in duplicate_groups:
         pair = positions[0].pair
-        not_about_to_close = [p for p in positions if not p.is_about_to_close()]
-        hypercore_duplicate = pair.is_hyperliquid_vault()
-        generic_duplicate = len(not_about_to_close) >= 2
+        double_positions = True
+        _print_duplicate_position_group(positions, printer=printer)
 
-        if generic_duplicate or hypercore_duplicate:
-            if hypercore_duplicate:
-                printer(
-                    "Warning: Hypercore vault pair "
-                    f"{pair} has multiple open/frozen positions: {len(positions)}. "
-                    "This usually means a residual dust position stayed open and a later cycle "
-                    "opened a second live position for the same vault."
-                )
-            else:
-                printer(f"Warning: pair {pair} has multiple open positions: {len(positions)}")
-
-            for p in positions:
-                printer(f"Position {p}: {_format_position_diagnostics(p)}")
-
-            double_positions = True
-
-            if crash:
-                if hypercore_duplicate:
-                    raise AssertionError(
-                        f"Duplicate Hypercore vault positions detected for pair {pair}. "
-                        "This usually means a stale Hypercore dust residual was left open and a later cycle "
-                        "opened a second live position for the same vault. "
-                        "Diagnose the duplicate positions from the logs and repair or close the residual state "
-                        "before continuing."
-                    )
+        if crash:
+            if pair.is_hyperliquid_vault():
                 raise AssertionError(
-                    f"Double positions detected for pair {pair} - crashing for safety reasons.\n"
-                    f"Positions: {positions}\n"
-                    "Diagnose what is causing the double position creation and manually clean up with close-position CLI command.\n"
-                    "See logs for more details."
+                    f"Duplicate Hypercore vault positions detected for pair {pair}. "
+                    "This usually means a stale Hypercore dust residual was left open and a later cycle "
+                    "opened a second live position for the same vault. "
+                    "Diagnose the duplicate positions from the logs and repair or close the residual state "
+                    "before continuing."
                 )
+            raise AssertionError(
+                f"Double positions detected for pair {pair} - crashing for safety reasons.\n"
+                f"Positions: {positions}\n"
+                "Diagnose what is causing the double position creation and manually clean up with close-position CLI command.\n"
+                "See logs for more details."
+            )
 
     return double_positions

--- a/tradeexecutor/cli/main.py
+++ b/tradeexecutor/cli/main.py
@@ -26,6 +26,7 @@ from .commands.token_cache import token_cache
 from .commands.trading_pair import trading_pair
 from .commands.version import version
 from .commands.repair import repair
+from .commands.repair_hypercore_dust import repair_hypercore_dust
 from .commands.retry import retry
 from .commands.visualise import visualise
 from .commands.init import init
@@ -48,7 +49,7 @@ __all__ = [
     check_universe, check_wallet, close_all, close_position, console,
     correct_accounts, correct_history, deploy_guard, distribute_gas_funds, enzyme_asset_list, enzyme_deploy_vault,
     export, hello, init, lagoon_deploy_vault, lagoon_first_deposit, lagoon_redeem, lagoon_settle, perform_test_trade, prepare_report, prune_state,
-    repair, reset, reset_deposits, retry, send_log_message, show_positions,
+    repair, repair_hypercore_dust, reset, reset_deposits, retry, send_log_message, show_positions,
     show_valuation, start, token_cache, trade_ui, trading_pair,
     version, visualise, webapi
 ]


### PR DESCRIPTION
## Why

Hypercore dust cleanup already existed as a Python helper, but operators did not have a dedicated command-line entry point for it. In practice that made duplicate Hypercore vault states harder to diagnose and left the workflow split between low-level helpers and manual state surgery.

This change adds an explicit CLI wrapper for the safe subset of that repair flow so operators can inspect duplicate Hypercore positions, auto-close closeable dust residuals, and stop early when the remaining duplicates are not dust and need manual intervention.

## Lessons learnt

Hypercore duplicate handling needs two layers:

- shared duplicate diagnostics that group by the real vault address
- a narrow repair command that only closes positions already within the dust epsilon

That split keeps operator tooling useful without pretending that all duplicate vault states are automatically repairable.

## Summary

- add `trade-executor repair-hypercore-dust` as a local-state-only CLI command around `close_hypercore_dust_positions()`
- warn about duplicate Hypercore vault positions before and after cleanup using the shared duplicate-position diagnostics
- save the state after creating repair trades and fail clearly when remaining duplicates are not closeable dust
- refactor duplicate-position detection so the new command and the existing tripwire share the same duplicate grouping logic
- add focused CLI regression tests for both the cleanable dust-duplicate case and the still-broken non-dust duplicate case
