### PR TITLE
Fix HyperCore transit recovery in correct-accounts

### DIFF
--- a/scripts/hyperliquid/clean-closed-vault-positions.py
+++ b/scripts/hyperliquid/clean-closed-vault-positions.py
@@ -30,7 +30,7 @@ from tradeexecutor.ethereum.vault.hyperliquid_cleanup import \
 
 def main() -> None:
     """Run the Hyperliquid clean-up flow from environment variables."""
-    raise NotImplementedError()
+    run_hyperliquid_cleanup_from_environment()
 
 
 if __name__ == "__main__":

--- a/scripts/lagoon/manual-trade-executor-hyperliquid.py
+++ b/scripts/lagoon/manual-trade-executor-hyperliquid.py
@@ -174,6 +174,7 @@ from eth_defi.utils import setup_console_logging
 from eth_defi.vault.base import VaultSpec
 
 from tradeexecutor.cli.main import app
+from tradeexecutor.ethereum.vault.hypercore_transit_recovery import get_spot_usdc_balances
 from tradeexecutor.ethereum.vault.hypercore_vault import HLP_VAULT_ADDRESS
 from tradeexecutor.state.state import State
 
@@ -239,10 +240,8 @@ def _is_within_tolerance(left: Decimal, right: Decimal) -> bool:
 def _get_spot_free_usdc_balance(session, user: str) -> Decimal:
     """Read the Safe's free HyperCore spot USDC balance."""
     state = fetch_spot_clearinghouse_state(session, user=user)
-    for balance in state.balances:
-        if balance.coin == "USDC":
-            return balance.total - balance.hold
-    return Decimal(0)
+    _spot_total, spot_free = get_spot_usdc_balances(state)
+    return spot_free
 
 
 def _get_perp_withdrawable_balance(session, user: str) -> Decimal:

