### PR TITLE
fix: cap tiny Hypercore withdrawal drift

### DIFF
--- a/scripts/hyper-ai/check-rebalance.py
+++ b/scripts/hyper-ai/check-rebalance.py
@@ -1,0 +1,517 @@
+"""Check the latest Hyper AI rebalance decision against state trades.
+
+Usage::
+
+    source .local-test.env && poetry run python scripts/hyper-ai/check-rebalance.py https://hyper-ai.tradingstrategy.ai/state
+
+The script reads the latest strategy decision message from the state,
+finds trades opened at the same decision timestamp, and compares them with
+the alpha model signal adjustments saved in ``visualisation.discardable_data``.
+"""
+
+import argparse
+import datetime
+import json
+import re
+import sys
+import urllib.request
+from decimal import Decimal, InvalidOperation
+from pathlib import Path
+from typing import Any
+
+from eth_defi.compat import native_datetime_utc_fromtimestamp
+
+
+DECISION_KEYS = {
+    "Cycle",
+    "Rebalanced",
+    "Max position value change",
+    "Rebalance threshold",
+    "Trades decided",
+    "Pairs meeting inclusion criteria",
+    "Candidate signals created",
+    "Selected survivor signals",
+    "Total equity",
+    "Cash",
+    "Redeemable capital",
+    "Locked capital carried forward",
+    "Pending redemptions",
+    "Investable equity",
+    "Accepted investable equity",
+    "Allocated to signals",
+    "Rebalance volume",
+}
+
+
+def timestamp_to_datetime(value: int | float | str | None) -> datetime.datetime | None:
+    """Convert a UNIX timestamp to a naive UTC datetime."""
+    if value is None:
+        return None
+    return native_datetime_utc_fromtimestamp(float(value))
+
+
+def format_time(value: int | float | str | None) -> str:
+    """Format a UNIX timestamp for console output."""
+    dt = timestamp_to_datetime(value)
+    if dt is None:
+        return "-"
+    return dt.strftime("%Y-%m-%d %H:%M:%S UTC")
+
+
+def parse_decimal(value: Any, default: Decimal = Decimal(0)) -> Decimal:
+    """Parse JSON value as Decimal without losing precision for strings."""
+    if value is None:
+        return default
+    if isinstance(value, Decimal):
+        return value
+    try:
+        return Decimal(str(value))
+    except (InvalidOperation, ValueError):
+        return default
+
+
+def parse_number_from_text(value: str | None) -> Decimal | None:
+    """Parse values like '$1,234.56 USD' from decision messages."""
+    if value is None:
+        return None
+    cleaned = value.replace("$", "").replace(",", "").replace("USD", "").strip()
+    cleaned = cleaned.replace("%", "").strip()
+    if not cleaned:
+        return None
+    try:
+        return Decimal(cleaned)
+    except InvalidOperation:
+        return None
+
+
+def load_state(source: str) -> dict[str, Any]:
+    """Load state JSON from a file path or an executor URL."""
+    if source.startswith("http://") or source.startswith("https://"):
+        url = source.rstrip("/")
+        if not url.endswith("/state"):
+            url += "/state"
+        request = urllib.request.Request(
+            url,
+            headers={"User-Agent": "trade-executor-hyper-ai-check/1.0"},
+        )
+        with urllib.request.urlopen(request, timeout=30) as response:
+            return json.loads(response.read().decode("utf-8"))
+
+    return json.loads(Path(source).read_text())
+
+
+def get_position_buckets(state: dict[str, Any]) -> list[tuple[str, dict[str, Any]]]:
+    """Return all portfolio position buckets."""
+    portfolio = state.get("portfolio", {})
+    return [
+        ("open", portfolio.get("open_positions") or {}),
+        ("closed", portfolio.get("closed_positions") or {}),
+        ("frozen", portfolio.get("frozen_positions") or {}),
+    ]
+
+
+def iter_trades(state: dict[str, Any]) -> list[dict[str, Any]]:
+    """Flatten all trades from all position buckets."""
+    trades = []
+    for bucket_name, positions in get_position_buckets(state):
+        for position in positions.values():
+            raw_trades = position.get("trades") or {}
+            position_trades = raw_trades.values() if isinstance(raw_trades, dict) else raw_trades
+            for trade in position_trades:
+                trade["_position_bucket"] = bucket_name
+                trades.append(trade)
+    return trades
+
+
+def get_trade_status(trade: dict[str, Any]) -> str:
+    """Resolve trade status from persisted trade timestamps."""
+    if trade.get("repaired_trade_id"):
+        return "success"
+    if trade.get("repaired_at"):
+        return "repaired"
+    if trade.get("failed_at"):
+        return "failed"
+    if trade.get("executed_at"):
+        return "success"
+    if trade.get("broadcasted_at"):
+        return "broadcasted"
+    if trade.get("started_at"):
+        return "started"
+    if trade.get("expired_at"):
+        return "expired"
+    return "planned"
+
+
+def get_pair_id(pair: dict[str, Any]) -> int | None:
+    """Read a pair internal id."""
+    value = pair.get("internal_id")
+    if value is None:
+        return None
+    return int(value)
+
+
+def get_ticker(pair: dict[str, Any]) -> str:
+    """Format a human-friendly pair ticker."""
+    base = pair.get("base", {}).get("token_symbol") or "?"
+    quote = pair.get("quote", {}).get("token_symbol") or "?"
+    return f"{base}-{quote}"
+
+
+def parse_decision_report(text: str) -> dict[str, str]:
+    """Parse the key-value lines saved by Hyper AI decide_trades()."""
+    data = {}
+    for line in text.splitlines():
+        if ":" not in line:
+            continue
+        key, value = line.split(":", 1)
+        key = key.strip()
+        if key in DECISION_KEYS or key.startswith("Signals with flag"):
+            data[key] = value.strip()
+    return data
+
+
+def get_decision_messages(state: dict[str, Any]) -> list[dict[str, Any]]:
+    """Return strategy decision messages sorted by timestamp."""
+    messages = state.get("visualisation", {}).get("messages") or {}
+    decisions = []
+    for raw_timestamp, values in messages.items():
+        timestamp = int(raw_timestamp)
+        text = "\n".join(values) if isinstance(values, list) else str(values)
+        if "Trades decided:" not in text or "Cycle:" not in text:
+            continue
+        parsed = parse_decision_report(text)
+        cycle = parsed.get("Cycle", "").lstrip("#")
+        decisions.append(
+            {
+                "timestamp": timestamp,
+                "cycle": int(cycle) if cycle.isdigit() else None,
+                "text": text,
+                "data": parsed,
+            }
+        )
+    return sorted(decisions, key=lambda item: item["timestamp"])
+
+
+def get_latest_completed_cycle_time(state: dict[str, Any]) -> tuple[int | None, int | None]:
+    """Return latest completed cycle number and timestamp from uptime data."""
+    cycles = state.get("uptime", {}).get("cycles_completed_at") or {}
+    if not cycles:
+        return None, None
+    latest_cycle = max(int(cycle) for cycle in cycles)
+    return latest_cycle, int(cycles[str(latest_cycle)])
+
+
+def choose_decision(state: dict[str, Any], mode: str) -> dict[str, Any]:
+    """Pick which decision message to analyse."""
+    decisions = get_decision_messages(state)
+    if not decisions:
+        raise RuntimeError("No decision messages found in state.visualisation.messages")
+
+    if mode == "latest":
+        return decisions[-1]
+
+    latest_cycle, completed_at = get_latest_completed_cycle_time(state)
+    if latest_cycle is None or completed_at is None:
+        raise RuntimeError("No completed cycle timestamps found in state.uptime.cycles_completed_at")
+
+    completed_decisions = [
+        decision
+        for decision in decisions
+        if decision["cycle"] == latest_cycle and decision["timestamp"] <= completed_at
+    ]
+    if not completed_decisions:
+        raise RuntimeError(f"No decision message found for latest completed cycle #{latest_cycle}")
+    return completed_decisions[-1]
+
+
+def get_status_counts(trades: list[dict[str, Any]]) -> dict[str, int]:
+    """Count trades by status."""
+    counts = {}
+    for trade in trades:
+        status = get_trade_status(trade)
+        counts[status] = counts.get(status, 0) + 1
+    return counts
+
+
+def get_signal_lookup(state: dict[str, Any]) -> tuple[dict[int, dict[str, Any]], dict[int, dict[str, Any]]]:
+    """Build signal lookup by position id and pair id."""
+    alpha_model = state.get("visualisation", {}).get("discardable_data", {}).get("alpha_model") or {}
+    signals = alpha_model.get("signals") or {}
+    by_position = {}
+    by_pair = {}
+    for signal in signals.values():
+        position_id = signal.get("position_id")
+        pair = signal.get("pair") or {}
+        pair_id = get_pair_id(pair)
+        if position_id is not None:
+            by_position[int(position_id)] = signal
+        if pair_id is not None:
+            by_pair[pair_id] = signal
+    return by_position, by_pair
+
+
+def get_alpha_model_timestamp(state: dict[str, Any]) -> int | None:
+    """Return the timestamp of the saved alpha model snapshot."""
+    alpha_model = state.get("visualisation", {}).get("discardable_data", {}).get("alpha_model") or {}
+    timestamp = alpha_model.get("timestamp")
+    if timestamp is None:
+        return None
+    return int(timestamp)
+
+
+def expected_trade_signals(
+    state: dict[str, Any],
+    threshold: Decimal,
+) -> list[dict[str, Any]]:
+    """Return alpha model signals that should have generated a trade."""
+    alpha_model = state.get("visualisation", {}).get("discardable_data", {}).get("alpha_model") or {}
+    signals = alpha_model.get("signals") or {}
+    expected = []
+    for signal in signals.values():
+        adjust = parse_decimal(signal.get("position_adjust_usd"))
+        flags = set(signal.get("flags") or [])
+        if abs(adjust) < threshold:
+            continue
+        if "cannot_redeem" in flags:
+            continue
+        if "individual_trade_size_too_small" in flags:
+            continue
+        expected.append(signal)
+    return expected
+
+
+def get_trade_signal(
+    trade: dict[str, Any],
+    by_position: dict[int, dict[str, Any]],
+    by_pair: dict[int, dict[str, Any]],
+) -> dict[str, Any] | None:
+    """Find the alpha model signal corresponding to a trade."""
+    position_id = trade.get("position_id")
+    if position_id is not None and int(position_id) in by_position:
+        return by_position[int(position_id)]
+
+    pair_id = get_pair_id(trade.get("pair") or {})
+    if pair_id is not None:
+        return by_pair.get(pair_id)
+
+    return None
+
+
+def get_trade_direction(trade: dict[str, Any]) -> str:
+    """Return buy or sell from planned quantity."""
+    planned_quantity = parse_decimal(trade.get("planned_quantity"))
+    return "buy" if planned_quantity > 0 else "sell"
+
+
+def get_signal_direction(signal: dict[str, Any]) -> str:
+    """Return buy or sell from alpha model adjustment."""
+    adjust = parse_decimal(signal.get("position_adjust_usd"))
+    return "buy" if adjust > 0 else "sell"
+
+
+def print_history(state: dict[str, Any], trades: list[dict[str, Any]], count: int) -> None:
+    """Print recent decision history."""
+    if count <= 0:
+        return
+
+    print()
+    print("Recent decision history")
+    for decision in get_decision_messages(state)[-count:]:
+        decision_trades = [trade for trade in trades if int(trade.get("opened_at") or 0) == decision["timestamp"]]
+        statuses = get_status_counts(decision_trades)
+        decided = decision["data"].get("Trades decided", "?")
+        print(
+            f"  {format_time(decision['timestamp'])} "
+            f"cycle #{decision['cycle']} decided {decided}, "
+            f"state trades {len(decision_trades)}, statuses {statuses}"
+        )
+
+
+def check_rebalance(args: argparse.Namespace) -> int:
+    """Run the Hyper AI rebalance check."""
+    state = load_state(args.source)
+    trades = iter_trades(state)
+    decision = choose_decision(state, args.decision)
+    decision_data = decision["data"]
+    decision_timestamp = decision["timestamp"]
+    decision_trades = [
+        trade
+        for trade in trades
+        if int(trade.get("opened_at") or 0) == decision_timestamp
+    ]
+    decision_trades = sorted(decision_trades, key=lambda trade: int(trade.get("trade_id") or 0))
+
+    latest_completed_cycle, completed_at = get_latest_completed_cycle_time(state)
+    threshold = parse_number_from_text(decision_data.get("Rebalance threshold")) or Decimal("0")
+    alpha_model_timestamp = get_alpha_model_timestamp(state)
+    alpha_model_matches_decision = alpha_model_timestamp == decision_timestamp
+    if alpha_model_matches_decision:
+        expected_signals = expected_trade_signals(state, threshold)
+        by_position, by_pair = get_signal_lookup(state)
+    else:
+        expected_signals = []
+        by_position, by_pair = {}, {}
+
+    issues = []
+    decided_count = int(decision_data.get("Trades decided", "0"))
+    if len(decision_trades) != decided_count:
+        issues.append(
+            f"Decision said {decided_count} trades, but {len(decision_trades)} trades share the decision timestamp"
+        )
+
+    if alpha_model_matches_decision and len(expected_signals) != decided_count:
+        issues.append(
+            f"Alpha model has {len(expected_signals)} trade-sized adjustments, but decision said {decided_count} trades"
+        )
+
+    statuses = get_status_counts(decision_trades)
+    unfinished = [
+        trade
+        for trade in decision_trades
+        if get_trade_status(trade) not in {"success", "repaired", "expired"}
+    ]
+    if unfinished:
+        status_text = ", ".join(f"{status}={count}" for status, count in sorted(statuses.items()))
+        issues.append(f"{len(unfinished)} decision trades are not executed/settled ({status_text})")
+
+    amount_tolerance = Decimal(str(args.amount_tolerance_pct)) / Decimal(100)
+    trade_rows = []
+    for trade in decision_trades:
+        signal = get_trade_signal(trade, by_position, by_pair)
+        ticker = get_ticker(trade.get("pair") or {})
+        planned_reserve = abs(parse_decimal(trade.get("planned_reserve")))
+        trade_direction = get_trade_direction(trade)
+        status = get_trade_status(trade)
+        signal_adjust = None
+        amount_diff_pct = None
+        direction_ok = None
+
+        if not alpha_model_matches_decision:
+            pass
+        elif signal is None:
+            issues.append(f"Trade #{trade.get('trade_id')} {ticker} has no matching alpha model signal")
+        else:
+            signal_adjust = parse_decimal(signal.get("position_adjust_usd"))
+            signal_direction = get_signal_direction(signal)
+            direction_ok = signal_direction == trade_direction
+            if not direction_ok:
+                issues.append(
+                    f"Trade #{trade.get('trade_id')} {ticker} direction {trade_direction} "
+                    f"does not match signal {signal_direction}"
+                )
+
+            expected_amount = abs(signal_adjust)
+            if expected_amount > 0:
+                amount_diff_pct = abs(planned_reserve - expected_amount) / expected_amount
+                if amount_diff_pct > amount_tolerance:
+                    issues.append(
+                        f"Trade #{trade.get('trade_id')} {ticker} amount differs from signal by "
+                        f"{amount_diff_pct * Decimal(100):.2f}%"
+                    )
+
+        trade_rows.append(
+            {
+                "id": trade.get("trade_id"),
+                "ticker": ticker,
+                "direction": trade_direction,
+                "amount": planned_reserve,
+                "signal_adjust": signal_adjust,
+                "diff_pct": amount_diff_pct,
+                "status": status,
+                "direction_ok": direction_ok,
+                "flags": ",".join(trade.get("flags") or []),
+            }
+        )
+
+    print("Hyper AI rebalance check")
+    print(f"Source: {args.source}")
+    print(f"State last updated: {format_time(state.get('last_updated_at'))}")
+    print(f"State cycle: {state.get('cycle')}")
+    if latest_completed_cycle is not None:
+        print(f"Latest completed cycle: #{latest_completed_cycle} at {format_time(completed_at)}")
+    print(f"Decision analysed: cycle #{decision['cycle']} at {format_time(decision_timestamp)} ({args.decision})")
+    if not alpha_model_matches_decision:
+        print(
+            "Alpha model snapshot: "
+            f"{format_time(alpha_model_timestamp)}; skipping historical amount matching"
+        )
+    print()
+    print("Decision summary")
+    for key in [
+        "Rebalanced",
+        "Trades decided",
+        "Max position value change",
+        "Rebalance threshold",
+        "Selected survivor signals",
+        "Total equity",
+        "Cash",
+        "Redeemable capital",
+        "Locked capital carried forward",
+        "Investable equity",
+        "Accepted investable equity",
+        "Allocated to signals",
+        "Rebalance volume",
+    ]:
+        value = decision_data.get(key)
+        if value is not None:
+            print(f"  {key}: {value}")
+    print(f"  Trade statuses: {statuses}")
+
+    print()
+    print("Decision trades")
+    for row in trade_rows:
+        expected = "-"
+        if row["signal_adjust"] is not None:
+            expected = f"{row['signal_adjust']:.4f}"
+        diff = "-"
+        if row["diff_pct"] is not None:
+            diff = f"{row['diff_pct'] * Decimal(100):.2f}%"
+        flags = f" flags={row['flags']}" if row["flags"] else ""
+        print(
+            f"  #{row['id']:>3} {row['ticker']:<18} {row['direction']:<4} "
+            f"{row['amount']:>10.4f} expected {expected:>11} "
+            f"diff {diff:>7} status={row['status']}{flags}"
+        )
+
+    print_history(state, trades, args.history)
+
+    print()
+    if issues:
+        print("Result: FAIL")
+        for issue in issues:
+            print(f"  - {issue}")
+        return 1
+
+    print("Result: PASS")
+    return 0
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "source",
+        help="State JSON file path, executor base URL, or executor /state URL",
+    )
+    parser.add_argument(
+        "--decision",
+        choices=("latest", "latest-completed"),
+        default="latest",
+        help="Which decision message to analyse",
+    )
+    parser.add_argument(
+        "--amount-tolerance-pct",
+        type=float,
+        default=15.0,
+        help="Allowed planned amount vs alpha model adjustment difference",
+    )
+    parser.add_argument(
+        "--history",
+        type=int,
+        default=5,
+        help="Number of recent decision history rows to print",
+    )
+    raise SystemExit(check_rebalance(parser.parse_args()))
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/hyperliquid/test_hypercore_activation_cost.py
+++ b/tests/hyperliquid/test_hypercore_activation_cost.py
@@ -270,6 +270,7 @@ def test_create_sell_transactions_build_vault_withdraw_phase1_only():
     # 2. Mock the reusable vault-withdraw builder and signing.
     # 3. Verify routing returns exactly one phase-1 withdrawal transaction.
     with patch.object(routing, "_check_live_withdrawal_preconditions") as preflight_check:
