### PR TITLE
fix: close Hypercore safety margin dust

### DIFF
--- a/tests/hyperliquid/test_close_dust_hypercore.py
+++ b/tests/hyperliquid/test_close_dust_hypercore.py
@@ -1,7 +1,7 @@
 """Test closing dusty Hypercore vault positions and verify account correction ignores them.
 
 Uses a downloaded production state (hyper-ai) that contains dust positions
-(positions #1, #2, #3 with quantities below HYPERLIQUID_VAULT_CLOSE_EPSILON = 0.02).
+(positions #1, #2, #3 with quantities below HYPERLIQUID_VAULT_CLOSE_EPSILON).
 
 1. Load production state and identify dust Hypercore vault positions.
 2. Verify can_be_closed() returns True for dust positions.

--- a/tests/hyperliquid/test_hypercore_accounting.py
+++ b/tests/hyperliquid/test_hypercore_accounting.py
@@ -231,16 +231,16 @@ def test_old_bug_equity_squared():
 def test_hypercore_vault_dust_epsilon_covers_safety_margin():
     """Hypercore vault close epsilon is large enough to cover withdrawal safety margin dust.
 
-    HYPERCORE_WITHDRAWAL_SAFETY_MARGIN_RAW (100_000 raw = $0.10) is subtracted
-    from live vault equity during full-close withdrawals, leaving ~$0.10 residual
+    HYPERCORE_WITHDRAWAL_SAFETY_MARGIN_RAW (1_500_000 raw = $1.50) is subtracted
+    from live vault equity during full-close withdrawals, leaving ~$1.50 residual
     in the position.  The close epsilon must exceed this so can_be_closed()
     recognises the position as effectively closed.
 
     1. Build a Hypercore vault pair using create_hypercore_vault_pair().
     2. Verify get_close_epsilon_for_pair() and get_dust_epsilon_for_pair()
        return the Hypercore-specific epsilon.