--- a/tests/hyperliquid/test_hypercore_transit_recovery.py
+++ b/tests/hyperliquid/test_hypercore_transit_recovery.py
@@ -1,0 +1,396 @@
+"""Test Safe-level HyperCore spot/perp transit recovery helpers."""
+
+import datetime
+from decimal import Decimal
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+from tradeexecutor.cli.commands import correct_accounts as correct_accounts_command
+from tradeexecutor.ethereum.vault import hypercore_transit_recovery
+from tradeexecutor.ethereum.vault.hypercore_transit_recovery import (
+    HYPERCORE_TRANSIT_RECOVERY_DUST_USDC,
+    HypercoreTransitBalanceSnapshot,
+    HypercoreTransitRecoveryAction,
+    plan_hypercore_transit_recovery_actions,
+)
+from tradeexecutor.state.identifier import AssetIdentifier
+from tradeexecutor.state.state import State
+from tradeexecutor.strategy.account_correction import (
+    AccountingBalanceCheck,
+    AccountingCorrectionCause,
+    apply_accounting_correction,
+)
+from tradeexecutor.strategy.execution_model import AssetManagementMode
+
+
+SAFE_ADDRESS = "0xB136581dFB3efA76Ae71293C1A70942f0726E8fD"
+
+
+def _snapshot(
+    *,
+    spot_free_usdc: Decimal = Decimal(0),
+    perp_withdrawable: Decimal = Decimal(0),
+    perp_position_count: int = 0,
+) -> HypercoreTransitBalanceSnapshot:
+    """Build a transit balance snapshot for planner tests."""
+    return HypercoreTransitBalanceSnapshot(
+        safe_address=SAFE_ADDRESS,
+        evm_usdc_balance=Decimal("1"),
+        spot_total_usdc=spot_free_usdc,
+        spot_free_usdc=spot_free_usdc,
+        perp_withdrawable=perp_withdrawable,
+        perp_account_value=perp_withdrawable,
+        perp_position_count=perp_position_count,
+    )
+
+
+def test_hypercore_transit_plan_leaves_perp_and_spot_dust() -> None:
+    """Perp and spot recovery leaves fixed dust on both HyperCore balances.
+
+    1. Build a snapshot with meaningful Safe-level spot and perp USDC.
+    2. Plan HyperCore transit recovery actions.
+    3. Assert the planner moves only balances above the fixed dust amount.
+    """
+    # Step 1: Build a snapshot with meaningful Safe-level spot and perp USDC.
+    snapshot = _snapshot(
+        spot_free_usdc=Decimal("33.611598"),
+        perp_withdrawable=Decimal("768.875892"),
+    )
+
+    # Step 2: Plan HyperCore transit recovery actions.
+    actions = plan_hypercore_transit_recovery_actions(snapshot)
+
+    # Step 3: Assert the planner moves only balances above the fixed dust amount.
+    assert [action.action_kind for action in actions] == [
+        "perp_to_spot",
+        "spot_to_evm",
+    ]
+    assert actions[0].amount == Decimal("768.375892")
+    assert actions[1].amount == Decimal("801.487490")
+
+
+def test_hypercore_transit_plan_handles_spot_only_balance() -> None:
+    """Spot-only recovery bridges spot USDC while leaving spot dust.
+
+    1. Build a snapshot with only Safe-level spot USDC.
+    2. Plan HyperCore transit recovery actions.
+    3. Assert only the spot-to-EVM leg is planned.
+    """
+    # Step 1: Build a snapshot with only Safe-level spot USDC.
+    snapshot = _snapshot(spot_free_usdc=Decimal("10"))
+
+    # Step 2: Plan HyperCore transit recovery actions.
+    actions = plan_hypercore_transit_recovery_actions(snapshot)
+
+    # Step 3: Assert only the spot-to-EVM leg is planned.
+    assert [action.action_kind for action in actions] == ["spot_to_evm"]
+    assert actions[0].amount == Decimal("9.50")
+
+
+def test_hypercore_transit_plan_handles_perp_only_balance() -> None:
+    """Perp-only recovery plans perp-to-spot and then bridges the post-transfer spot balance.
+
+    1. Build a snapshot with only Safe-level perp USDC.
+    2. Plan HyperCore transit recovery actions.
+    3. Assert the planner leaves fixed dust in both perp and spot.
+    """
+    # Step 1: Build a snapshot with only Safe-level perp USDC.
+    snapshot = _snapshot(perp_withdrawable=Decimal("10"))
+
+    # Step 2: Plan HyperCore transit recovery actions.
+    actions = plan_hypercore_transit_recovery_actions(snapshot)
+
+    # Step 3: Assert the planner leaves fixed dust in both perp and spot.
+    assert [action.action_kind for action in actions] == [
+        "perp_to_spot",
+        "spot_to_evm",
+    ]
+    assert actions[0].amount == Decimal("9.50")
+    assert actions[1].amount == Decimal("9.00")
+
+
+def test_hypercore_transit_plan_ignores_dust_only_balances() -> None:
+    """Dust-only spot and perp balances do not produce recovery actions.
+
+    1. Build a snapshot at the fixed dust threshold for both spot and perp.
+    2. Plan HyperCore transit recovery actions.
+    3. Assert no zero, negative, or dust-only action is emitted.
+    """
+    # Step 1: Build a snapshot at the fixed dust threshold for both spot and perp.
+    snapshot = _snapshot(
+        spot_free_usdc=HYPERCORE_TRANSIT_RECOVERY_DUST_USDC,
+        perp_withdrawable=HYPERCORE_TRANSIT_RECOVERY_DUST_USDC,
+    )
+
+    # Step 2: Plan HyperCore transit recovery actions.
+    actions = plan_hypercore_transit_recovery_actions(snapshot)
+
+    # Step 3: Assert no zero, negative, or dust-only action is emitted.
+    assert actions == []
+
+
+def test_hypercore_transit_plan_rejects_active_perp_positions() -> None:
+    """Active Safe-level perp positions abort recovery before broadcasting.
+
+    1. Build a snapshot with an active HyperCore perp position.
+    2. Attempt to plan HyperCore transit recovery actions.
+    3. Assert planning raises a manual-review error.
+    """
+    # Step 1: Build a snapshot with an active HyperCore perp position.
+    snapshot = _snapshot(perp_withdrawable=Decimal("10"), perp_position_count=1)
+
+    # Step 2: Attempt to plan HyperCore transit recovery actions.
+    # Step 3: Assert planning raises a manual-review error.
+    with pytest.raises(RuntimeError, match="active HyperCore perp position"):
+        plan_hypercore_transit_recovery_actions(snapshot)
+
+
+def test_hypercore_transit_execution_uses_dust_safe_spot_amount(monkeypatch) -> None:
+    """Execution broadcasts perp-to-spot and spot-to-EVM using dust-preserving amounts.
+
+    1. Mock live snapshots before each execution phase.
+    2. Execute a two-leg recovery plan with mocked CoreWriter calls and waits.
+    3. Assert the spot bridge amount is below the full spot balance and leaves dust.
+
+    CoreWriter broadcasts are mocked because the test verifies recovery accounting,
+    not contract execution on a live HyperEVM node.
+    """
+    # Step 1: Mock live snapshots before each execution phase.
+    snapshots = [
+        _snapshot(spot_free_usdc=Decimal("0"), perp_withdrawable=Decimal("5")),
+        _snapshot(spot_free_usdc=Decimal("4.50"), perp_withdrawable=Decimal("0.50")),
+    ]
+    monkeypatch.setattr(
+        hypercore_transit_recovery,
+        "fetch_hypercore_transit_balances",
+        lambda **kwargs: snapshots.pop(0),
+    )
+
+    reserve_token = MagicMock()
+    reserve_token.convert_to_raw.side_effect = lambda amount: int(
+        (Decimal(amount) * Decimal(10**6)).to_integral_value()
+    )
+
+    sent_calls: list[tuple[str, int]] = []
+    monkeypatch.setattr(
+        hypercore_transit_recovery,
+        "build_hypercore_transfer_usd_class_call",
+        lambda lagoon_vault, hypercore_usdc_amount, to_perp: (
+            "perp_to_spot",
+            hypercore_usdc_amount,
+        ),
+    )
+    monkeypatch.setattr(
+        hypercore_transit_recovery,
+        "build_hypercore_send_asset_to_evm_call",
+        lambda lagoon_vault, evm_usdc_amount: ("spot_to_evm", evm_usdc_amount),
+    )
+    monkeypatch.setattr(
+        hypercore_transit_recovery,
+        "broadcast_bound_call",
+        lambda web3, hot_wallet, bound_func, gas_limit=650000: sent_calls.append(bound_func) or "0x1",
+    )
+    monkeypatch.setattr(
+        hypercore_transit_recovery,
+        "wait_for_spot_free_balance",
+        lambda session, user, baseline_balance, expected_increase: Decimal("4.50"),
+    )
+    monkeypatch.setattr(
+        hypercore_transit_recovery,
+        "wait_for_evm_usdc_balance",
+        lambda token, address, baseline_balance, expected_increase: Decimal("5.00"),
+    )
+
+    actions = [
+        HypercoreTransitRecoveryAction(
+            action_kind="perp_to_spot",
+            amount=Decimal("4.50"),
+            reason="test",
+        ),
+        HypercoreTransitRecoveryAction(
+            action_kind="spot_to_evm",
+            amount=Decimal("4.00"),
+            reason="test",
+        ),
+    ]
+
+    # Step 2: Execute a two-leg recovery plan with mocked CoreWriter calls and waits.
+    executed = hypercore_transit_recovery.execute_hypercore_transit_recovery_actions(
+        web3=MagicMock(),
+        hot_wallet=MagicMock(),
+        lagoon_vault=SimpleNamespace(safe_address=SAFE_ADDRESS),
+        session=object(),
+        reserve_token=reserve_token,
+        actions=actions,
+    )
+
+    # Step 3: Assert the spot bridge amount is below the full spot balance and leaves dust.
+    assert executed == ["perp_to_spot", "spot_to_evm"]
+    assert sent_calls == [
+        ("perp_to_spot", 4_500_000),
+        ("spot_to_evm", 4_000_000),
+    ]
+
+
+def test_correct_accounts_recovery_helper_executes_for_closed_hypercore_position(monkeypatch) -> None:
+    """Correct-accounts recovery helper executes when a closed Hypercore position exists.
+
+    1. Build a fake Lagoon sync model and state with one closed Hypercore position.
+    2. Mock HyperCore snapshot planning and execution.
+    3. Assert recovery is broadcast through the shared executor.
+
+    The Lagoon sync model is mocked because this is a command hook test, not a
+    Lagoon vault deployment test.
+    """
+    # Step 1: Build a fake Lagoon sync model and state with one closed Hypercore position.
+    class FakeLagoonVaultSyncModel:
+        def __init__(self) -> None:
+            self.vault = SimpleNamespace(
+                safe_address=SAFE_ADDRESS,
+                underlying_token=MagicMock(),
+            )
+
+        def get_token_storage_address(self) -> str:
+            return SAFE_ADDRESS
+
+    state = SimpleNamespace(
+        portfolio=SimpleNamespace(
+            closed_positions={
+                1: SimpleNamespace(
+                    pair=SimpleNamespace(is_hyperliquid_vault=lambda: True)
+                )
+            }
+        )
+    )
+    sync_model = FakeLagoonVaultSyncModel()
+    hot_wallet = MagicMock()
+    correct_accounts_command.logger = MagicMock()
+    monkeypatch.setattr(
+        correct_accounts_command,
+        "LagoonVaultSyncModel",
+        FakeLagoonVaultSyncModel,
+    )
+
+    action = HypercoreTransitRecoveryAction(
+        action_kind="spot_to_evm",
+        amount=Decimal("9.50"),
+        reason="test",
+    )
+    monkeypatch.setattr(
+        hypercore_transit_recovery,
+        "fetch_hypercore_transit_balances",
+        lambda **kwargs: _snapshot(spot_free_usdc=Decimal("10")),
+    )
+    monkeypatch.setattr(
+        hypercore_transit_recovery,
+        "plan_hypercore_transit_recovery_actions",
+        lambda snapshot: [action],
+    )
+    executed_arguments = {}
+    monkeypatch.setattr(
+        hypercore_transit_recovery,
+        "execute_hypercore_transit_recovery_actions",
+        lambda **kwargs: executed_arguments.update(kwargs) or ["spot_to_evm"],
+    )
+
+    # Step 2: Mock HyperCore snapshot planning and execution.
+    executed = correct_accounts_command._recover_hypercore_transit_balances(
+        asset_management_mode=AssetManagementMode.lagoon,
+        sync_model=sync_model,
+        web3=SimpleNamespace(eth=SimpleNamespace(chain_id=999)),
+        hot_wallet=hot_wallet,
+        state=state,
+        skip_hypercore_transit_recovery=False,
+    )
+
+    # Step 3: Assert recovery is broadcast through the shared executor.
+    assert executed == ["spot_to_evm"]
+    assert executed_arguments["actions"] == [action]
+    hot_wallet.sync_nonce.assert_called_once()
+
+
+def test_correct_accounts_recovery_helper_can_be_skipped(monkeypatch) -> None:
+    """Correct-accounts skip flag bypasses HyperCore recovery broadcasts.
+
+    1. Build a fake state with one closed Hypercore position.
+    2. Run the recovery helper with the skip flag enabled.
+    3. Assert no HyperCore session or broadcast is attempted.
+    """
+    # Step 1: Build a fake state with one closed Hypercore position.
+    state = SimpleNamespace(
+        portfolio=SimpleNamespace(
+            closed_positions={
+                1: SimpleNamespace(
+                    pair=SimpleNamespace(is_hyperliquid_vault=lambda: True)
+                )
+            }
+        )
+    )
+    correct_accounts_command.logger = MagicMock()
+    monkeypatch.setattr(
+        hypercore_transit_recovery,
+        "execute_hypercore_transit_recovery_actions",
+        MagicMock(side_effect=AssertionError("should not broadcast")),
+    )
+
+    # Step 2: Run the recovery helper with the skip flag enabled.
+    executed = correct_accounts_command._recover_hypercore_transit_balances(
+        asset_management_mode=AssetManagementMode.lagoon,
+        sync_model=MagicMock(),
+        web3=SimpleNamespace(eth=SimpleNamespace(chain_id=999)),
+        hot_wallet=MagicMock(),
+        state=state,
+        skip_hypercore_transit_recovery=True,
+    )
+
+    # Step 3: Assert no HyperCore session or broadcast is attempted.
+    assert executed == []
+
+
+def test_apply_accounting_correction_records_expected_old_balance() -> None:
+    """Accounting correction audit event records the pre-correction ledger balance.
+
+    1. Build a state reserve position with an expected ledger balance.
+    2. Apply an accounting correction to a different actual balance.
+    3. Assert the balance update old_balance is the expected amount.
+    """
+    # Step 1: Build a state reserve position with an expected ledger balance.
+    asset = AssetIdentifier(
+        chain_id=999,
+        address="0x0000000000000000000000000000000000000001",
+        token_symbol="USDC",
+        decimals=6,
+    )
+    state = State()
+    reserve = state.portfolio.initialise_reserves(asset, reserve_token_price=1.0)
+    reserve.quantity = Decimal("100")
+    correction = AccountingBalanceCheck(
+        type=AccountingCorrectionCause.unknown_cause,
+        holding_address=SAFE_ADDRESS,
+        asset=asset,
+        positions={reserve},
+        expected_amount=Decimal("100"),
+        actual_amount=Decimal("125"),
+        dust_epsilon=Decimal("0.01"),
+        relative_epsilon=0.0,
+        block_number=123,
+        timestamp=datetime.datetime(2026, 4, 17, 12, 0, 0),
+        usd_value=25.0,
+        reserve_asset=True,
+        mismatch=True,
+        price=Decimal("1"),
+        price_at=datetime.datetime(2026, 4, 17, 12, 0, 0),
+    )
+
+    # Step 2: Apply an accounting correction to a different actual balance.
+    event = apply_accounting_correction(
+        state=state,
+        correction=correction,
+        strategy_cycle_included_at=None,
+    )
+
+    # Step 3: Assert the balance update old_balance is the expected amount.
+    assert event.old_balance == Decimal("100")
+    assert reserve.quantity == Decimal("125")

