### PR TITLE
fix: re-check Hypercore withdrawal eligibility at execution time

### DIFF
--- a/tests/hyperliquid/test_hypercore_activation_cost.py
+++ b/tests/hyperliquid/test_hypercore_activation_cost.py
@@ -6,8 +6,14 @@ Verifies that:
 3. Settlement reads the per-trade value, not a stale instance variable.
 """
 
+import datetime
 from decimal import Decimal
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
+
+import pytest
+from eth_defi.compat import native_datetime_utc_now
+from eth_defi.hyperliquid.api import UserVaultEquity
 
 from tradeexecutor.ethereum.vault.hypercore_routing import (
     compute_spot_to_evm_withdrawal_amount,
@@ -263,11 +269,17 @@ def test_create_sell_transactions_build_vault_withdraw_phase1_only():
     # 1. Create one sell trade for live Hypercore routing with no close flag.
     # 2. Mock the reusable vault-withdraw builder and signing.
     # 3. Verify routing returns exactly one phase-1 withdrawal transaction.
-    with patch("tradeexecutor.ethereum.vault.hypercore_routing.build_hypercore_withdraw_from_vault_call", return_value=withdraw_fn) as build_withdraw:
-        with patch.object(routing, "_sign_module_call", return_value=signed_tx) as sign_call:
-            txs = routing._create_deposit_or_withdraw_txs(trade)
+    with patch.object(routing, "_check_live_withdrawal_preconditions") as preflight_check:
+        with patch("tradeexecutor.ethereum.vault.hypercore_routing.build_hypercore_withdraw_from_vault_call", return_value=withdraw_fn) as build_withdraw:
+            with patch.object(routing, "_sign_module_call", return_value=signed_tx) as sign_call:
+                txs = routing._create_deposit_or_withdraw_txs(trade)
 
     assert txs == [signed_tx]
+    preflight_check.assert_called_once_with(
+        trade=trade,
+        requested_raw=25_000_000,
+        vault_address="0x1111111111111111111111111111111111111111",
+    )
     build_withdraw.assert_called_once_with(
         routing.lagoon_vault,
         vault_address="0x1111111111111111111111111111111111111111",
@@ -290,8 +302,6 @@ def test_withdrawal_uses_live_equity_on_close():
     3. Verify the withdrawal tx is built with live equity minus safety margin.
     4. Verify the safe amount is stored in ``trade.other_data`` for settlement.
     """
-    import datetime
-    from eth_defi.hyperliquid.api import UserVaultEquity
     from tradeexecutor.state.trade import TradeFlag
     from tradeexecutor.ethereum.vault.hypercore_routing import HYPERCORE_WITHDRAWAL_SAFETY_MARGIN_RAW
 
@@ -313,11 +323,17 @@ def test_withdrawal_uses_live_equity_on_close():
 
     # 2. Mock the equity fetch and tx building.
     with patch("tradeexecutor.ethereum.vault.hypercore_routing.fetch_user_vault_equity", return_value=live_equity):
-        with patch("tradeexecutor.ethereum.vault.hypercore_routing.build_hypercore_withdraw_from_vault_call", return_value=withdraw_fn) as build_withdraw:
-            with patch.object(routing, "_sign_module_call", return_value=signed_tx):
-                txs = routing._create_deposit_or_withdraw_txs(trade)
+        with patch.object(routing, "_check_live_withdrawal_preconditions") as preflight_check:
+            with patch("tradeexecutor.ethereum.vault.hypercore_routing.build_hypercore_withdraw_from_vault_call", return_value=withdraw_fn) as build_withdraw:
+                with patch.object(routing, "_sign_module_call", return_value=signed_tx):
+                    txs = routing._create_deposit_or_withdraw_txs(trade)
 
     assert txs == [signed_tx]
