### PR TITLE
fix: tighten vault history freshness cache and warning semantics

### DIFF
--- a/tests/ethereum/test_vault_history_diagnostics.py
+++ b/tests/ethereum/test_vault_history_diagnostics.py
@@ -410,8 +410,95 @@ def test_vault_history_logging_keeps_summary_before_per_vault_stale_entries(
     assert "Vault history freshness summary" in relevant_records[0].message
     assert relevant_records[1].levelname == "WARNING"
     assert (
-        "Vault candle data is stale (>24h after 1d resampling floor) for 1 vault(s); "
+        "Vault candle data is stale (>24h after source-history check) for 1 vault(s); "
         "1 vault(s) are up to date"
     ) in relevant_records[1].message
     assert "\nvault" in relevant_records[1].message
     assert "MirVault" in relevant_records[1].message
+
+
+def test_log_stale_vault_candle_data_ignores_daily_floor_when_source_is_fresh(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Verify fresh per-vault source history suppresses false stale daily-candle warnings.
+
+    1. Build a daily resampled vault candle that looks older than 24 hours after midnight.
+    2. Attach fresher filtered source history for the same vault on the previous UTC day.
+    3. Assert no stale-vault warning is emitted because the source history is still fresh.
+    """
+    vault_candle_df = pd.DataFrame(
+        {
+            "pair_id": [272079929],
+            "timestamp": [pd.Timestamp(datetime.datetime(2026, 4, 13, 0, 0, 0))],
+        }
+    )
+    source_vault_price_df = _build_vault_price_history_df(
+        "0x10aa8b767d0742de206bfafe36b8556634379c39",
+        [datetime.datetime(2026, 4, 13, 21, 22, 4, 28000)],
+    )
+    vault_pairs_df = pd.DataFrame(
+        {
+            "pair_id": [272079929],
+            "exchange_name": ["MirVault"],
+            "address": ["0x10aa8b767d0742de206bfafe36b8556634379c39"],
+            "token_metadata": [SimpleNamespace(tvl=80_107.73)],
+        }
+    )
+
+    # 1. Build a daily resampled vault candle that looks older than 24 hours after midnight.
+    # 2. Attach fresher filtered source history for the same vault on the previous UTC day.
+    with caplog.at_level("INFO"):
+        log_stale_vault_candle_data(
+            vault_candle_df=vault_candle_df,
+            vault_pairs_df=vault_pairs_df,
+            source_vault_price_df=source_vault_price_df,
+            now=datetime.datetime(2026, 4, 14, 1, 21, 40),
+        )
+
+    # 3. Assert no stale-vault warning is emitted because the source history is still fresh.
+    assert not any("Vault candle data is stale" in record.message for record in caplog.records)
+
+
+def test_log_stale_vault_candle_data_warns_when_source_history_is_stale(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Verify stale per-vault source history still triggers the aggregated warning.
+
+    1. Build a daily resampled vault candle and matching source history that are both older than 24 hours.
+    2. Emit the aggregated stale-vault warning with the source history attached.
+    3. Assert the warning is logged and includes the stale source timestamp column.
+    """
+    vault_candle_df = pd.DataFrame(
+        {
+            "pair_id": [272079929],
+            "timestamp": [pd.Timestamp(datetime.datetime(2026, 4, 12, 0, 0, 0))],
+        }
+    )
+    source_vault_price_df = _build_vault_price_history_df(
+        "0x10aa8b767d0742de206bfafe36b8556634379c39",
+        [datetime.datetime(2026, 4, 12, 2, 0, 0)],
+    )
+    vault_pairs_df = pd.DataFrame(
+        {
+            "pair_id": [272079929],
+            "exchange_name": ["MirVault"],
+            "address": ["0x10aa8b767d0742de206bfafe36b8556634379c39"],
+            "token_metadata": [SimpleNamespace(tvl=80_107.73)],
+        }
+    )
+
+    # 1. Build a daily resampled vault candle and matching source history that are both older than 24 hours.
+    # 2. Emit the aggregated stale-vault warning with the source history attached.
+    with caplog.at_level("INFO"):
+        log_stale_vault_candle_data(
+            vault_candle_df=vault_candle_df,
+            vault_pairs_df=vault_pairs_df,
+            source_vault_price_df=source_vault_price_df,
+            now=datetime.datetime(2026, 4, 14, 12, 0, 0),
+        )
+
+    # 3. Assert the warning is logged and includes the stale source timestamp column.
+    warning_record = next(record for record in caplog.records if "Vault candle data is stale" in record.message)
+    assert warning_record.levelname == "WARNING"
+    assert "last_source" in warning_record.message
+    assert "2026-04-12 02:00:00" in warning_record.message

--- a/tradeexecutor/ethereum/vault/checks.py
+++ b/tradeexecutor/ethereum/vault/checks.py
@@ -405,6 +405,7 @@ def _build_vault_history_warning_rows(
 def log_stale_vault_candle_data(
     vault_candle_df: pd.DataFrame | None,
     vault_pairs_df: pd.DataFrame,
+    source_vault_price_df: pd.DataFrame | None = None,
     now: datetime.datetime | None = None,
     stale_tolerance: datetime.timedelta = datetime.timedelta(hours=24),
 ) -> None:
@@ -415,6 +416,28 @@ def log_stale_vault_candle_data(
     reference_now = pd.Timestamp(now or native_datetime_utc_now())
     stale_entries = []
     checked_vault_count = 0
+    source_max_timestamp_by_pair_id: dict[int, pd.Timestamp] = {}
+
+    if (
+        source_vault_price_df is not None
+        and len(source_vault_price_df) > 0
+        and "timestamp" in source_vault_price_df.columns
+        and "address" in source_vault_price_df.columns
+        and "pair_id" in vault_pairs_df.columns
+        and "address" in vault_pairs_df.columns
+    ):
+        pair_lookup = vault_pairs_df[["pair_id", "address"]].copy()
+        pair_lookup["address"] = pair_lookup["address"].astype(str).str.lower()
+
+        source_with_pairs = source_vault_price_df.copy()
+        source_with_pairs["address"] = source_with_pairs["address"].astype(str).str.lower()
+        source_with_pairs["timestamp"] = pd.to_datetime(source_with_pairs["timestamp"])
+        source_with_pairs = source_with_pairs.merge(pair_lookup, on="address", how="inner")
+
+        if len(source_with_pairs) > 0:
+            source_max_timestamp_by_pair_id = (
+                source_with_pairs.groupby("pair_id")["timestamp"].max().to_dict()
+            )
 
     for pair_id in vault_candle_df["pair_id"].unique():
         pair_candles = vault_candle_df[vault_candle_df["pair_id"] == pair_id]
@@ -423,7 +446,9 @@ def log_stale_vault_candle_data(
 
         checked_vault_count += 1
         last_ts = pair_candles["timestamp"].max()
-        age = reference_now - last_ts
+        last_source_ts = source_max_timestamp_by_pair_id.get(pair_id)
+        reference_ts = last_source_ts if last_source_ts is not None else last_ts
+        age = reference_now - reference_ts
         if age <= pd.Timedelta(stale_tolerance):
             continue
 
@@ -443,6 +468,7 @@ def log_stale_vault_candle_data(
                 "tvl": vault_tvl,
                 "pair_id": pair_id,
                 "last_candle": last_ts,
+                "last_source": last_source_ts,
                 "age": age,
             }
         )
@@ -457,7 +483,7 @@ def log_stale_vault_candle_data(
             showindex=False,
         )
         logger.warning(
-            "Vault candle data is stale (>24h after 1d resampling floor) for %d vault(s); %d vault(s) are up to date:\n%s",
+            "Vault candle data is stale (>24h after source-history check) for %d vault(s); %d vault(s) are up to date:\n%s",
             len(stale_entries),
             up_to_date_vault_count,
             stale_entries_table,

--- a/tradeexecutor/strategy/trading_strategy_universe.py
+++ b/tradeexecutor/strategy/trading_strategy_universe.py
@@ -2927,6 +2927,7 @@ def load_partial_data(
                 log_stale_vault_candle_data(
                     vault_candle_df=vault_candle_df,
                     vault_pairs_df=vault_pairs_df,
+                    source_vault_price_df=filtered_website_vault_prices_df,
                 )
 
         # Collect some debug data for the first 5 pairs


### PR DESCRIPTION
## Why

Trade Executor was still redownloading the cleaned vault price history parquet once the local cache aged past 24 hours even when the remote file had not changed. In addition, live `d1` startup diagnostics could log every vault as stale shortly after midnight UTC even when the underlying vault source history was only a few hours old.

The cache fix lives in `trading-strategy`, so this repository needs to point at the updated dependency commit. On top of that, the per-vault warning in Trade Executor needs to inspect filtered source timestamps instead of only the floored daily candle timestamps.

Depends on tradingstrategy-ai/trading-strategy#231.

## Lessons learnt

For large remote artefacts, cache age alone is not a good enough invalidation signal. A cheap `HEAD` metadata check in the shared client avoids repeated 150 MB downloads while still allowing safe refreshes when the remote object changes.

Vault source freshness and visible daily-candle freshness are also different signals. After `1d` resampling, a candle timestamp can be floored to `00:00 UTC` while its value still comes from much fresher intraday source rows, so warning logic must distinguish those two cases.

## Summary

- bump `deps/trading-strategy` to the commit that adds `HEAD`-based vault history cache validation
- pull in sidecar metadata storage for `ETag`, `Last-Modified`, and `Content-Length`
- add focused tests for unchanged-cache reuse and changed-remote redownload behaviour
- make the per-vault live startup warning prefer filtered source-history timestamps over floored `d1` candle timestamps when source data is available
- add regression coverage for the post-midnight false-positive warning case and for genuinely stale source-history rows
