### PR TITLE
Fix HyperCore withdrawal phase 2 silent no-op crash

### DIFF
--- a/tradeexecutor/ethereum/vault/hypercore_routing.py
+++ b/tradeexecutor/ethereum/vault/hypercore_routing.py
@@ -962,8 +962,8 @@ class HypercoreVaultRouting(RoutingModel):
         poll_interval: float = 2.0,
     ) -> Decimal:
         """Poll HyperCore spot free USDC until the perp-to-spot move is visible."""
-        # Temporary stop-gap: accept a slightly smaller spot balance here.
-        # Proper fix: propagate the observed perp balance into phase 2.
+        # Accept a slightly smaller spot balance to cover minor drift between
+        # the requested amount and what HyperCore actually delivers.
         expected_increase_threshold_raw = max(
             expected_increase_raw - HYPERCORE_FOLLOW_UP_PHASE_TOLERANCE_RAW,
             0,
@@ -2008,6 +2008,22 @@ class HypercoreVaultRouting(RoutingModel):
                 perp_balance,
             )
 
+            # Propagate the observed perp balance into the phase 2 amount.
+            # Phase 1 may have delivered slightly less USDC than expected
+            # (HyperCore fees/rounding).  If we request more than what the
+            # perp account holds, HyperCore silently rejects the
+            # transferUsdClass action (EVM tx status=1 but nothing moves).
+            actual_perp_increase_raw = usdc_to_raw(perp_balance - baseline_perp_withdrawable)
+            if actual_perp_increase_raw > 0 and actual_perp_increase_raw < expected_raw:
+                logger.info(
+                    "Capping phase 2 amount to observed perp increase for trade %s: "
+                    "%d raw (%s USDC) vs planned %d raw (%s USDC)",
+                    trade.trade_id,
+                    actual_perp_increase_raw, raw_to_usdc(actual_perp_increase_raw),
+                    expected_raw, raw_to_usdc(expected_raw),
+                )
+                expected_raw = actual_perp_increase_raw
+
             self.deployer.sync_nonce(web3)
 
             try:
@@ -2040,7 +2056,16 @@ class HypercoreVaultRouting(RoutingModel):
                     "Withdrawal phase 2 verification failed for trade %s: %s",
                     trade.trade_id, e,
                 )
-                self._mark_stranded_usdc(trade, expected_raw, "hypercore_spot")
+                # Determine where the USDC actually is: if perp balance is
+                # still elevated above the pre-phase-1 baseline, the
+                # transferUsdClass silently no-opped and USDC is in perp.
+                current_perp = self._fetch_safe_perp_withdrawable_balance()
+                perp_increase = current_perp - baseline_perp_withdrawable
+                if usdc_to_raw(perp_increase) > expected_raw // 2:
+                    stranded_location = "hypercore_perp"
+                else:
+                    stranded_location = "hypercore_spot"
+                self._mark_stranded_usdc(trade, expected_raw, stranded_location)
                 report_failure(ts, state, trade, stop_on_execution_failure)
                 return
 


### PR DESCRIPTION
## Why

The `hyper-ai` executor crashed because `transferUsdClass(perp→spot)` was called with the originally planned withdrawal amount, which exceeded the actual USDC available in the perp account. Phase 1 (`vaultTransfer`) delivered slightly less USDC than expected due to HyperCore fees/rounding, but phase 2 still requested the full planned amount. HyperCore silently rejected the transfer (EVM tx status=1 but nothing moved), causing the spot free balance poll to time out after 30s, freezing the position and crashing the executor.

Additionally, when phase 2 verification fails, the stranded USDC location was always reported as `hypercore_spot`, which was misleading — the USDC was actually still in `hypercore_perp` since the transfer never happened.

## Lessons learnt

- HyperCore `transferUsdClass` follows the same silent no-op pattern as `vaultTransfer`: the EVM wrapper tx succeeds but HyperCore ignores the action if the requested amount exceeds available balance.
- The code already had a TODO comment identifying this as the proper fix (line 965-966: "Proper fix: propagate the observed perp balance into phase 2").
- Stranded USDC diagnostics should check actual balances to determine where funds are, not assume a location.

## Summary

- Cap phase 2 `transferUsdClass` amount to the actual observed perp increase (`perp_balance - baseline_perp_withdrawable`) instead of the planned `expected_raw`
- When phase 2 verification times out, check the current perp balance to correctly identify whether USDC is stranded in `hypercore_perp` (transfer no-opped) or `hypercore_spot` (on hold)
- Removed the now-resolved TODO comment about propagating observed perp balance

🤖 Generated with [Claude Code](https://claude.com/claude-code)