+    preflight_check.assert_called_once_with(
+        trade=trade,
+        requested_raw=expected_withdrawal_raw,
+        vault_address="0x4dec0a851849056e259128464ef28ce78afa27f6",
+    )
 
     # 3. Verify the withdrawal uses live equity minus safety margin.
     build_withdraw.assert_called_once_with(
@@ -338,8 +354,6 @@ def test_withdrawal_logs_large_equity_mismatch_but_uses_live_amount(caplog):
     3. Verify the withdrawal still uses live equity minus safety margin.
     4. Verify the warning is logged so the operator can inspect the drift.
     """
-    import datetime
-    from eth_defi.hyperliquid.api import UserVaultEquity
     from tradeexecutor.state.trade import TradeFlag
     from tradeexecutor.ethereum.vault.hypercore_routing import HYPERCORE_WITHDRAWAL_SAFETY_MARGIN_RAW
 
@@ -361,12 +375,18 @@ def test_withdrawal_logs_large_equity_mismatch_but_uses_live_amount(caplog):
     # Step 2: Mock the live equity so the drift warning path is exercised.
     with caplog.at_level("WARNING"):
         with patch("tradeexecutor.ethereum.vault.hypercore_routing.fetch_user_vault_equity", return_value=live_equity):
-            with patch("tradeexecutor.ethereum.vault.hypercore_routing.build_hypercore_withdraw_from_vault_call", return_value=withdraw_fn) as build_withdraw:
-                with patch.object(routing, "_sign_module_call", return_value=signed_tx):
-                    txs = routing._create_deposit_or_withdraw_txs(trade)
+            with patch.object(routing, "_check_live_withdrawal_preconditions") as preflight_check:
+                with patch("tradeexecutor.ethereum.vault.hypercore_routing.build_hypercore_withdraw_from_vault_call", return_value=withdraw_fn) as build_withdraw:
+                    with patch.object(routing, "_sign_module_call", return_value=signed_tx):
+                        txs = routing._create_deposit_or_withdraw_txs(trade)
 
     # Step 3: Verify the withdrawal still uses live equity minus safety margin.
     assert txs == [signed_tx]
+    preflight_check.assert_called_once_with(
+        trade=trade,
+        requested_raw=expected_withdrawal_raw,
+        vault_address="0x1111111111111111111111111111111111111111",
+    )
     build_withdraw.assert_called_once_with(
         routing.lagoon_vault,
         vault_address="0x1111111111111111111111111111111111111111",
@@ -376,6 +396,74 @@ def test_withdrawal_logs_large_equity_mismatch_but_uses_live_amount(caplog):
 
     # Step 4: Verify the warning is logged so the operator can inspect the drift.
     assert any("planned/live drift is large" in record.message for record in caplog.records)
+
+
+def test_live_withdrawal_preflight_blocks_active_lockup():
+    """Live withdrawal preflight must block users still inside lock-up.
+
+    1. Create one live Hypercore sell trade and keep the requested withdrawal below the vault liquidity cap.
+    2. Mock Hyperliquid to report an active user lock-up for the Safe.
+    3. Verify the preflight raises before any withdrawal can be broadcast.
+    """
+    from tradeexecutor.ethereum.vault.hypercore_routing import HypercoreWithdrawalPreflightError
+
+    routing = _make_routing(simulate=False)
+    trade = _make_trade(planned_reserve=Decimal("25.0"), is_buy=False)
+
+    locked_equity = UserVaultEquity(
+        vault_address="0xVAULT",
+        equity=Decimal("50.0"),
+        locked_until=native_datetime_utc_now() + datetime.timedelta(hours=6),
+    )
+
+    # 1. Create one live Hypercore sell trade and keep the request below the liquidity cap.
+    # 2. Mock Hyperliquid to report an active user lock-up.
+    # 3. Verify the preflight raises before broadcast.
+    with patch("tradeexecutor.ethereum.vault.hypercore_routing.HyperliquidVault.fetch_info", return_value=SimpleNamespace(max_withdrawable=Decimal("100.0"))):
+        with patch("tradeexecutor.ethereum.vault.hypercore_routing.fetch_user_vault_equity", return_value=locked_equity):
+            with patch.object(routing, "_get_session", return_value=routing._session):
+                with pytest.raises(HypercoreWithdrawalPreflightError) as exc_info:
+                    routing._check_live_withdrawal_preconditions(
+                        trade=trade,
+                        requested_raw=25_000_000,
+                        vault_address="0xVAULT",
+                    )
+
+    assert "lock-up remains active" in str(exc_info.value)
+
+
+def test_live_withdrawal_preflight_blocks_requests_above_max_withdrawable():
+    """Live withdrawal preflight must block requests above current withdrawable liquidity.
+
+    1. Create one live Hypercore sell trade whose requested amount exceeds the vault liquidity cap.
+    2. Mock Hyperliquid to report an expired lock-up and a smaller ``max_withdrawable``.
+    3. Verify the preflight raises before any withdrawal can be broadcast.
+    """
+    from tradeexecutor.ethereum.vault.hypercore_routing import HypercoreWithdrawalPreflightError
+
+    routing = _make_routing(simulate=False)
+    trade = _make_trade(planned_reserve=Decimal("25.0"), is_buy=False)
+
+    unlocked_equity = UserVaultEquity(
+        vault_address="0xVAULT",
+        equity=Decimal("50.0"),
+        locked_until=native_datetime_utc_now() - datetime.timedelta(days=1),
+    )
+
+    # 1. Create one live Hypercore sell trade whose request exceeds max_withdrawable.
+    # 2. Mock Hyperliquid to report unlocked equity but insufficient vault liquidity.
+    # 3. Verify the preflight raises before broadcast.
+    with patch("tradeexecutor.ethereum.vault.hypercore_routing.HyperliquidVault.fetch_info", return_value=SimpleNamespace(max_withdrawable=Decimal("20.0"))):
+        with patch("tradeexecutor.ethereum.vault.hypercore_routing.fetch_user_vault_equity", return_value=unlocked_equity):
+            with patch.object(routing, "_get_session", return_value=routing._session):
+                with pytest.raises(HypercoreWithdrawalPreflightError) as exc_info:
+                    routing._check_live_withdrawal_preconditions(
+                        trade=trade,
+                        requested_raw=25_000_000,
+                        vault_address="0xVAULT",
+                    )
+
+    assert "exceeds current max_withdrawable" in str(exc_info.value)
 
 
 @patch("tradeexecutor.ethereum.vault.hypercore_routing.report_failure")

--- a/tradeexecutor/ethereum/vault/hypercore_routing.py
+++ b/tradeexecutor/ethereum/vault/hypercore_routing.py
@@ -78,6 +78,7 @@ from eth_defi.hyperliquid.session import (
     HyperliquidSession,
     create_hyperliquid_session,
 )
+from eth_defi.hyperliquid.vault import HyperliquidVault
 
 from tradeexecutor.ethereum.swap import report_failure
 from tradeexecutor.state.blockhain_transaction import (
@@ -130,15 +131,15 @@ HYPERCORE_LIKELY_CLOSE_TOLERANCE = 0.975
 #: action, the vault NAV can fluctuate (fees, PnL, mark-to-market).  The
 #: API may also round the equity string upward vs. the on-chain value.
 #:
-#: $1.00 (1 000 000 raw) covers larger observed drift for volatile vaults.
+#: $1.50 (1 500 000 raw) covers larger observed drift for volatile vaults.
 #: The original $0.01 margin was too tight, and even the later $0.10 margin
 #: proved insufficient for some live withdrawals when vault share price moved
 #: between the API read and HyperCore processing the queued action.
 #:
-#: This will leave up to ~$1.00 unclaimable dust in the vault (below the $5
+#: This will leave up to ~$1.50 unclaimable dust in the vault (below the $5
 #: minimum vault withdrawal threshold) that must be cleaned up in
 #: accounting later.
-HYPERCORE_WITHDRAWAL_SAFETY_MARGIN_RAW = 1_000_000
+HYPERCORE_WITHDRAWAL_SAFETY_MARGIN_RAW = 1_500_000
 
 # Temporary stop-gap for follow-up withdrawal verification phases.
 # Proper fix: carry the actually observed amount from one phase to the next.
@@ -171,6 +172,10 @@ class HypercoreWithdrawalVerificationError(Exception):
     (``vaultTransfer``, ``transferUsdClass``, ``spotSend``) fail silently
     on HyperCore, or when the HyperCore-to-EVM bridge is delayed or dry.
     """
+
+
+class HypercoreWithdrawalPreflightError(Exception):
+    """Raised when a live Hypercore withdrawal is blocked before broadcast."""
 
 
 class HypercoreVaultRoutingState(RoutingState):
@@ -501,7 +506,7 @@ class HypercoreVaultRouting(RoutingModel):
         #    actual equity — even by 1 raw USDC.  The vault NAV fluctuates
         #    due to fees, PnL, and mark-to-market during the ~2-5 s between
         #    reading the API and HyperCore processing the queued action.
-        #    This leaves ~$0.01 unclaimable dust in the vault that must be
+        #    This leaves ~$1.50 unclaimable dust in the vault that must be
         #    cleaned up in accounting later.
         safe_raw = live_raw - HYPERCORE_WITHDRAWAL_SAFETY_MARGIN_RAW
         assert safe_raw > 0, (
@@ -525,6 +530,66 @@ class HypercoreVaultRouting(RoutingModel):
         trade.other_data["hypercore_capped_withdrawal_raw"] = safe_raw
 
         return safe_raw
+
+    def _check_live_withdrawal_preconditions(
+        self,
+        trade: TradeExecution,
+        requested_raw: int,
+        vault_address: str,
+    ) -> None:
+        """Check live Hypercore withdrawal eligibility before broadcasting.
+
+        HyperCore withdrawals can be blocked by per-user lock-up periods and
+        per-vault liquidity constraints. The strategy model already checks
+        these when planning trades, but the state can change before the live
+        execution phase, so re-check right before building phase 1.
+        """
+        session = self._get_session()
+        vault = HyperliquidVault(session=session, vault_address=vault_address)
+        vault_info = vault.fetch_info(user=self.safe_address)
+        max_withdrawable_raw = usdc_to_raw(vault_info.max_withdrawable)
+
+        if vault_info.max_withdrawable <= 0:
+            raise HypercoreWithdrawalPreflightError(
+                f"Hypercore withdrawal blocked for Safe {self.safe_address} in vault {vault_address}: "
+                "vault reports zero max_withdrawable liquidity."
+            )
+
+        user_equity = fetch_user_vault_equity(
+            session,
+            user=self.safe_address,
+            vault_address=vault_address,
+            bypass_cache=True,
+        )
+        if user_equity is None:
+            raise HypercoreWithdrawalPreflightError(
+                f"Hypercore withdrawal blocked for Safe {self.safe_address} in vault {vault_address}: "
+                "user equity lookup returned no position data."
+            )
+
+        if not user_equity.is_lockup_expired:
+            raise HypercoreWithdrawalPreflightError(
+                f"Hypercore withdrawal blocked for Safe {self.safe_address} in vault {vault_address}: "
+                f"user lock-up remains active until {user_equity.locked_until} "
+                f"({user_equity.lockup_remaining} remaining)."
+            )
+
+        if requested_raw > max_withdrawable_raw:
+            raise HypercoreWithdrawalPreflightError(
+                f"Hypercore withdrawal blocked for Safe {self.safe_address} in vault {vault_address}: "
+                f"requested {raw_to_usdc(requested_raw)} USDC exceeds current max_withdrawable "
+                f"{vault_info.max_withdrawable} USDC."
+            )
+
+        logger.info(
+            "Hypercore withdrawal preflight ok for Safe %s in vault %s: "
+            "requested %s USDC, max_withdrawable %s USDC, lock-up expired at %s",
+            self.safe_address,
+            vault_address,
+            raw_to_usdc(requested_raw),
+            vault_info.max_withdrawable,
+            user_equity.locked_until,
+        )
 
     def _fetch_safe_evm_usdc_balance(self) -> int:
         """Read the Safe's EVM USDC balance (raw, 6 decimals).
@@ -941,6 +1006,12 @@ class HypercoreVaultRouting(RoutingModel):
             if TradeFlag.close in trade.flags and not self.simulate:
                 raw_amount = self._get_live_withdrawal_amount_for_close(
                     trade, raw_amount, vault_address,
+                )
+            if not self.simulate:
+                self._check_live_withdrawal_preconditions(
+                    trade=trade,
+                    requested_raw=raw_amount,
+                    vault_address=vault_address,
                 )
 
             logger.info(


### PR DESCRIPTION
## Why

HyperCore withdrawal eligibility can change between strategy planning and live execution. We already check lock-up and `max_withdrawable` when planning trades, but the live withdrawal builder did not re-check them before broadcasting `vaultTransfer`.

This left a gap where HyperCore could silently ignore a withdrawal that was no longer allowed or no longer liquid enough by execution time.

## Lessons learnt

- HyperCore planning-time redemption checks are not enough on their own; the live withdrawal path needs its own preflight guard.
- A slightly larger withdrawal dust margin is safer than letting `vaultTransfer` hit live NAV drift and silently no-op.

## Summary

- Add an execution-time HyperCore withdrawal preflight that re-checks user lock-up expiry and current `max_withdrawable` before broadcasting phase 1.
- Raise the close withdrawal safety margin from `1.0` to `1.5` USDC and align the inline comments with the real dust left behind.
- Extend the focused HyperCore routing tests to cover the new preflight guard and the updated withdrawal build path.