+        preflight_check.return_value = 25_000_000
         with patch("tradeexecutor.ethereum.vault.hypercore_routing.build_hypercore_withdraw_from_vault_call", return_value=withdraw_fn) as build_withdraw:
             with patch.object(routing, "_sign_module_call", return_value=signed_tx) as sign_call:
                 txs = routing._create_deposit_or_withdraw_txs(trade)
@@ -324,6 +325,7 @@ def test_withdrawal_uses_live_equity_on_close():
     # 2. Mock the equity fetch and tx building.
     with patch("tradeexecutor.ethereum.vault.hypercore_routing.fetch_user_vault_equity", return_value=live_equity):
         with patch.object(routing, "_check_live_withdrawal_preconditions") as preflight_check:
+            preflight_check.return_value = expected_withdrawal_raw
             with patch("tradeexecutor.ethereum.vault.hypercore_routing.build_hypercore_withdraw_from_vault_call", return_value=withdraw_fn) as build_withdraw:
                 with patch.object(routing, "_sign_module_call", return_value=signed_tx):
                     txs = routing._create_deposit_or_withdraw_txs(trade)
@@ -376,6 +378,7 @@ def test_withdrawal_logs_large_equity_mismatch_but_uses_live_amount(caplog):
     with caplog.at_level("WARNING"):
         with patch("tradeexecutor.ethereum.vault.hypercore_routing.fetch_user_vault_equity", return_value=live_equity):
             with patch.object(routing, "_check_live_withdrawal_preconditions") as preflight_check:
