### PR TITLE
Fix TooSmallTrade crash for Hyperliquid vault buy trades

### DIFF
--- a/tests/hyperliquid/test_hypercore_accounting.py
+++ b/tests/hyperliquid/test_hypercore_accounting.py
@@ -237,8 +237,8 @@ def test_hypercore_vault_dust_epsilon_covers_safety_margin():
     recognises the position as effectively closed.
 
     1. Build a Hypercore vault pair using create_hypercore_vault_pair().
-    2. Verify get_close_epsilon_for_pair() and get_dust_epsilon_for_pair()
-       return the Hypercore-specific epsilon.
+    2. Verify get_close_epsilon_for_pair() returns the Hypercore-specific epsilon
+       and get_dust_epsilon_for_pair() returns the smaller vault default.
     3. Create a TradingPosition with safety-margin dust quantity (1.50) and assert can_be_closed().
     4. Same position with non-dust quantity (2.50) must NOT be closeable.
     5. Build a non-Hypercore vault pair and verify it still gets DEFAULT_VAULT_EPSILON.
@@ -257,9 +257,10 @@ def test_hypercore_vault_dust_epsilon_covers_safety_margin():
     )
     assert hypercore_pair.is_hyperliquid_vault()
 
-    # 2. Epsilon functions return Hypercore-specific value
+    # 2. Close epsilon returns Hypercore-specific value; dust epsilon uses
+    #    the smaller vault default so that buy trades are not rejected
     assert get_close_epsilon_for_pair(hypercore_pair) == HYPERLIQUID_VAULT_CLOSE_EPSILON
-    assert get_dust_epsilon_for_pair(hypercore_pair) == HYPERLIQUID_VAULT_CLOSE_EPSILON
+    assert get_dust_epsilon_for_pair(hypercore_pair) == DEFAULT_VAULT_EPSILON
 
     # 3. Position with safety-margin dust quantity (1.50 USDC) can be closed
     ts = native_datetime_utc_now()

--- a/tradeexecutor/strategy/account_correction.py
+++ b/tradeexecutor/strategy/account_correction.py
@@ -33,7 +33,7 @@ from tradeexecutor.state.generic_position import GenericPosition
 from tradeexecutor.state.portfolio import Portfolio
 from tradeexecutor.state.repair import close_position_with_empty_trade
 from tradeexecutor.state.trade import TradeFlag, TradeExecution, TradeType
-from tradeexecutor.strategy.dust import DEFAULT_DUST_EPSILON, get_dust_epsilon_for_pair, get_dust_epsilon_for_asset, DEFAULT_RELATIVE_EPSILON, \
+from tradeexecutor.strategy.dust import DEFAULT_DUST_EPSILON, get_close_epsilon_for_pair, get_dust_epsilon_for_asset, DEFAULT_RELATIVE_EPSILON, \
     get_relative_epsilon_for_asset, get_relative_epsilon_for_pair, DEFAULT_USD_LOW_VALUE_THRESHOLD
 from tradeexecutor.strategy.lending_protocol_leverage import reset_credit_supply_loan
 from tradeexecutor.strategy.pandas_trader.position_manager import PositionManager
