### PR TITLE
fix: refresh Hypercore marks before post-trade account checks

### DIFF
--- a/tests/hyperliquid/test_hypercore_accounting.py
+++ b/tests/hyperliquid/test_hypercore_accounting.py
@@ -39,8 +39,11 @@ from tradeexecutor.strategy.dust import (
     get_close_epsilon_for_pair,
     get_dust_epsilon_for_pair,
     HYPERLIQUID_VAULT_CLOSE_EPSILON,
+    HYPERLIQUID_VAULT_RELATIVE_EPSILON,
     DEFAULT_VAULT_EPSILON,
 )
+from tradeexecutor.strategy.execution_context import unit_test_execution_context
+from tradeexecutor.strategy.runner import StrategyRunner
 from tradeexecutor.strategy.sync_model import OnChainBalance
 
 
@@ -381,8 +384,109 @@ def test_hypercore_account_check_compares_equity_not_quantity() -> None:
     correction = corrections[0]
     assert correction.expected_amount == Decimal("55.767395")
     assert correction.actual_amount == live_equity
+    assert correction.relative_epsilon == HYPERLIQUID_VAULT_RELATIVE_EPSILON
     assert correction.usd_value == 0.0
     assert correction.mismatch is False
+
+
+def test_post_trade_hypercore_revaluation_runs_only_for_open_hypercore_positions() -> None:
+    """Revalue Hypercore positions immediately before post-trade account checks.
+
+    1. Build a minimal runner with one open Hypercore vault position and one non-Hypercore position.
+    2. Run the post-trade Hypercore refresh helper and verify only the Hypercore position is revalued.
+    3. Remove the open Hypercore position and verify the helper skips the extra valuation pass entirely.
+    """
+
+    class DummyRunner(StrategyRunner):
+        """Minimal runner used to exercise post-trade Hypercore revaluation."""
+
+        def pretick_check(self, ts: datetime.datetime, universe) -> None:
+            return None
+
+    # 1. Build a minimal runner with one open Hypercore vault position and one non-Hypercore position.
+    runner = DummyRunner(
+        timed_task_context_manager=MagicMock(),
+        execution_model=MagicMock(),
+        approval_model=MagicMock(),
+        valuation_model_factory=MagicMock(),
+        sync_model=None,
+        pricing_model_factory=MagicMock(),
+        execution_context=unit_test_execution_context,
+    )
+
+    reserve_asset = AssetIdentifier(
+        chain_id=999,
+        address="0xb88339cb7199b77e23db6e890353e22632ba630f",
+        token_symbol="USDC",
+        decimals=6,
+    )
+    hypercore_pair = create_hypercore_vault_pair(
+        quote=reserve_asset,
+        vault_address="0x1111111111111111111111111111111111111111",
+    )
+    spot_pair = TradingPairIdentifier(
+        base=AssetIdentifier(
+            chain_id=1,
+            address="0x0000000000000000000000000000000000000001",
+            token_symbol="WETH",
+            decimals=18,
+        ),
+        quote=AssetIdentifier(
+            chain_id=1,
+            address="0x0000000000000000000000000000000000000002",
+            token_symbol="USDC",
+            decimals=6,
+        ),
+        pool_address="0x0000000000000000000000000000000000000003",
+        exchange_address="0x0000000000000000000000000000000000000004",
+        internal_id=2,
+        internal_exchange_id=2,
+        fee=0.003,
+    )
+
+    hypercore_position = MagicMock()
+    hypercore_position.pair = hypercore_pair
+    spot_position = MagicMock()
+    spot_position.pair = spot_pair
+
+    state = MagicMock()
+    state.portfolio.open_positions = {
+        1: hypercore_position,
+        2: spot_position,
+    }
+    state.portfolio.get_open_and_frozen_positions.return_value = [
+        hypercore_position,
+        spot_position,
+    ]
+
+    valuation_model = MagicMock()
+    universe = MagicMock()
+    runner.setup_routing_context = MagicMock(
+        return_value=MagicMock(valuation_model=valuation_model),
+    )
+
+    # 2. Run the post-trade Hypercore refresh helper and verify only the Hypercore position is revalued.
+    runner._revalue_open_hypercore_positions_before_post_trade_account_check(
+        universe,
+        state,
+    )
+
+    assert valuation_model.call_count == 1
+    assert valuation_model.call_args[0][1] is hypercore_position
+
+    # 3. Remove the open Hypercore position and verify the helper skips the extra valuation pass entirely.
+    valuation_model.reset_mock()
+    runner.setup_routing_context.reset_mock()
+    state.portfolio.open_positions = {2: spot_position}
+    state.portfolio.get_open_and_frozen_positions.return_value = [spot_position]
+
+    runner._revalue_open_hypercore_positions_before_post_trade_account_check(
+        universe,
+        state,
+    )
+
+    valuation_model.assert_not_called()
+    runner.setup_routing_context.assert_not_called()
 
 
 def test_hypercore_dust_position_is_reused_without_planned_close() -> None:

