### PR TITLE
Fix Hypercore live rebalance sell sizing

### DIFF
--- a/tests/hyperliquid/test_close_position_hypercore.py
+++ b/tests/hyperliquid/test_close_position_hypercore.py
@@ -24,6 +24,7 @@ from tradeexecutor.ethereum.multichain_balance import (
 from tradeexecutor.ethereum.vault.hypercore_vault import (
     HLP_VAULT_ADDRESS,
     create_hypercore_vault_pair,
+    create_hypercore_vault_value_func,
 )
 from tradeexecutor.state.identifier import AssetIdentifier, TradingPairIdentifier
 from tradeexecutor.state.state import State
@@ -246,6 +247,44 @@ def test_fetch_onchain_balances_multichain_handles_none_equity(
     assert len(results) == 1
     assert results[0].amount == Decimal(0)
     assert results[0].asset == hypercore_vault_pair.base
+
+
+def test_create_hypercore_value_func_can_bypass_cache(
+    monkeypatch: pytest.MonkeyPatch,
+    hypercore_vault_pair: TradingPairIdentifier,
+) -> None:
+    """Verify live Hypercore valuation can force a fresh equity lookup.
+
+    1. Create a Hypercore value function with bypass_cache enabled.
+    2. Mock fetch_user_vault_equity and capture the bypass_cache argument.
+    3. Assert the generated value function requests a fresh lookup and returns the live equity.
+    """
+    calls: list[bool] = []
+
+    # 1. Create a Hypercore value function with bypass_cache enabled.
+    def mock_fetch_user_vault_equity(session, user, vault_address, bypass_cache=False):
+        # 2. Mock fetch_user_vault_equity and capture the bypass_cache argument.
+        calls.append(bypass_cache)
+        return UserVaultEquity(
+            vault_address=vault_address,
+            equity=Decimal("42"),
+            locked_until=datetime.datetime(2026, 3, 25),
+        )
+
+    monkeypatch.setattr(
+        "tradeexecutor.ethereum.vault.hypercore_vault.fetch_user_vault_equity",
+        mock_fetch_user_vault_equity,
+    )
+
+    value_func = create_hypercore_vault_value_func(
+        session=MagicMock(),
+        safe_address=FAKE_SAFE_ADDRESS,
+        bypass_cache=True,
+    )
+
+    # 3. Assert the generated value function requests a fresh lookup and returns the live equity.
+    assert value_func(hypercore_vault_pair) == Decimal("42")
+    assert calls == [True]
 
 
 def test_fetch_onchain_balances_multichain_routes_erc20(

--- a/tests/test_rebalance.py
+++ b/tests/test_rebalance.py
@@ -17,6 +17,10 @@ from tradeexecutor.backtest.backtest_execution import BacktestExecution
 from tradeexecutor.backtest.backtest_pricing import BacktestPricing
 from tradeexecutor.backtest.backtest_routing import BacktestRoutingModel, BacktestRoutingState
 from tradeexecutor.backtest.simulated_wallet import SimulatedWallet
+from tradeexecutor.ethereum.vault.hypercore_vault import (
+    HLP_VAULT_ADDRESS,
+    create_hypercore_vault_pair,
+)
 from tradeexecutor.state.size_risk import SizeRisk
 from tradeexecutor.state.state import State, TradeType
 from tradeexecutor.state.portfolio import Portfolio
@@ -29,7 +33,7 @@ from tradeexecutor.state.types import USDollarPrice, USDollarAmount
 from tradeexecutor.strategy import size_risk_model
 from tradeexecutor.strategy.alpha_model import AlphaModel, TradingPairSignalFlags
 from tradeexecutor.strategy.fixed_size_risk import FixedSizeRiskModel
-from tradeexecutor.strategy.pandas_trader.position_manager import PositionManager
+from tradeexecutor.strategy.pandas_trader.position_manager import NotEnoughCasForBuys, PositionManager
 from tradeexecutor.strategy.pandas_trader.rebalance import get_existing_portfolio_weights, rebalance_portfolio_old, \
     get_weight_diffs
 from tradeexecutor.strategy.redemption import (
@@ -37,6 +41,7 @@ from tradeexecutor.strategy.redemption import (
     RedemptionCheckResult,
     RedemptionCheckStage,
 )
+from tradeexecutor.strategy.trade_pricing import TradePricing
 from tradeexecutor.strategy.weighting import BadWeightsException, clip_to_normalised, weight_passthrouh
 from tradeexecutor.strategy.trading_strategy_universe import TradingStrategyUniverse, create_pair_universe_from_code
 from tradeexecutor.testing.synthetic_ethereum_data import generate_random_ethereum_address
@@ -1825,6 +1830,273 @@ def test_alpha_model_skips_sell_rebalance_for_non_redeemable_position(
     assert len(signal.redemption_check_results) == 1
     assert signal.redemption_check_results[0].stage == RedemptionCheckStage.sell_rebalance
     assert signal.redemption_check_results[0].reason_code == RedemptionBlockReason.user_lockup_not_expired
+
+
+def _create_hypercore_position_for_rebalance_test(
+    state: State,
+    start_ts: datetime.datetime,
+    usdc: AssetIdentifier,
+) -> TradingPairIdentifier:
+    """Create one open Hypercore vault position for alpha-model rebalance tests."""
+    pair = create_hypercore_vault_pair(
+        quote=usdc,
+        vault_address=HLP_VAULT_ADDRESS["mainnet"],
+        internal_id=101,
+    )
+
+    state.portfolio.initialise_reserves(usdc, reserve_token_price=1.0)
+
+    position, trade, _created = state.create_trade(
+        strategy_cycle_at=start_ts,
+        pair=pair,
+        quantity=None,
+        reserve=Decimal(50),
+        assumed_price=1.0,
+        trade_type=TradeType.rebalance,
+        reserve_currency=usdc,
+        reserve_currency_price=1.0,
+        notes="Test Hypercore vault position",
+    )
+    trade.mark_success(
+        executed_at=start_ts,
+        executed_price=1.0,
+        executed_quantity=Decimal(50),
+        executed_reserve=Decimal(50),
+        lp_fees=0,
+        native_token_price=0,
+        force=True,
+    )
+    position.last_token_price = 2.0
+    position.last_reserve_price = 1.0
+    position.last_pricing_at = start_ts
+    return pair
+
+
+def _patch_hypercore_pricing(
+    monkeypatch: pytest.MonkeyPatch,
+    pricing_model: BacktestPricing,
+    hypercore_vault_pair: TradingPairIdentifier,
+) -> None:
+    """Patch Hypercore pricing calls to stay deterministic in unit tests."""
+    original_get_mid_price = pricing_model.get_mid_price
+    original_get_sell_price = pricing_model.get_sell_price
+
+    monkeypatch.setattr(
+        pricing_model,
+        "get_mid_price",
+        lambda ts, pair: 1.0 if pair == hypercore_vault_pair else original_get_mid_price(ts, pair),
+    )
+    monkeypatch.setattr(
+        pricing_model,
+        "get_sell_price",
+        lambda ts, pair, quantity: (
+            TradePricing(price=1.0, mid_price=1.0, lp_fee=[0.0], pair_fee=[0.0])
+            if pair == hypercore_vault_pair
+            else original_get_sell_price(ts, pair, quantity)
+        ),
+    )
+
+
+def test_alpha_model_caps_profitable_hypercore_sell_before_trade_generation(
+    start_ts: datetime.datetime,
+    strategy_universe: TradingStrategyUniverse,
+    pricing_model: BacktestPricing,
+    usdc: AssetIdentifier,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Check Hypercore sell sizing uses live position price and capped quantity before trade creation.
+
+    1. Create a profitable Hypercore position whose marked value is above its stored quantity.
+    2. Cap redemption below the requested sell so the alpha model must recompute the effective sell.
+    3. Verify the signal stores the capped marked-value delta, while the sell trade stores the smaller released cash amount.
+    """
+    state = State()
+    hypercore_vault_pair = _create_hypercore_position_for_rebalance_test(state, start_ts, usdc)
+
+    # 1. Create a profitable Hypercore position whose marked value is above its stored quantity.
+    position_manager = PositionManager(
+        start_ts + datetime.timedelta(days=1),
+        strategy_universe.data_universe,
+        state,
+        pricing_model,
+    )
+    _patch_hypercore_pricing(monkeypatch, pricing_model, hypercore_vault_pair)
+    monkeypatch.setattr(
+        pricing_model,
+        "check_redemption",
+        lambda ts, pair, **kwargs: RedemptionCheckResult(
+            timestamp=ts,
+            stage=kwargs["stage"],
+            can_redeem=True,
+            pair_ticker=pair.get_ticker(),
+            vault_address=pair.pool_address,
+            safe_address="0x0000000000000000000000000000000000000abc",
+            max_withdrawable=10.0,
+            max_redemption=10.0,
+            message="Hypercore sell is partially redeemable",
+        ),
+    )
+
+    alpha_model = AlphaModel(timestamp=position_manager.timestamp)
+    alpha_model.set_signal(hypercore_vault_pair, 1.0)
+    alpha_model.select_top_signals(count=5)
+    alpha_model.assign_weights(method=weight_passthrouh)
+    alpha_model.normalise_weights(max_weight=1.0)
+    alpha_model.update_old_weights(state.portfolio, ignore_credit=False)
+    alpha_model.calculate_target_positions(position_manager, investable_equity=20.0)
+
+    # 2. Cap redemption below the requested sell so the alpha model must recompute the effective sell.
+    trades = alpha_model.generate_rebalance_trades_and_triggers(
+        position_manager,
+        min_trade_threshold=0.01,
+        individual_rebalance_min_threshold=0.01,
+        sell_rebalance_min_threshold=0.01,
+    )
+
+    signal = alpha_model.get_signal_by_pair(hypercore_vault_pair)
+    assert signal is not None
+
+    # 3. Verify the signal stores the capped marked-value delta, while the sell trade stores the smaller released cash amount.
+    assert signal.position_adjust_usd == pytest.approx(-20.0)
+    assert signal.position_adjust_quantity == pytest.approx(-10.0)
+    assert len(trades) == 1
+    assert trades[0].is_sell()
+    assert trades[0].planned_quantity == Decimal("-10")
+    assert trades[0].planned_reserve == Decimal("10")
+
+
+def test_alpha_model_skips_hypercore_sell_below_threshold_after_capping(
+    start_ts: datetime.datetime,
+    strategy_universe: TradingStrategyUniverse,
+    pricing_model: BacktestPricing,
+    usdc: AssetIdentifier,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Check Hypercore sell thresholds are evaluated after the live redemption cap is applied.
+
+    1. Create a profitable Hypercore position whose requested marked-value reduction is large.
+    2. Cap the redeemable quantity so the effective sell becomes smaller than the sell threshold.
+    3. Verify the alpha model skips the trade instead of emitting a dust Hypercore withdrawal.
+    """
+    state = State()
+    hypercore_vault_pair = _create_hypercore_position_for_rebalance_test(state, start_ts, usdc)
+
+    # 1. Create a profitable Hypercore position whose requested marked-value reduction is large.
+    position_manager = PositionManager(
+        start_ts + datetime.timedelta(days=1),
+        strategy_universe.data_universe,
+        state,
+        pricing_model,
+    )
+    _patch_hypercore_pricing(monkeypatch, pricing_model, hypercore_vault_pair)
+    monkeypatch.setattr(
+        pricing_model,
+        "check_redemption",
+        lambda ts, pair, **kwargs: RedemptionCheckResult(
+            timestamp=ts,
+            stage=kwargs["stage"],
+            can_redeem=True,
+            pair_ticker=pair.get_ticker(),
+            vault_address=pair.pool_address,
+            safe_address="0x0000000000000000000000000000000000000abc",
+            max_withdrawable=2.0,
+            max_redemption=2.0,
+            message="Hypercore sell is capped to dust size",
+        ),
+    )
+
+    alpha_model = AlphaModel(timestamp=position_manager.timestamp)
+    alpha_model.set_signal(hypercore_vault_pair, 1.0)
+    alpha_model.select_top_signals(count=5)
+    alpha_model.assign_weights(method=weight_passthrouh)
+    alpha_model.normalise_weights(max_weight=1.0)
+    alpha_model.update_old_weights(state.portfolio, ignore_credit=False)
+    alpha_model.calculate_target_positions(position_manager, investable_equity=20.0)
+
+    # 2. Cap the redeemable quantity so the effective sell becomes smaller than the sell threshold.
+    trades = alpha_model.generate_rebalance_trades_and_triggers(
+        position_manager,
+        min_trade_threshold=0.01,
+        individual_rebalance_min_threshold=5.0,
+        sell_rebalance_min_threshold=5.0,
+    )
+
+    signal = alpha_model.get_signal_by_pair(hypercore_vault_pair)
+    assert signal is not None
+
+    # 3. Verify the alpha model skips the trade instead of emitting a dust Hypercore withdrawal.
+    assert trades == []
+    assert signal.position_adjust_usd == pytest.approx(-4.0)
+    assert signal.position_adjust_quantity == pytest.approx(-2.0)
+    assert TradingPairSignalFlags.individual_trade_size_too_small in signal.flags
+
+
+def test_alpha_model_uses_capped_hypercore_cash_release_for_buy_checks(
+    start_ts: datetime.datetime,
+    strategy_universe: TradingStrategyUniverse,
+    pricing_model: BacktestPricing,
+    aave_usdc: TradingPairIdentifier,
+    usdc: AssetIdentifier,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Check same-cycle cash planning uses capped Hypercore cash release, not marked value reduction.
+
+    1. Create a profitable Hypercore position and a second buy signal competing for the released cash.
+    2. Cap the Hypercore sell so its released cash is smaller than the buy that follows in the same cycle.
+    3. Verify check_enough_cash() fails against the capped planned reserve instead of the larger marked-value reduction.
+    """
+    state = State()
+    hypercore_vault_pair = _create_hypercore_position_for_rebalance_test(state, start_ts, usdc)
+
+    # 1. Create a profitable Hypercore position and a second buy signal competing for the released cash.
+    position_manager = PositionManager(
+        start_ts + datetime.timedelta(days=1),
+        strategy_universe.data_universe,
+        state,
+        pricing_model,
+    )
+    _patch_hypercore_pricing(monkeypatch, pricing_model, hypercore_vault_pair)
+    monkeypatch.setattr(
+        pricing_model,
+        "check_redemption",
+        lambda ts, pair, **kwargs: RedemptionCheckResult(
+            timestamp=ts,
+            stage=kwargs["stage"],
+            can_redeem=True,
+            pair_ticker=pair.get_ticker(),
+            vault_address=pair.pool_address,
+            safe_address="0x0000000000000000000000000000000000000abc",
+            max_withdrawable=10.0,
+            max_redemption=10.0,
+            message="Hypercore sell is partially redeemable",
+        ),
+    )
+
+    alpha_model = AlphaModel(timestamp=position_manager.timestamp)
+    alpha_model.set_signal(hypercore_vault_pair, 2.0)
+    alpha_model.set_signal(aave_usdc, 1.0)
+    alpha_model.select_top_signals(count=5)
+    alpha_model.assign_weights(method=weight_passthrouh)
+    alpha_model.normalise_weights(max_weight=1.0)
+    alpha_model.update_old_weights(state.portfolio, ignore_credit=False)
+    alpha_model.calculate_target_positions(position_manager, investable_equity=45.0)
+
+    # 2. Cap the Hypercore sell so its released cash is smaller than the buy that follows in the same cycle.
+    trades = alpha_model.generate_rebalance_trades_and_triggers(
+        position_manager,
+        min_trade_threshold=0.01,
+        individual_rebalance_min_threshold=0.01,
+        sell_rebalance_min_threshold=0.01,
+    )
+
+    hypercore_sell = next(t for t in trades if t.pair == hypercore_vault_pair)
+    aave_buy = next(t for t in trades if t.pair == aave_usdc)
+
+    # 3. Verify check_enough_cash() fails against the capped planned reserve instead of the larger marked-value reduction.
+    assert hypercore_sell.planned_reserve == Decimal("10")
+    assert aave_buy.planned_reserve == Decimal("15")
+    with pytest.raises(NotEnoughCasForBuys):
+        position_manager.check_enough_cash(trades)
 
 
 def test_generic_pricing_delegates_check_redemption_with_diagnostics(

--- a/tradeexecutor/ethereum/ethereum_protocol_adapters.py
+++ b/tradeexecutor/ethereum/ethereum_protocol_adapters.py
@@ -876,7 +876,10 @@ class EthereumPairConfigurator(PairConfigurator):
             # cannot be created. Pricing will fall back to candle data.
             logger.info("Hypercore vault value func not available (no vault in tx_builder, hot wallet mode?)")
             return
-        self.hypercore_vault_value_func = create_hypercore_vault_value_func(self.execution_model)
+        self.hypercore_vault_value_func = create_hypercore_vault_value_func(
+            self.execution_model,
+            bypass_cache=True,
+        )
         self.hypercore_vault_lockup_func = create_hypercore_vault_lockup_func(self.execution_model)
         logger.info("Auto-discovered Hypercore vault pairs — wired up Hypercore value func")
 

--- a/tradeexecutor/ethereum/vault/hypercore_vault.py
+++ b/tradeexecutor/ethereum/vault/hypercore_vault.py
@@ -209,11 +209,12 @@ def create_hypercore_vault_value_func(
     session=None,
     safe_address: str | None = None,
     is_testnet: bool = False,
+    bypass_cache: bool = False,
 ) -> Callable[[TradingPairIdentifier], Decimal]:
     """Create Hypercore vault account value function.
 
     The returned function queries the Hyperliquid info API for the
-    user's vault equity position using the cached
+    user's vault equity position using
     :py:func:`~eth_defi.hyperliquid.api.fetch_user_vault_equity`,
     returning the USDC equity for the specific vault address stored
     in ``pair.pool_address``.
@@ -233,6 +234,10 @@ def create_hypercore_vault_value_func(
 
     :param is_testnet:
         Whether to use testnet API URL (only used when creating session lazily).
+
+    :param bypass_cache:
+        Force fresh Hyperliquid equity lookups instead of the default session cache.
+        Used in live trading so that rebalance calculations see up-to-date vault equity.
 
     :return:
         Function that takes a TradingPairIdentifier and returns
@@ -274,6 +279,7 @@ def create_hypercore_vault_value_func(
                 session,
                 user=safe_address,
                 vault_address=vault_address,
+                bypass_cache=bypass_cache,
             )
 
             if eq is not None:

--- a/tradeexecutor/exchange_account/allocation.py
+++ b/tradeexecutor/exchange_account/allocation.py
@@ -90,7 +90,9 @@ def get_redeemable_capital(
 
     For normal positions, assume the full marked value is redeemable.
     For Hyperliquid vaults, return zero until the known lock-up window has
-    expired for the latest capital inflow.
+    expired for the latest capital inflow. Once unlocked, return the actual
+    cash that could be released by redeeming the position, not the marked
+    position value.
 
     :param position:
         Position whose currently redeemable marked value is being estimated.
@@ -100,7 +102,7 @@ def get_redeemable_capital(
         current naive UTC time when omitted.
 
     :return:
-        Redeemable marked value in US dollars for the given cycle.
+        Redeemable cash amount in US dollars for the given cycle.
     """
 
     if timestamp is None:
@@ -112,6 +114,9 @@ def get_redeemable_capital(
     unlock_at = get_latest_capital_inflow_at(position) + get_redemption_delay(position)
     if timestamp < unlock_at:
         return 0.0
+
+    if hasattr(position, "get_available_trading_quantity"):
+        return float(position.get_available_trading_quantity())
 
     return position.get_value()
 

--- a/tradeexecutor/strategy/alpha_model.py
+++ b/tradeexecutor/strategy/alpha_model.py
@@ -21,7 +21,7 @@ from tradeexecutor.state.types import (LeverageMultiplier, PairInternalId,
                                        Percent, USDollarAmount)
 from tradeexecutor.strategy.execution_context import ExecutionContext
 from tradeexecutor.strategy.pandas_trader.position_manager import \
-    PositionManager
+    HypercorePositionReductionPlan, PositionManager
 from tradeexecutor.strategy.redemption import (
     RedemptionCheckResult,
     RedemptionCheckStage,
@@ -1656,12 +1656,17 @@ class AlphaModel:
                 s.position_adjust_usd = s.position_target - s.old_value
 
                 if s.position_adjust_usd < 0:
-                    # Decreasing positions by selling the token
-                    # A lot of options here how to go about this.
-                    # We might get some minor position size skew here because fees not included
-                    # for these transactions
-                    s.position_adjust_quantity = position_manager.estimate_asset_quantity(s.pair, s.position_adjust_usd)
-                    assert type(s.position_adjust_quantity) == float
+                    if s.pair.is_hyperliquid_vault():
+                        # Hypercore sell quantity is derived later from the fresh
+                        # position valuation and live redeemable amount.
+                        s.position_adjust_quantity = 0.0
+                    else:
+                        # Decreasing positions by selling the token
+                        # A lot of options here how to go about this.
+                        # We might get some minor position size skew here because fees not included
+                        # for these transactions
+                        s.position_adjust_quantity = position_manager.estimate_asset_quantity(s.pair, s.position_adjust_usd)
+                        assert type(s.position_adjust_quantity) == float
 
     def map_pair_for_signal(
         self,
@@ -1714,6 +1719,10 @@ class AlphaModel:
             logger.warning("Does not generate trades for a pair with frozen positions: %s", signal.pair)
             return True
 
+        if signal.position_adjust_usd == 0:
+            signal.position_adjust_ignored = True
+            return True
+
         if individual_rebalance_min_threshold:
             trade_size = abs(signal.position_adjust_usd)
             if signal.position_adjust_usd < 0:
@@ -1728,12 +1737,73 @@ class AlphaModel:
 
         return False
 
+    def _prepare_hypercore_sell_signals(
+        self,
+        position_manager: PositionManager,
+    ) -> tuple[
+        dict[int, TradingPosition | None],
+        dict[int, RedemptionCheckResult],
+        dict[int, HypercorePositionReductionPlan],
+    ]:
+        """Refresh Hypercore sell signals before thresholds and cash checks."""
+        current_positions: dict[int, TradingPosition | None] = {}
+        redemption_results: dict[int, RedemptionCheckResult] = {}
+        reduction_plans: dict[int, HypercorePositionReductionPlan] = {}
+
+        for signal in self.iterate_signals():
+            current_positions[signal.pair.internal_id] = self._get_current_position_for_signal(
+                position_manager,
+                signal,
+            )
+
+        for signal in self.iterate_signals():
+            if not signal.pair.is_hyperliquid_vault():
+                continue
+
+            if signal.position_adjust_usd >= 0:
+                continue
+
+            current_position = current_positions[signal.pair.internal_id]
+            if current_position is None:
+                continue
+
+            redemption_result = self._check_redemption_for_position(
+                position_manager,
+                current_position,
+                stage=RedemptionCheckStage.sell_rebalance,
+            )
+            redemption_results[signal.pair.internal_id] = redemption_result
+
+            if not redemption_result.can_redeem:
+                signal.position_adjust_usd = 0.0
+                signal.position_adjust_quantity = 0.0
+                signal.position_adjust_ignored = True
+                self._mark_signal_cannot_redeem(
+                    signal,
+                    redemption_result,
+                    current_value=current_position.get_value(),
+                )
+                continue
+
+            reduction_plan = position_manager.prepare_hypercore_position_reduction(
+                current_position,
+                signal.position_adjust_usd,
+                redemption_result.max_redemption,
+            )
+            reduction_plans[signal.pair.internal_id] = reduction_plan
+            signal.position_adjust_usd = reduction_plan.effective_marked_value_delta
+            signal.position_adjust_quantity = reduction_plan.effective_quantity_delta
+
+        return current_positions, redemption_results, reduction_plans
+
     def _generate_signal_rebalance_trades(
         self,
         signal: TradingPairSignal,
         position_manager: PositionManager,
         current_position,
         execution_context: ExecutionContext | None,
+        redemption_result: RedemptionCheckResult | None = None,
+        hypercore_reduction_plan: HypercorePositionReductionPlan | None = None,
     ) -> list[TradeExecution]:
         """Generate the concrete rebalance trades for a single signal."""
         position_rebalance_trades = []
@@ -1743,8 +1813,7 @@ class AlphaModel:
         underlying = signal.pair
         synthetic = signal.synthetic_pair
 
-        redemption_result = None
-        if current_position and dollar_diff < 0:
+        if current_position and dollar_diff < 0 and redemption_result is None:
             redemption_result = self._check_redemption_for_position(
                 position_manager,
                 current_position,
@@ -1766,19 +1835,33 @@ class AlphaModel:
 
         if signal.normalised_weight < self.close_position_weight_epsilon:
             if current_position:
-                logger.info("Closing the position fully: %s", current_position)
-                position_rebalance_trades += position_manager.close_position(
-                    current_position,
-                    TradeType.rebalance,
-                    notes=f"Closing position, because the signal weight is below close position weight threshold: {signal}"
+                use_partial_hypercore_close = (
+                    current_position.pair.is_hyperliquid_vault()
+                    and hypercore_reduction_plan is not None
+                    and not hypercore_reduction_plan.treat_as_full_close
                 )
-                signal.position_id = current_position.position_id
-                signal.flags.add(TradingPairSignalFlags.closed)
+                if use_partial_hypercore_close:
+                    logger.info(
+                        "Hypercore close signal capped to a partial reduction because live redemption limits are binding: %s",
+                        current_position,
+                    )
+                else:
+                    logger.info("Closing the position fully: %s", current_position)
+                    position_rebalance_trades += position_manager.close_position(
+                        current_position,
+                        TradeType.rebalance,
+                        notes=f"Closing position, because the signal weight is below close position weight threshold: {signal}"
+                    )
+                    signal.position_id = current_position.position_id
+                    signal.flags.add(TradingPairSignalFlags.closed)
+                    signal.flags.add(TradingPairSignalFlags.close_position_weight_limit)
+                    return position_rebalance_trades
             else:
                 logger.info("Zero signal, but no position to close")
                 signal.position_adjust_ignored = True
+                signal.flags.add(TradingPairSignalFlags.close_position_weight_limit)
+                return position_rebalance_trades
             signal.flags.add(TradingPairSignalFlags.close_position_weight_limit)
-            return position_rebalance_trades
 
         if signal.is_flipping():
             logger.info("Alpha model signal flipping for %s: %s, new strength %f", signal.pair.get_pricing_pair().base.token_symbol, signal.get_flip_label(), signal.signal)
@@ -1922,6 +2005,8 @@ class AlphaModel:
             len(self.signals),
         )
 
+        current_positions, redemption_results, reduction_plans = self._prepare_hypercore_sell_signals(position_manager)
+
         #
         # Would the portfolio value change enough to justify the rebalance.
         # We calculate this by taking the highest adjust,
@@ -1961,7 +2046,7 @@ class AlphaModel:
 
             # Do backtesting record keeping, so that
             # it is later easier to display alpha model thinking
-            current_position = self._get_current_position_for_signal(position_manager, signal)
+            current_position = current_positions.get(signal.pair.internal_id)
 
             logger.info("Rebalancing %s, trading as %s, signal #%d, old position %s, old weight: %f, new weight: %f, size diff: %f USD",
                         underlying.base.token_symbol,
@@ -1971,6 +2056,13 @@ class AlphaModel:
                         signal.old_weight,
                         signal.normalised_weight,
                         dollar_diff)
+
+            if TradingPairSignalFlags.cannot_redeem in signal.flags and signal.position_adjust_usd == 0:
+                logger.info(
+                    "Skipping sell-side rebalance for %s because the position is not redeemable yet",
+                    signal.pair,
+                )
+                continue
 
             if self._should_skip_signal_rebalance(
                 signal,
@@ -1986,6 +2078,8 @@ class AlphaModel:
                 position_manager,
                 current_position,
                 execution_context,
+                redemption_result=redemption_results.get(signal.pair.internal_id),
+                hypercore_reduction_plan=reduction_plans.get(signal.pair.internal_id),
             )
 
             if position_rebalance_trades:

--- a/tradeexecutor/strategy/pandas_trader/position_manager.py
+++ b/tradeexecutor/strategy/pandas_trader/position_manager.py
@@ -2,6 +2,7 @@
 
 import datetime
 import warnings
+from dataclasses import dataclass
 from decimal import Decimal
 from io import StringIO
 from typing import List, Optional, Union, Set, Literal
@@ -26,6 +27,7 @@ from tradeexecutor.state.position import TradingPosition, TriggerPriceUpdate
 from tradeexecutor.state.state import State
 from tradeexecutor.state.trade import TradeType, TradeExecution, TradeFlag, TradeStatus
 from tradeexecutor.state.types import USDollarAmount, Percent, LeverageMultiplier, USDollarPrice
+from tradeexecutor.strategy.dust import get_close_epsilon_for_pair
 from tradeexecutor.strategy.pricing_model import PricingModel
 from tradeexecutor.strategy.trading_strategy_universe import translate_trading_pair, TradingStrategyUniverse
 from tradeexecutor.utils.leverage_calculations import LeverageEstimate
@@ -57,6 +59,22 @@ class NotEnoughCasForBuys(Exception):
 
     See :py:meth:`PositionManager.check_enough_case.
     """
+
+
+@dataclass(slots=True, frozen=True)
+class HypercorePositionReductionPlan:
+    """Describe a live-capped Hypercore sell reduction.
+
+    The plan distinguishes between:
+
+    - marked value reduction, driven by live position valuation
+    - quantity reduction / cash release, driven by Hypercore withdrawal sizing
+    """
+
+    effective_quantity_delta: float
+    effective_marked_value_delta: float
+    redemption_cap_bound: bool
+    treat_as_full_close: bool
 
 
 class PositionManager:
@@ -1547,6 +1565,43 @@ class PositionManager:
         pricing_model = self.pricing_model
         price = pricing_model.get_mid_price(timestamp, pair)
         return float(dollar_amount / price)
+
+    def prepare_hypercore_position_reduction(
+        self,
+        position: TradingPosition,
+        dollar_delta: USDollarAmount,
+        max_redemption: USDollarAmount | None,
+    ) -> HypercorePositionReductionPlan:
+        """Convert a marked-value Hypercore reduction to a live-capped quantity plan."""
+        assert position.pair.is_hyperliquid_vault(), f"Not a Hypercore position: {position}"
+        assert dollar_delta < 0, f"Expected negative Hypercore reduction delta, got {dollar_delta}"
+
+        current_price = Decimal(str(position.get_current_price()))
+        assert current_price > 0, f"Hypercore position price must be positive, got {current_price} for {position}"
+
+        requested_marked_value = abs(Decimal(str(dollar_delta)))
+        requested_quantity = requested_marked_value / current_price
+        available_quantity = position.get_available_trading_quantity()
+
+        effective_quantity = min(requested_quantity, available_quantity)
+        redemption_cap_bound = False
+
+        if max_redemption is not None:
+            max_redeemable_quantity = Decimal(str(max_redemption))
+            if effective_quantity > max_redeemable_quantity:
+                effective_quantity = max_redeemable_quantity
+                redemption_cap_bound = True
+
+        remaining_quantity = max(Decimal(0), available_quantity - effective_quantity)
+        close_epsilon = get_close_epsilon_for_pair(position.pair)
+        treat_as_full_close = not redemption_cap_bound and remaining_quantity <= close_epsilon
+
+        return HypercorePositionReductionPlan(
+            effective_quantity_delta=-float(effective_quantity),
+            effective_marked_value_delta=-float(effective_quantity * current_price),
+            redemption_cap_bound=redemption_cap_bound,
+            treat_as_full_close=treat_as_full_close,
+        )
 
     def update_stop_loss(
         self, position: TradingPosition,


### PR DESCRIPTION
## Why

Hypercore vault positions were being revalued from live equity, but sell-side rebalance sizing could still be derived from stale candle-style pricing. That mismatch could oversize withdrawals, trip Hypercore preflight checks, and overstate same-cycle cash released for follow-up buys.

This change moves Hypercore sell sizing onto fresh live valuation plus live redeemable limits before rebalance thresholds and cash checks are evaluated.

## Lessons learnt

Hypercore vaults need two separate concepts during planning: marked value reduction and actual cash released. The marked exposure change should follow the live position price, while the released cash should still follow the resulting withdrawal quantity at 1:1 USDC.

It also turned out that fixing the issue only in routing is not enough. The alpha-model and cash-planning layers need to see the capped sell size first, otherwise later buys can still assume more released cash than the vault can actually unlock in the same cycle.

## Summary

- bypass the cached Hypercore equity lookup for live valuation refreshes used before rebalance planning
- stop deriving Hypercore sell quantities from generic mid-price estimates in `AlphaModel.calculate_target_positions()`
- add a Hypercore-specific reduction helper in `PositionManager` that converts marked-value sells into live-capped quantities using the current position price and redemption cap
- add an alpha-model pre-pass so capped Hypercore sell sizes feed threshold checks, cycle-level rebalance triggering, and same-cycle cash planning
- keep cap-bound near-full Hypercore exits on the partial reduction path instead of switching to full close
- add focused regression tests for fresh valuation bypass, profitable Hypercore sell capping, threshold-after-capping behaviour, and same-cycle cash planning
