### PR TITLE
Fix Hyper AI rebalance report volume

### DIFF
--- a/strategies/hyper-ai.py
+++ b/strategies/hyper-ai.py
@@ -104,6 +104,12 @@ from tradeexecutor.utils.dedent import dedent_any
 
 logger = logging.getLogger(__name__)
 
+
+def calculate_rebalance_volume(trades: list[TradeExecution]) -> USDollarAmount:
+    """Calculate decision-time rebalance volume for reporting."""
+    return sum(trade.get_planned_value() for trade in trades)
+
+
 #
 # Trading universe constants
 #
@@ -422,7 +428,7 @@ def decide_trades(input: StrategyInput) -> list[TradeExecution]:
         except StopIteration:
             top_signal = None
 
-        rebalance_volume = sum(trade.get_value() for trade in trades)
+        rebalance_volume = calculate_rebalance_volume(trades)
         report = dedent_any(
             f"""
             Cycle: #{input.cycle}

--- a/tests/hyperliquid/test_hyper_ai_rebalance_report.py
+++ b/tests/hyperliquid/test_hyper_ai_rebalance_report.py
@@ -1,0 +1,47 @@
+"""Tests for Hyper AI rebalance report diagnostics."""
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+
+def _load_hyper_ai_strategy_module():
+    strategy_path = Path(__file__).resolve().parents[2] / "strategies" / "hyper-ai.py"
+    spec = importlib.util.spec_from_file_location("hyper_ai_strategy_rebalance_report", strategy_path)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+class _PlannedTrade:
+    """Stand-in for a planned trade before capital allocation."""
+
+    def get_value(self) -> float:
+        return 0.0
+
+    def get_planned_value(self) -> float:
+        return 9.74323524
+
+
+def test_hyper_ai_rebalance_volume_uses_planned_trade_value() -> None:
+    """Hyper AI report volume must include planned trades before execution.
+
+    1. Load the production Hyper AI strategy module.
+    2. Use a planned-trade stand-in whose accounting value is zero, because
+       the bug is the report method choice and a full strategy decision setup
+       would need a live Hyperliquid universe.
+    3. Verify the report volume uses the planned notional.
+    """
+
+    # 1. Load the production Hyper AI strategy module.
+    module = _load_hyper_ai_strategy_module()
+
+    # 2. Use a planned-trade stand-in whose accounting value is zero.
+    trade = _PlannedTrade()
+    assert trade.get_value() == 0.0
+
+    # 3. Verify the report volume uses the planned notional.
+    assert module.calculate_rebalance_volume([trade]) == pytest.approx(9.74323524)


### PR DESCRIPTION
## Why

Hyper AI decision visualisations reported zero rebalance volume for planned trades because the report used TradeExecution.get_value(), which intentionally returns 0.0 before capital allocation.

## Lessons learnt

Decision-time diagnostics should use planned notional, while get_value() remains an accounting-oriented method for allocated, executed, or failed trades.

## Summary

- Added a Hyper AI helper for decision-time rebalance volume.
- Updated the visualisation report to use planned trade value.
- Added a focused regression test for planned trades whose accounting value is still zero.