@@ -378,7 +378,7 @@ def calculate_account_corrections(
             position = mapping.get_only_position()
 
             if isinstance(position, TradingPosition):
-                dust_epsilon = get_dust_epsilon_for_pair(position.pair)
+                dust_epsilon = get_close_epsilon_for_pair(position.pair)
             elif isinstance(position, ReservePosition):
                 dust_epsilon = get_dust_epsilon_for_asset(position.asset)
             elif position is None:
@@ -1172,7 +1172,7 @@ def create_missing_vault_positions(
         # Dust-level equity: create a position and immediately close it
         # so it appears in closed positions rather than lingering as an
         # un-trackable open position.
-        dust_epsilon = get_dust_epsilon_for_pair(pair)
+        dust_epsilon = get_close_epsilon_for_pair(pair)
         if equity < float(dust_epsilon):
             logger.info(
                 "Vault equity $%.4f for %s is below dust epsilon %.2f, closing as dust",
@@ -1410,7 +1410,7 @@ def _build_hypercore_vault_account_checks(
         quantity = position.get_quantity()
         expected_amount = Decimal(str(position.calculate_quantity_usd_value(quantity)))
         actual_amount = balance.amount
-        dust_epsilon = get_dust_epsilon_for_pair(position.pair)
+        dust_epsilon = get_close_epsilon_for_pair(position.pair)
         relative_epsilon = get_relative_epsilon_for_pair(position.pair)
         mismatch = is_relative_mismatch(
             actual_amount,

--- a/tradeexecutor/strategy/alpha_model.py
+++ b/tradeexecutor/strategy/alpha_model.py
@@ -20,7 +20,7 @@ from tradeexecutor.state.size_risk import SizeRisk
 from tradeexecutor.state.trade import TradeExecution, TradeType
 from tradeexecutor.state.types import (LeverageMultiplier, PairInternalId,
                                        Percent, USDollarAmount)
-from tradeexecutor.strategy.dust import get_dust_epsilon_for_pair
+from tradeexecutor.strategy.dust import get_close_epsilon_for_pair
 from tradeexecutor.strategy.execution_context import ExecutionContext
 from tradeexecutor.strategy.pandas_trader.position_manager import \
     HypercorePositionReductionPlan, PositionManager
@@ -1742,7 +1742,7 @@ class AlphaModel:
 
         if signal.leverage is None and signal.position_adjust_usd < 0:
             trade_quantity = abs(Decimal(str(signal.position_adjust_quantity)))
-            dust_epsilon = get_dust_epsilon_for_pair(signal.synthetic_pair or signal.pair)
+            dust_epsilon = get_close_epsilon_for_pair(signal.synthetic_pair or signal.pair)
             if trade_quantity <= dust_epsilon:
                 logger.info(
                     "Individual trade quantity too small, trade quantity is %s, dust epsilon is %s",

--- a/tradeexecutor/strategy/dust.py
+++ b/tradeexecutor/strategy/dust.py
@@ -82,9 +82,6 @@ def get_dust_epsilon_for_pair(pair: TradingPairIdentifier) -> Decimal:
 
     """
 
-    if pair.is_hyperliquid_vault():
-        return HYPERLIQUID_VAULT_CLOSE_EPSILON
-
     if pair.is_vault():
         return DEFAULT_VAULT_EPSILON
 


### PR DESCRIPTION
## Why

The `automated-test-suite` CI has been failing on the Citadel notebook backtest with:

```
TooSmallTrade: Trade cannot be this small
Quantity 1.246607974491987585460800373, dust epsilon 2.00
Trade: <Buy #619 1.246607974491987585460800373 Citadel at 48.26579636665389, planned phase>
```

`get_dust_epsilon_for_pair()` returned `HYPERLIQUID_VAULT_CLOSE_EPSILON = 2.00` for all Hyperliquid vault pairs, including buy trades. At $48/token, this means any buy under $96 was rejected as "too small", even though the alpha model USD threshold ($50) had already approved it.

The close epsilon (2.00) is correct for detecting whether a position residual is dust after a withdrawal with safety margin, but it was incorrectly used as the minimum trade size for new buys.

## Lessons learnt

- `get_dust_epsilon_for_pair()` ("minimum meaningful trade quantity") and `get_close_epsilon_for_pair()` ("when to consider a position closed") are different concepts that were conflated for Hyperliquid vaults.
- Callers that check for dust-level positions or balance mismatches should use `get_close_epsilon_for_pair()`, while trade creation validation should use `get_dust_epsilon_for_pair()` with a smaller threshold.

## Summary

- `get_dust_epsilon_for_pair()` no longer returns the close epsilon for Hyperliquid vaults — falls through to `DEFAULT_VAULT_EPSILON` like regular vaults
- `get_close_epsilon_for_pair()` unchanged — still returns 2.00 for Hyperliquid vaults
- Alpha model sell-side quantity filter switched to `get_close_epsilon_for_pair()`
- Account correction balance/mismatch checks switched to `get_close_epsilon_for_pair()`
- Updated test assertions to match new behaviour

🤖 Generated with [Claude Code](https://claude.com/claude-code)