### PR TITLE
fix: close safe Hypercore duplicate clones

### DIFF
--- a/tests/hyperliquid/test_cli_repair_hypercore_dust.py
+++ b/tests/hyperliquid/test_cli_repair_hypercore_dust.py
@@ -331,11 +331,11 @@ def test_repair_hypercore_dust_cli_warns_for_non_dust_duplicates(
 def test_repair_hypercore_dust_cli_suppresses_safe_later_clone_with_confirmation(
     tmp_path: Path,
 ) -> None:
-    """Test the CLI suppresses a safe later Hypercore clone after explicit confirmation.
+    """Test the CLI closes a safe later Hypercore clone after explicit confirmation.
 
     1. Create a state file with two exact-match non-dust Hypercore positions for the same vault.
     2. Run the CLI repair command with ``--merge-dustless-duplicates`` and explicit `y` confirmations.
-    3. Verify the older position stays open and the later clone moves to suppressed duplicates.
+    3. Verify the older position stays open and the later clone is closed with a flagged repair trade.
     """
 
     # 1. Create a state file with two exact-match non-dust Hypercore positions for the same vault.
@@ -362,13 +362,15 @@ def test_repair_hypercore_dust_cli_suppresses_safe_later_clone_with_confirmation
         input="y\ny\n",
     )
 
-    # 3. Verify the older position stays open and the later clone moves to suppressed duplicates.
+    # 3. Verify the older position stays open and the later clone is closed with a flagged repair trade.
     assert result.exit_code == 0, result.stdout
 
     repaired_state = State.read_json_file(state_file)
     assert survivor_position_id in repaired_state.portfolio.open_positions
     assert clone_position_id not in repaired_state.portfolio.open_positions
-    assert clone_position_id in repaired_state.portfolio.suppressed_duplicate_positions
+    assert clone_position_id in repaired_state.portfolio.closed_positions
+    clone_position = repaired_state.portfolio.closed_positions[clone_position_id]
+    assert TradeFlag.hypercore_duplicate_close in (clone_position.get_last_trade().flags or set())
 
 
 def test_repair_hypercore_dust_cli_safe_clone_still_fails_without_merge_flag(
@@ -459,7 +461,7 @@ def test_repair_hypercore_dust_cli_combines_dust_cleanup_and_clone_suppression(
     assert dust_live_position_id in repaired_state.portfolio.open_positions
     assert clone_survivor_position_id in repaired_state.portfolio.open_positions
     assert clone_position_id not in repaired_state.portfolio.open_positions
-    assert clone_position_id in repaired_state.portfolio.suppressed_duplicate_positions
+    assert clone_position_id in repaired_state.portfolio.closed_positions
 
 
 def test_repair_hypercore_dust_cli_does_not_save_partial_results_when_unsafe_group_remains(
@@ -512,7 +514,7 @@ def test_repair_hypercore_dust_cli_does_not_save_partial_results_when_unsafe_gro
     assert safe_clone_position_id in repaired_state.portfolio.open_positions
     assert unsafe_first_position_id in repaired_state.portfolio.open_positions
     assert unsafe_second_position_id in repaired_state.portfolio.open_positions
-    assert len(repaired_state.portfolio.suppressed_duplicate_positions) == 0
+    assert len(repaired_state.portfolio.closed_positions) == 0
 
 
 def test_repair_hypercore_dust_cli_rejects_auto_approve_for_merge_mode(

--- a/tests/hyperliquid/test_cli_repair_hypercore_dust.py
+++ b/tests/hyperliquid/test_cli_repair_hypercore_dust.py
@@ -26,6 +26,12 @@ pytestmark = pytest.mark.timeout(60)
 def _build_hypercore_duplicate_state(
     *,
     dust_quantity: Decimal | None,
+    initial_reserve: Decimal = Decimal("1.00"),
+    duplicate_reserve: Decimal = Decimal("25"),
+    duplicate_flags: set[TradeFlag] | None = None,
+    duplicate_balance_update_quantity: Decimal | None = None,
+    duplicate_last_token_price: float | None = None,
+    vault_address: str = "0x2222222222222222222222222222222222222222",
 ) -> tuple[State, int, int]:
     """Build a Hypercore state with one original position and one duplicate."""
 
@@ -37,7 +43,7 @@ def _build_hypercore_duplicate_state(
     )
     pair = create_hypercore_vault_pair(
         quote=reserve_asset,
-        vault_address="0x2222222222222222222222222222222222222222",
+        vault_address=vault_address,
     )
 
     state = State()
@@ -48,7 +54,7 @@ def _build_hypercore_duplicate_state(
         strategy_cycle_at=datetime.datetime(2026, 4, 13),
         pair=pair,
         quantity=None,
-        reserve=Decimal("1.00"),
+        reserve=initial_reserve,
         assumed_price=1.0,
         trade_type=TradeType.rebalance,
         reserve_currency=reserve_asset,
@@ -58,14 +64,15 @@ def _build_hypercore_duplicate_state(
     dust_trade.mark_success(
         executed_at=datetime.datetime(2026, 4, 13, 0, 1),
         executed_price=1.0,
-        executed_quantity=Decimal("1.00"),
-        executed_reserve=Decimal("1.00"),
+        executed_quantity=initial_reserve,
+        executed_reserve=initial_reserve,
         lp_fees=0,
         native_token_price=0,
         force=True,
     )
 
     if dust_quantity is not None:
+        assert initial_reserve >= dust_quantity
         dust_position.balance_updates[1] = BalanceUpdate(
             balance_update_id=1,
             cause=BalanceUpdateCause.vault_flow,
@@ -74,9 +81,9 @@ def _build_hypercore_duplicate_state(
             block_mined_at=datetime.datetime(2026, 4, 13, 0, 2),
             strategy_cycle_included_at=datetime.datetime(2026, 4, 13),
             chain_id=pair.base.chain_id,
-            quantity=-(Decimal("1.00") - dust_quantity),
-            old_balance=Decimal("1.00"),
-            usd_value=float(-(Decimal("1.00") - dust_quantity)),
+            quantity=-(initial_reserve - dust_quantity),
+            old_balance=initial_reserve,
+            usd_value=float(-(initial_reserve - dust_quantity)),
             position_id=dust_position.position_id,
             notes="Simulate Hypercore withdrawal dust",
             block_number=1,
@@ -86,7 +93,7 @@ def _build_hypercore_duplicate_state(
         strategy_cycle_at=datetime.datetime(2026, 4, 14),
         pair=pair,
         quantity=None,
-        reserve=Decimal("25"),
+        reserve=duplicate_reserve,
         assumed_price=1.0,
         trade_type=TradeType.rebalance,
         reserve_currency=reserve_asset,
@@ -97,14 +104,145 @@ def _build_hypercore_duplicate_state(
     duplicate_trade.mark_success(
         executed_at=datetime.datetime(2026, 4, 14, 0, 1),
         executed_price=1.0,
-        executed_quantity=Decimal("25"),
-        executed_reserve=Decimal("25"),
+        executed_quantity=duplicate_reserve,
+        executed_reserve=duplicate_reserve,
         lp_fees=0,
         native_token_price=0,
         force=True,
     )
 
+    if duplicate_flags is not None:
+        duplicate_trade.flags = duplicate_flags
+
+    if duplicate_balance_update_quantity is not None:
+        duplicate_position.balance_updates[2] = BalanceUpdate(
+            balance_update_id=2,
+            cause=BalanceUpdateCause.vault_flow,
+            position_type=BalanceUpdatePositionType.open_position,
+            asset=pair.base,
+            block_mined_at=datetime.datetime(2026, 4, 14, 0, 2),
+            strategy_cycle_included_at=datetime.datetime(2026, 4, 14),
+            chain_id=pair.base.chain_id,
+            quantity=duplicate_balance_update_quantity,
+            old_balance=duplicate_reserve,
+            usd_value=float(duplicate_balance_update_quantity),
+            position_id=duplicate_position.position_id,
+            notes="Simulate duplicate-side balance update",
+            block_number=2,
+        )
+
+    if duplicate_last_token_price is not None:
+        duplicate_position.last_token_price = duplicate_last_token_price
+
     return state, dust_position.position_id, duplicate_position.position_id
+
+
+def _append_hypercore_duplicate_group_to_state(
+    state: State,
+    *,
+    vault_address: str,
+    initial_reserve: Decimal,
+    duplicate_reserve: Decimal,
+    dust_quantity: Decimal | None = None,
+    duplicate_flags: set[TradeFlag] | None = None,
+    duplicate_balance_update_quantity: Decimal | None = None,
+    duplicate_last_token_price: float | None = None,
+) -> tuple[int, int]:
+    """Append one Hypercore duplicate-position group to an existing state."""
+
+    reserve_asset = state.portfolio.get_default_reserve_position().asset
+    pair = create_hypercore_vault_pair(
+        quote=reserve_asset,
+        vault_address=vault_address,
+    )
+
+    original_position, original_trade, _created = state.create_trade(
+        strategy_cycle_at=datetime.datetime(2026, 4, 15),
+        pair=pair,
+        quantity=None,
+        reserve=initial_reserve,
+        assumed_price=1.0,
+        trade_type=TradeType.rebalance,
+        reserve_currency=reserve_asset,
+        reserve_currency_price=1.0,
+        notes="Create original Hypercore position",
+        flags={TradeFlag.ignore_open},
+    )
+    original_trade.mark_success(
+        executed_at=datetime.datetime(2026, 4, 15, 0, 1),
+        executed_price=1.0,
+        executed_quantity=initial_reserve,
+        executed_reserve=initial_reserve,
+        lp_fees=0,
+        native_token_price=0,
+        force=True,
+    )
+
+    if dust_quantity is not None:
+        original_position.balance_updates[state.portfolio.next_balance_update_id] = BalanceUpdate(
+            balance_update_id=state.portfolio.next_balance_update_id,
+            cause=BalanceUpdateCause.vault_flow,
+            position_type=BalanceUpdatePositionType.open_position,
+            asset=pair.base,
+            block_mined_at=datetime.datetime(2026, 4, 15, 0, 2),
+            strategy_cycle_included_at=datetime.datetime(2026, 4, 15),
+            chain_id=pair.base.chain_id,
+            quantity=-(initial_reserve - dust_quantity),
+            old_balance=initial_reserve,
+            usd_value=float(-(initial_reserve - dust_quantity)),
+            position_id=original_position.position_id,
+            notes="Simulate Hypercore withdrawal dust",
+            block_number=10,
+        )
+        state.portfolio.next_balance_update_id += 1
+
+    duplicate_position, duplicate_trade, _duplicate_created = state.create_trade(
+        strategy_cycle_at=datetime.datetime(2026, 4, 16),
+        pair=pair,
+        quantity=None,
+        reserve=duplicate_reserve,
+        assumed_price=1.0,
+        trade_type=TradeType.rebalance,
+        reserve_currency=reserve_asset,
+        reserve_currency_price=1.0,
+        notes="Create duplicate Hypercore position",
+        flags={TradeFlag.ignore_open},
+    )
+    duplicate_trade.mark_success(
+        executed_at=datetime.datetime(2026, 4, 16, 0, 1),
+        executed_price=1.0,
+        executed_quantity=duplicate_reserve,
+        executed_reserve=duplicate_reserve,
+        lp_fees=0,
+        native_token_price=0,
+        force=True,
+    )
+
+    if duplicate_flags is not None:
+        duplicate_trade.flags = duplicate_flags
+
+    if duplicate_balance_update_quantity is not None:
+        duplicate_position.balance_updates[state.portfolio.next_balance_update_id] = BalanceUpdate(
+            balance_update_id=state.portfolio.next_balance_update_id,
+            cause=BalanceUpdateCause.vault_flow,
+            position_type=BalanceUpdatePositionType.open_position,
+            asset=pair.base,
+            block_mined_at=datetime.datetime(2026, 4, 16, 0, 2),
+            strategy_cycle_included_at=datetime.datetime(2026, 4, 16),
+            chain_id=pair.base.chain_id,
+            quantity=duplicate_balance_update_quantity,
+            old_balance=duplicate_reserve,
+            usd_value=float(duplicate_balance_update_quantity),
+            position_id=duplicate_position.position_id,
+            notes="Simulate duplicate-side balance update",
+            block_number=11,
+        )
+        state.portfolio.next_balance_update_id += 1
+
+    if duplicate_last_token_price is not None:
+        duplicate_position.last_token_price = duplicate_last_token_price
+
+    return original_position.position_id, duplicate_position.position_id
 
 
 def test_repair_hypercore_dust_cli_closes_duplicate_residual_position(
@@ -188,6 +326,237 @@ def test_repair_hypercore_dust_cli_warns_for_non_dust_duplicates(
     repaired_state = State.read_json_file(state_file)
     assert first_position_id in repaired_state.portfolio.open_positions
     assert second_position_id in repaired_state.portfolio.open_positions
+
+
+def test_repair_hypercore_dust_cli_suppresses_safe_later_clone_with_confirmation(
+    tmp_path: Path,
+) -> None:
+    """Test the CLI suppresses a safe later Hypercore clone after explicit confirmation.
+
+    1. Create a state file with two exact-match non-dust Hypercore positions for the same vault.
+    2. Run the CLI repair command with ``--merge-dustless-duplicates`` and explicit `y` confirmations.
+    3. Verify the older position stays open and the later clone moves to suppressed duplicates.
+    """
+
+    # 1. Create a state file with two exact-match non-dust Hypercore positions for the same vault.
+    state, survivor_position_id, clone_position_id = _build_hypercore_duplicate_state(
+        dust_quantity=None,
+        initial_reserve=Decimal("25"),
+        duplicate_reserve=Decimal("25"),
+    )
+    state_file = tmp_path / "hypercore-safe-clone-state.json"
+    JSONFileStore(state_file).sync(state)
+
+    # 2. Run the CLI repair command with ``--merge-dustless-duplicates`` and explicit `y` confirmations.
+    runner = CliRunner()
+    result = runner.invoke(
+        app,
+        [
+            "repair-hypercore-dust",
+            "--state-file",
+            str(state_file),
+            "--merge-dustless-duplicates",
+            "--log-level",
+            "disabled",
+        ],
+        input="y\ny\n",
+    )
+
+    # 3. Verify the older position stays open and the later clone moves to suppressed duplicates.
+    assert result.exit_code == 0, result.stdout
+
+    repaired_state = State.read_json_file(state_file)
+    assert survivor_position_id in repaired_state.portfolio.open_positions
+    assert clone_position_id not in repaired_state.portfolio.open_positions
+    assert clone_position_id in repaired_state.portfolio.suppressed_duplicate_positions
+
+
+def test_repair_hypercore_dust_cli_safe_clone_still_fails_without_merge_flag(
+    tmp_path: Path,
+) -> None:
+    """Test the CLI still fails on a safe later clone when merge mode is not enabled.
+
+    1. Create a state file with one older Hypercore position and one exact-match later clone.
+    2. Run the CLI repair command without ``--merge-dustless-duplicates``.
+    3. Verify both positions remain open because the command refuses to suppress duplicates by default.
+    """
+
+    # 1. Create a state file with one older Hypercore position and one exact-match later clone.
+    state, survivor_position_id, clone_position_id = _build_hypercore_duplicate_state(
+        dust_quantity=None,
+        initial_reserve=Decimal("25"),
+        duplicate_reserve=Decimal("25"),
+    )
+    state_file = tmp_path / "hypercore-safe-clone-no-merge-state.json"
+    JSONFileStore(state_file).sync(state)
+
+    # 2. Run the CLI repair command without ``--merge-dustless-duplicates``.
+    runner = CliRunner()
+    result = runner.invoke(
+        app,
+        [
+            "repair-hypercore-dust",
+            "--state-file",
+            str(state_file),
+            "--auto-approve",
+            "--unit-testing",
+            "--log-level",
+            "disabled",
+        ],
+    )
+
+    # 3. Verify both positions remain open because the command refuses to suppress duplicates by default.
+    assert result.exit_code != 0
+
+    repaired_state = State.read_json_file(state_file)
+    assert survivor_position_id in repaired_state.portfolio.open_positions
+    assert clone_position_id in repaired_state.portfolio.open_positions
+
+
+def test_repair_hypercore_dust_cli_combines_dust_cleanup_and_clone_suppression(
+    tmp_path: Path,
+) -> None:
+    """Test the CLI can finish one dust cleanup group and one safe clone group in one transactional save.
+
+    1. Create a state file with one dust duplicate group and one safe later-clone duplicate group.
+    2. Run the CLI repair command with merge mode and explicit confirmations.
+    3. Verify the dust residual is closed, the clone is suppressed, and the survivors remain open.
+    """
+
+    # 1. Create a state file with one dust duplicate group and one safe later-clone duplicate group.
+    state, dust_position_id, dust_live_position_id = _build_hypercore_duplicate_state(
+        dust_quantity=Decimal("0.10"),
+    )
+    clone_survivor_position_id, clone_position_id = _append_hypercore_duplicate_group_to_state(
+        state,
+        vault_address="0x3333333333333333333333333333333333333333",
+        initial_reserve=Decimal("25"),
+        duplicate_reserve=Decimal("25"),
+    )
+    state_file = tmp_path / "hypercore-dust-and-clone-state.json"
+    JSONFileStore(state_file).sync(state)
+
+    # 2. Run the CLI repair command with merge mode and explicit confirmations.
+    runner = CliRunner()
+    result = runner.invoke(
+        app,
+        [
+            "repair-hypercore-dust",
+            "--state-file",
+            str(state_file),
+            "--merge-dustless-duplicates",
+            "--log-level",
+            "disabled",
+        ],
+        input="y\ny\n",
+    )
+
+    # 3. Verify the dust residual is closed, the clone is suppressed, and the survivors remain open.
+    assert result.exit_code == 0, result.stdout
+
+    repaired_state = State.read_json_file(state_file)
+    assert dust_position_id in repaired_state.portfolio.closed_positions
+    assert dust_live_position_id in repaired_state.portfolio.open_positions
+    assert clone_survivor_position_id in repaired_state.portfolio.open_positions
+    assert clone_position_id not in repaired_state.portfolio.open_positions
+    assert clone_position_id in repaired_state.portfolio.suppressed_duplicate_positions
+
+
+def test_repair_hypercore_dust_cli_does_not_save_partial_results_when_unsafe_group_remains(
+    tmp_path: Path,
+) -> None:
+    """Test merge mode keeps the state file untouched when any remaining duplicate group is unsafe.
+
+    1. Create a state file with one safe clone group and one unsafe duplicate group.
+    2. Run the CLI repair command with merge mode.
+    3. Verify the command fails before saving and the state file still contains only open duplicate positions.
+    """
+
+    # 1. Create a state file with one safe clone group and one unsafe duplicate group.
+    state, safe_survivor_position_id, safe_clone_position_id = _build_hypercore_duplicate_state(
+        dust_quantity=None,
+        initial_reserve=Decimal("25"),
+        duplicate_reserve=Decimal("25"),
+    )
+    unsafe_first_position_id, unsafe_second_position_id = _append_hypercore_duplicate_group_to_state(
+        state,
+        vault_address="0x4444444444444444444444444444444444444444",
+        initial_reserve=Decimal("25"),
+        duplicate_reserve=Decimal("25"),
+        duplicate_balance_update_quantity=Decimal("0.01"),
+    )
+    state_file = tmp_path / "hypercore-unsafe-mixed-state.json"
+    JSONFileStore(state_file).sync(state)
+
+    # 2. Run the CLI repair command with merge mode.
+    runner = CliRunner()
+    result = runner.invoke(
+        app,
+        [
+            "repair-hypercore-dust",
+            "--state-file",
+            str(state_file),
+            "--merge-dustless-duplicates",
+            "--unit-testing",
+            "--log-level",
+            "disabled",
+        ],
+    )
+
+    # 3. Verify the command fails before saving and the state file still contains only open duplicate positions.
+    assert result.exit_code != 0
+    assert "The state file was not updated" in str(result.exception)
+
+    repaired_state = State.read_json_file(state_file)
+    assert safe_survivor_position_id in repaired_state.portfolio.open_positions
+    assert safe_clone_position_id in repaired_state.portfolio.open_positions
+    assert unsafe_first_position_id in repaired_state.portfolio.open_positions
+    assert unsafe_second_position_id in repaired_state.portfolio.open_positions
+    assert len(repaired_state.portfolio.suppressed_duplicate_positions) == 0
+
+
+def test_repair_hypercore_dust_cli_rejects_auto_approve_for_merge_mode(
+    tmp_path: Path,
+) -> None:
+    """Test merge mode refuses ``--auto-approve`` because dangerous suppressions require explicit `y/n`.
+
+    1. Create a state file with a safe later-clone duplicate group.
+    2. Run the CLI repair command with both merge mode and ``--auto-approve``.
+    3. Verify the command fails and does not suppress the duplicate clone.
+    """
+
+    # 1. Create a state file with a safe later-clone duplicate group.
+    state, survivor_position_id, clone_position_id = _build_hypercore_duplicate_state(
+        dust_quantity=None,
+        initial_reserve=Decimal("25"),
+        duplicate_reserve=Decimal("25"),
+    )
+    state_file = tmp_path / "hypercore-auto-approve-merge-state.json"
+    JSONFileStore(state_file).sync(state)
+
+    # 2. Run the CLI repair command with both merge mode and ``--auto-approve``.
+    runner = CliRunner()
+    result = runner.invoke(
+        app,
+        [
+            "repair-hypercore-dust",
+            "--state-file",
+            str(state_file),
+            "--merge-dustless-duplicates",
+            "--auto-approve",
+            "--log-level",
+            "disabled",
+        ],
+        input="y\n",
+    )
+
+    # 3. Verify the command fails and does not suppress the duplicate clone.
+    assert result.exit_code != 0
+    assert "requires an explicit y/n confirmation" in str(result.exception)
+
+    repaired_state = State.read_json_file(state_file)
+    assert survivor_position_id in repaired_state.portfolio.open_positions
+    assert clone_position_id in repaired_state.portfolio.open_positions
 
 
 def test_repair_hypercore_dust_cli_infers_default_state_file_from_id() -> None:

--- a/tests/hyperliquid/test_cli_repair_hypercore_dust.py
+++ b/tests/hyperliquid/test_cli_repair_hypercore_dust.py
@@ -328,7 +328,7 @@ def test_repair_hypercore_dust_cli_warns_for_non_dust_duplicates(
     assert second_position_id in repaired_state.portfolio.open_positions
 
 
-def test_repair_hypercore_dust_cli_suppresses_safe_later_clone_with_confirmation(
+def test_repair_hypercore_dust_cli_closes_safe_later_clone_with_confirmation(
     tmp_path: Path,
 ) -> None:
     """Test the CLI closes a safe later Hypercore clone after explicit confirmation.
@@ -380,7 +380,7 @@ def test_repair_hypercore_dust_cli_safe_clone_still_fails_without_merge_flag(
 
     1. Create a state file with one older Hypercore position and one exact-match later clone.
     2. Run the CLI repair command without ``--merge-dustless-duplicates``.
-    3. Verify both positions remain open because the command refuses to suppress duplicates by default.
+    3. Verify both positions remain open because the command refuses to close duplicate clones by default.
     """
 
     # 1. Create a state file with one older Hypercore position and one exact-match later clone.
@@ -407,7 +407,7 @@ def test_repair_hypercore_dust_cli_safe_clone_still_fails_without_merge_flag(
         ],
     )
 
-    # 3. Verify both positions remain open because the command refuses to suppress duplicates by default.
+    # 3. Verify both positions remain open because the command refuses to close duplicate clones by default.
     assert result.exit_code != 0
 
     repaired_state = State.read_json_file(state_file)
@@ -415,14 +415,14 @@ def test_repair_hypercore_dust_cli_safe_clone_still_fails_without_merge_flag(
     assert clone_position_id in repaired_state.portfolio.open_positions
 
 
-def test_repair_hypercore_dust_cli_combines_dust_cleanup_and_clone_suppression(
+def test_repair_hypercore_dust_cli_combines_dust_cleanup_and_clone_close(
     tmp_path: Path,
 ) -> None:
     """Test the CLI can finish one dust cleanup group and one safe clone group in one transactional save.
 
     1. Create a state file with one dust duplicate group and one safe later-clone duplicate group.
     2. Run the CLI repair command with merge mode and explicit confirmations.
-    3. Verify the dust residual is closed, the clone is suppressed, and the survivors remain open.
+    3. Verify the dust residual is closed, the clone is closed, and the survivors remain open.
     """
 
     # 1. Create a state file with one dust duplicate group and one safe later-clone duplicate group.
@@ -453,7 +453,7 @@ def test_repair_hypercore_dust_cli_combines_dust_cleanup_and_clone_suppression(
         input="y\ny\n",
     )
 
-    # 3. Verify the dust residual is closed, the clone is suppressed, and the survivors remain open.
+    # 3. Verify the dust residual is closed, the clone is closed, and the survivors remain open.
     assert result.exit_code == 0, result.stdout
 
     repaired_state = State.read_json_file(state_file)
@@ -520,11 +520,11 @@ def test_repair_hypercore_dust_cli_does_not_save_partial_results_when_unsafe_gro
 def test_repair_hypercore_dust_cli_rejects_auto_approve_for_merge_mode(
     tmp_path: Path,
 ) -> None:
-    """Test merge mode refuses ``--auto-approve`` because dangerous suppressions require explicit `y/n`.
+    """Test merge mode refuses ``--auto-approve`` because dangerous duplicate closes require explicit `y/n`.
 
     1. Create a state file with a safe later-clone duplicate group.
     2. Run the CLI repair command with both merge mode and ``--auto-approve``.
-    3. Verify the command fails and does not suppress the duplicate clone.
+    3. Verify the command fails and does not close the duplicate clone.
     """
 
     # 1. Create a state file with a safe later-clone duplicate group.
@@ -552,7 +552,7 @@ def test_repair_hypercore_dust_cli_rejects_auto_approve_for_merge_mode(
         input="y\n",
     )
 
-    # 3. Verify the command fails and does not suppress the duplicate clone.
+    # 3. Verify the command fails and does not close the duplicate clone.
     assert result.exit_code != 0
     assert "requires an explicit y/n confirmation" in str(result.exception)
 

--- a/tests/hyperliquid/test_hypercore_accounting.py
+++ b/tests/hyperliquid/test_hypercore_accounting.py
@@ -29,7 +29,7 @@ from tradeexecutor.state.position import TradingPosition
 from tradeexecutor.state.repair import (
     close_hypercore_duplicate_clone,
     close_hypercore_dust_positions,
-    find_hypercore_duplicate_clone_candidates,
+    find_hypercore_duplicate_close_candidates,
 )
 from tradeexecutor.state.state import State
 from tradeexecutor.state.trade import TradeFlag, TradeType
@@ -889,19 +889,19 @@ def test_close_hypercore_dust_positions_closes_duplicate_residual_state() -> Non
     assert created_trades[0].trade_type == TradeType.repair
 
 
-def test_hypercore_duplicate_clone_suppression_keeps_canonical_position() -> None:
+def test_hypercore_duplicate_clone_close_keeps_canonical_position() -> None:
     """Test safe Hypercore later-clone repair closes the clone and keeps the older canonical position active.
 
     1. Build a state with one canonical Hypercore position and one later duplicate clone.
-    2. Discover the strict suppression candidate and apply it.
+    2. Discover the strict close candidate and apply it.
     3. Verify the canonical position stays open and the later clone is closed with a flagged repair trade.
     """
 
     # 1. Build a state with one canonical Hypercore position and one later duplicate clone.
     state, survivor_position, clone_position = _build_hypercore_clone_duplicate_state()
 
-    # 2. Discover the strict suppression candidate and apply it.
-    candidates, rejected_groups = find_hypercore_duplicate_clone_candidates(state.portfolio)
+    # 2. Discover the strict close candidate and apply it.
+    candidates, rejected_groups = find_hypercore_duplicate_close_candidates(state.portfolio)
     assert rejected_groups == []
     assert len(candidates) == 1
 
@@ -925,12 +925,12 @@ def test_hypercore_duplicate_clone_suppression_keeps_canonical_position() -> Non
     assert note in (clone_position.notes or "")
 
 
-def test_hypercore_duplicate_clone_suppression_rejects_clone_without_ignore_open() -> None:
-    """Test later-clone suppression rejects duplicates whose later trade lacks `ignore_open`.
+def test_hypercore_duplicate_clone_close_rejects_clone_without_ignore_open() -> None:
+    """Test later-clone closing rejects duplicates whose later trade lacks `ignore_open`.
 
     1. Build a state with a later Hypercore duplicate whose opening trade lacks `ignore_open`.
-    2. Discover suppression candidates.
-    3. Verify the group is rejected and no safe suppression candidate is returned.
+    2. Discover close candidates.
+    3. Verify the group is rejected and no safe close candidate is returned.
     """
 
     # 1. Build a state with a later Hypercore duplicate whose opening trade lacks `ignore_open`.
@@ -938,20 +938,20 @@ def test_hypercore_duplicate_clone_suppression_rejects_clone_without_ignore_open
         duplicate_flags=set(),
     )
 
-    # 2. Discover suppression candidates.
-    candidates, rejected_groups = find_hypercore_duplicate_clone_candidates(state.portfolio)
+    # 2. Discover close candidates.
+    candidates, rejected_groups = find_hypercore_duplicate_close_candidates(state.portfolio)
 
-    # 3. Verify the group is rejected and no safe suppression candidate is returned.
+    # 3. Verify the group is rejected and no safe close candidate is returned.
     assert candidates == []
     assert len(rejected_groups) == 1
     assert "lacks ignore_open flag" in rejected_groups[0]
 
 
-def test_hypercore_duplicate_clone_suppression_rejects_clone_with_balance_updates() -> None:
-    """Test later-clone suppression rejects duplicates when the clone already has balance updates.
+def test_hypercore_duplicate_clone_close_rejects_clone_with_balance_updates() -> None:
+    """Test later-clone closing rejects duplicates when the clone already has balance updates.
 
     1. Build a state with a later Hypercore duplicate clone that has balance updates.
-    2. Discover suppression candidates.
+    2. Discover close candidates.
     3. Verify the group is rejected because the later position is no longer a clean phantom clone.
     """
 
@@ -960,8 +960,8 @@ def test_hypercore_duplicate_clone_suppression_rejects_clone_with_balance_update
         duplicate_balance_update_quantity=Decimal("0.01"),
     )
 
-    # 2. Discover suppression candidates.
-    candidates, rejected_groups = find_hypercore_duplicate_clone_candidates(state.portfolio)
+    # 2. Discover close candidates.
+    candidates, rejected_groups = find_hypercore_duplicate_close_candidates(state.portfolio)
 
     # 3. Verify the group is rejected because the later position is no longer a clean phantom clone.
     assert candidates == []
@@ -969,11 +969,11 @@ def test_hypercore_duplicate_clone_suppression_rejects_clone_with_balance_update
     assert "has balance updates" in rejected_groups[0]
 
 
-def test_hypercore_duplicate_clone_suppression_rejects_expected_equity_mismatch() -> None:
-    """Test later-clone suppression rejects duplicates when expected USD equity differs.
+def test_hypercore_duplicate_clone_close_rejects_expected_equity_mismatch() -> None:
+    """Test later-clone closing rejects duplicates when expected USD equity differs.
 
     1. Build a state whose later Hypercore clone keeps the same quantity but has different valuation metadata.
-    2. Discover suppression candidates.
+    2. Discover close candidates.
     3. Verify the group is rejected because expected USD equity no longer matches.
     """
 
@@ -982,8 +982,8 @@ def test_hypercore_duplicate_clone_suppression_rejects_expected_equity_mismatch(
         duplicate_last_token_price=1.1,
     )
 
-    # 2. Discover suppression candidates.
-    candidates, rejected_groups = find_hypercore_duplicate_clone_candidates(state.portfolio)
+    # 2. Discover close candidates.
+    candidates, rejected_groups = find_hypercore_duplicate_close_candidates(state.portfolio)
 
     # 3. Verify the group is rejected because expected USD equity no longer matches.
     assert candidates == []
@@ -991,12 +991,12 @@ def test_hypercore_duplicate_clone_suppression_rejects_expected_equity_mismatch(
     assert "expected USD equity differs" in rejected_groups[0]
 
 
-def test_hypercore_duplicate_clone_suppression_rejects_frozen_group() -> None:
-    """Test later-clone suppression rejects duplicate groups that contain frozen positions.
+def test_hypercore_duplicate_clone_close_rejects_frozen_group() -> None:
+    """Test later-clone closing rejects duplicate groups that contain frozen positions.
 
     1. Build a state with one canonical Hypercore position and one later clone.
     2. Move the later clone into frozen positions to simulate an unsafe repair case.
-    3. Verify the duplicate group is rejected for automatic suppression.
+    3. Verify the duplicate group is rejected for automatic closing.
     """
 
     # 1. Build a state with one canonical Hypercore position and one later clone.
@@ -1007,8 +1007,8 @@ def test_hypercore_duplicate_clone_suppression_rejects_frozen_group() -> None:
     del state.portfolio.open_positions[clone_position.position_id]
     state.portfolio.frozen_positions[clone_position.position_id] = clone_position
 
-    # 3. Verify the duplicate group is rejected for automatic suppression.
-    candidates, rejected_groups = find_hypercore_duplicate_clone_candidates(state.portfolio)
+    # 3. Verify the duplicate group is rejected for automatic closing.
+    candidates, rejected_groups = find_hypercore_duplicate_close_candidates(state.portfolio)
     assert candidates == []
     assert len(rejected_groups) == 1
     assert "contains frozen positions" in rejected_groups[0]

--- a/tests/hyperliquid/test_hypercore_accounting.py
+++ b/tests/hyperliquid/test_hypercore_accounting.py
@@ -27,9 +27,9 @@ from tradeexecutor.state.balance_update import (
 from tradeexecutor.state.identifier import TradingPairIdentifier, TradingPairKind, AssetIdentifier
 from tradeexecutor.state.position import TradingPosition
 from tradeexecutor.state.repair import (
+    close_hypercore_duplicate_clone,
     close_hypercore_dust_positions,
     find_hypercore_duplicate_clone_candidates,
-    suppress_hypercore_duplicate_clone,
 )
 from tradeexecutor.state.state import State
 from tradeexecutor.state.trade import TradeFlag, TradeType
@@ -890,11 +890,11 @@ def test_close_hypercore_dust_positions_closes_duplicate_residual_state() -> Non
 
 
 def test_hypercore_duplicate_clone_suppression_keeps_canonical_position() -> None:
-    """Test safe Hypercore later-clone suppression keeps the older canonical position active.
+    """Test safe Hypercore later-clone repair closes the clone and keeps the older canonical position active.
 
     1. Build a state with one canonical Hypercore position and one later duplicate clone.
     2. Discover the strict suppression candidate and apply it.
-    3. Verify the canonical position stays open and the later clone moves to suppressed duplicates.
+    3. Verify the canonical position stays open and the later clone is closed with a flagged repair trade.
     """
 
     # 1. Build a state with one canonical Hypercore position and one later duplicate clone.
@@ -905,17 +905,24 @@ def test_hypercore_duplicate_clone_suppression_keeps_canonical_position() -> Non
     assert rejected_groups == []
     assert len(candidates) == 1
 
-    suppress_hypercore_duplicate_clone(
+    closing_trade = close_hypercore_duplicate_clone(
         state.portfolio,
         candidates[0],
         now=datetime.datetime(2026, 4, 15),
     )
 
-    # 3. Verify the canonical position stays open and the later clone moves to suppressed duplicates.
+    # 3. Verify the canonical position stays open and the later clone is closed with a flagged repair trade.
     assert survivor_position.position_id in state.portfolio.open_positions
     assert clone_position.position_id not in state.portfolio.open_positions
-    assert clone_position.position_id in state.portfolio.suppressed_duplicate_positions
+    assert clone_position.position_id in state.portfolio.closed_positions
     assert state.portfolio.get_position_by_id(clone_position.position_id) == clone_position
+    assert TradeFlag.hypercore_duplicate_close in (closing_trade.flags or set())
+    note = (
+        f"Closed as duplicate Hypercore clone of position #{survivor_position.position_id} "
+        f"during Hypercore duplicate repair (2026-04-15T00:00:00)"
+    )
+    assert note in (closing_trade.notes or "")
+    assert note in (clone_position.notes or "")
 
 
 def test_hypercore_duplicate_clone_suppression_rejects_clone_without_ignore_open() -> None:

--- a/tests/hyperliquid/test_hypercore_accounting.py
+++ b/tests/hyperliquid/test_hypercore_accounting.py
@@ -26,7 +26,11 @@ from tradeexecutor.state.balance_update import (
 )
 from tradeexecutor.state.identifier import TradingPairIdentifier, TradingPairKind, AssetIdentifier
 from tradeexecutor.state.position import TradingPosition
-from tradeexecutor.state.repair import close_hypercore_dust_positions
+from tradeexecutor.state.repair import (
+    close_hypercore_dust_positions,
+    find_hypercore_duplicate_clone_candidates,
+    suppress_hypercore_duplicate_clone,
+)
 from tradeexecutor.state.state import State
 from tradeexecutor.state.trade import TradeFlag, TradeType
 from tradeexecutor.strategy.account_correction import (
@@ -539,6 +543,98 @@ def test_hypercore_dust_position_is_not_about_to_close_without_planned_trades() 
         assert position.is_about_to_close() is True
 
 
+def _build_hypercore_clone_duplicate_state(
+    *,
+    duplicate_flags: set[TradeFlag] | None = None,
+    duplicate_balance_update_quantity: Decimal | None = None,
+    duplicate_last_token_price: float | None = None,
+) -> tuple[State, TradingPosition, TradingPosition]:
+    """Build a state with one canonical Hypercore position and one later clone."""
+
+    reserve_asset = AssetIdentifier(
+        chain_id=999,
+        address="0xb88339cb7199b77e23db6e890353e22632ba630f",
+        token_symbol="USDC",
+        decimals=6,
+    )
+    pair = create_hypercore_vault_pair(
+        quote=reserve_asset,
+        vault_address="0x7777777777777777777777777777777777777777",
+    )
+
+    state = State()
+    state.portfolio.initialise_reserves(reserve_asset, reserve_token_price=1.0)
+    state.portfolio.adjust_reserves(reserve_asset, Decimal("100"), "Initial reserve")
+
+    survivor_position, survivor_trade, _created = state.create_trade(
+        strategy_cycle_at=datetime.datetime(2026, 4, 13),
+        pair=pair,
+        quantity=None,
+        reserve=Decimal("25"),
+        assumed_price=1.0,
+        trade_type=TradeType.rebalance,
+        reserve_currency=reserve_asset,
+        reserve_currency_price=1.0,
+        notes="Create canonical Hypercore position",
+    )
+    survivor_trade.mark_success(
+        executed_at=datetime.datetime(2026, 4, 13, 0, 1),
+        executed_price=1.0,
+        executed_quantity=Decimal("25"),
+        executed_reserve=Decimal("25"),
+        lp_fees=0,
+        native_token_price=0,
+        force=True,
+    )
+
+    clone_position, clone_trade, _duplicate_created = state.create_trade(
+        strategy_cycle_at=datetime.datetime(2026, 4, 14),
+        pair=pair,
+        quantity=None,
+        reserve=Decimal("25"),
+        assumed_price=1.0,
+        trade_type=TradeType.rebalance,
+        reserve_currency=reserve_asset,
+        reserve_currency_price=1.0,
+        notes="Create later Hypercore clone",
+        flags={TradeFlag.ignore_open},
+    )
+    clone_trade.mark_success(
+        executed_at=datetime.datetime(2026, 4, 14, 0, 1),
+        executed_price=1.0,
+        executed_quantity=Decimal("25"),
+        executed_reserve=Decimal("25"),
+        lp_fees=0,
+        native_token_price=0,
+        force=True,
+    )
+
+    if duplicate_flags is not None:
+        clone_trade.flags = duplicate_flags
+
+    if duplicate_balance_update_quantity is not None:
+        clone_position.balance_updates[1] = BalanceUpdate(
+            balance_update_id=1,
+            cause=BalanceUpdateCause.vault_flow,
+            position_type=BalanceUpdatePositionType.open_position,
+            asset=pair.base,
+            block_mined_at=datetime.datetime(2026, 4, 14, 0, 2),
+            strategy_cycle_included_at=datetime.datetime(2026, 4, 14),
+            chain_id=pair.base.chain_id,
+            quantity=duplicate_balance_update_quantity,
+            old_balance=Decimal("25"),
+            usd_value=float(duplicate_balance_update_quantity),
+            position_id=clone_position.position_id,
+            notes="Simulate clone-side balance update",
+            block_number=1,
+        )
+
+    if duplicate_last_token_price is not None:
+        clone_position.last_token_price = duplicate_last_token_price
+
+    return state, survivor_position, clone_position
+
+
 def test_check_double_position_distinguishes_different_hypercore_vaults() -> None:
     """Test duplicate-position checks do not merge distinct Hypercore vaults.
 
@@ -791,3 +887,121 @@ def test_close_hypercore_dust_positions_closes_duplicate_residual_state() -> Non
     assert live_position.position_id in state.portfolio.open_positions
     assert live_position.position_id not in state.portfolio.closed_positions
     assert created_trades[0].trade_type == TradeType.repair
+
+
+def test_hypercore_duplicate_clone_suppression_keeps_canonical_position() -> None:
+    """Test safe Hypercore later-clone suppression keeps the older canonical position active.
+
+    1. Build a state with one canonical Hypercore position and one later duplicate clone.
+    2. Discover the strict suppression candidate and apply it.
+    3. Verify the canonical position stays open and the later clone moves to suppressed duplicates.
+    """
+
+    # 1. Build a state with one canonical Hypercore position and one later duplicate clone.
+    state, survivor_position, clone_position = _build_hypercore_clone_duplicate_state()
+
+    # 2. Discover the strict suppression candidate and apply it.
+    candidates, rejected_groups = find_hypercore_duplicate_clone_candidates(state.portfolio)
+    assert rejected_groups == []
+    assert len(candidates) == 1
+
+    suppress_hypercore_duplicate_clone(
+        state.portfolio,
+        candidates[0],
+        now=datetime.datetime(2026, 4, 15),
+    )
+
+    # 3. Verify the canonical position stays open and the later clone moves to suppressed duplicates.
+    assert survivor_position.position_id in state.portfolio.open_positions
+    assert clone_position.position_id not in state.portfolio.open_positions
+    assert clone_position.position_id in state.portfolio.suppressed_duplicate_positions
+    assert state.portfolio.get_position_by_id(clone_position.position_id) == clone_position
+
+
+def test_hypercore_duplicate_clone_suppression_rejects_clone_without_ignore_open() -> None:
+    """Test later-clone suppression rejects duplicates whose later trade lacks `ignore_open`.
+
+    1. Build a state with a later Hypercore duplicate whose opening trade lacks `ignore_open`.
+    2. Discover suppression candidates.
+    3. Verify the group is rejected and no safe suppression candidate is returned.
+    """
+
+    # 1. Build a state with a later Hypercore duplicate whose opening trade lacks `ignore_open`.
+    state, _survivor_position, _clone_position = _build_hypercore_clone_duplicate_state(
+        duplicate_flags=set(),
+    )
+
+    # 2. Discover suppression candidates.
+    candidates, rejected_groups = find_hypercore_duplicate_clone_candidates(state.portfolio)
+
+    # 3. Verify the group is rejected and no safe suppression candidate is returned.
+    assert candidates == []
+    assert len(rejected_groups) == 1
+    assert "lacks ignore_open flag" in rejected_groups[0]
+
+
+def test_hypercore_duplicate_clone_suppression_rejects_clone_with_balance_updates() -> None:
+    """Test later-clone suppression rejects duplicates when the clone already has balance updates.
+
+    1. Build a state with a later Hypercore duplicate clone that has balance updates.
+    2. Discover suppression candidates.
+    3. Verify the group is rejected because the later position is no longer a clean phantom clone.
+    """
+
+    # 1. Build a state with a later Hypercore duplicate clone that has balance updates.
+    state, _survivor_position, _clone_position = _build_hypercore_clone_duplicate_state(
+        duplicate_balance_update_quantity=Decimal("0.01"),
+    )
+
+    # 2. Discover suppression candidates.
+    candidates, rejected_groups = find_hypercore_duplicate_clone_candidates(state.portfolio)
+
+    # 3. Verify the group is rejected because the later position is no longer a clean phantom clone.
+    assert candidates == []
+    assert len(rejected_groups) == 1
+    assert "has balance updates" in rejected_groups[0]
+
+
+def test_hypercore_duplicate_clone_suppression_rejects_expected_equity_mismatch() -> None:
+    """Test later-clone suppression rejects duplicates when expected USD equity differs.
+
+    1. Build a state whose later Hypercore clone keeps the same quantity but has different valuation metadata.
+    2. Discover suppression candidates.
+    3. Verify the group is rejected because expected USD equity no longer matches.
+    """
+
+    # 1. Build a state whose later Hypercore clone keeps the same quantity but has different valuation metadata.
+    state, _survivor_position, _clone_position = _build_hypercore_clone_duplicate_state(
+        duplicate_last_token_price=1.1,
+    )
+
+    # 2. Discover suppression candidates.
+    candidates, rejected_groups = find_hypercore_duplicate_clone_candidates(state.portfolio)
+
+    # 3. Verify the group is rejected because expected USD equity no longer matches.
+    assert candidates == []
+    assert len(rejected_groups) == 1
+    assert "expected USD equity differs" in rejected_groups[0]
+
+
+def test_hypercore_duplicate_clone_suppression_rejects_frozen_group() -> None:
+    """Test later-clone suppression rejects duplicate groups that contain frozen positions.
+
+    1. Build a state with one canonical Hypercore position and one later clone.
+    2. Move the later clone into frozen positions to simulate an unsafe repair case.
+    3. Verify the duplicate group is rejected for automatic suppression.
+    """
+
+    # 1. Build a state with one canonical Hypercore position and one later clone.
+    state, _survivor_position, clone_position = _build_hypercore_clone_duplicate_state()
+
+    # 2. Move the later clone into frozen positions to simulate an unsafe repair case.
+    clone_position.frozen_at = datetime.datetime(2026, 4, 14, 0, 3)
+    del state.portfolio.open_positions[clone_position.position_id]
+    state.portfolio.frozen_positions[clone_position.position_id] = clone_position
+
+    # 3. Verify the duplicate group is rejected for automatic suppression.
+    candidates, rejected_groups = find_hypercore_duplicate_clone_candidates(state.portfolio)
+    assert candidates == []
+    assert len(rejected_groups) == 1
+    assert "contains frozen positions" in rejected_groups[0]

--- a/tradeexecutor/cli/commands/repair_hypercore_dust.py
+++ b/tradeexecutor/cli/commands/repair_hypercore_dust.py
@@ -14,7 +14,7 @@ from ..log import setup_logging
 from ...state.repair import (
     close_hypercore_duplicate_clone,
     close_hypercore_dust_positions,
-    find_hypercore_duplicate_clone_candidates,
+    find_hypercore_duplicate_close_candidates,
 )
 from ...state.store import JSONFileStore
 
@@ -55,9 +55,9 @@ def repair_hypercore_dust(
         False,
         envvar="MERGE_DUSTLESS_DUPLICATES",
         help=(
-            "Suppress a later phantom Hypercore duplicate clone when the duplicate group "
+            "Close a later phantom Hypercore duplicate clone when the duplicate group "
             "passes strict safety checks. This always requires an explicit y/n confirmation "
-            "for each dangerous suppression."
+            "for each dangerous duplicate close."
         ),
     ),
     auto_approve: bool = Option(
@@ -66,7 +66,7 @@ def repair_hypercore_dust(
         help="Approve Hypercore dust cleanup without asking for confirmation.",
     ),
 ):
-    """Close Hypercore dust positions and optionally suppress safe duplicate clones.
+    """Close Hypercore dust positions and optionally close safe duplicate clones.
 
     This command is intentionally local-state only. It does not attempt any
     on-chain execution; instead it creates repair trades for Hypercore vault
@@ -132,34 +132,34 @@ def repair_hypercore_dust(
     duplicate_group_count_after = _count_duplicate_hypercore_groups(state)
 
     if duplicate_group_count_after and merge_dustless_duplicates:
-        candidates, rejected_groups = find_hypercore_duplicate_clone_candidates(state.portfolio)
+        candidates, rejected_groups = find_hypercore_duplicate_close_candidates(state.portfolio)
 
         if rejected_groups:
             logger.warning(
-                "Hypercore duplicate groups remaining after dust cleanup are not safe for automatic suppression"
+                "Hypercore duplicate groups remaining after dust cleanup are not safe for automatic closing"
             )
             for reason in rejected_groups:
                 logger.warning(reason)
             raise RuntimeError(
                 "Hypercore duplicate positions still remain after dust cleanup, and at least one duplicate "
-                "group is not safe for automatic suppression. The state file was not updated."
+                "group is not safe for automatic closing. The state file was not updated."
             )
 
         if candidates:
             if auto_approve and not unit_testing:
                 raise RuntimeError(
                     "--auto-approve cannot be used with --merge-dustless-duplicates because "
-                    "each dangerous duplicate suppression requires an explicit y/n confirmation."
+                    "each dangerous duplicate close requires an explicit y/n confirmation."
                 )
 
             logger.warning(
-                "Detected %d Hypercore duplicate clone group(s) that are eligible for strict suppression",
+                "Detected %d Hypercore duplicate clone group(s) that are eligible for strict closing",
                 len(candidates),
             )
 
             for candidate in candidates:
                 logger.warning(
-                    "Eligible Hypercore duplicate clone suppression for vault %s at %s",
+                    "Eligible Hypercore duplicate clone close for vault %s at %s",
                     candidate.vault_name,
                     candidate.vault_address,
                 )
@@ -168,19 +168,19 @@ def repair_hypercore_dust(
                     _format_candidate_position(candidate.survivor_position),
                 )
                 logger.warning(
-                    "Suppressing clone position: %s",
+                    "Closing clone position: %s",
                     _format_candidate_position(candidate.clone_position),
                 )
 
                 if not unit_testing:
                     confirmation = typer.confirm(
-                        f"Suppress duplicate clone position #{candidate.clone_position.position_id} "
+                        f"Close duplicate clone position #{candidate.clone_position.position_id} "
                         f"and keep survivor #{candidate.survivor_position.position_id} for vault "
                         f"{candidate.vault_name}?"
                     )
                     if not confirmation:
                         raise RuntimeError(
-                            "Operator aborted Hypercore duplicate-clone suppression. "
+                            "Operator aborted Hypercore duplicate-clone close. "
                             "The state file was not updated."
                         )
 
@@ -200,7 +200,7 @@ def repair_hypercore_dust(
         check_double_position(state, printer=logger.warning, crash=False)
         raise RuntimeError(
             "Hypercore duplicate positions still remain after dust cleanup. "
-            "Any remaining duplicates are not closeable dust or safe clone suppressions, "
+            "Any remaining duplicates are not closeable dust or safe clone closes, "
             "and require manual repair. The state file was not updated."
         )
 

--- a/tradeexecutor/cli/commands/repair_hypercore_dust.py
+++ b/tradeexecutor/cli/commands/repair_hypercore_dust.py
@@ -11,7 +11,11 @@ from .app import app
 from ..bootstrap import backup_state, create_state_store, prepare_executor_id
 from ..double_position import check_double_position, get_duplicate_position_groups
 from ..log import setup_logging
-from ...state.repair import close_hypercore_dust_positions
+from ...state.repair import (
+    close_hypercore_dust_positions,
+    find_hypercore_duplicate_clone_candidates,
+    suppress_hypercore_duplicate_clone,
+)
 from ...state.store import JSONFileStore
 
 
@@ -24,6 +28,22 @@ def _count_duplicate_hypercore_groups(state) -> int:
     )
 
 
+def _format_candidate_position(position) -> str:
+    """Format one Hypercore duplicate-clone candidate position for CLI logging."""
+
+    return (
+        f"position_id={position.position_id}, "
+        f"quantity={position.get_quantity(planned=False)}, "
+        f"planned_quantity={position.get_quantity(planned=True)}, "
+        f"expected_usd_equity={position.get_value(include_interest=False)}, "
+        f"last_token_price={position.last_token_price}, "
+        f"has_planned_trades={position.has_planned_trades()}, "
+        f"is_about_to_close={position.is_about_to_close()}, "
+        f"balance_updates={len(position.balance_updates)}, "
+        f"trades={len(position.trades)}"
+    )
+
+
 @app.command()
 def repair_hypercore_dust(
     id: str = shared_options.id,
@@ -31,13 +51,22 @@ def repair_hypercore_dust(
     state_file: Optional[Path] = shared_options.state_file,
     log_level: str = shared_options.log_level,
     unit_testing: bool = shared_options.unit_testing,
+    merge_dustless_duplicates: bool = Option(
+        False,
+        envvar="MERGE_DUSTLESS_DUPLICATES",
+        help=(
+            "Suppress a later phantom Hypercore duplicate clone when the duplicate group "
+            "passes strict safety checks. This always requires an explicit y/n confirmation "
+            "for each dangerous suppression."
+        ),
+    ),
     auto_approve: bool = Option(
         False,
         envvar="AUTO_APPROVE",
         help="Approve Hypercore dust cleanup without asking for confirmation.",
     ),
 ):
-    """Close Hypercore dust positions and warn about duplicate vault entries.
+    """Close Hypercore dust positions and optionally suppress safe duplicate clones.
 
     This command is intentionally local-state only. It does not attempt any
     on-chain execution; instead it creates repair trades for Hypercore vault
@@ -61,8 +90,6 @@ def repair_hypercore_dust(
     assert isinstance(store, JSONFileStore)
     assert not store.is_pristine(), f"State file does not exist: {state_file}"
 
-    # Follow the standard mutating-command pattern: take a backup first, then
-    # operate on the live state file copy.
     store, state = backup_state(
         state_file,
         backup_suffix="repair-hypercore-dust-backup",
@@ -93,13 +120,78 @@ def repair_hypercore_dust(
             len(created_trades),
         )
         for trade in created_trades:
-            logger.info("Created repair trade %s for position %s", trade.trade_id, trade.position_id)
-        logger.info("Saving repaired state to %s", store.path)
-        store.sync(state)
+            logger.info(
+                "Created repair trade %s for position %s",
+                trade.trade_id,
+                trade.position_id,
+            )
     else:
         logger.info("No closeable Hypercore dust positions were found")
 
+    suppressed_positions: list = []
     duplicate_group_count_after = _count_duplicate_hypercore_groups(state)
+
+    if duplicate_group_count_after and merge_dustless_duplicates:
+        candidates, rejected_groups = find_hypercore_duplicate_clone_candidates(state.portfolio)
+
+        if rejected_groups:
+            logger.warning(
+                "Hypercore duplicate groups remaining after dust cleanup are not safe for automatic suppression"
+            )
+            for reason in rejected_groups:
+                logger.warning(reason)
+            raise RuntimeError(
+                "Hypercore duplicate positions still remain after dust cleanup, and at least one duplicate "
+                "group is not safe for automatic suppression. The state file was not updated."
+            )
+
+        if candidates:
+            if auto_approve and not unit_testing:
+                raise RuntimeError(
+                    "--auto-approve cannot be used with --merge-dustless-duplicates because "
+                    "each dangerous duplicate suppression requires an explicit y/n confirmation."
+                )
+
+            logger.warning(
+                "Detected %d Hypercore duplicate clone group(s) that are eligible for strict suppression",
+                len(candidates),
+            )
+
+            for candidate in candidates:
+                logger.warning(
+                    "Eligible Hypercore duplicate clone suppression for vault %s at %s",
+                    candidate.vault_name,
+                    candidate.vault_address,
+                )
+                logger.warning(
+                    "Keeping survivor position: %s",
+                    _format_candidate_position(candidate.survivor_position),
+                )
+                logger.warning(
+                    "Suppressing clone position: %s",
+                    _format_candidate_position(candidate.clone_position),
+                )
+
+                if not unit_testing:
+                    confirmation = typer.confirm(
+                        f"Suppress duplicate clone position #{candidate.clone_position.position_id} "
+                        f"and keep survivor #{candidate.survivor_position.position_id} for vault "
+                        f"{candidate.vault_name}?"
+                    )
+                    if not confirmation:
+                        raise RuntimeError(
+                            "Operator aborted Hypercore duplicate-clone suppression. "
+                            "The state file was not updated."
+                        )
+
+                suppressed_position = suppress_hypercore_duplicate_clone(
+                    state.portfolio,
+                    candidate,
+                )
+                suppressed_positions.append(suppressed_position)
+
+            duplicate_group_count_after = _count_duplicate_hypercore_groups(state)
+
     if duplicate_group_count_after:
         logger.warning(
             "Hypercore duplicate position groups remaining after dust cleanup: %d",
@@ -108,8 +200,16 @@ def repair_hypercore_dust(
         check_double_position(state, printer=logger.warning, crash=False)
         raise RuntimeError(
             "Hypercore duplicate positions still remain after dust cleanup. "
-            "Any remaining duplicates are not closeable dust and require manual repair."
+            "Any remaining duplicates are not closeable dust or safe clone suppressions, "
+            "and require manual repair. The state file was not updated."
         )
+
+    state_changed = bool(created_trades) or bool(suppressed_positions)
+    if state_changed:
+        logger.info("Saving repaired state to %s", store.path)
+        store.sync(state)
+    else:
+        logger.info("No state changes were needed")
 
     logger.info("No Hypercore duplicate position groups remain after dust cleanup")
     logger.info("All ok")

--- a/tradeexecutor/cli/commands/repair_hypercore_dust.py
+++ b/tradeexecutor/cli/commands/repair_hypercore_dust.py
@@ -12,9 +12,9 @@ from ..bootstrap import backup_state, create_state_store, prepare_executor_id
 from ..double_position import check_double_position, get_duplicate_position_groups
 from ..log import setup_logging
 from ...state.repair import (
+    close_hypercore_duplicate_clone,
     close_hypercore_dust_positions,
     find_hypercore_duplicate_clone_candidates,
-    suppress_hypercore_duplicate_clone,
 )
 from ...state.store import JSONFileStore
 
@@ -128,7 +128,7 @@ def repair_hypercore_dust(
     else:
         logger.info("No closeable Hypercore dust positions were found")
 
-    suppressed_positions: list = []
+    duplicate_close_trades: list = []
     duplicate_group_count_after = _count_duplicate_hypercore_groups(state)
 
     if duplicate_group_count_after and merge_dustless_duplicates:
@@ -184,11 +184,11 @@ def repair_hypercore_dust(
                             "The state file was not updated."
                         )
 
-                suppressed_position = suppress_hypercore_duplicate_clone(
+                duplicate_close_trade = close_hypercore_duplicate_clone(
                     state.portfolio,
                     candidate,
                 )
-                suppressed_positions.append(suppressed_position)
+                duplicate_close_trades.append(duplicate_close_trade)
 
             duplicate_group_count_after = _count_duplicate_hypercore_groups(state)
 
@@ -204,7 +204,7 @@ def repair_hypercore_dust(
             "and require manual repair. The state file was not updated."
         )
 
-    state_changed = bool(created_trades) or bool(suppressed_positions)
+    state_changed = bool(created_trades) or bool(duplicate_close_trades)
     if state_changed:
         logger.info("Saving repaired state to %s", store.path)
         store.sync(state)

--- a/tradeexecutor/state/portfolio.py
+++ b/tradeexecutor/state/portfolio.py
@@ -109,12 +109,6 @@ class Portfolio:
     #: - rug pull token - transfer disabled
     frozen_positions: Dict[int, TradingPosition] = field(default_factory=dict)
 
-    #: Duplicate positions intentionally removed from active accounting.
-    #:
-    #: These entries are preserved for audit/debugging, but they must not
-    #: participate in normal analytics, duplicate checks, or trade routing.
-    suppressed_duplicate_positions: Dict[int, TradingPosition] = field(default_factory=dict)
-
     #: Mark positions that we cannot value as zero
     #:
     #: This is a backtesting issue workaround flag for disappearing markets.
@@ -141,22 +135,11 @@ class Portfolio:
     def __repr__(self):
         reserve_asset, _ = self.get_default_reserve_asset()
         reserve_position = self.get_reserve_position(reserve_asset)
-        return (
-            f"<Portfolio with positions open:{len(self.open_positions)} "
-            f"frozen:{len(self.frozen_positions)} "
-            f"closed:{len(self.closed_positions)} "
-            f"suppressed:{len(self.suppressed_duplicate_positions)} "
-            f"and reserve {reserve_position.quantity} {reserve_position.asset.token_symbol}>"
-        )
+        return f"<Portfolio with positions open:{len(self.open_positions)} frozen:{len(self.frozen_positions)} closed:{len(self.closed_positions)} and reserve {reserve_position.quantity} {reserve_position.asset.token_symbol}>"
 
     def is_empty(self):
         """This portfolio has no open or past trades or any reserves."""
-        return (
-            len(self.open_positions) == 0
-            and len(self.reserves) == 0
-            and len(self.closed_positions) == 0
-            and len(self.suppressed_duplicate_positions) == 0
-        )
+        return len(self.open_positions) == 0 and len(self.reserves) == 0 and len(self.closed_positions) == 0
 
     def get_position_by_id(self, position_id: int) -> TradingPosition:
         """Get any position open/closed/frozen by id.
@@ -185,14 +168,9 @@ class Portfolio:
         if p3:
             # Sanity check we do not have the same position in multiple tables
             assert not (p1 or p2)
-        p4 = self.suppressed_duplicate_positions.get(position_id)
-        if p4:
-            # Sanity check we do not have the same position in multiple tables
-            assert not (p1 or p2 or p3)
+        assert p1 or p2 or p3, f"Did not have position with id {position_id}"
 
-        assert p1 or p2 or p3 or p4, f"Did not have position with id {position_id}"
-
-        return p1 or p2 or p3 or p4
+        return p1 or p2 or p3
 
     def get_trade_by_id(self, trade_id: int) -> Optional[TradeExecution]:
         """Look up any trade in all positions.
@@ -204,7 +182,7 @@ class Portfolio:
         :return:
             Found trade or
         """
-        for p in self.get_all_positions(include_suppressed=True):
+        for p in self.get_all_positions():
             t = p.trades.get(trade_id)
             if t is not None:
                 return t
@@ -220,32 +198,28 @@ class Portfolio:
         :return:
             None if the portfolio does not contain such a trade
         """
-        for t in self.get_all_trades(include_suppressed=True):
+        for t in self.get_all_trades():
             for b in t.blockchain_transactions:
                 if b.tx_hash == tx_hash:
                     return t
 
         return None
 
-    def get_all_positions(self, pending=False, include_suppressed=False) -> Iterable[TradingPosition]:
+    def get_all_positions(self, pending=False) -> Iterable[TradingPosition]:
         """Get open, closed and frozen, positions.
 
         :param pending:
             Include hypotethical market limit positions.
         """
-        positions = [
-            self.open_positions.values(),
-            self.closed_positions.values(),
-            self.frozen_positions.values(),
-        ]
-        if include_suppressed:
-            positions.append(self.suppressed_duplicate_positions.values())
-
         if pending:
-            positions.append(self.pending_positions.values())
-            return chain(*positions)
+            return chain(
+                self.open_positions.values(),
+                self.closed_positions.values(),
+                self.frozen_positions.values(),
+                self.pending_positions.values(),
+            )
         else:
-            return chain(*positions)
+            return chain(self.open_positions.values(), self.closed_positions.values(), self.frozen_positions.values())
 
     def get_open_loans(self) -> Iterable[Loan]:
         """Get loans across all positions."""
@@ -928,23 +902,6 @@ class Portfolio:
 
         assert position.is_closed()
 
-    def suppress_duplicate_position(
-        self,
-        position: TradingPosition,
-        suppressed_at: datetime.datetime,
-    ) -> None:
-        """Move a duplicate position out of active accounting into the audit bucket."""
-
-        assert position.position_id in self.open_positions, f"Not in open positions: {position}"
-        assert position.position_id not in self.suppressed_duplicate_positions, (
-            f"Already suppressed: {position}"
-        )
-
-        logger.info("Suppressing duplicate position: %s at %s", position, suppressed_at)
-        position.other_data["suppressed_duplicate_at"] = suppressed_at
-        del self.open_positions[position.position_id]
-        self.suppressed_duplicate_positions[position.position_id] = position
-
     def adjust_reserves(
         self,
         asset: AssetIdentifier,
@@ -1164,10 +1121,10 @@ class Portfolio:
         res_pos = next(iter(self.reserves.values()))
         return res_pos.asset, res_pos.reserve_token_price
 
-    def get_all_trades(self, include_suppressed=False) -> Iterable[TradeExecution]:
+    def get_all_trades(self) -> Iterable[TradeExecution]:
         """Iterate through all trades: completed, failed and in progress"""
         pos: TradingPosition
-        for pos in self.get_all_positions(include_suppressed=include_suppressed):
+        for pos in self.get_all_positions():
             for t in pos.trades.values():
                 yield t
 

--- a/tradeexecutor/state/portfolio.py
+++ b/tradeexecutor/state/portfolio.py
@@ -109,6 +109,12 @@ class Portfolio:
     #: - rug pull token - transfer disabled
     frozen_positions: Dict[int, TradingPosition] = field(default_factory=dict)
 
+    #: Duplicate positions intentionally removed from active accounting.
+    #:
+    #: These entries are preserved for audit/debugging, but they must not
+    #: participate in normal analytics, duplicate checks, or trade routing.
+    suppressed_duplicate_positions: Dict[int, TradingPosition] = field(default_factory=dict)
+
     #: Mark positions that we cannot value as zero
     #:
     #: This is a backtesting issue workaround flag for disappearing markets.
@@ -135,11 +141,22 @@ class Portfolio:
     def __repr__(self):
         reserve_asset, _ = self.get_default_reserve_asset()
         reserve_position = self.get_reserve_position(reserve_asset)
-        return f"<Portfolio with positions open:{len(self.open_positions)} frozen:{len(self.frozen_positions)} closed:{len(self.closed_positions)} and reserve {reserve_position.quantity} {reserve_position.asset.token_symbol}>"
+        return (
+            f"<Portfolio with positions open:{len(self.open_positions)} "
+            f"frozen:{len(self.frozen_positions)} "
+            f"closed:{len(self.closed_positions)} "
+            f"suppressed:{len(self.suppressed_duplicate_positions)} "
+            f"and reserve {reserve_position.quantity} {reserve_position.asset.token_symbol}>"
+        )
 
     def is_empty(self):
         """This portfolio has no open or past trades or any reserves."""
-        return len(self.open_positions) == 0 and len(self.reserves) == 0 and len(self.closed_positions) == 0
+        return (
+            len(self.open_positions) == 0
+            and len(self.reserves) == 0
+            and len(self.closed_positions) == 0
+            and len(self.suppressed_duplicate_positions) == 0
+        )
 
     def get_position_by_id(self, position_id: int) -> TradingPosition:
         """Get any position open/closed/frozen by id.
@@ -168,10 +185,14 @@ class Portfolio:
         if p3:
             # Sanity check we do not have the same position in multiple tables
             assert not (p1 or p2)
+        p4 = self.suppressed_duplicate_positions.get(position_id)
+        if p4:
+            # Sanity check we do not have the same position in multiple tables
+            assert not (p1 or p2 or p3)
 
-        assert p1 or p2 or p3, f"Did not have position with id {position_id}"
+        assert p1 or p2 or p3 or p4, f"Did not have position with id {position_id}"
 
-        return p1 or p2 or p3
+        return p1 or p2 or p3 or p4
 
     def get_trade_by_id(self, trade_id: int) -> Optional[TradeExecution]:
         """Look up any trade in all positions.
@@ -183,7 +204,7 @@ class Portfolio:
         :return:
             Found trade or
         """
-        for p in self.get_all_positions():
+        for p in self.get_all_positions(include_suppressed=True):
             t = p.trades.get(trade_id)
             if t is not None:
                 return t
@@ -199,28 +220,32 @@ class Portfolio:
         :return:
             None if the portfolio does not contain such a trade
         """
-        for t in self.get_all_trades():
+        for t in self.get_all_trades(include_suppressed=True):
             for b in t.blockchain_transactions:
                 if b.tx_hash == tx_hash:
                     return t
 
         return None
 
-    def get_all_positions(self, pending=False) -> Iterable[TradingPosition]:
+    def get_all_positions(self, pending=False, include_suppressed=False) -> Iterable[TradingPosition]:
         """Get open, closed and frozen, positions.
 
         :param pending:
             Include hypotethical market limit positions.
         """
+        positions = [
+            self.open_positions.values(),
+            self.closed_positions.values(),
+            self.frozen_positions.values(),
+        ]
+        if include_suppressed:
+            positions.append(self.suppressed_duplicate_positions.values())
+
         if pending:
-            return chain(
-                self.open_positions.values(),
-                self.closed_positions.values(),
-                self.frozen_positions.values(),
-                self.pending_positions.values(),
-            )
+            positions.append(self.pending_positions.values())
+            return chain(*positions)
         else:
-            return chain(self.open_positions.values(), self.closed_positions.values(), self.frozen_positions.values())
+            return chain(*positions)
 
     def get_open_loans(self) -> Iterable[Loan]:
         """Get loans across all positions."""
@@ -903,6 +928,23 @@ class Portfolio:
 
         assert position.is_closed()
 
+    def suppress_duplicate_position(
+        self,
+        position: TradingPosition,
+        suppressed_at: datetime.datetime,
+    ) -> None:
+        """Move a duplicate position out of active accounting into the audit bucket."""
+
+        assert position.position_id in self.open_positions, f"Not in open positions: {position}"
+        assert position.position_id not in self.suppressed_duplicate_positions, (
+            f"Already suppressed: {position}"
+        )
+
+        logger.info("Suppressing duplicate position: %s at %s", position, suppressed_at)
+        position.other_data["suppressed_duplicate_at"] = suppressed_at
+        del self.open_positions[position.position_id]
+        self.suppressed_duplicate_positions[position.position_id] = position
+
     def adjust_reserves(
         self,
         asset: AssetIdentifier,
@@ -1122,10 +1164,10 @@ class Portfolio:
         res_pos = next(iter(self.reserves.values()))
         return res_pos.asset, res_pos.reserve_token_price
 
-    def get_all_trades(self) -> Iterable[TradeExecution]:
+    def get_all_trades(self, include_suppressed=False) -> Iterable[TradeExecution]:
         """Iterate through all trades: completed, failed and in progress"""
         pos: TradingPosition
-        for pos in self.get_all_positions():
+        for pos in self.get_all_positions(include_suppressed=include_suppressed):
             for t in pos.trades.values():
                 yield t
 

--- a/tradeexecutor/state/repair.py
+++ b/tradeexecutor/state/repair.py
@@ -31,7 +31,7 @@ from eth_defi.compat import native_datetime_utc_now
 from tradeexecutor.state.portfolio import Portfolio
 from tradeexecutor.state.position import TradingPosition
 from tradeexecutor.state.state import State
-from tradeexecutor.state.trade import TradeExecution, TradeType, TradeStatus
+from tradeexecutor.state.trade import TradeExecution, TradeType, TradeStatus, TradeFlag
 from eth_defi.compat import native_datetime_utc_now
 
 logger = logging.getLogger(__name__)
@@ -39,6 +39,10 @@ logger = logging.getLogger(__name__)
 
 class RepairAborted(Exception):
     """User chose no"""
+
+
+class HypercoreDuplicateSuppressionError(Exception):
+    """A Hypercore duplicate group was not safe to suppress automatically."""
 
 
 @dataclass(slots=True)
@@ -59,6 +63,170 @@ class RepairResult:
 
     #: New trades we made to fix the accounting
     new_trades: List[TradeExecution]
+
+
+@dataclass(slots=True)
+class HypercoreDuplicateSuppressionCandidate:
+    """One safe Hypercore duplicate-clone suppression candidate."""
+
+    vault_address: str
+    vault_name: str
+    survivor_position: TradingPosition
+    clone_position: TradingPosition
+
+
+def _get_hypercore_vault_address(position: TradingPosition) -> str:
+    """Get the canonical vault address for a Hypercore position."""
+
+    return (position.pair.pool_address or position.pair.base.address).lower()
+
+
+def _get_position_expected_usd_equity(position: TradingPosition) -> Decimal:
+    """Get the expected USD equity using the position valuation semantics."""
+
+    value = position.get_value(include_interest=False)
+    return Decimal(str(value))
+
+
+def _validate_hypercore_duplicate_clone_group(
+    positions: list[TradingPosition],
+) -> HypercoreDuplicateSuppressionCandidate:
+    """Validate that a duplicate group is safe to suppress as a later phantom clone."""
+
+    if len(positions) != 2:
+        raise HypercoreDuplicateSuppressionError(
+            f"Expected exactly 2 duplicate positions, got {len(positions)}"
+        )
+
+    survivor_position, clone_position = sorted(positions, key=lambda p: p.position_id)
+    reasons: list[str] = []
+
+    if survivor_position.is_frozen() or clone_position.is_frozen():
+        reasons.append("group contains frozen positions")
+
+    if survivor_position.has_planned_trades() or clone_position.has_planned_trades():
+        reasons.append("group contains planned trades")
+
+    if survivor_position.is_about_to_close() or clone_position.is_about_to_close():
+        reasons.append("group contains positions about to close")
+
+    if survivor_position.loan is not None or clone_position.loan is not None:
+        reasons.append("group contains loan-backed state")
+
+    if survivor_position.is_loan_based() or clone_position.is_loan_based():
+        reasons.append("group contains loan-based positions")
+
+    if clone_position.balance_updates:
+        reasons.append("clone candidate has balance updates")
+
+    if len(clone_position.trades) != 1:
+        reasons.append("clone candidate does not have exactly one trade")
+    else:
+        clone_trade = clone_position.get_first_trade()
+        clone_flags = clone_trade.flags or set()
+        if not clone_trade.is_success():
+            reasons.append("clone candidate opening trade is not successful")
+        if clone_trade.is_sell():
+            reasons.append("clone candidate trade is a sell")
+        if clone_trade.is_failed():
+            reasons.append("clone candidate trade is failed")
+        if clone_trade.is_repair_trade() or clone_trade.trade_type == TradeType.repair:
+            reasons.append("clone candidate trade is a repair trade")
+        if TradeFlag.ignore_open not in clone_flags:
+            reasons.append("clone candidate opening trade lacks ignore_open flag")
+
+    survivor_trade = survivor_position.get_first_trade()
+    clone_trade = clone_position.get_first_trade()
+
+    if survivor_position.pair.pool_address != clone_position.pair.pool_address:
+        reasons.append("pool addresses differ")
+    if survivor_position.pair.base != clone_position.pair.base:
+        reasons.append("base assets differ")
+    if survivor_position.pair.quote != clone_position.pair.quote:
+        reasons.append("quote assets differ")
+    if survivor_trade.reserve_currency != clone_trade.reserve_currency:
+        reasons.append("reserve currencies differ")
+
+    if survivor_position.get_quantity(planned=False) != clone_position.get_quantity(planned=False):
+        reasons.append("current quantities differ")
+    if survivor_position.get_quantity(planned=True) != clone_position.get_quantity(planned=True):
+        reasons.append("planned quantities differ")
+    if survivor_position.last_token_price != clone_position.last_token_price:
+        reasons.append("last_token_price differs")
+    if survivor_position.last_reserve_price != clone_position.last_reserve_price:
+        reasons.append("last_reserve_price differs")
+    if _get_position_expected_usd_equity(survivor_position) != _get_position_expected_usd_equity(clone_position):
+        reasons.append("expected USD equity differs")
+
+    if reasons:
+        raise HypercoreDuplicateSuppressionError(
+            f"Vault {_get_hypercore_vault_address(survivor_position)} "
+            f"positions #{survivor_position.position_id} and #{clone_position.position_id} "
+            f"are not safe to suppress automatically: {', '.join(reasons)}"
+        )
+
+    return HypercoreDuplicateSuppressionCandidate(
+        vault_address=_get_hypercore_vault_address(survivor_position),
+        vault_name=survivor_position.pair.get_vault_name() or survivor_position.pair.get_ticker(),
+        survivor_position=survivor_position,
+        clone_position=clone_position,
+    )
+
+
+def find_hypercore_duplicate_clone_candidates(
+    portfolio: Portfolio,
+) -> tuple[list[HypercoreDuplicateSuppressionCandidate], list[str]]:
+    """Find Hypercore duplicate groups that are safe to suppress as later clones."""
+
+    positions_by_vault: dict[str, list[TradingPosition]] = {}
+    for position in portfolio.get_open_and_frozen_positions():
+        if not position.pair.is_hyperliquid_vault():
+            continue
+        positions_by_vault.setdefault(_get_hypercore_vault_address(position), []).append(position)
+
+    candidates: list[HypercoreDuplicateSuppressionCandidate] = []
+    rejected_groups: list[str] = []
+
+    for positions in positions_by_vault.values():
+        if len(positions) < 2:
+            continue
+        try:
+            candidates.append(_validate_hypercore_duplicate_clone_group(positions))
+        except HypercoreDuplicateSuppressionError as e:
+            rejected_groups.append(str(e))
+
+    return candidates, rejected_groups
+
+
+def suppress_hypercore_duplicate_clone(
+    portfolio: Portfolio,
+    candidate: HypercoreDuplicateSuppressionCandidate,
+    now: datetime.datetime | None = None,
+) -> TradingPosition:
+    """Suppress a later Hypercore duplicate clone from active accounting."""
+
+    now = now or native_datetime_utc_now()
+    survivor_position = candidate.survivor_position
+    clone_position = candidate.clone_position
+
+    clone_position.add_notes_message(
+        f"Suppressed as duplicate clone of position #{survivor_position.position_id} "
+        f"during Hypercore duplicate repair ({now.isoformat()})"
+    )
+    survivor_position.add_notes_message(
+        f"Suppressed duplicate position #{clone_position.position_id} during Hypercore duplicate repair "
+        f"({now.isoformat()})"
+    )
+    clone_position.other_data["suppressed_duplicate_survivor_position_id"] = survivor_position.position_id
+    portfolio.suppress_duplicate_position(clone_position, now)
+    logger.info(
+        "Suppressed Hypercore duplicate clone position #%d and kept survivor #%d for vault %s at %s",
+        clone_position.position_id,
+        survivor_position.position_id,
+        candidate.vault_name,
+        candidate.vault_address,
+    )
+    return clone_position
 
 
 def make_counter_trade(portfolio: Portfolio, p: TradingPosition, t: TradeExecution) -> TradeExecution:

--- a/tradeexecutor/state/repair.py
+++ b/tradeexecutor/state/repair.py
@@ -198,35 +198,75 @@ def find_hypercore_duplicate_clone_candidates(
     return candidates, rejected_groups
 
 
-def suppress_hypercore_duplicate_clone(
+def close_hypercore_duplicate_clone(
     portfolio: Portfolio,
     candidate: HypercoreDuplicateSuppressionCandidate,
     now: datetime.datetime | None = None,
-) -> TradingPosition:
-    """Suppress a later Hypercore duplicate clone from active accounting."""
+) -> TradeExecution:
+    """Close a later Hypercore duplicate clone with a flagged repair trade."""
 
     now = now or native_datetime_utc_now()
     survivor_position = candidate.survivor_position
     clone_position = candidate.clone_position
-
-    clone_position.add_notes_message(
-        f"Suppressed as duplicate clone of position #{survivor_position.position_id} "
+    opening_trade = clone_position.get_first_trade()
+    note = (
+        f"Closed as duplicate Hypercore clone of position #{survivor_position.position_id} "
         f"during Hypercore duplicate repair ({now.isoformat()})"
     )
-    survivor_position.add_notes_message(
-        f"Suppressed duplicate position #{clone_position.position_id} during Hypercore duplicate repair "
-        f"({now.isoformat()})"
+
+    position, counter_trade, created = portfolio.create_trade(
+        strategy_cycle_at=opening_trade.strategy_cycle_at,
+        pair=clone_position.pair,
+        quantity=Decimal(0),
+        assumed_price=opening_trade.planned_price,
+        trade_type=TradeType.repair,
+        reserve_currency=opening_trade.reserve_currency,
+        planned_mid_price=opening_trade.planned_mid_price,
+        price_structure=opening_trade.price_structure,
+        reserve=None,
+        reserve_currency_price=opening_trade.get_reserve_currency_exchange_rate(),
+        position=clone_position,
     )
-    clone_position.other_data["suppressed_duplicate_survivor_position_id"] = survivor_position.position_id
-    portfolio.suppress_duplicate_position(clone_position, now)
+    counter_trade.started_at = now
+    assert created is False
+    assert position == clone_position
+
+    counter_trade.flags = (counter_trade.flags or set()) | {
+        TradeFlag.close,
+        TradeFlag.hypercore_duplicate_close,
+    }
+    counter_trade.mark_success(
+        now,
+        opening_trade.planned_price,
+        Decimal(0),
+        Decimal(0),
+        0,
+        opening_trade.native_token_price,
+        force=True,
+    )
+    assert counter_trade.is_success()
+
+    counter_trade.repaired_trade_id = opening_trade.trade_id
+    opening_trade.add_note(
+        f"Closed duplicate Hypercore clone at {now.strftime('%Y-%m-%d %H:%M')}, by #{counter_trade.trade_id}"
+    )
+    counter_trade.add_note(note)
+    clone_position.add_notes_message(note)
+    survivor_position.add_notes_message(
+        f"Kept canonical Hypercore position while closing duplicate clone position "
+        f"#{clone_position.position_id} ({now.isoformat()})"
+    )
+    clone_position.other_data["closed_duplicate_survivor_position_id"] = survivor_position.position_id
+    portfolio.close_position(clone_position, now)
     logger.info(
-        "Suppressed Hypercore duplicate clone position #%d and kept survivor #%d for vault %s at %s",
+        "Closed Hypercore duplicate clone position #%d with repair trade #%d and kept survivor #%d for vault %s at %s",
         clone_position.position_id,
+        counter_trade.trade_id,
         survivor_position.position_id,
         candidate.vault_name,
         candidate.vault_address,
     )
-    return clone_position
+    return counter_trade
 
 
 def make_counter_trade(portfolio: Portfolio, p: TradingPosition, t: TradeExecution) -> TradeExecution:

--- a/tradeexecutor/state/repair.py
+++ b/tradeexecutor/state/repair.py
@@ -41,8 +41,8 @@ class RepairAborted(Exception):
     """User chose no"""
 
 
-class HypercoreDuplicateSuppressionError(Exception):
-    """A Hypercore duplicate group was not safe to suppress automatically."""
+class HypercoreDuplicateCloseError(Exception):
+    """A Hypercore duplicate group was not safe to close automatically."""
 
 
 @dataclass(slots=True)
@@ -66,8 +66,8 @@ class RepairResult:
 
 
 @dataclass(slots=True)
-class HypercoreDuplicateSuppressionCandidate:
-    """One safe Hypercore duplicate-clone suppression candidate."""
+class HypercoreDuplicateCloseCandidate:
+    """One safe Hypercore duplicate-clone close candidate."""
 
     vault_address: str
     vault_name: str
@@ -90,11 +90,11 @@ def _get_position_expected_usd_equity(position: TradingPosition) -> Decimal:
 
 def _validate_hypercore_duplicate_clone_group(
     positions: list[TradingPosition],
-) -> HypercoreDuplicateSuppressionCandidate:
-    """Validate that a duplicate group is safe to suppress as a later phantom clone."""
+) -> HypercoreDuplicateCloseCandidate:
+    """Validate that a duplicate group is safe to close as a later phantom clone."""
 
     if len(positions) != 2:
-        raise HypercoreDuplicateSuppressionError(
+        raise HypercoreDuplicateCloseError(
             f"Expected exactly 2 duplicate positions, got {len(positions)}"
         )
 
@@ -159,13 +159,13 @@ def _validate_hypercore_duplicate_clone_group(
         reasons.append("expected USD equity differs")
 
     if reasons:
-        raise HypercoreDuplicateSuppressionError(
+        raise HypercoreDuplicateCloseError(
             f"Vault {_get_hypercore_vault_address(survivor_position)} "
             f"positions #{survivor_position.position_id} and #{clone_position.position_id} "
-            f"are not safe to suppress automatically: {', '.join(reasons)}"
+            f"are not safe to close automatically: {', '.join(reasons)}"
         )
 
-    return HypercoreDuplicateSuppressionCandidate(
+    return HypercoreDuplicateCloseCandidate(
         vault_address=_get_hypercore_vault_address(survivor_position),
         vault_name=survivor_position.pair.get_vault_name() or survivor_position.pair.get_ticker(),
         survivor_position=survivor_position,
@@ -173,10 +173,10 @@ def _validate_hypercore_duplicate_clone_group(
     )
 
 
-def find_hypercore_duplicate_clone_candidates(
+def find_hypercore_duplicate_close_candidates(
     portfolio: Portfolio,
-) -> tuple[list[HypercoreDuplicateSuppressionCandidate], list[str]]:
-    """Find Hypercore duplicate groups that are safe to suppress as later clones."""
+) -> tuple[list[HypercoreDuplicateCloseCandidate], list[str]]:
+    """Find Hypercore duplicate groups that are safe to close as later clones."""
 
     positions_by_vault: dict[str, list[TradingPosition]] = {}
     for position in portfolio.get_open_and_frozen_positions():
@@ -184,7 +184,7 @@ def find_hypercore_duplicate_clone_candidates(
             continue
         positions_by_vault.setdefault(_get_hypercore_vault_address(position), []).append(position)
 
-    candidates: list[HypercoreDuplicateSuppressionCandidate] = []
+    candidates: list[HypercoreDuplicateCloseCandidate] = []
     rejected_groups: list[str] = []
 
     for positions in positions_by_vault.values():
@@ -192,7 +192,7 @@ def find_hypercore_duplicate_clone_candidates(
             continue
         try:
             candidates.append(_validate_hypercore_duplicate_clone_group(positions))
-        except HypercoreDuplicateSuppressionError as e:
+        except HypercoreDuplicateCloseError as e:
             rejected_groups.append(str(e))
 
     return candidates, rejected_groups
@@ -200,7 +200,7 @@ def find_hypercore_duplicate_clone_candidates(
 
 def close_hypercore_duplicate_clone(
     portfolio: Portfolio,
-    candidate: HypercoreDuplicateSuppressionCandidate,
+    candidate: HypercoreDuplicateCloseCandidate,
     now: datetime.datetime | None = None,
 ) -> TradeExecution:
     """Close a later Hypercore duplicate clone with a flagged repair trade."""

--- a/tradeexecutor/state/trade.py
+++ b/tradeexecutor/state/trade.py
@@ -148,6 +148,12 @@ class TradeFlag(enum.Enum):
     #:
     partial_take_profit = "partial_take_profit"
 
+    #: This repair trade closes a later phantom Hypercore duplicate clone.
+    #:
+    #: Used by the Hypercore duplicate repair CLI to distinguish a synthetic
+    #: duplicate-clone close from dust closes and other repair flows.
+    hypercore_duplicate_close = "hypercore_duplicate_close"
+
     #: If there is an existing open position, do not try to match the trade for an open position.
     #:
     #: We trade by pair. If in same cycle we close and open position for the same pair, the trade


### PR DESCRIPTION
## Why

`repair-hypercore-dust` could already clean residual Hypercore dust, but operators still got stuck when the state contained a later phantom duplicate clone for the same vault. We needed a narrow repair path for that case that stays transactional, demands explicit operator confirmation, and leaves a clear audit trail about what was closed and why.

## Lessons learnt

The review feedback was useful here. Quantity matching alone was too weak for Hypercore, and the earlier suppressed-bucket approach added complexity we did not need. The final design keeps the stricter safety gate, but records the duplicate clone as a normal closed position with a dedicated repair flag and matching notes on both the trade and the position so the close remains explicit and auditable.

## Summary

- add `--merge-dustless-duplicates` to `repair-hypercore-dust` for the narrow later-clone close case
- keep the operation transactional so the state file is only saved after the full pass succeeds
- require explicit per-group confirmation and reject `--auto-approve` for duplicate-clone closes
- add a dedicated `TradeFlag.hypercore_duplicate_close` so these synthetic closes are explicit in state and analytics
- close safe later duplicate clones with a flagged repair trade and matching notes on both the trade and the position
- add Hypercore duplicate-clone discovery helpers with strict safety checks around expected USD equity, valuation fields, trade flags, and clone cleanliness
- extend helper and CLI regression coverage for safe closes, rejection cases, mixed dust-plus-clone runs, and no-partial-save behaviour