### PR TITLE
Fix APScheduler listen_error crash on JobSubmissionEvent

### DIFF
--- a/tradeexecutor/cli/loop.py
+++ b/tradeexecutor/cli/loop.py
@@ -1734,12 +1734,12 @@ class ExecutionLoop:
             )
 
         def listen_error(event):
-            if event.exception:
-                logger.info("Scheduled task received exception. event: %s, exception: %s", event, event.exception)
+            if event.code == EVENT_JOB_MAX_INSTANCES:
+                logger.warning("Scheduled task skipped because max instances are already running. event: %s", event)
             elif event.code == EVENT_JOB_MISSED:
                 logger.warning("Scheduled task missed its run time. event: %s", event)
-            elif event.code == EVENT_JOB_MAX_INSTANCES:
-                logger.warning("Scheduled task skipped because max instances are already running. event: %s", event)
+            elif hasattr(event, 'exception') and event.exception:
+                logger.info("Scheduled task received exception. event: %s, exception: %s", event, event.exception)
             else:
                 logger.error("Should not happen")
 


### PR DESCRIPTION
## Why

The `listen_error` APScheduler callback in `ExecutionLoop.run_live()` crashes with `AttributeError: 'JobSubmissionEvent' object has no attribute 'exception'` when `EVENT_JOB_MAX_INSTANCES` fires. This happens because the callback checked `event.exception` before `event.code`, but `EVENT_JOB_MAX_INSTANCES` dispatches a `JobSubmissionEvent` (no `.exception`) rather than a `JobExecutionEvent`.

The skip itself is benign — it fires when a trade execution cycle takes longer than the 3-minute trigger check interval.

## Lessons learnt

APScheduler dispatches different event classes for different event codes. `JobExecutionEvent` has `.exception`, `JobSubmissionEvent` does not. Always check `event.code` or use `hasattr` before accessing type-specific attributes.

## Summary

Reordered checks in `listen_error` so `event.code` is tested first, and `.exception` is only accessed with a `hasattr` guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)