+                preflight_check.return_value = expected_withdrawal_raw
                 with patch("tradeexecutor.ethereum.vault.hypercore_routing.build_hypercore_withdraw_from_vault_call", return_value=withdraw_fn) as build_withdraw:
                     with patch.object(routing, "_sign_module_call", return_value=signed_tx):
                         txs = routing._create_deposit_or_withdraw_txs(trade)
@@ -464,6 +467,38 @@ def test_live_withdrawal_preflight_blocks_requests_above_max_withdrawable():
                     )
 
     assert "exceeds current max_withdrawable" in str(exc_info.value)
+
+
+def test_live_withdrawal_preflight_caps_tiny_max_withdrawable_drift():
+    """Live withdrawal preflight caps dust-sized max-withdrawable drift instead of crashing.
+
+    1. Create one live Hypercore sell trade whose request is only tiny raw units above max_withdrawable.
+    2. Mock Hyperliquid to report an expired lock-up and the slightly lower live max_withdrawable.
+    3. Verify the preflight returns the live max_withdrawable and stores it for settlement.
+    """
+    routing = _make_routing(simulate=False)
+    trade = _make_trade(planned_reserve=Decimal("13.104554"), is_buy=False)
+
+    unlocked_equity = UserVaultEquity(
+        vault_address="0xVAULT",
+        equity=Decimal("13.104323"),
+        locked_until=native_datetime_utc_now() - datetime.timedelta(days=1),
+    )
+
+    # 1. Create one live Hypercore sell trade whose request is only tiny raw units above max_withdrawable.
+    # 2. Mock Hyperliquid to report an expired lock-up and the slightly lower live max_withdrawable.
+    # 3. Verify the preflight returns the live max_withdrawable and stores it for settlement.
+    with patch("tradeexecutor.ethereum.vault.hypercore_routing.HyperliquidVault.fetch_info", return_value=SimpleNamespace(max_withdrawable=Decimal("13.104323"))):
+        with patch("tradeexecutor.ethereum.vault.hypercore_routing.fetch_user_vault_equity", return_value=unlocked_equity):
+            with patch.object(routing, "_get_session", return_value=routing._session):
+                effective_raw = routing._check_live_withdrawal_preconditions(
+                    trade=trade,
+                    requested_raw=13_104_554,
+                    vault_address="0xVAULT",
+                )
+
+    assert effective_raw == 13_104_323
+    assert trade.other_data["hypercore_capped_withdrawal_raw"] == 13_104_323
 
 
 @patch("tradeexecutor.ethereum.vault.hypercore_routing.report_failure")