-    3. Create a TradingPosition with dust quantity (0.01) and assert can_be_closed().
-    4. Same position with non-dust quantity (1.0) must NOT be closeable.
+    3. Create a TradingPosition with safety-margin dust quantity (1.50) and assert can_be_closed().
+    4. Same position with non-dust quantity (2.50) must NOT be closeable.
     5. Build a non-Hypercore vault pair and verify it still gets DEFAULT_VAULT_EPSILON.
     """
 
@@ -261,7 +261,7 @@ def test_hypercore_vault_dust_epsilon_covers_safety_margin():
     assert get_close_epsilon_for_pair(hypercore_pair) == HYPERLIQUID_VAULT_CLOSE_EPSILON
     assert get_dust_epsilon_for_pair(hypercore_pair) == HYPERLIQUID_VAULT_CLOSE_EPSILON
 
-    # 3. Position with dust quantity (0.10 USDC) can be closed
+    # 3. Position with safety-margin dust quantity (1.50 USDC) can be closed
     ts = native_datetime_utc_now()
     position = TradingPosition(
         position_id=1,
@@ -277,11 +277,11 @@ def test_hypercore_vault_dust_epsilon_covers_safety_margin():
     dummy_trade.is_spot.return_value = False
     position.trades[1] = dummy_trade
 
-    with patch.object(position, "get_quantity", return_value=Decimal("0.10")):
+    with patch.object(position, "get_quantity", return_value=Decimal("1.50")):
         assert position.can_be_closed() is True
 
-    # 4. Position with non-dust quantity (1.0 USDC) must NOT be closeable
-    with patch.object(position, "get_quantity", return_value=Decimal("1.0")):
+    # 4. Position with non-dust quantity (2.50 USDC) must NOT be closeable
+    with patch.object(position, "get_quantity", return_value=Decimal("2.50")):
         assert position.can_be_closed() is False
 
     # 5. Non-Hypercore vault pair still gets DEFAULT_VAULT_EPSILON
@@ -535,7 +535,7 @@ def test_hypercore_dust_position_is_reused_without_planned_close() -> None:
         strategy_cycle_at=datetime.datetime(2026, 4, 13),
         pair=pair,
         quantity=None,
-        reserve=Decimal("1.00"),
+        reserve=Decimal("5.00"),
         assumed_price=1.0,
         trade_type=TradeType.rebalance,
         reserve_currency=reserve_asset,
@@ -545,8 +545,8 @@ def test_hypercore_dust_position_is_reused_without_planned_close() -> None:
     trade.mark_success(
         executed_at=datetime.datetime(2026, 4, 13, 0, 1),
         executed_price=1.0,
-        executed_quantity=Decimal("1.00"),
-        executed_reserve=Decimal("1.00"),
+        executed_quantity=Decimal("5.00"),
+        executed_reserve=Decimal("5.00"),
         lp_fees=0,
         native_token_price=0,
         force=True,
@@ -559,9 +559,9 @@ def test_hypercore_dust_position_is_reused_without_planned_close() -> None:
         block_mined_at=datetime.datetime(2026, 4, 13, 0, 2),
         strategy_cycle_included_at=datetime.datetime(2026, 4, 13),
         chain_id=pair.base.chain_id,
-        quantity=Decimal("-0.90"),
-        old_balance=Decimal("1.00"),
-        usd_value=-0.90,
+        quantity=Decimal("-3.50"),
+        old_balance=Decimal("5.00"),
+        usd_value=-3.50,
         position_id=position.position_id,
         notes="Simulate Hypercore withdrawal dust",
         block_number=1,
@@ -618,7 +618,7 @@ def test_hypercore_dust_position_is_not_about_to_close_without_planned_trades() 
         strategy_cycle_at=datetime.datetime(2026, 4, 13),
         pair=pair,
         quantity=None,
-        reserve=Decimal("1.00"),
+        reserve=Decimal("5.00"),
         assumed_price=1.0,
         trade_type=TradeType.rebalance,
         reserve_currency=reserve_asset,
@@ -628,8 +628,8 @@ def test_hypercore_dust_position_is_not_about_to_close_without_planned_trades() 
     trade.mark_success(
         executed_at=datetime.datetime(2026, 4, 13, 0, 1),
         executed_price=1.0,
-        executed_quantity=Decimal("1.00"),
-        executed_reserve=Decimal("1.00"),
+        executed_quantity=Decimal("5.00"),
+        executed_reserve=Decimal("5.00"),
         lp_fees=0,
         native_token_price=0,
         force=True,
@@ -642,9 +642,9 @@ def test_hypercore_dust_position_is_not_about_to_close_without_planned_trades() 
         block_mined_at=datetime.datetime(2026, 4, 13, 0, 2),
         strategy_cycle_included_at=datetime.datetime(2026, 4, 13),
         chain_id=pair.base.chain_id,
-        quantity=Decimal("-0.90"),
-        old_balance=Decimal("1.00"),
-        usd_value=-0.90,
+        quantity=Decimal("-3.50"),
+        old_balance=Decimal("5.00"),
+        usd_value=-3.50,
         position_id=position.position_id,
         notes="Simulate Hypercore withdrawal dust",
         block_number=1,
@@ -750,7 +750,7 @@ def test_hypercore_account_check_rejects_duplicate_vault_positions() -> None:
         strategy_cycle_at=datetime.datetime(2026, 4, 13),
         pair=pair,
         quantity=None,
-        reserve=Decimal("1.00"),
+        reserve=Decimal("5.00"),
         assumed_price=1.0,
         trade_type=TradeType.rebalance,
         reserve_currency=reserve_asset,
@@ -760,8 +760,8 @@ def test_hypercore_account_check_rejects_duplicate_vault_positions() -> None:
     dust_trade.mark_success(
         executed_at=datetime.datetime(2026, 4, 13, 0, 1),
         executed_price=1.0,
-        executed_quantity=Decimal("1.00"),
-        executed_reserve=Decimal("1.00"),
+        executed_quantity=Decimal("5.00"),
+        executed_reserve=Decimal("5.00"),
         lp_fees=0,
         native_token_price=0,
         force=True,
@@ -774,9 +774,9 @@ def test_hypercore_account_check_rejects_duplicate_vault_positions() -> None:
         block_mined_at=datetime.datetime(2026, 4, 13, 0, 2),
         strategy_cycle_included_at=datetime.datetime(2026, 4, 13),
         chain_id=pair.base.chain_id,
-        quantity=Decimal("-0.90"),
-        old_balance=Decimal("1.00"),
-        usd_value=-0.90,
+        quantity=Decimal("-3.50"),
+        old_balance=Decimal("5.00"),
+        usd_value=-3.50,
         position_id=dust_position.position_id,
         notes="Simulate Hypercore withdrawal dust",
         block_number=1,
@@ -844,7 +844,7 @@ def test_close_hypercore_dust_positions_closes_duplicate_residual_state() -> Non
         strategy_cycle_at=datetime.datetime(2026, 4, 13),
         pair=pair,
         quantity=None,
-        reserve=Decimal("1.00"),
+        reserve=Decimal("5.00"),
         assumed_price=1.0,
         trade_type=TradeType.rebalance,
         reserve_currency=reserve_asset,
@@ -854,8 +854,8 @@ def test_close_hypercore_dust_positions_closes_duplicate_residual_state() -> Non
     dust_trade.mark_success(
         executed_at=datetime.datetime(2026, 4, 13, 0, 1),
         executed_price=1.0,
-        executed_quantity=Decimal("1.00"),
-        executed_reserve=Decimal("1.00"),
+        executed_quantity=Decimal("5.00"),
+        executed_reserve=Decimal("5.00"),
         lp_fees=0,
         native_token_price=0,
         force=True,
@@ -868,9 +868,9 @@ def test_close_hypercore_dust_positions_closes_duplicate_residual_state() -> Non
         block_mined_at=datetime.datetime(2026, 4, 13, 0, 2),
         strategy_cycle_included_at=datetime.datetime(2026, 4, 13),
         chain_id=pair.base.chain_id,
-        quantity=Decimal("-0.90"),
-        old_balance=Decimal("1.00"),
-        usd_value=-0.90,
+        quantity=Decimal("-3.50"),
+        old_balance=Decimal("5.00"),
+        usd_value=-3.50,
         position_id=dust_position.position_id,
         notes="Simulate Hypercore withdrawal dust",
         block_number=1,

--- a/tradeexecutor/strategy/dust.py
+++ b/tradeexecutor/strategy/dust.py
@@ -39,11 +39,20 @@ DEFAULT_USD_LOW_VALUE_THRESHOLD = 0.10
 #: Set by maxRedeem() issue on Spark USDC on Morpho
 DEFAULT_VAULT_EPSILON = Decimal(10 ** -6)
 
-#: Hypercore vault withdrawal leaves ~$0.10 dust due to the safety margin
-#: subtracted from live equity (HYPERCORE_WITHDRAWAL_SAFETY_MARGIN_RAW = 100_000
-#: raw = $0.10 in 6-decimal USDC).  This epsilon must exceed that margin so
-#: can_be_closed() recognises the residual as dust.
-HYPERLIQUID_VAULT_CLOSE_EPSILON = Decimal("0.20")
+#: Hypercore vault withdrawal leaves dust due to the safety margin subtracted
+#: from live equity.
+#:
+#: Incident reference:
+#:
+#: - HyperAI trade #326, Super Moon, on 2026-04-15 withdrew successfully.
+#: - Routing used the live full-close safety margin of 1.5 USDC.
+#: - The position then remained open with 1.500000 quantity because this close
+#:   epsilon was still 0.20 USDC from an older safety-margin setting.
+#:
+#: Keep this above HYPERCORE_WITHDRAWAL_SAFETY_MARGIN_RAW = 1_500_000 raw
+#: ($1.50 in 6-decimal USDC) so can_be_closed() recognises the intentional
+#: residual as dust and the runner can auto-close it before account checks.
+HYPERLIQUID_VAULT_CLOSE_EPSILON = Decimal("2.00")
 
 #: Hypercore vault equities fluctuate every block due to active trading
 #: inside the vault, and live cycles can spend a long time in sequential


### PR DESCRIPTION
## Why

Hypercore full-close withdrawals intentionally subtract a 1.5 USDC safety margin from live vault equity. After the 2026-04-15 HyperAI incident, this meant a successful full close could leave a 1.500000 residual quantity that was larger than the old 0.20 USDC Hyperliquid vault close epsilon, keeping the position open after settlement.

## Lessons learnt

The routing safety margin and the accounting dust epsilon must move together. Otherwise a protective live-execution buffer becomes a stale open-position accounting bug after an otherwise successful withdrawal.

## Summary

- Raise the Hyperliquid vault close epsilon above the 1.5 USDC full-close withdrawal safety margin.
- Add incident comments documenting the HyperAI Super Moon residual from 2026-04-15.
- Update Hypercore accounting fixtures to open non-dust positions before simulating the post-withdrawal safety-margin residual.