### PR TITLE
Fix vault stale logging when source history already has pair ids

### DIFF
--- a/tests/ethereum/test_vault_history_diagnostics.py
+++ b/tests/ethereum/test_vault_history_diagnostics.py
@@ -459,6 +459,51 @@ def test_log_stale_vault_candle_data_ignores_daily_floor_when_source_is_fresh(
     assert not any("Vault candle data is stale" in record.message for record in caplog.records)
 
 
+def test_log_stale_vault_candle_data_handles_source_history_with_existing_pair_id(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Verify stale-vault logging handles source history that already carries pair ids.
+
+    1. Build fresh source history and run candle conversion that mutates the source frame to include ``pair_id``.
+    2. Call ``log_stale_vault_candle_data()`` with the mutated source history and a daily candle timestamp.
+    3. Assert the logging path does not raise and still suppresses the stale warning for fresh source data.
+    """
+    vault_candle_df = pd.DataFrame(
+        {
+            "pair_id": [272079929],
+            "timestamp": [pd.Timestamp(datetime.datetime(2026, 4, 13, 0, 0, 0))],
+        }
+    )
+    source_vault_price_df = _build_vault_price_history_df(
+        "0x10aa8b767d0742de206bfafe36b8556634379c39",
+        [datetime.datetime(2026, 4, 13, 21, 22, 4, 28000)],
+    )
+    vault_pairs_df = pd.DataFrame(
+        {
+            "pair_id": [272079929],
+            "exchange_name": ["MirVault"],
+            "address": ["0x10aa8b767d0742de206bfafe36b8556634379c39"],
+            "token_metadata": [SimpleNamespace(tvl=80_107.73)],
+        }
+    )
+
+    # 1. Build fresh source history and mutate it through candle conversion.
+    convert_vault_prices_to_candles(source_vault_price_df, "1d")
+    assert "pair_id" in source_vault_price_df.columns
+
+    # 2. Call the stale-vault logger with the mutated source history.
+    with caplog.at_level("INFO"):
+        log_stale_vault_candle_data(
+            vault_candle_df=vault_candle_df,
+            vault_pairs_df=vault_pairs_df,
+            source_vault_price_df=source_vault_price_df,
+            now=datetime.datetime(2026, 4, 14, 1, 21, 40),
+        )
+
+    # 3. Assert the fresh source history still suppresses the stale warning.
+    assert not any("Vault candle data is stale" in record.message for record in caplog.records)
+
+
 def test_log_stale_vault_candle_data_warns_when_source_history_is_stale(
     caplog: pytest.LogCaptureFixture,
 ) -> None:

--- a/tradeexecutor/ethereum/vault/checks.py
+++ b/tradeexecutor/ethereum/vault/checks.py
@@ -426,17 +426,39 @@ def log_stale_vault_candle_data(
         and "pair_id" in vault_pairs_df.columns
         and "address" in vault_pairs_df.columns
     ):
-        pair_lookup = vault_pairs_df[["pair_id", "address"]].copy()
-        pair_lookup["address"] = pair_lookup["address"].astype(str).str.lower()
-
         source_with_pairs = source_vault_price_df.copy()
         source_with_pairs["address"] = source_with_pairs["address"].astype(str).str.lower()
         source_with_pairs["timestamp"] = pd.to_datetime(source_with_pairs["timestamp"])
-        source_with_pairs = source_with_pairs.merge(pair_lookup, on="address", how="inner")
 
-        if len(source_with_pairs) > 0:
+        pair_id_column = "pair_id" if "pair_id" in source_with_pairs.columns else None
+
+        if pair_id_column is None:
+            merge_columns = ["address"]
+            pair_lookup = vault_pairs_df[["pair_id", "address"]].copy()
+
+            if "chain" in source_with_pairs.columns and "chain_id" in vault_pairs_df.columns:
+                merge_columns = ["chain", "address"]
+                pair_lookup = vault_pairs_df[["pair_id", "chain_id", "address"]].copy()
+                pair_lookup = pair_lookup.rename(columns={"chain_id": "chain"})
+                pair_lookup["chain"] = pd.to_numeric(pair_lookup["chain"], errors="coerce")
+                source_with_pairs["chain"] = pd.to_numeric(source_with_pairs["chain"], errors="coerce")
+
+            pair_lookup["address"] = pair_lookup["address"].astype(str).str.lower()
+            source_with_pairs = source_with_pairs.merge(
+                pair_lookup,
+                on=merge_columns,
+                how="inner",
+                suffixes=("", "_lookup"),
+            )
+
+            if "pair_id" in source_with_pairs.columns:
+                pair_id_column = "pair_id"
+            elif "pair_id_lookup" in source_with_pairs.columns:
+                pair_id_column = "pair_id_lookup"
+
+        if len(source_with_pairs) > 0 and pair_id_column is not None:
             source_max_timestamp_by_pair_id = (
-                source_with_pairs.groupby("pair_id")["timestamp"].max().to_dict()
+                source_with_pairs.groupby(pair_id_column)["timestamp"].max().to_dict()
             )
 
     for pair_id in vault_candle_df["pair_id"].unique():


### PR DESCRIPTION
## Why
The live startup diagnostics for vault history can crash before the strategy finishes warming up. When the source vault history DataFrame has already been mutated to include `pair_id`, the stale-data logger can merge in a second `pair_id` column and then fail when it tries to group by a column name that no longer exists.

## Lessons learnt
The vault price conversion helper mutates its input DataFrame in place, so downstream diagnostics need to tolerate both pre-conversion and post-conversion source-history shapes.

## Summary
- make `log_stale_vault_candle_data()` use an existing source `pair_id` when present
- prefer exact `chain` + `address` matching when deriving pair ids from vault metadata
- add a regression test covering the mutated source-history case that was crashing live startup
- keep the existing fresh-source suppression behaviour for daily resampling diagnostics