--- a/tradeexecutor/ethereum/vault/hypercore_routing.py
+++ b/tradeexecutor/ethereum/vault/hypercore_routing.py
@@ -141,6 +141,22 @@ HYPERCORE_LIKELY_CLOSE_TOLERANCE = 0.975
 #: accounting later.
 HYPERCORE_WITHDRAWAL_SAFETY_MARGIN_RAW = 1_500_000
 
+#: Tiny live preflight cap tolerance (raw USDC, 6 decimals).
+#:
+#: Incident reference:
+#:
+#: - HyperAI crashed on 2026-04-15 during trade #336, Jay Pennie.
+#: - Planned withdrawal was 13.104554 USDC.
+#: - Live HyperCore ``max_withdrawable`` had drifted to 13.104323 USDC.
+#: - The difference was only 231 raw USDC (0.000231 USDC).
+#: - Treating that dust-sized drift as fatal stopped the whole 21-trade
+#:   sequential rebalance and left the executor down.
+#:
+#: Keep this tolerance deliberately small. It is only for raw-unit/API/NAV
+#: drift between decision making and live execution, not for real liquidity
+#: shortages.
+HYPERCORE_WITHDRAWAL_PREFLIGHT_CAP_TOLERANCE_RAW = 500_000
+
 # Temporary stop-gap for follow-up withdrawal verification phases.
 # Proper fix: carry the actually observed amount from one phase to the next.
 # Remove this extra slack once settlement becomes amount-adaptive across phases.