--- a/tests/hyperliquid/test_hypercore_accounting.py
+++ b/tests/hyperliquid/test_hypercore_accounting.py
@@ -394,7 +394,8 @@ def test_post_trade_hypercore_revaluation_runs_only_for_open_hypercore_positions
 
     1. Build a minimal runner with one open Hypercore vault position and one non-Hypercore position.
     2. Run the post-trade Hypercore refresh helper and verify only the Hypercore position is revalued.
-    3. Remove the open Hypercore position and verify the helper skips the extra valuation pass entirely.
+    3. Leave only a frozen Hypercore vault position and verify the helper still performs the refresh.
+    4. Remove all Hypercore positions and verify the helper skips the extra valuation pass entirely.
     """
 
     class DummyRunner(StrategyRunner):
@@ -446,6 +447,8 @@ def test_post_trade_hypercore_revaluation_runs_only_for_open_hypercore_positions
 
     hypercore_position = MagicMock()
     hypercore_position.pair = hypercore_pair
+    frozen_hypercore_position = MagicMock()
+    frozen_hypercore_position.pair = hypercore_pair
     spot_position = MagicMock()
     spot_position.pair = spot_pair
 
@@ -474,10 +477,26 @@ def test_post_trade_hypercore_revaluation_runs_only_for_open_hypercore_positions
     assert valuation_model.call_count == 1
     assert valuation_model.call_args[0][1] is hypercore_position
 
-    # 3. Remove the open Hypercore position and verify the helper skips the extra valuation pass entirely.
+    # 3. Leave only a frozen Hypercore position and verify the helper still refreshes it.
     valuation_model.reset_mock()
     runner.setup_routing_context.reset_mock()
     state.portfolio.open_positions = {2: spot_position}
+    state.portfolio.get_open_and_frozen_positions.return_value = [
+        spot_position,
+        frozen_hypercore_position,
+    ]
+
+    runner._revalue_open_hypercore_positions_before_post_trade_account_check(
+        universe,
+        state,
+    )
+
+    assert valuation_model.call_count == 1
+    assert valuation_model.call_args[0][1] is frozen_hypercore_position
+
+    # 4. Remove all Hypercore positions and verify the helper skips the extra valuation pass entirely.
+    valuation_model.reset_mock()
+    runner.setup_routing_context.reset_mock()
     state.portfolio.get_open_and_frozen_positions.return_value = [spot_position]
 
     runner._revalue_open_hypercore_positions_before_post_trade_account_check(

--- a/tradeexecutor/strategy/dust.py
+++ b/tradeexecutor/strategy/dust.py
@@ -46,9 +46,18 @@ DEFAULT_VAULT_EPSILON = Decimal(10 ** -6)
 HYPERLIQUID_VAULT_CLOSE_EPSILON = Decimal("0.20")
 
 #: Hypercore vault equities fluctuate every block due to active trading
-#: inside the vault, so we allow 100 BPS (1%) relative drift before
-#: flagging a mismatch.
-HYPERLIQUID_VAULT_RELATIVE_EPSILON = 0.01
+#: inside the vault, and live cycles can spend a long time in sequential
+#: settlement before the final accounting read happens.
+#:
+#: This is problematic because even small absolute NAV moves on tiny vault
+#: positions can become multi-percent relative drift by the time we compare the
+#: fresh API equity against our state mark. We now refresh Hypercore marks right
+#: before post-trade checks, but still keep a wider 2% tolerance here because
+#: the live API and the state read are not truly atomic.
+#:
+#: This must stay a compromise, not the main fix: widening the tolerance too
+#: much would hide genuine settlement failures and stale-state bugs.
+HYPERLIQUID_VAULT_RELATIVE_EPSILON = 0.02
 
 
 def get_dust_epsilon_for_pair(pair: TradingPairIdentifier) -> Decimal:
@@ -159,4 +168,3 @@ def get_relative_epsilon_for_pair(pair: TradingPairIdentifier) -> Percent:
     if pair.is_hyperliquid_vault():
         return HYPERLIQUID_VAULT_RELATIVE_EPSILON
     return get_relative_epsilon_for_asset(pair.base)
-

--- a/tradeexecutor/strategy/runner.py
+++ b/tradeexecutor/strategy/runner.py
@@ -703,12 +703,65 @@ class StrategyRunner(abc.ABC):
                     "Auto-closed %d Hypercore dust position(s) before post-trade account checks",
                     len(closed_dust_trades),
                 )
+            self._revalue_open_hypercore_positions_before_post_trade_account_check(
+                universe,
+                state,
+            )
             self.check_accounts(
                 universe,
                 state,
                 end_block=end_block,
                 cycle=cycle,
             )
+
+    def _has_open_hypercore_vault_positions(self, state: State) -> bool:
+        """Check if the portfolio currently has any open Hypercore vault positions."""
+        return any(
+            position.pair.is_hyperliquid_vault()
+            for position in state.portfolio.open_positions.values()
+        )
+
+    def _revalue_open_hypercore_positions_before_post_trade_account_check(
+        self,
+        universe: StrategyExecutionUniverse,
+        state: State,
+    ) -> None:
+        """Refresh Hypercore vault marks right before post-trade accounting checks.
+
+        Hypercore account checks compare a fresh live Hyperliquid API equity
+        reading against the state-side marked value ``quantity * last_token_price``.
+        A long live cycle can execute sequential Hypercore trades for many minutes,
+        so the earlier cycle-start valuation can be stale enough to trip the
+        post-trade accounting guard even when settlement itself succeeded.
+
+        Only run this extra pass when we still have an open Hypercore vault
+        position. This keeps the normal non-Hypercore path untouched and avoids
+        an extra live valuation round on cycles that cannot benefit from it.
+        """
+
+        if not self._has_open_hypercore_vault_positions(state):
+            return
+
+        hypercore_positions = [
+            position
+            for position in state.portfolio.get_open_and_frozen_positions()
+            if position.pair.is_hyperliquid_vault()
+        ]
+
+        if not hypercore_positions:
+            return
+
+        logger.info(
+            "Refreshing %d Hypercore vault position(s) immediately before post-trade account checks",
+            len(hypercore_positions),
+        )
+
+        routing_setup = self.setup_routing_context(universe)
+        valuation_model = routing_setup.valuation_model
+        valuation_timestamp = native_datetime_utc_now()
+
+        for position in hypercore_positions:
+            valuation_model(valuation_timestamp, position)
 
     def tick(
         self,

--- a/tradeexecutor/strategy/runner.py
+++ b/tradeexecutor/strategy/runner.py
@@ -715,10 +715,17 @@ class StrategyRunner(abc.ABC):
             )
 
     def _has_open_hypercore_vault_positions(self, state: State) -> bool:
-        """Check if the portfolio currently has any open Hypercore vault positions."""
+        """Check if the portfolio currently has any live Hypercore vault positions.
+
+        Hypercore account checks cover both open and frozen positions, so the
+        post-trade revaluation guard must mirror that same scope. Otherwise a
+        portfolio that currently has only frozen Hypercore vault positions would
+        skip the refresh and still compare stale state marks against fresh live
+        API equity during account checks.
+        """
         return any(
             position.pair.is_hyperliquid_vault()
-            for position in state.portfolio.open_positions.values()
+            for position in state.portfolio.get_open_and_frozen_positions()
         )
 
     def _revalue_open_hypercore_positions_before_post_trade_account_check(


### PR DESCRIPTION
## Why

Hypercore post-trade account checks compare a fresh live API equity read against the state-side marked value. When a live cycle spends a long time in sequential Hypercore settlement, the cycle-start valuation can become stale enough to trigger false accounting mismatches even though settlement succeeded.

The stale-mark issue needs a direct fix in the post-trade path. We also still need a slightly wider Hypercore relative tolerance because the live API read and the state read are not atomic, especially for small vault positions where modest NAV movement quickly becomes a multi-percent relative drift.

## Lessons learnt

Hypercore accounting is awkward because the protocol exposes live vault equity through an external API, while our state keeps quantity and mark separately. If we compare a fresh API value against an old mark after a long sequential execution window, the accounting guard can flag healthy positions as broken.

This also showed that widening tolerance alone is not enough. A looser threshold can reduce noise, but it should remain a backstop rather than the main fix, otherwise we risk hiding genuine settlement failures.

## Summary

- revalue open Hypercore vault positions immediately before post-trade account checks
- gate the extra revaluation so it only runs when the portfolio still has open Hypercore vault positions
- add comments in the runner explaining why Hypercore needs the extra refresh step
- widen the Hypercore relative accounting tolerance from 1% to 2% and document why the tolerance is still only a compromise
- add focused regression coverage for the Hypercore epsilon and the new post-trade revaluation helper
