### PR TITLE
fix: make getting-started dispatch best effort

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -51,10 +51,12 @@ jobs:
             GIT_COMMIT_MESSAGE=${{ github.event.head_commit.message }}
             GIT_VERSION_HASH=${{ github.sha }}
       - name: Trigger getting-started tests
+        id: getting_started_dispatch
         # If build was successful and this is a release tag, dispatch a trade-executor-released
         # event, which is used as a workflow trigger in getting-started text.yml workflow.
         if: success() && github.event_name == 'push' && contains(github.ref, 'refs/tags/v')
-        uses: peter-evans/repository-dispatch@v3
+        uses: peter-evans/repository-dispatch@v4
+        continue-on-error: true
         with:
           # NOTE: The GETTING_STARTED_DISPATCH PAT will expire on 2026-09-16.
           # Generate a new fine-grained PAT with the following permissions on getting-started repo:
@@ -63,3 +65,6 @@ jobs:
           repository: tradingstrategy-ai/getting-started
           event-type: trade-executor-released
           client-payload: '{"image_tag": "${{ env.RELEASE_VERSION }}", "git_sha": "${{ github.sha }}"}'
+      - name: Warn if getting-started dispatch failed
+        if: steps.getting_started_dispatch.outcome == 'failure'
+        run: echo "::warning::Could not trigger getting-started release tests. Check GETTING_STARTED_DISPATCH secret permissions."


### PR DESCRIPTION
## Why

The release Docker image workflow can fail after a successful image build when the optional downstream `getting-started` repository dispatch token is not accessible. The v1349 release hit this with `Resource not accessible by personal access token`, which made the image workflow red even though the Docker image had already been built and pushed.

## Lessons learnt

Cross-repository dispatch depends on external GitHub token permissions that cannot be repaired from this repository. The Docker release should surface that problem clearly without marking the image build itself as failed.

## Summary

- Upgrade `peter-evans/repository-dispatch` from v3 to v4.
- Make the `getting-started` dispatch step best-effort with `continue-on-error`.
- Emit a GitHub Actions warning when the downstream dispatch cannot be triggered.