--- a/tests/hyperliquid/test_hyperliquid_cleanup.py
+++ b/tests/hyperliquid/test_hyperliquid_cleanup.py
@@ -6,7 +6,7 @@ Verifies that:
 3. Mocked Hyperliquid and HyperEVM balances produce only stranded-money recovery actions.
 4. The clean-up flow executes ``perp -> spot`` and ``spot -> EVM`` in order.
 5. The state repair and accounting correction hooks run and the state is treated as saveable.
-6. The spot -> EVM withdrawal subtracts the bridge fee margin from the bridged amount.
+6. The spot -> EVM withdrawal leaves the configured HyperCore spot dust.
 7. A small spot balance (below fee margin) raises a clear operator error.
 """
 
@@ -19,8 +19,8 @@ from unittest.mock import MagicMock
 import pytest
 from hexbytes import HexBytes
 
-from eth_defi.hyperliquid.constants import HYPERCORE_BRIDGE_FEE_MARGIN
 from tradeexecutor.ethereum.vault import hyperliquid_cleanup
+from tradeexecutor.ethereum.vault import hypercore_transit_recovery
 from tradeexecutor.state.state import State
 from tradeexecutor.state.store import JSONFileStore
 
@@ -80,14 +80,14 @@ def test_hyperliquid_cleanup_recovers_stranded_safe_balances(
     hot_wallet = MagicMock()
 
     def broadcast_side_effect(bound_func, gas_limit=hyperliquid_cleanup.SAFE_GAS_LIMIT):
-        if bound_func == "perp_to_spot_fn":
+        if isinstance(bound_func, tuple) and bound_func[0] == "perp_to_spot_fn":
             # Step 3: Simulate recovery from HyperCore perp back to spot.
             broadcast_order.append("perp_to_spot")
-            amount = live_balances["perp_withdrawable"]
+            amount = Decimal(bound_func[1]) / Decimal(10**6)
             live_balances["spot_total"] += amount
             live_balances["spot_free"] += amount
-            live_balances["perp_withdrawable"] = Decimal("0")
-            live_balances["perp_account_value"] = Decimal("0")
+            live_balances["perp_withdrawable"] -= amount
+            live_balances["perp_account_value"] -= amount
             return HexBytes("0x01")
 
         if isinstance(bound_func, tuple) and bound_func[0] == "spot_to_evm_fn":
@@ -178,10 +178,10 @@ def test_hyperliquid_cleanup_recovers_stranded_safe_balances(
         hyperliquid_cleanup, "load_cleanup_context", lambda **kwargs: context
     )
     monkeypatch.setattr(
-        hyperliquid_cleanup, "fetch_spot_clearinghouse_state", fake_fetch_spot
+        hypercore_transit_recovery, "fetch_spot_clearinghouse_state", fake_fetch_spot
     )
     monkeypatch.setattr(
-        hyperliquid_cleanup, "fetch_perp_clearinghouse_state", fake_fetch_perp
+        hypercore_transit_recovery, "fetch_perp_clearinghouse_state", fake_fetch_perp
     )
     monkeypatch.setattr(
         hyperliquid_cleanup, "fetch_user_vault_equities", fake_fetch_vault_equities
@@ -195,7 +195,7 @@ def test_hyperliquid_cleanup_recovers_stranded_safe_balances(
         assert lagoon_vault_arg is lagoon_vault
         assert isinstance(hypercore_usdc_amount, int)
         assert to_perp is False
-        return "perp_to_spot_fn"
+        return ("perp_to_spot_fn", hypercore_usdc_amount)
 
     def fake_build_hypercore_send_asset_to_evm_call(
         lagoon_vault_arg,
@@ -207,17 +207,17 @@ def test_hyperliquid_cleanup_recovers_stranded_safe_balances(
         return ("spot_to_evm_fn", evm_usdc_amount)
 
     monkeypatch.setattr(
-        hyperliquid_cleanup,
+        hypercore_transit_recovery,
         "build_hypercore_transfer_usd_class_call",
         fake_build_hypercore_transfer_usd_class_call,
     )
     monkeypatch.setattr(
-        hyperliquid_cleanup,
+        hypercore_transit_recovery,
         "build_hypercore_send_asset_to_evm_call",
         fake_build_hypercore_send_asset_to_evm_call,
     )
     monkeypatch.setattr(
-        hyperliquid_cleanup,
+        hypercore_transit_recovery,
         "assert_transaction_success_with_explanation",
         lambda *args, **kwargs: None,
     )
@@ -292,15 +292,15 @@ def test_hyperliquid_cleanup_recovers_stranded_safe_balances(
     assert report.state_saved is True
     assert state_file.with_suffix(".backup-1.json").exists()
 
-    # Step 7: Confirm the spot->EVM withdrawal was reduced by the bridge fee margin.
-    # Total spot after perp->spot recovery: 1 + 6.99345 = 7.99345 USDC.
-    # The fee-adjusted withdrawal should be 7.99345 - 0.01 = 7.98345 USDC
-    # = 7_983_450 raw (6 decimals).
+    # Step 7: Confirm the spot->EVM withdrawal leaves the configured spot dust.
+    # Total spot after perp->spot recovery: 1 + (6.99345 - 0.50) = 7.49345 USDC.
+    # The withdrawal should be 7.49345 - 0.50 = 6.99345 USDC
+    # = 6_993_450 raw (6 decimals).
     assert len(captured_evm_usdc_amounts) == 1
-    total_spot = Decimal("1") + Decimal("6.99345")
+    total_spot = Decimal("1") + Decimal("6.99345") - Decimal("0.50")
     expected_raw = int(
         (
-            (total_spot - HYPERCORE_BRIDGE_FEE_MARGIN) * Decimal(10**6)
+            (total_spot - Decimal("0.50")) * Decimal(10**6)
         ).to_integral_value()
     )
     assert captured_evm_usdc_amounts[0] == expected_raw
@@ -336,13 +336,10 @@ def test_hyperliquid_cleanup_raises_on_dust_spot_balance(monkeypatch):
         return []
 
     monkeypatch.setattr(
-        hyperliquid_cleanup, "fetch_spot_clearinghouse_state", fake_fetch_spot
+        hypercore_transit_recovery, "fetch_spot_clearinghouse_state", fake_fetch_spot
     )
     monkeypatch.setattr(
-        hyperliquid_cleanup, "fetch_perp_clearinghouse_state", fake_fetch_perp
-    )
-    monkeypatch.setattr(
-        hyperliquid_cleanup, "fetch_user_vault_equities", fake_fetch_vault_equities
+        hypercore_transit_recovery, "fetch_perp_clearinghouse_state", fake_fetch_perp
     )
 
     reserve_token = MagicMock()
@@ -435,8 +432,8 @@ def test_hyperliquid_cleanup_allows_live_vault_rows_when_stranded_recovery_exist
         "perp_to_spot",
         "spot_to_evm",
     ]
-    assert actions[0].amount == Decimal("4177.73")
-    assert actions[1].amount == Decimal("4177.739252")
+    assert actions[0].amount == Decimal("4177.23")
+    assert actions[1].amount == Decimal("4176.739252")
 
 
 def test_wait_for_spot_free_balance_accepts_threshold_instead_of_exact_match(
@@ -451,7 +448,7 @@ def test_wait_for_spot_free_balance_accepts_threshold_instead_of_exact_match(
 
     # Step 1: Mock HyperCore spot balance slightly above the threshold implied by the expected increase.
     monkeypatch.setattr(
-        hyperliquid_cleanup,
+        hypercore_transit_recovery,
         "fetch_spot_clearinghouse_state",
         lambda _session, user: SimpleNamespace(
             balances=[

--- a/tradeexecutor/cli/commands/correct_accounts.py
+++ b/tradeexecutor/cli/commands/correct_accounts.py
@@ -26,6 +26,7 @@ from ..log import setup_logging
 from ...ethereum.enzyme.tx import EnzymeTransactionBuilder
 from ...ethereum.enzyme.vault import EnzymeVaultSyncModel
 from ...ethereum.hot_wallet_sync_model import HotWalletSyncModel
+from ...ethereum.lagoon.vault import LagoonVaultSyncModel
 from ...ethereum.tx import HotWalletTransactionBuilder
 from ...state.repair import close_hypercore_dust_positions
 from ...state.state import UncleanState
@@ -168,6 +169,103 @@ def _sync_hypercore_vault_positions(
         logger.info("Vault equity sync: %d balance update(s)", len(vault_sync_events))
 
 
+def _has_closed_hypercore_positions(state) -> bool:
+    """Check whether state has closed Hypercore vault positions."""
+    return any(
+        position.pair.is_hyperliquid_vault()
+        for position in state.portfolio.closed_positions.values()
+    )
+
+
+def _recover_hypercore_transit_balances(
+    *,
+    asset_management_mode: AssetManagementMode,
+    sync_model,
+    web3,
+    hot_wallet: HotWallet | None,
+    state,
+    skip_hypercore_transit_recovery: bool,
+) -> list[str]:
+    """Recover Safe-level HyperCore spot/perp USDC before account correction."""
+    if not asset_management_mode.is_vault():
+        return []
+
+    if not _has_closed_hypercore_positions(state):
+        return []
+
+    if skip_hypercore_transit_recovery:
+        logger.info(
+            "Skipping HyperCore transit recovery although closed Hypercore positions exist"
+        )
+        return []
+
+    if not isinstance(sync_model, LagoonVaultSyncModel):
+        raise RuntimeError(
+            "Closed Hypercore positions exist, but automatic HyperCore transit recovery "
+            f"is only implemented for Lagoon vaults. Got sync model {type(sync_model)}."
+        )
+
+    if hot_wallet is None:
+        raise RuntimeError(
+            "Closed Hypercore positions exist and HyperCore transit recovery is needed, "
+            "but no hot wallet/private key is configured for broadcasting Safe transactions."
+        )
+
+    from eth_defi.hyperliquid.session import (
+        HYPERLIQUID_API_URL,
+        HYPERLIQUID_TESTNET_API_URL,
+        create_hyperliquid_session,
+    )
+    from tradeexecutor.ethereum.vault.hypercore_transit_recovery import (
+        execute_hypercore_transit_recovery_actions,
+        fetch_hypercore_transit_balances,
+        plan_hypercore_transit_recovery_actions,
+    )
+
+    is_testnet = web3.eth.chain_id == 998
+    api_url = HYPERLIQUID_TESTNET_API_URL if is_testnet else HYPERLIQUID_API_URL
+    session = create_hyperliquid_session(api_url=api_url)
+    safe_address = sync_model.get_token_storage_address()
+    reserve_token = sync_model.vault.underlying_token
+
+    logger.info(
+        "Closed Hypercore positions detected; checking Safe-level HyperCore transit balances for %s",
+        safe_address,
+    )
+    snapshot = fetch_hypercore_transit_balances(
+        session=session,
+        safe_address=safe_address,
+        reserve_token=reserve_token,
+    )
+    actions = plan_hypercore_transit_recovery_actions(snapshot)
+    if not actions:
+        logger.info("No HyperCore spot/perp transit balances need recovery")
+        return []
+
+    for action in actions:
+        logger.info(
+            "HyperCore transit recovery planned: %s %.6f USDC (%s)",
+            action.action_kind,
+            action.amount,
+            action.reason,
+        )
+
+    hot_wallet.sync_nonce(web3)
+    executed_action_kinds = execute_hypercore_transit_recovery_actions(
+        web3=web3,
+        hot_wallet=hot_wallet,
+        lagoon_vault=sync_model.vault,
+        session=session,
+        reserve_token=reserve_token,
+        actions=actions,
+    )
+    logger.info(
+        "HyperCore transit recovery completed: %s",
+        ", ".join(executed_action_kinds),
+    )
+    return executed_action_kinds
+
+
 @app.command()
 @shared_options.with_json_rpc_options()
 def correct_accounts(
@@ -205,6 +303,7 @@ def correct_accounts(
     process_redemption_end_block_hint: int = Option(None, "--process-redemption-end-block-hint", envvar="PROCESS_REDEMPTION_END_BLOCK_HINT", help="Used in integration testing."),
     transfer_away: bool = Option(False, "--transfer-away", envvar="TRANSFER_AWAY", help="For tokens without assigned position, scoop them to the hot wallet instead of trying to construct a new position"),
     raise_on_unclean: bool = typer.Option(False, is_flag=True, envvar="RAISE_ON_UNCLEAN", help="Raise an exception if unclean. Unit test option."),
+    skip_hypercore_transit_recovery: bool = Option(False, "--skip-hypercore-transit-recovery", envvar="SKIP_HYPERCORE_TRANSIT_RECOVERY", help="Skip automatic Safe-level HyperCore spot/perp USDC recovery before account correction."),
 
     # Derive exchange account options
     derive_owner_private_key: Optional[str] = Option(None, envvar="DERIVE_OWNER_PRIVATE_KEY", help="Derive owner wallet private key"),
@@ -531,6 +630,15 @@ def correct_accounts(
             "Auto-closed %d Hypercore dust position(s) before duplicate and accounting checks",
             len(closed_dust_trades),
         )
+
+    _recover_hypercore_transit_balances(
+        asset_management_mode=asset_management_mode,
+        sync_model=sync_model,
+        web3=web3,
+        hot_wallet=hot_wallet,
+        state=state,
+        skip_hypercore_transit_recovery=skip_hypercore_transit_recovery,
+    )
 
     block_number = get_almost_latest_block_number(web3)
     logger.info(f"Correcting accounts at block {block_number:,}")

--- a/tradeexecutor/ethereum/vault/hypercore_dust_claim.py
+++ b/tradeexecutor/ethereum/vault/hypercore_dust_claim.py
@@ -38,10 +38,13 @@ from tradeexecutor.ethereum.vault.hypercore_routing import (
     raw_to_usdc,
     usdc_to_raw,
 )
-from tradeexecutor.ethereum.vault.hyperliquid_cleanup import (
+from tradeexecutor.ethereum.vault.hypercore_transit_recovery import (
     BALANCE_TIMEOUT,
     BALANCE_TOLERANCE,
     CLEANUP_WAIT_RELATIVE_TOLERANCE,
+    get_spot_usdc_balances,
+)
+from tradeexecutor.ethereum.vault.hyperliquid_cleanup import (
     HyperliquidCleanupContext,
     load_cleanup_context,
 )
@@ -123,10 +126,7 @@ def _normalise_vault_address(address: str) -> str:
 
 def _get_spot_usdc_balances(spot_state) -> tuple[Decimal, Decimal]:
     """Extract total and free spot USDC from HyperCore state."""
-    for balance in spot_state.balances:
-        if balance.coin == "USDC":
-            return balance.total, balance.total - balance.hold
-    return Decimal(0), Decimal(0)
+    return get_spot_usdc_balances(spot_state)
 
 
 def _fetch_live_snapshot(

--- a/tradeexecutor/ethereum/vault/hypercore_transit_recovery.py
+++ b/tradeexecutor/ethereum/vault/hypercore_transit_recovery.py
@@ -1,0 +1,350 @@
+"""Recover stranded HyperCore spot/perp USDC back to HyperEVM reserves.
+
+This module only handles Safe-level HyperCore transit balances. It never
+withdraws live vault equity. Untracked vault dust remains the responsibility of
+``hypercore_dust_claim``.
+"""
+
+import logging
+import time
+from dataclasses import dataclass
+from decimal import Decimal
+
+from eth_defi.hotwallet import HotWallet
+from eth_defi.hyperliquid.api import (
+    HyperliquidSession,
+    fetch_perp_clearinghouse_state,
+    fetch_spot_clearinghouse_state,
+)
+from eth_defi.hyperliquid.constants import HYPERCORE_BRIDGE_FEE_MARGIN
+from eth_defi.hyperliquid.core_writer import (
+    build_hypercore_send_asset_to_evm_call,
+    build_hypercore_transfer_usd_class_call,
+    compute_spot_to_evm_withdrawal_amount,
+)
+from eth_defi.token import TokenDetails
+from eth_defi.trace import assert_transaction_success_with_explanation
+from web3 import Web3
+
+
+logger = logging.getLogger(__name__)
+
+BALANCE_TOLERANCE = Decimal("0.02")
+CLEANUP_WAIT_RELATIVE_TOLERANCE = Decimal("0.001")
+HYPERCORE_TRANSIT_RECOVERY_DUST_USDC = Decimal("0.50")
+POLL_INTERVAL = 2.0
+BALANCE_TIMEOUT = 60.0
+SAFE_GAS_LIMIT = 650_000
+
+
+@dataclass(slots=True)
+class HypercoreTransitBalanceSnapshot:
+    """Live Safe balances observed from HyperEVM and HyperCore."""
+
+    safe_address: str
+    evm_usdc_balance: Decimal
+    spot_total_usdc: Decimal
+    spot_free_usdc: Decimal
+    perp_withdrawable: Decimal
+    perp_account_value: Decimal
+    perp_position_count: int
+
+
+@dataclass(slots=True)
+class HypercoreTransitRecoveryAction:
+    """One Safe-side HyperCore transit-balance recovery action."""
+
+    action_kind: str
+    amount: Decimal
+    reason: str
+
+
+def get_spot_usdc_balances(spot_state) -> tuple[Decimal, Decimal]:
+    """Extract total and free spot USDC from HyperCore state."""
+    for balance in spot_state.balances:
+        if balance.coin == "USDC":
+            return balance.total, balance.total - balance.hold
+    return Decimal(0), Decimal(0)
+
+
+def fetch_hypercore_transit_balances(
+    *,
+    session: HyperliquidSession,
+    safe_address: str,
+    reserve_token: TokenDetails,
+) -> HypercoreTransitBalanceSnapshot:
+    """Read live Safe transit balances from HyperEVM and HyperCore."""
+    spot_state = fetch_spot_clearinghouse_state(session, user=safe_address)
+    perp_state = fetch_perp_clearinghouse_state(session, user=safe_address)
+    spot_total_usdc, spot_free_usdc = get_spot_usdc_balances(spot_state)
+    return HypercoreTransitBalanceSnapshot(
+        safe_address=safe_address,
+        evm_usdc_balance=reserve_token.fetch_balance_of(safe_address),
+        spot_total_usdc=spot_total_usdc,
+        spot_free_usdc=spot_free_usdc,
+        perp_withdrawable=perp_state.withdrawable,
+        perp_account_value=perp_state.margin_summary.account_value,
+        perp_position_count=len(perp_state.asset_positions),
+    )
+
+
+def _positive_recovery_amount(amount: Decimal) -> Decimal:
+    """Clamp negative recovery amounts to zero."""
+    if amount <= BALANCE_TOLERANCE:
+        return Decimal(0)
+    return amount
+
+
+def plan_hypercore_transit_recovery_actions(
+    snapshot: HypercoreTransitBalanceSnapshot,
+    *,
+    leave_dust: Decimal = HYPERCORE_TRANSIT_RECOVERY_DUST_USDC,
+) -> list[HypercoreTransitRecoveryAction]:
+    """Plan recovery actions for Safe-level HyperCore spot/perp USDC.
+
+    Leaves ``leave_dust`` in both perp and spot balances. The spot action is
+    planned against the post-perp-to-spot balance when a perp recovery is
+    needed.
+    """
+    if snapshot.perp_position_count > 0:
+        raise RuntimeError(
+            f"Refusing HyperCore transit recovery because Safe {snapshot.safe_address} "
+            f"has {snapshot.perp_position_count} active HyperCore perp position(s). "
+            "Manual review is required before stranded USDC can be interpreted safely."
+        )
+
+    actions: list[HypercoreTransitRecoveryAction] = []
+
+    perp_recovery_amount = _positive_recovery_amount(
+        snapshot.perp_withdrawable - leave_dust
+    )
+    if perp_recovery_amount > 0:
+        actions.append(
+            HypercoreTransitRecoveryAction(
+                action_kind="perp_to_spot",
+                amount=perp_recovery_amount,
+                reason=(
+                    f"Recover HyperCore perp USDC back to HyperCore spot, "
+                    f"leaving {leave_dust} USDC perp dust"
+                ),
+            )
+        )
+
+    projected_spot_free = snapshot.spot_free_usdc + perp_recovery_amount
+    spot_recovery_amount = _positive_recovery_amount(projected_spot_free - leave_dust)
+    if spot_recovery_amount > 0:
+        actions.append(
+            HypercoreTransitRecoveryAction(
+                action_kind="spot_to_evm",
+                amount=spot_recovery_amount,
+                reason=(
+                    f"Recover HyperCore spot USDC back to the Safe on HyperEVM, "
+                    f"leaving {leave_dust} USDC spot dust"
+                ),
+            )
+        )
+
+    return actions
+
+
+def get_wait_threshold(
+    baseline_balance: Decimal,
+    expected_increase: Decimal,
+) -> tuple[Decimal, Decimal]:
+    """Calculate the minimum balance increase that recovery waits should accept."""
+    accepted_tolerance = max(
+        BALANCE_TOLERANCE,
+        expected_increase * CLEANUP_WAIT_RELATIVE_TOLERANCE,
+    )
+    return baseline_balance + expected_increase - accepted_tolerance, accepted_tolerance
+
+
+def wait_for_spot_free_balance(
+    session: HyperliquidSession,
+    user: str,
+    baseline_balance: Decimal,
+    expected_increase: Decimal,
+    timeout: float = BALANCE_TIMEOUT,
+    poll_interval: float = POLL_INTERVAL,
+) -> Decimal:
+    """Wait until free spot USDC reaches the expected threshold."""
+    expected_balance, accepted_tolerance = get_wait_threshold(
+        baseline_balance=baseline_balance,
+        expected_increase=expected_increase,
+    )
+    deadline = time.time() + timeout
+    while True:
+        spot_state = fetch_spot_clearinghouse_state(session, user=user)
+        _spot_total, spot_free = get_spot_usdc_balances(spot_state)
+        if spot_free >= expected_balance:
+            return spot_free
+        if time.time() >= deadline:
+            raise AssertionError(
+                f"Timed out waiting for HyperCore free spot USDC threshold {expected_balance} "
+                f"for {user} (expected increase {expected_increase}, tolerance {accepted_tolerance}), "
+                f"last observed balance was {spot_free}"
+            )
+        time.sleep(poll_interval)
+
+
+def wait_for_evm_usdc_balance(
+    token: TokenDetails,
+    address: str,
+    baseline_balance: Decimal,
+    expected_increase: Decimal,
+    timeout: float = BALANCE_TIMEOUT,
+    poll_interval: float = POLL_INTERVAL,
+) -> Decimal:
+    """Wait until EVM USDC reaches the expected threshold."""
+    expected_balance, accepted_tolerance = get_wait_threshold(
+        baseline_balance=baseline_balance,
+        expected_increase=expected_increase,
+    )
+    deadline = time.time() + timeout
+    while True:
+        balance = token.fetch_balance_of(address)
+        if balance >= expected_balance:
+            return balance
+        if time.time() >= deadline:
+            raise AssertionError(
+                f"Timed out waiting for HyperEVM USDC threshold {expected_balance} "
+                f"for {address} (expected increase {expected_increase}, tolerance {accepted_tolerance}), "
+                f"last observed balance was {balance}"
+            )
+        time.sleep(poll_interval)
+
+
+def broadcast_bound_call(
+    web3: Web3,
+    hot_wallet: HotWallet,
+    bound_func,
+    gas_limit: int = SAFE_GAS_LIMIT,
+) -> str:
+    """Broadcast a single Safe/module transaction and assert success."""
+    tx_hash = hot_wallet.transact_and_broadcast_with_contract(
+        bound_func, gas_limit=gas_limit
+    )
+    assert_transaction_success_with_explanation(web3, tx_hash)
+    return tx_hash.hex()
+
+
+def execute_perp_to_spot(
+    *,
+    web3: Web3,
+    hot_wallet: HotWallet,
+    lagoon_vault,
+    session: HyperliquidSession,
+    reserve_token: TokenDetails,
+    amount: Decimal,
+) -> str:
+    """Recover stranded USDC from HyperCore perp back to spot."""
+    safe_address = lagoon_vault.safe_address
+    live_snapshot = fetch_hypercore_transit_balances(
+        session=session,
+        safe_address=safe_address,
+        reserve_token=reserve_token,
+    )
+    assert live_snapshot.perp_withdrawable + BALANCE_TOLERANCE >= amount, (
+        f"Before transferUsdClass(perp->spot), Safe {safe_address} perp withdrawable balance is "
+        f"{live_snapshot.perp_withdrawable}, expected at least {amount}"
+    )
+
+    baseline_spot_free = live_snapshot.spot_free_usdc
+    fn = build_hypercore_transfer_usd_class_call(
+        lagoon_vault,
+        hypercore_usdc_amount=reserve_token.convert_to_raw(amount),
+        to_perp=False,
+    )
+    tx_hash = broadcast_bound_call(web3, hot_wallet, fn)
+    wait_for_spot_free_balance(
+        session,
+        safe_address,
+        baseline_balance=baseline_spot_free,
+        expected_increase=amount,
+    )
+    return tx_hash
+
+
+def execute_spot_to_evm(
+    *,
+    web3: Web3,
+    hot_wallet: HotWallet,
+    lagoon_vault,
+    session: HyperliquidSession,
+    reserve_token: TokenDetails,
+    amount: Decimal,
+) -> str:
+    """Recover stranded USDC from HyperCore spot back to HyperEVM."""
+    safe_address = lagoon_vault.safe_address
+    live_snapshot = fetch_hypercore_transit_balances(
+        session=session,
+        safe_address=safe_address,
+        reserve_token=reserve_token,
+    )
+    assert live_snapshot.spot_free_usdc + BALANCE_TOLERANCE >= amount, (
+        f"Before spotSend(spot->EVM), Safe {safe_address} free spot USDC balance is "
+        f"{live_snapshot.spot_free_usdc}, expected at least {amount}"
+    )
+
+    withdraw_amount = compute_spot_to_evm_withdrawal_amount(
+        spot_balance=live_snapshot.spot_free_usdc,
+        desired_amount=amount,
+    )
+    if withdraw_amount < BALANCE_TOLERANCE:
+        raise RuntimeError(
+            f"Spot balance {live_snapshot.spot_free_usdc} for Safe {safe_address} "
+            f"is too small to cover the HyperCore bridge fee margin "
+            f"({HYPERCORE_BRIDGE_FEE_MARGIN} USDC); cannot withdraw to EVM"
+        )
+
+    baseline_evm_balance = live_snapshot.evm_usdc_balance
+    fn = build_hypercore_send_asset_to_evm_call(
+        lagoon_vault,
+        evm_usdc_amount=reserve_token.convert_to_raw(withdraw_amount),
+    )
+    tx_hash = broadcast_bound_call(web3, hot_wallet, fn)
+    wait_for_evm_usdc_balance(
+        reserve_token,
+        safe_address,
+        baseline_balance=baseline_evm_balance,
+        expected_increase=withdraw_amount,
+    )
+    return tx_hash
+
+
+def execute_hypercore_transit_recovery_actions(
+    *,
+    web3: Web3,
+    hot_wallet: HotWallet,
+    lagoon_vault,
+    session: HyperliquidSession,
+    reserve_token: TokenDetails,
+    actions: list[HypercoreTransitRecoveryAction],
+) -> list[str]:
+    """Execute Safe-side HyperCore transit recovery actions in order."""
+    executed: list[str] = []
+    for action in actions:
+        if action.action_kind == "perp_to_spot":
+            execute_perp_to_spot(
+                web3=web3,
+                hot_wallet=hot_wallet,
+                lagoon_vault=lagoon_vault,
+                session=session,
+                reserve_token=reserve_token,
+                amount=action.amount,
+            )
+        elif action.action_kind == "spot_to_evm":
+            execute_spot_to_evm(
+                web3=web3,
+                hot_wallet=hot_wallet,
+                lagoon_vault=lagoon_vault,
+                session=session,
+                reserve_token=reserve_token,
+                amount=action.amount,
+            )
+        else:
+            raise NotImplementedError(
+                f"Unsupported HyperCore transit recovery action: {action.action_kind}"
+            )
+        executed.append(action.action_kind)
+    return executed

--- a/tradeexecutor/ethereum/vault/hyperliquid_cleanup.py
+++ b/tradeexecutor/ethereum/vault/hyperliquid_cleanup.py
@@ -32,7 +32,6 @@ active perp positions, because that requires manual review.
 import datetime
 import logging
 import os
-import time
 from dataclasses import dataclass
 from decimal import Decimal
 from pathlib import Path
@@ -40,21 +39,13 @@ from pathlib import Path
 from eth_defi.compat import native_datetime_utc_now
 from eth_defi.erc_4626.vault_protocol.lagoon.vault import LagoonVault
 from eth_defi.hotwallet import HotWallet
-from eth_defi.hyperliquid.api import (HyperliquidSession, UserVaultEquity,
-                                      fetch_perp_clearinghouse_state,
-                                      fetch_spot_clearinghouse_state,
+from eth_defi.hyperliquid.api import (HyperliquidSession,
                                       fetch_user_vault_equities)
-from eth_defi.hyperliquid.constants import HYPERCORE_BRIDGE_FEE_MARGIN
-from eth_defi.hyperliquid.core_writer import (
-    build_hypercore_send_asset_to_evm_call,
-    build_hypercore_transfer_usd_class_call,
-    compute_spot_to_evm_withdrawal_amount)
 from eth_defi.hyperliquid.session import (HYPERLIQUID_API_URL,
                                           HYPERLIQUID_TESTNET_API_URL,
                                           create_hyperliquid_session)
 from eth_defi.provider.broken_provider import get_almost_latest_block_number
 from eth_defi.token import TokenDetails
-from eth_defi.trace import assert_transaction_success_with_explanation
 from tabulate import tabulate
 from web3 import Web3
 
@@ -65,6 +56,22 @@ from tradeexecutor.cli.bootstrap import (backup_state, create_client,
                                          prepare_executor_id)
 from tradeexecutor.cli.log import setup_logging
 from tradeexecutor.ethereum.lagoon.vault import LagoonVaultSyncModel
+from tradeexecutor.ethereum.vault.hypercore_transit_recovery import (
+    BALANCE_TIMEOUT,
+    BALANCE_TOLERANCE,
+    HypercoreTransitRecoveryAction,
+    POLL_INTERVAL,
+    SAFE_GAS_LIMIT,
+    execute_hypercore_transit_recovery_actions,
+    execute_perp_to_spot,
+    execute_spot_to_evm,
+    fetch_hypercore_transit_balances,
+    get_spot_usdc_balances,
+    get_wait_threshold,
+    plan_hypercore_transit_recovery_actions,
+    wait_for_evm_usdc_balance,
+    wait_for_spot_free_balance,
+)
 from tradeexecutor.state.repair import close_hypercore_dust_positions, repair_trades
 from tradeexecutor.state.state import State
 from tradeexecutor.state.store import JSONFileStore
@@ -85,12 +92,7 @@ from tradeexecutor.strategy.universe_model import UniverseOptions
 
 logger = logging.getLogger(__name__)
 
-BALANCE_TOLERANCE = Decimal("0.02")
-CLEANUP_WAIT_RELATIVE_TOLERANCE = Decimal("0.001")
 RESIDUAL_VAULT_EQUITY_THRESHOLD = Decimal("0.10")
-POLL_INTERVAL = 2.0
-BALANCE_TIMEOUT = 60.0
-SAFE_GAS_LIMIT = 650_000
 
 
 @dataclass(slots=True)
@@ -209,11 +211,7 @@ def _get_cleanup_wait_threshold(
     expected_increase: Decimal,
 ) -> tuple[Decimal, Decimal]:
     """Calculate the minimum balance increase that cleanup waits should accept."""
-    accepted_tolerance = max(
-        BALANCE_TOLERANCE,
-        expected_increase * CLEANUP_WAIT_RELATIVE_TOLERANCE,
-    )
-    return baseline_balance + expected_increase - accepted_tolerance, accepted_tolerance
+    return get_wait_threshold(baseline_balance, expected_increase)
 
 
 def _position_vault_address(position) -> str:
@@ -224,10 +222,7 @@ def _position_vault_address(position) -> str:
 
 def _get_spot_usdc_balances(spot_state) -> tuple[Decimal, Decimal]:
     """Extract total and free spot USDC from HyperCore state."""
-    for balance in spot_state.balances:
-        if balance.coin == "USDC":
-            return balance.total, balance.total - balance.hold
-    return Decimal(0), Decimal(0)
+    return get_spot_usdc_balances(spot_state)
 
 
 def _fetch_live_cleanup_snapshot(
@@ -235,21 +230,23 @@ def _fetch_live_cleanup_snapshot(
 ) -> HyperliquidCleanupSnapshot:
     """Read live Safe balances from HyperEVM and Hyperliquid."""
     safe_address = context.lagoon_vault.safe_address
-    spot_state = fetch_spot_clearinghouse_state(context.session, user=safe_address)
-    perp_state = fetch_perp_clearinghouse_state(context.session, user=safe_address)
+    transit_snapshot = fetch_hypercore_transit_balances(
+        session=context.session,
+        safe_address=safe_address,
+        reserve_token=context.reserve_token,
+    )
     vault_equities = {
         Web3.to_checksum_address(entry.vault_address): entry.equity
         for entry in fetch_user_vault_equities(context.session, user=safe_address)
     }
-    spot_total_usdc, spot_free_usdc = _get_spot_usdc_balances(spot_state)
     return HyperliquidCleanupSnapshot(
         safe_address=safe_address,
-        evm_usdc_balance=context.reserve_token.fetch_balance_of(safe_address),
-        spot_total_usdc=spot_total_usdc,
-        spot_free_usdc=spot_free_usdc,
-        perp_withdrawable=perp_state.withdrawable,
-        perp_account_value=perp_state.margin_summary.account_value,
-        perp_position_count=len(perp_state.asset_positions),
+        evm_usdc_balance=transit_snapshot.evm_usdc_balance,
+        spot_total_usdc=transit_snapshot.spot_total_usdc,
+        spot_free_usdc=transit_snapshot.spot_free_usdc,
+        perp_withdrawable=transit_snapshot.perp_withdrawable,
+        perp_account_value=transit_snapshot.perp_account_value,
+        perp_position_count=transit_snapshot.perp_position_count,
         vault_equities=vault_equities,
     )
 
@@ -261,10 +258,11 @@ def _build_state_snapshot(state: State) -> HyperliquidStateSnapshot:
         reserve_quantity = state.portfolio.get_default_reserve_position().quantity
 
     positions: list[HyperliquidStatePositionSnapshot] = []
-    for position in state.portfolio.get_open_and_frozen_positions():
-        if not position.is_vault():
-            continue
-        if position.pair.other_data.get("vault_protocol") != "hyperliquid":
+    state_positions = list(state.portfolio.get_open_and_frozen_positions())
+    state_positions.extend(state.portfolio.closed_positions.values())
+
+    for position in state_positions:
+        if not position.pair.is_hyperliquid_vault():
             continue
 
         failed_trade_ids = [
@@ -282,7 +280,13 @@ def _build_state_snapshot(state: State) -> HyperliquidStateSnapshot:
         positions.append(
             HyperliquidStatePositionSnapshot(
                 position_id=position.position_id,
-                state_status="frozen" if position.is_frozen() else "open",
+                state_status=(
+                    "closed"
+                    if position.is_closed()
+                    else "frozen"
+                    if position.is_frozen()
+                    else "open"
+                ),
                 quantity=position.get_quantity(),
                 vault_address=_position_vault_address(position),
                 vault_name=position.pair.other_data.get(
@@ -308,8 +312,10 @@ def _classify_cleanup_row(
         position.vault_address, Decimal(0)
     )
     stranded_balance = live_snapshot.spot_free_usdc + live_snapshot.perp_withdrawable
-    is_failed_close_candidate = position.state_status == "frozen" or bool(
-        position.failed_trade_ids
+    is_failed_close_candidate = (
+        position.state_status in {"frozen", "closed"}
+        or bool(position.failed_trade_ids)
+        or bool(position.stranded_metadata)
     )
     residual_vault_equity = live_vault_equity <= RESIDUAL_VAULT_EQUITY_THRESHOLD
     stranded_balance_dominates = (
@@ -409,30 +415,27 @@ def _plan_cleanup_actions(
             "No recognised stranded-balance failed-close Hypercore position was found for clean-up."
         )
 
-    actions: list[HyperliquidCleanupAction] = []
-    if live_snapshot.perp_withdrawable > BALANCE_TOLERANCE:
-        actions.append(
-            HyperliquidCleanupAction(
-                action_kind="perp_to_spot",
-                amount=live_snapshot.perp_withdrawable,
-                reason="Recover stranded HyperCore perp USDC back to HyperCore spot",
-            )
+    transit_actions = plan_hypercore_transit_recovery_actions(live_snapshot)
+    return [
+        HyperliquidCleanupAction(
+            action_kind=action.action_kind,
+            amount=action.amount,
+            reason=action.reason,
         )
+        for action in transit_actions
+    ]
 
-    total_spot_to_recover = live_snapshot.spot_free_usdc
-    if live_snapshot.perp_withdrawable > BALANCE_TOLERANCE:
-        total_spot_to_recover += live_snapshot.perp_withdrawable
 
-    if total_spot_to_recover > BALANCE_TOLERANCE:
-        actions.append(
-            HyperliquidCleanupAction(
-                action_kind="spot_to_evm",
-                amount=total_spot_to_recover,
-                reason="Recover stranded HyperCore spot USDC back to the Safe on HyperEVM",
-            )
+def _as_transit_actions(actions: list[HyperliquidCleanupAction]) -> list[HypercoreTransitRecoveryAction]:
+    """Convert historical clean-up actions to shared transit actions."""
+    return [
+        HypercoreTransitRecoveryAction(
+            action_kind=action.action_kind,
+            amount=action.amount,
+            reason=action.reason,
         )
-
-    return actions
+        for action in actions
+    ]
 
 
 def _print_reality_table(
@@ -543,28 +546,14 @@ def _wait_for_spot_free_balance(
     poll_interval: float = POLL_INTERVAL,
 ) -> Decimal:
     """Wait until free spot USDC reaches the expected balance."""
-    # WARNING: Do not wait for an exact final spot balance here.
-    # Cleanup is an operator recovery flow and the Safe can already have spot
-    # dust or receive nearby balance changes while we are polling.  We only
-    # need to prove that the expected recovery amount arrived within a modest
-    # tolerance, not that the final balance matches one exact snapshot.
-    expected_balance, accepted_tolerance = _get_cleanup_wait_threshold(
+    return wait_for_spot_free_balance(
+        session,
+        user,
         baseline_balance=baseline_balance,
         expected_increase=expected_increase,
+        timeout=timeout,
+        poll_interval=poll_interval,
     )
-    deadline = time.time() + timeout
-    while True:
-        spot_state = fetch_spot_clearinghouse_state(session, user=user)
-        _spot_total, spot_free = _get_spot_usdc_balances(spot_state)
-        if spot_free >= expected_balance:
-            return spot_free
-        if time.time() >= deadline:
-            raise AssertionError(
-                f"Timed out waiting for HyperCore free spot USDC threshold {expected_balance} "
-                f"for {user} (expected increase {expected_increase}, tolerance {accepted_tolerance}), "
-                f"last observed balance was {spot_free}"
-            )
-        time.sleep(poll_interval)
 
 
 def _wait_for_evm_usdc_balance(
@@ -576,27 +565,14 @@ def _wait_for_evm_usdc_balance(
     poll_interval: float = POLL_INTERVAL,
 ) -> Decimal:
     """Wait until EVM USDC reaches the expected balance."""
-    # WARNING: Do not wait for one exact final EVM balance here.
-    # The cleanup bridge confirmation only needs to prove that the expected
-    # increase arrived.  Requiring an exact final balance causes false
-    # failures when the Safe balance is slightly higher than the snapshot we
-    # started from or when minor bridge-side rounding drifts occur.
-    expected_balance, accepted_tolerance = _get_cleanup_wait_threshold(
+    return wait_for_evm_usdc_balance(
+        token,
+        address,
         baseline_balance=baseline_balance,
         expected_increase=expected_increase,
+        timeout=timeout,
+        poll_interval=poll_interval,
     )
-    deadline = time.time() + timeout
-    while True:
-        balance = token.fetch_balance_of(address)
-        if balance >= expected_balance:
-            return balance
-        if time.time() >= deadline:
-            raise AssertionError(
-                f"Timed out waiting for HyperEVM USDC threshold {expected_balance} "
-                f"for {address} (expected increase {expected_increase}, tolerance {accepted_tolerance}), "
-                f"last observed balance was {balance}"
-            )
-        time.sleep(poll_interval)
 
 
 def _broadcast_bound_call(
@@ -606,11 +582,9 @@ def _broadcast_bound_call(
     gas_limit: int = SAFE_GAS_LIMIT,
 ) -> str:
     """Broadcast a single Safe/module transaction and assert success."""
-    tx_hash = hot_wallet.transact_and_broadcast_with_contract(
-        bound_func, gas_limit=gas_limit
-    )
-    assert_transaction_success_with_explanation(web3, tx_hash)
-    return tx_hash.hex()
+    from tradeexecutor.ethereum.vault.hypercore_transit_recovery import broadcast_bound_call
+
+    return broadcast_bound_call(web3, hot_wallet, bound_func, gas_limit=gas_limit)
 
 
 def _execute_perp_to_spot(
@@ -618,27 +592,14 @@ def _execute_perp_to_spot(
     amount: Decimal,
 ) -> str:
     """Recover stranded USDC from HyperCore perp back to spot."""
-    safe_address = context.lagoon_vault.safe_address
-    live_snapshot = _fetch_live_cleanup_snapshot(context)
-    assert live_snapshot.perp_withdrawable + BALANCE_TOLERANCE >= amount, (
-        f"Before transferUsdClass(perp->spot), Safe {safe_address} perp withdrawable balance is "
-        f"{live_snapshot.perp_withdrawable}, expected at least {amount}"
+    return execute_perp_to_spot(
+        web3=context.web3,
+        hot_wallet=context.hot_wallet,
+        lagoon_vault=context.lagoon_vault,
+        session=context.session,
+        reserve_token=context.reserve_token,
+        amount=amount,
     )
-
-    baseline_spot_free = live_snapshot.spot_free_usdc
-    fn = build_hypercore_transfer_usd_class_call(
-        context.lagoon_vault,
-        hypercore_usdc_amount=context.reserve_token.convert_to_raw(amount),
-        to_perp=False,
-    )
-    tx_hash = _broadcast_bound_call(context.web3, context.hot_wallet, fn)
-    _wait_for_spot_free_balance(
-        context.session,
-        safe_address,
-        baseline_balance=baseline_spot_free,
-        expected_increase=amount,
-    )
-    return tx_hash
 
 
 def _execute_spot_to_evm(
@@ -646,40 +607,14 @@ def _execute_spot_to_evm(
     amount: Decimal,
 ) -> str:
     """Recover stranded USDC from HyperCore spot back to HyperEVM."""
-    safe_address = context.lagoon_vault.safe_address
-    live_snapshot = _fetch_live_cleanup_snapshot(context)
-    assert live_snapshot.spot_free_usdc + BALANCE_TOLERANCE >= amount, (
-        f"Before spotSend(spot->EVM), Safe {safe_address} free spot USDC balance is "
-        f"{live_snapshot.spot_free_usdc}, expected at least {amount}"
+    return execute_spot_to_evm(
+        web3=context.web3,
+        hot_wallet=context.hot_wallet,
+        lagoon_vault=context.lagoon_vault,
+        session=context.session,
+        reserve_token=context.reserve_token,
+        amount=amount,
     )
-
-    # Reserve a margin for the HyperCore -> HyperEVM bridge fee which is
-    # deducted from spot *before* settlement.  Without this the withdrawal
-    # silently fails when we try to bridge the entire spot balance.
-    withdraw_amount = compute_spot_to_evm_withdrawal_amount(
-        spot_balance=live_snapshot.spot_free_usdc,
-        desired_amount=amount,
-    )
-    if withdraw_amount < BALANCE_TOLERANCE:
-        raise RuntimeError(
-            f"Spot balance {live_snapshot.spot_free_usdc} for Safe {safe_address} "
-            f"is too small to cover the HyperCore bridge fee margin "
-            f"({HYPERCORE_BRIDGE_FEE_MARGIN} USDC); cannot withdraw to EVM"
-        )
-
-    baseline_evm_balance = live_snapshot.evm_usdc_balance
-    fn = build_hypercore_send_asset_to_evm_call(
-        context.lagoon_vault,
-        evm_usdc_amount=context.reserve_token.convert_to_raw(withdraw_amount),
-    )
-    tx_hash = _broadcast_bound_call(context.web3, context.hot_wallet, fn)
-    _wait_for_evm_usdc_balance(
-        context.reserve_token,
-        safe_address,
-        baseline_balance=baseline_evm_balance,
-        expected_increase=withdraw_amount,
-    )
-    return tx_hash
 
 
 def _execute_cleanup_actions(
@@ -687,18 +622,14 @@ def _execute_cleanup_actions(
     actions: list[HyperliquidCleanupAction],
 ) -> list[str]:
     """Execute Safe-side recovery actions in order."""
-    executed: list[str] = []
-    for action in actions:
-        if action.action_kind == "perp_to_spot":
-            _execute_perp_to_spot(context, action.amount)
-        elif action.action_kind == "spot_to_evm":
-            _execute_spot_to_evm(context, action.amount)
-        else:
-            raise NotImplementedError(
-                f"Unsupported Hyperliquid clean-up action: {action.action_kind}"
-            )
-        executed.append(action.action_kind)
-    return executed
+    return execute_hypercore_transit_recovery_actions(
+        web3=context.web3,
+        hot_wallet=context.hot_wallet,
+        lagoon_vault=context.lagoon_vault,
+        session=context.session,
+        reserve_token=context.reserve_token,
+        actions=_as_transit_actions(actions),
+    )
 
 
 def _build_accounting_correction_context(

--- a/tradeexecutor/strategy/account_correction.py
+++ b/tradeexecutor/strategy/account_correction.py
@@ -487,7 +487,7 @@ def apply_accounting_correction(
         block_mined_at=correction.timestamp,
         strategy_cycle_included_at=strategy_cycle_included_at,
         chain_id=asset.chain_id,
-        old_balance=correction.actual_amount,
+        old_balance=correction.expected_amount,
         usd_value=correction.usd_value,
         quantity=correction.quantity,
         owner_address=None,


### PR DESCRIPTION
## Why

Closed Hypercore vault positions can leave Safe-level USDC stranded on HyperCore spot or perp even when the actual vault close is already complete. The normal account correction flow only sees HyperEVM reserve balances, so it needs to bring these transit balances back before calculating corrections.

This also fixes an accounting audit issue where correction events recorded the actual balance as the old balance instead of the expected ledger balance.

## Lessons learnt

The stuck money was not live vault equity and should not be recovered by reopening closed vault positions or by folding vault dust claiming into correct-accounts. Safe-level spot/perp transit balances need their own narrow recovery path, and tiny dust should remain on HyperCore so bridge/withdraw operations do not fail.

## Summary

- Added reusable HyperCore transit recovery helpers for spot/perp snapshots, action planning, execution, and threshold waits.
- Wired automatic transit recovery into correct-accounts when closed Hypercore vault positions exist, with --skip-hypercore-transit-recovery / SKIP_HYPERCORE_TRANSIT_RECOVERY for emergencies.
- Left 0.50 USDC dust on both perp and spot recovery legs and aborted recovery when active perp positions exist.
- Refactored Hyperliquid cleanup and dust/manual tooling to reuse shared balance helpers where safe.
- Fixed correction event old_balance to record expected_amount.
- Added focused tests for recovery planning, execution, correct-accounts hook behaviour, cleanup integration, and the accounting audit regression.