@@ -536,13 +552,18 @@ class HypercoreVaultRouting(RoutingModel):
         trade: TradeExecution,
         requested_raw: int,
         vault_address: str,
-    ) -> None:
+    ) -> int:
         """Check live Hypercore withdrawal eligibility before broadcasting.
 
         HyperCore withdrawals can be blocked by per-user lock-up periods and
         per-vault liquidity constraints. The strategy model already checks
         these when planning trades, but the state can change before the live
         execution phase, so re-check right before building phase 1.
+
+        :return:
+            Raw USDC amount to use for the withdrawal. This is normally the
+            requested amount, but can be capped to the live max-withdrawable
+            when the over-request is only dust-sized.
         """
         session = self._get_session()
         vault = HyperliquidVault(session=session, vault_address=vault_address)
@@ -574,11 +595,67 @@ class HypercoreVaultRouting(RoutingModel):
                 f"({user_equity.lockup_remaining} remaining)."
             )
 
+        # Start with the strategy-planned amount. In the common path the live
+        # preflight is only a check and this value is returned unchanged.
+        effective_requested_raw = requested_raw
         if requested_raw > max_withdrawable_raw:
+            # HyperCore reports the live withdrawal cap in USDC decimals.
+            # Between trade planning and setup_trades() this can move by tiny
+            # raw amounts because vault equity and max_withdrawable are live
+            # HyperCore values, while the trade was planned from state/pricing
+            # snapshots taken slightly earlier.
+            overshoot_raw = requested_raw - max_withdrawable_raw
+            if overshoot_raw <= HYPERCORE_WITHDRAWAL_PREFLIGHT_CAP_TOLERANCE_RAW:
+                # 2026-04-15 HyperAI incident:
+                # - Trade #336 requested 13.104554 USDC.
+                # - Live max_withdrawable was 13.104323 USDC.
+                # - Overshoot was 231 raw units, i.e. 0.000231 USDC.
+                #
+                # A strict abort here is worse than a tiny live cap because
+                # sequential execution stops at the first exception. The
+                # earlier trades may already have executed, while the remaining
+                # planned trades are stranded and the executor exits.
+                logger.warning(
+                    "Hypercore withdrawal request for Safe %s in vault %s is %d raw USDC "
+                    "(%s USDC) above current max_withdrawable %s USDC; capping withdrawal "
+                    "from %d raw (%s USDC) to %d raw (%s USDC)",
+                    self.safe_address,
+                    vault_address,
+                    overshoot_raw,
+                    raw_to_usdc(overshoot_raw),
+                    vault_info.max_withdrawable,
+                    requested_raw,
+                    raw_to_usdc(requested_raw),
+                    max_withdrawable_raw,
+                    raw_to_usdc(max_withdrawable_raw),
+                )
+                # Use the live cap for the phase-1 vaultTransfer call. This is
+                # the amount HyperCore says can be withdrawn now, so it avoids
+                # the silent no-op behaviour seen when vaultTransfer is asked
+                # for even a tiny amount above the live cap.
+                effective_requested_raw = max_withdrawable_raw
+                # Settlement phases 2-3 must use exactly the same amount that
+                # phase 1 was built with. Reuse the existing key used by
+                # full-close live-equity caps so downstream code remains on a
+                # single path.
+                trade.other_data["hypercore_capped_withdrawal_raw"] = effective_requested_raw
+            else:
+                # A larger gap is not the 2026-04-15 dust-drift incident.
+                # Preserve the original fail-fast behaviour for material
+                # liquidity shortages, wrong vault/state issues, or genuinely
+                # stale strategy decisions.
+                raise HypercoreWithdrawalPreflightError(
+                    f"Hypercore withdrawal blocked for Safe {self.safe_address} in vault {vault_address}: "
+                    f"requested {raw_to_usdc(requested_raw)} USDC exceeds current max_withdrawable "
+                    f"{vault_info.max_withdrawable} USDC."
+                )
+
+        if effective_requested_raw <= 0:
+            # Defensive guard: if the live cap ever rounds down to zero, do not
+            # build a meaningless HyperCore withdrawal action.
             raise HypercoreWithdrawalPreflightError(
                 f"Hypercore withdrawal blocked for Safe {self.safe_address} in vault {vault_address}: "
-                f"requested {raw_to_usdc(requested_raw)} USDC exceeds current max_withdrawable "
-                f"{vault_info.max_withdrawable} USDC."
+                f"effective withdrawal after live cap is {raw_to_usdc(effective_requested_raw)} USDC."
             )
 
         logger.info(
@@ -586,10 +663,11 @@ class HypercoreVaultRouting(RoutingModel):
             "requested %s USDC, max_withdrawable %s USDC, lock-up expired at %s",
             self.safe_address,
             vault_address,
-            raw_to_usdc(requested_raw),
+            raw_to_usdc(effective_requested_raw),
             vault_info.max_withdrawable,
             user_equity.locked_until,
         )
+        return effective_requested_raw
 
     def _fetch_safe_evm_usdc_balance(self) -> int:
         """Read the Safe's EVM USDC balance (raw, 6 decimals).
@@ -1008,7 +1086,7 @@ class HypercoreVaultRouting(RoutingModel):
                     trade, raw_amount, vault_address,
                 )
             if not self.simulate:
-                self._check_live_withdrawal_preconditions(
+                raw_amount = self._check_live_withdrawal_preconditions(
                     trade=trade,
                     requested_raw=raw_amount,
                     vault_address=vault_address,


### PR DESCRIPTION
## Why

HyperAI crashed on 2026-04-15 during HyperCore withdrawal trade #336 because the planned Jay Pennie withdrawal was 13.104554 USDC while live HyperCore max_withdrawable had drifted to 13.104323 USDC. The 0.000231 USDC dust-sized difference was treated as fatal and stopped the whole sequential rebalance.

## Lessons learnt

Live HyperCore max_withdrawable can drift by tiny raw-unit amounts between decision making and execution. Preflight should still fail fast for material liquidity shortages, but dust-sized over-requests should be capped to the live value so settlement can continue with the exact amount used by phase 1.

## Summary

- Cap tiny live HyperCore withdrawal over-requests to the current max_withdrawable and persist the capped raw amount for settlement.
- Keep the original preflight error for material over-requests, zero liquidity, and lock-up failures.
- Add a regression test for the 2026-04-15 HyperAI drift shape.
- Add scripts/hyper-ai/check-rebalance.py to audit live HyperAI decision trades against state and alpha model snapshots.