### PR TITLE
feat: automated cross-chain CCTP rebalance for master vault strategies

### DIFF
--- a/strategies/test_only/xchain-cctp-cycling-test.py
+++ b/strategies/test_only/xchain-cctp-cycling-test.py
@@ -1,0 +1,125 @@
+"""Deterministic 3-chain position cycling strategy for CCTP integration tests.
+
+Cycles vault positions across Arbitrum (primary), Base, and HyperEVM
+over 3 decision cycles to exercise the full automated CCTP rebalance
+pipeline: bridge trade injection, multi-phase settlement, and
+bridge position accounting.
+
+- Cycle 1: Open vault positions on all 3 chains
+- Cycle 2: Close Base vault, increase Arbitrum vault
+- Cycle 3: Close all remaining positions
+"""
+
+import importlib.util
+from pathlib import Path
+from decimal import Decimal
+
+from tradeexecutor.state.trade import TradeExecution
+from tradeexecutor.strategy.pandas_trader.strategy_input import StrategyInput
+from tradeexecutor.strategy.pandas_trader.trading_universe_input import CreateTradingUniverseInput
+
+
+def _load_test_strategy():
+    strategy_path = Path(__file__).resolve().parent / "xchain-master-vault-test.py"
+    spec = importlib.util.spec_from_file_location("xchain_master_vault_test", strategy_path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+_base = _load_test_strategy()
+
+trading_strategy_engine_version = _base.trading_strategy_engine_version
+indicators = _base.indicators
+tags = _base.tags
+icon = _base.icon
+
+
+class Parameters(_base.Parameters):
+    """Test-only parameter overrides for the cycling integration test."""
+
+    id = "xchain-cctp-cycling-test"
+
+
+def create_trading_universe(
+    input: CreateTradingUniverseInput,
+):
+    """Reuse the test universe builder with cycling-test parameter overrides."""
+    if input.parameters is None:
+        input = CreateTradingUniverseInput(
+            client=input.client,
+            timestamp=input.timestamp,
+            parameters=Parameters,
+            execution_context=input.execution_context,
+            execution_model=input.execution_model,
+            universe_options=input.universe_options,
+        )
+    return _base.create_trading_universe(input)
+
+
+def create_indicators(timestamp, parameters, strategy_universe, execution_context):
+    return _base.create_indicators(timestamp, parameters, strategy_universe, execution_context)
+
+
+def decide_trades(input: StrategyInput) -> list[TradeExecution]:
+    """Deterministic 3-cycle position cycling across 3 chains.
+
+    The bridge planner injects CCTP bridge trades automatically;
+    this strategy never creates bridge trades directly.
+
+    - Cycle 1: open vault positions on all 3 chains (Arb, Base, HyperEVM)
+    - Cycle 2: close Base vault, increase Arbitrum vault
+    - Cycle 3: close all remaining vault positions
+    """
+    cycle = input.cycle
+    position_manager = input.get_position_manager()
+    strategy_universe = input.strategy_universe
+    state = input.state
+
+    trades = []
+
+    if cycle == 1:
+        # 1. Open vault positions on all 3 chains
+        for pair in strategy_universe.iterate_pairs():
+            if pair.kind.is_vault():
+                trades += position_manager.open_spot(
+                    pair,
+                    value=Decimal("3"),
+                    notes=f"Cycle 1: open vault on chain {pair.chain_id}",
+                )
+
+    elif cycle == 2:
+        # 2. Close Base vault (chain_id 8453), keep Arb and HyperEVM
+        for position in list(state.portfolio.open_positions.values()):
+            if position.pair.kind.is_vault() and position.pair.chain_id == 8453:
+                trades += position_manager.close_position(
+                    position,
+                    notes="Cycle 2: close Base vault",
+                )
+
+    elif cycle == 3:
+        # 3. Close all remaining vault positions
+        for position in list(state.portfolio.open_positions.values()):
+            if position.pair.kind.is_vault():
+                trades += position_manager.close_position(
+                    position,
+                    notes="Cycle 3: close remaining vaults",
+                )
+
+    return trades
+
+
+name = "Xchain CCTP cycling test"
+short_description = "Deterministic 3-chain position cycling for CCTP integration tests"
+long_description = """
+# Xchain CCTP cycling test
+
+Deterministic 3-cycle strategy that exercises the full CCTP auto-rebalance pipeline:
+
+- Cycle 1: Open vault positions on Arbitrum, Base, and HyperEVM
+- Cycle 2: Close Base vault, keep Arbitrum and HyperEVM
+- Cycle 3: Close all remaining positions
+
+The bridge planner automatically injects CCTP bridge trades as needed.
+"""

--- a/tests/backtest/test_cctp_backtest_sequential.py
+++ b/tests/backtest/test_cctp_backtest_sequential.py
@@ -1,0 +1,271 @@
+"""Test sequential trade execution for CCTP bridge-dependent batches.
+
+Verifies that BacktestExecution detects CCTP bridge trades and switches
+to per-trade start/simulate/settle ordering, so that bridge positions
+exist before satellite trades try to allocate from them.
+"""
+import datetime
+from decimal import Decimal
+from unittest.mock import patch
+
+import pytest
+
+from tradeexecutor.backtest.backtest_execution import BacktestExecution
+from tradeexecutor.backtest.backtest_routing import BacktestRoutingIgnoredModel, BacktestRoutingState
+from tradeexecutor.backtest.simulated_wallet import SimulatedWallet
+from tradeexecutor.state.identifier import (
+    AssetIdentifier,
+    TradingPairIdentifier,
+    TradingPairKind,
+)
+from tradeexecutor.state.state import State
+from tradeexecutor.state.trade import TradeType
+
+
+#: Arbitrum native USDC address
+USDC_ARBITRUM_ADDRESS = "0xaf88d065e77c8cc2239327c5edb3a432268e5831"
+
+#: Base native USDC address
+USDC_BASE_ADDRESS = "0x833589fcd6edb6e08f4c7c32d4f71b54bda02913"
+
+#: Dummy WETH on Base
+WETH_BASE_ADDRESS = "0x4200000000000000000000000000000000000006"
+
+
+@pytest.fixture()
+def usdc_arbitrum() -> AssetIdentifier:
+    """USDC on Arbitrum — the reserve currency."""
+    return AssetIdentifier(
+        chain_id=42161,
+        address=USDC_ARBITRUM_ADDRESS,
+        token_symbol="USDC",
+        decimals=6,
+    )
+
+
+@pytest.fixture()
+def usdc_base() -> AssetIdentifier:
+    """USDC on Base — destination chain stablecoin."""
+    return AssetIdentifier(
+        chain_id=8453,
+        address=USDC_BASE_ADDRESS,
+        token_symbol="USDC",
+        decimals=6,
+    )
+
+
+@pytest.fixture()
+def weth_base() -> AssetIdentifier:
+    """WETH on Base — a satellite chain token."""
+    return AssetIdentifier(
+        chain_id=8453,
+        address=WETH_BASE_ADDRESS,
+        token_symbol="WETH",
+        decimals=18,
+    )
+
+
+@pytest.fixture()
+def cctp_pair(usdc_arbitrum: AssetIdentifier, usdc_base: AssetIdentifier) -> TradingPairIdentifier:
+    """CCTP bridge pair: Arbitrum -> Base."""
+    return TradingPairIdentifier(
+        base=usdc_base,
+        quote=usdc_arbitrum,
+        pool_address="0x28b5a0e9c621a5badaa536219b3a228c8168cf5d",
+        exchange_address="0x28b5a0e9c621a5badaa536219b3a228c8168cf5d",
+        fee=0,
+        kind=TradingPairKind.cctp_bridge,
+        other_data={"bridge_protocol": "cctp"},
+    )
+
+
+@pytest.fixture()
+def spot_pair(weth_base: AssetIdentifier, usdc_base: AssetIdentifier) -> TradingPairIdentifier:
+    """A simple satellite-chain spot pair (WETH/USDC on Base)."""
+    return TradingPairIdentifier(
+        base=weth_base,
+        quote=usdc_base,
+        pool_address="0xd0b53d9277642d899df5c87a3966a349a798f224",
+        exchange_address="0x33128a8fc17869897dce68ed026d694621f6fdfd",
+        fee=0.0005,
+        kind=TradingPairKind.spot_market_hold,
+    )
+
+
+@pytest.fixture()
+def wallet(usdc_arbitrum: AssetIdentifier) -> SimulatedWallet:
+    """A simulated wallet seeded with 10 000 USDC on Arbitrum."""
+    w = SimulatedWallet()
+    w.set_balance(usdc_arbitrum, Decimal(10_000))
+    return w
+
+
+@pytest.fixture()
+def execution(wallet: SimulatedWallet) -> BacktestExecution:
+    """BacktestExecution wired to the simulated wallet."""
+    return BacktestExecution(wallet=wallet)
+
+
+@pytest.fixture()
+def state_with_reserves(usdc_arbitrum: AssetIdentifier) -> State:
+    """A fresh State with 10 000 USDC reserves on Arbitrum."""
+    state = State()
+    state.portfolio.initialise_reserves(usdc_arbitrum)
+    reserve = state.portfolio.get_default_reserve_position()
+    reserve.quantity = Decimal(10_000)
+    reserve.reserve_token_price = 1.0
+    return state
+
+
+def test_backtest_bridge_then_spot_sequential(
+    state_with_reserves: State,
+    execution: BacktestExecution,
+    wallet: SimulatedWallet,
+    cctp_pair: TradingPairIdentifier,
+    spot_pair: TradingPairIdentifier,
+    usdc_arbitrum: AssetIdentifier,
+):
+    """Verify that a bridge-out buy followed by a satellite spot buy
+    executes correctly via the sequential path.
+
+    1. Create two trades: a CCTP bridge-out buy and a satellite spot buy
+    2. Sort them by execution sort position (bridge first)
+    3. Call execute_trades() — should detect bridge trades and use sequential path
+    4. Verify the bridge trade completes and a bridge position exists
+    5. Verify the satellite spot trade completes using bridge capital
+    6. Verify wallet balances are consistent
+    """
+    ts = datetime.datetime(2025, 6, 1)
+    state = state_with_reserves
+
+    # 1. Create a bridge-out buy: 1000 USDC from Arbitrum to Base
+    _, bridge_trade, _ = state.create_trade(
+        strategy_cycle_at=ts,
+        pair=cctp_pair,
+        quantity=None,
+        reserve=Decimal(1000),
+        assumed_price=1.0,
+        trade_type=TradeType.rebalance,
+        reserve_currency=usdc_arbitrum,
+        reserve_currency_price=1.0,
+    )
+
+    # 2. Create a satellite spot buy: 500 USDC worth of WETH on Base
+    _, spot_trade, _ = state.create_trade(
+        strategy_cycle_at=ts,
+        pair=spot_pair,
+        quantity=None,
+        reserve=Decimal(500),
+        assumed_price=2000.0,
+        trade_type=TradeType.rebalance,
+        reserve_currency=usdc_arbitrum,
+        reserve_currency_price=1.0,
+    )
+
+    # 3. Sort by execution sort position (bridge-out comes before spot buy)
+    trades = sorted(
+        [bridge_trade, spot_trade],
+        key=lambda t: t.get_execution_sort_position(),
+    )
+
+    # Set up a minimal routing model/state for the backtest
+    routing_model = BacktestRoutingIgnoredModel(
+        reserve_token_address=usdc_arbitrum.address,
+    )
+    routing_state = BacktestRoutingState(pair_universe=None, wallet=wallet)
+
+    # 4. Execute — should take the sequential path because of the bridge trade
+    execution.execute_trades(
+        ts=ts,
+        state=state,
+        trades=trades,
+        routing_model=routing_model,
+        routing_state=routing_state,
+        check_balances=False,
+    )
+
+    # 5. Verify bridge trade completed
+    assert bridge_trade.is_success()
+    assert bridge_trade.executed_quantity == Decimal(1000)
+
+    # 6. Verify bridge position exists with correct quantity
+    bridge_positions = [
+        p for p in state.portfolio.open_positions.values()
+        if p.pair.is_cctp_bridge()
+    ]
+    assert len(bridge_positions) == 1
+    bridge_pos = bridge_positions[0]
+    assert bridge_pos.get_quantity() == Decimal(1000)
+
+    # 7. Verify spot trade completed
+    assert spot_trade.is_success()
+    assert spot_trade.executed_quantity == pytest.approx(Decimal(500) / Decimal(2000), abs=Decimal("0.001"))
+
+    # 8. Verify reserves decreased by the bridge amount only
+    # (the spot trade draws from bridge capital, not from the main reserves)
+    reserve = state.portfolio.get_default_reserve_position()
+    assert reserve.quantity == Decimal(10_000) - Decimal(1000)
+
+    # 9. Verify bridge position has capital allocated to the satellite trade
+    assert bridge_pos.bridge_capital_allocated == Decimal(500)
+
+
+def test_backtest_no_bridge_uses_batch_path(
+    state_with_reserves: State,
+    execution: BacktestExecution,
+    wallet: SimulatedWallet,
+    spot_pair: TradingPairIdentifier,
+    usdc_arbitrum: AssetIdentifier,
+    usdc_base: AssetIdentifier,
+):
+    """Verify that a backtest without bridge trades still uses the fast
+    batch path (start_execution_all) with no regression.
+
+    1. Create a single spot buy trade (no bridge trades)
+    2. Call execute_trades() with a patched start_execution_all
+    3. Assert start_execution_all was called (batch path)
+    4. Verify the trade succeeds
+    """
+    ts = datetime.datetime(2025, 6, 1)
+    state = state_with_reserves
+
+    # The spot pair uses Base USDC as quote — but the wallet/reserves hold
+    # Arbitrum USDC. For a pure non-bridge test we need the wallet to have
+    # the quote token so simulate_spot doesn't fail.
+    wallet.set_balance(usdc_base, Decimal(10_000))
+
+    # 1. Create a spot buy on Base: 500 USDC worth of WETH
+    _, spot_trade, _ = state.create_trade(
+        strategy_cycle_at=ts,
+        pair=spot_pair,
+        quantity=None,
+        reserve=Decimal(500),
+        assumed_price=2000.0,
+        trade_type=TradeType.rebalance,
+        reserve_currency=usdc_arbitrum,
+        reserve_currency_price=1.0,
+    )
+
+    trades = [spot_trade]
+
+    routing_model = BacktestRoutingIgnoredModel(
+        reserve_token_address=usdc_arbitrum.address,
+    )
+    routing_state = BacktestRoutingState(pair_universe=None, wallet=wallet)
+
+    # 2. Patch start_execution_all to verify it is called
+    with patch.object(State, "start_execution_all", wraps=state.start_execution_all) as mock_start_all:
+        execution.execute_trades(
+            ts=ts,
+            state=state,
+            trades=trades,
+            routing_model=routing_model,
+            routing_state=routing_state,
+            check_balances=False,
+        )
+
+        # 3. Assert batch path was used
+        mock_start_all.assert_called_once()
+
+    # 4. Verify the trade succeeded
+    assert spot_trade.is_success()

--- a/tests/ethereum/test_cctp_bridge_planner.py
+++ b/tests/ethereum/test_cctp_bridge_planner.py
@@ -1,0 +1,585 @@
+"""Test CCTP bridge trade injection planner.
+
+Verifies that :py:func:`inject_cctp_bridge_trades` correctly analyses
+alpha model trades and injects the necessary bridge transfers:
+
+- Bridge-out buys for satellite chain purchases
+- Bridge-back sells for satellite chain sell proceeds
+- Net flow calculation to avoid unnecessary round-trips
+- No bridge injection for primary chain trades
+- Correct handling of multiple satellite chains
+"""
+
+import datetime
+from decimal import Decimal
+from unittest.mock import MagicMock
+
+import pytest
+
+from tradeexecutor.ethereum.cctp.planner import inject_cctp_bridge_trades
+from tradeexecutor.state.identifier import (
+    AssetIdentifier,
+    TradingPairIdentifier,
+    TradingPairKind,
+)
+from tradeexecutor.state.state import State
+from tradeexecutor.state.trade import TradeExecution, TradeType
+
+
+USDC_ARBITRUM_ADDRESS = "0xaf88d065e77c8cC2239327C5EDb3A432268e5831"
+USDC_BASE_ADDRESS = "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913"
+USDC_AVALANCHE_ADDRESS = "0xB97EF9Ef8734C71904D8002F8b6Bc66Dd9c48a6E"
+
+PRIMARY_CHAIN_ID = 42161  # Arbitrum
+BASE_CHAIN_ID = 8453
+AVALANCHE_CHAIN_ID = 43114
+
+TS = datetime.datetime(2025, 6, 1)
+
+
+@pytest.fixture()
+def usdc_arbitrum() -> AssetIdentifier:
+    """USDC on Arbitrum (primary chain reserve)."""
+    return AssetIdentifier(
+        chain_id=PRIMARY_CHAIN_ID,
+        address=USDC_ARBITRUM_ADDRESS,
+        token_symbol="USDC",
+        decimals=6,
+    )
+
+
+@pytest.fixture()
+def usdc_base() -> AssetIdentifier:
+    """USDC on Base."""
+    return AssetIdentifier(
+        chain_id=BASE_CHAIN_ID,
+        address=USDC_BASE_ADDRESS,
+        token_symbol="USDC",
+        decimals=6,
+    )
+
+
+@pytest.fixture()
+def usdc_avalanche() -> AssetIdentifier:
+    """USDC on Avalanche."""
+    return AssetIdentifier(
+        chain_id=AVALANCHE_CHAIN_ID,
+        address=USDC_AVALANCHE_ADDRESS,
+        token_symbol="USDC",
+        decimals=6,
+    )
+
+
+@pytest.fixture()
+def cctp_pair_base(
+    usdc_arbitrum: AssetIdentifier,
+    usdc_base: AssetIdentifier,
+) -> TradingPairIdentifier:
+    """CCTP bridge pair: Arbitrum -> Base."""
+    return TradingPairIdentifier(
+        base=usdc_base,
+        quote=usdc_arbitrum,
+        pool_address="0x28b5a0e9C621a5BadaA536219b3a228C8168cf5d",
+        exchange_address="0x28b5a0e9C621a5BadaA536219b3a228C8168cf5d",
+        fee=0,
+        kind=TradingPairKind.cctp_bridge,
+        other_data={"bridge_protocol": "cctp"},
+    )
+
+
+@pytest.fixture()
+def cctp_pair_avalanche(
+    usdc_arbitrum: AssetIdentifier,
+    usdc_avalanche: AssetIdentifier,
+) -> TradingPairIdentifier:
+    """CCTP bridge pair: Arbitrum -> Avalanche."""
+    return TradingPairIdentifier(
+        base=usdc_avalanche,
+        quote=usdc_arbitrum,
+        pool_address="0x0000000000000000000000000000000000000077",
+        exchange_address="0x0000000000000000000000000000000000000077",
+        fee=0,
+        kind=TradingPairKind.cctp_bridge,
+        other_data={"bridge_protocol": "cctp"},
+    )
+
+
+@pytest.fixture()
+def vault_pair_base(usdc_base: AssetIdentifier) -> TradingPairIdentifier:
+    """A vault pair on Base (satellite chain)."""
+    vault_token = AssetIdentifier(
+        chain_id=BASE_CHAIN_ID,
+        address="0x0000000000000000000000000000000000000011",
+        token_symbol="vaultBASE",
+        decimals=18,
+    )
+    return TradingPairIdentifier(
+        base=vault_token,
+        quote=usdc_base,
+        pool_address="0x0000000000000000000000000000000000000022",
+        exchange_address="0x0000000000000000000000000000000000000022",
+        fee=0,
+        kind=TradingPairKind.vault,
+    )
+
+
+@pytest.fixture()
+def vault_pair_base_2(usdc_base: AssetIdentifier) -> TradingPairIdentifier:
+    """A second vault pair on Base (satellite chain)."""
+    vault_token = AssetIdentifier(
+        chain_id=BASE_CHAIN_ID,
+        address="0x0000000000000000000000000000000000000033",
+        token_symbol="vaultBASE2",
+        decimals=18,
+    )
+    return TradingPairIdentifier(
+        base=vault_token,
+        quote=usdc_base,
+        pool_address="0x0000000000000000000000000000000000000044",
+        exchange_address="0x0000000000000000000000000000000000000044",
+        fee=0,
+        kind=TradingPairKind.vault,
+    )
+
+
+@pytest.fixture()
+def vault_pair_primary(usdc_arbitrum: AssetIdentifier) -> TradingPairIdentifier:
+    """A vault pair on the primary chain (Arbitrum)."""
+    vault_token = AssetIdentifier(
+        chain_id=PRIMARY_CHAIN_ID,
+        address="0x0000000000000000000000000000000000000055",
+        token_symbol="vaultARB",
+        decimals=18,
+    )
+    return TradingPairIdentifier(
+        base=vault_token,
+        quote=usdc_arbitrum,
+        pool_address="0x0000000000000000000000000000000000000066",
+        exchange_address="0x0000000000000000000000000000000000000066",
+        fee=0,
+        kind=TradingPairKind.vault,
+    )
+
+
+@pytest.fixture()
+def vault_pair_avalanche(usdc_avalanche: AssetIdentifier) -> TradingPairIdentifier:
+    """A vault pair on Avalanche (another satellite chain)."""
+    vault_token = AssetIdentifier(
+        chain_id=AVALANCHE_CHAIN_ID,
+        address="0x0000000000000000000000000000000000000088",
+        token_symbol="vaultAVAX",
+        decimals=18,
+    )
+    return TradingPairIdentifier(
+        base=vault_token,
+        quote=usdc_avalanche,
+        pool_address="0x0000000000000000000000000000000000000099",
+        exchange_address="0x0000000000000000000000000000000000000099",
+        fee=0,
+        kind=TradingPairKind.vault,
+    )
+
+
+def _make_mock_universe(pairs: list[TradingPairIdentifier]):
+    """Build a mock strategy universe that yields the given pairs."""
+    mock = MagicMock()
+    mock.iterate_pairs.return_value = pairs
+    return mock
+
+
+def _make_state_with_reserves(
+    usdc_arbitrum: AssetIdentifier,
+    reserve_amount: Decimal = Decimal(50_000),
+) -> State:
+    """Create a fresh state with reserves on the primary chain."""
+    state = State()
+    state.portfolio.initialise_reserves(usdc_arbitrum)
+    reserve = state.portfolio.get_default_reserve_position()
+    reserve.quantity = reserve_amount
+    reserve.reserve_token_price = 1.0
+    return state
+
+
+def _execute_trade(
+    state: State,
+    trade: TradeExecution,
+    ts: datetime.datetime,
+    quantity: Decimal,
+    reserve: Decimal,
+    price: float = 1.0,
+):
+    """Simulate trade execution: start -> broadcast -> success."""
+    state.start_execution(ts, trade)
+    trade.mark_broadcasted(ts)
+    trade.mark_success(
+        executed_at=ts,
+        executed_price=price,
+        executed_quantity=quantity,
+        executed_reserve=reserve,
+        lp_fees=0.0,
+        native_token_price=0.0,
+    )
+
+
+def test_inject_bridge_out_for_satellite_buy(
+    usdc_arbitrum: AssetIdentifier,
+    cctp_pair_base: TradingPairIdentifier,
+    vault_pair_base: TradingPairIdentifier,
+):
+    """Verify that a satellite chain buy injects a bridge-out (primary -> satellite).
+
+    1. Create a state with reserves on the primary chain
+    2. Create a vault buy trade on Base (satellite)
+    3. Call inject_cctp_bridge_trades with a universe containing the bridge pair
+    4. Assert exactly one bridge trade was injected
+    5. Assert the bridge trade is a buy (bridge-out) for the correct amount
+    6. Assert the bridge pair targets Base
+    """
+    # 1. Create state with reserves
+    state = _make_state_with_reserves(usdc_arbitrum)
+    universe = _make_mock_universe([cctp_pair_base, vault_pair_base])
+
+    # 2. Create a vault buy on Base for 3000 USDC
+    _, vault_buy, _ = state.create_trade(
+        strategy_cycle_at=TS,
+        pair=vault_pair_base,
+        quantity=None,
+        reserve=Decimal(3000),
+        assumed_price=1.0,
+        trade_type=TradeType.rebalance,
+        reserve_currency=usdc_arbitrum,
+        reserve_currency_price=1.0,
+    )
+
+    # 3. Inject bridge trades
+    result = inject_cctp_bridge_trades(
+        state=state,
+        trades=[vault_buy],
+        strategy_universe=universe,
+        primary_chain_id=PRIMARY_CHAIN_ID,
+        ts=TS,
+        reserve_asset=usdc_arbitrum,
+    )
+
+    # 4. Assert one bridge trade was injected (original + bridge)
+    assert len(result) == 2
+    bridge_trade = result[1]
+
+    # 5. Assert the bridge trade is a buy (bridge-out)
+    assert bridge_trade.is_buy()
+    assert bridge_trade.pair.is_cctp_bridge()
+    assert bridge_trade.planned_reserve == Decimal("3000")
+
+    # 6. Assert the bridge pair targets Base
+    assert bridge_trade.pair.get_destination_chain_id() == BASE_CHAIN_ID
+
+
+def test_inject_bridge_back_for_satellite_sell(
+    usdc_arbitrum: AssetIdentifier,
+    cctp_pair_base: TradingPairIdentifier,
+    vault_pair_base: TradingPairIdentifier,
+):
+    """Verify that a satellite chain sell injects a bridge-back (satellite -> primary).
+
+    1. Create a state with reserves and an existing bridge position on Base
+    2. Create a vault sell trade on Base
+    3. Call inject_cctp_bridge_trades
+    4. Assert exactly one bridge trade was injected
+    5. Assert the bridge trade is a sell (bridge-back) for the correct amount
+    6. Assert the bridge position is used for the sell
+    """
+    # 1. Create state with reserves and open a bridge position on Base
+    state = _make_state_with_reserves(usdc_arbitrum)
+
+    # First create a bridge-out to establish the bridge position
+    _, bridge_out, _ = state.create_trade(
+        strategy_cycle_at=TS,
+        pair=cctp_pair_base,
+        quantity=None,
+        reserve=Decimal(10_000),
+        assumed_price=1.0,
+        trade_type=TradeType.rebalance,
+        reserve_currency=usdc_arbitrum,
+        reserve_currency_price=1.0,
+    )
+    # Simulate the bridge-out completing
+    _execute_trade(state, bridge_out, TS, Decimal(10_000), Decimal(10_000))
+
+    # Verify bridge position exists
+    bridge_pos = state.portfolio.get_bridge_position_for_chain(BASE_CHAIN_ID)
+    assert bridge_pos is not None
+
+    universe = _make_mock_universe([cctp_pair_base, vault_pair_base])
+
+    # 2. Create a vault sell on Base for 5000 USDC
+    # Open the vault position first
+    _, vault_buy, _ = state.create_trade(
+        strategy_cycle_at=TS,
+        pair=vault_pair_base,
+        quantity=None,
+        reserve=Decimal(5000),
+        assumed_price=1.0,
+        trade_type=TradeType.rebalance,
+        reserve_currency=usdc_arbitrum,
+        reserve_currency_price=1.0,
+    )
+    _execute_trade(state, vault_buy, TS, Decimal(5000), Decimal(5000))
+
+    # Now create the sell trade
+    vault_position = list(state.portfolio.open_positions.values())
+    vault_pos = [p for p in vault_position if p.pair == vault_pair_base][0]
+    _, vault_sell, _ = state.create_trade(
+        strategy_cycle_at=TS,
+        pair=vault_pair_base,
+        quantity=Decimal(-5000),
+        reserve=None,
+        assumed_price=1.0,
+        trade_type=TradeType.rebalance,
+        reserve_currency=usdc_arbitrum,
+        reserve_currency_price=1.0,
+        position=vault_pos,
+        closing=True,
+    )
+
+    # 3. Inject bridge trades
+    result = inject_cctp_bridge_trades(
+        state=state,
+        trades=[vault_sell],
+        strategy_universe=universe,
+        primary_chain_id=PRIMARY_CHAIN_ID,
+        ts=TS,
+        reserve_asset=usdc_arbitrum,
+    )
+
+    # 4. Assert one bridge trade was injected
+    assert len(result) == 2
+    bridge_trade = result[1]
+
+    # 5. Assert the bridge trade is a sell (bridge-back)
+    assert bridge_trade.is_sell()
+    assert bridge_trade.pair.is_cctp_bridge()
+    assert bridge_trade.planned_quantity == Decimal(-5000)
+
+    # 6. Assert the bridge position is reused
+    bridge_trade_position = [
+        p for p in state.portfolio.open_positions.values()
+        if p.pair.is_cctp_bridge()
+    ][0]
+    assert bridge_trade in bridge_trade_position.trades.values()
+
+
+def test_net_flow_same_chain_cancels(
+    usdc_arbitrum: AssetIdentifier,
+    cctp_pair_base: TradingPairIdentifier,
+    vault_pair_base: TradingPairIdentifier,
+    vault_pair_base_2: TradingPairIdentifier,
+):
+    """Verify that net flow calculation cancels opposing trades on the same chain.
+
+    When selling $5000 and buying $4000 on Base, only a $1000 bridge-back
+    should be injected, not separate $5000 back + $4000 out.
+
+    1. Create a state with reserves and an existing bridge position on Base
+    2. Create a vault sell ($5000) and a vault buy ($4000) both on Base
+    3. Call inject_cctp_bridge_trades
+    4. Assert exactly one bridge trade was injected (the net $1000 bridge-back)
+    5. Assert the bridge trade is a sell for $1000
+    """
+    # 1. Create state with bridge position on Base
+    state = _make_state_with_reserves(usdc_arbitrum)
+
+    # Create and complete a bridge-out to establish the bridge position
+    _, bridge_out, _ = state.create_trade(
+        strategy_cycle_at=TS,
+        pair=cctp_pair_base,
+        quantity=None,
+        reserve=Decimal(10_000),
+        assumed_price=1.0,
+        trade_type=TradeType.rebalance,
+        reserve_currency=usdc_arbitrum,
+        reserve_currency_price=1.0,
+    )
+    _execute_trade(state, bridge_out, TS, Decimal(10_000), Decimal(10_000))
+
+    # Open vault position 1 (will sell)
+    _, vault_buy_1, _ = state.create_trade(
+        strategy_cycle_at=TS,
+        pair=vault_pair_base,
+        quantity=None,
+        reserve=Decimal(5000),
+        assumed_price=1.0,
+        trade_type=TradeType.rebalance,
+        reserve_currency=usdc_arbitrum,
+        reserve_currency_price=1.0,
+    )
+    _execute_trade(state, vault_buy_1, TS, Decimal(5000), Decimal(5000))
+
+    universe = _make_mock_universe([cctp_pair_base, vault_pair_base, vault_pair_base_2])
+
+    # 2. Create a vault sell ($5000) on Base
+    vault_pos_1 = [p for p in state.portfolio.open_positions.values() if p.pair == vault_pair_base][0]
+    _, vault_sell, _ = state.create_trade(
+        strategy_cycle_at=TS,
+        pair=vault_pair_base,
+        quantity=Decimal(-5000),
+        reserve=None,
+        assumed_price=1.0,
+        trade_type=TradeType.rebalance,
+        reserve_currency=usdc_arbitrum,
+        reserve_currency_price=1.0,
+        position=vault_pos_1,
+        closing=True,
+    )
+
+    # Create a vault buy ($4000) on Base (different vault)
+    _, vault_buy_2, _ = state.create_trade(
+        strategy_cycle_at=TS,
+        pair=vault_pair_base_2,
+        quantity=None,
+        reserve=Decimal(4000),
+        assumed_price=1.0,
+        trade_type=TradeType.rebalance,
+        reserve_currency=usdc_arbitrum,
+        reserve_currency_price=1.0,
+    )
+
+    # 3. Inject bridge trades
+    result = inject_cctp_bridge_trades(
+        state=state,
+        trades=[vault_sell, vault_buy_2],
+        strategy_universe=universe,
+        primary_chain_id=PRIMARY_CHAIN_ID,
+        ts=TS,
+        reserve_asset=usdc_arbitrum,
+    )
+
+    # 4. Assert only one bridge trade was injected (net $1000 bridge-back)
+    bridge_trades = [t for t in result if t.pair.is_cctp_bridge()]
+    assert len(bridge_trades) == 1
+
+    # 5. Assert the bridge trade is a sell for $1000
+    bridge_trade = bridge_trades[0]
+    assert bridge_trade.is_sell()
+    assert bridge_trade.planned_quantity == Decimal("-1000")
+
+
+def test_no_bridge_for_primary_chain(
+    usdc_arbitrum: AssetIdentifier,
+    cctp_pair_base: TradingPairIdentifier,
+    vault_pair_primary: TradingPairIdentifier,
+):
+    """Verify that trades on the primary chain do not trigger bridge injection.
+
+    1. Create a state with reserves
+    2. Create vault buy and sell trades on the primary chain (Arbitrum)
+    3. Call inject_cctp_bridge_trades
+    4. Assert no bridge trades were injected
+    5. Assert the returned list equals the original trades
+    """
+    # 1. Create state
+    state = _make_state_with_reserves(usdc_arbitrum)
+    universe = _make_mock_universe([cctp_pair_base, vault_pair_primary])
+
+    # 2. Create a vault buy on the primary chain
+    _, vault_buy, _ = state.create_trade(
+        strategy_cycle_at=TS,
+        pair=vault_pair_primary,
+        quantity=None,
+        reserve=Decimal(5000),
+        assumed_price=1.0,
+        trade_type=TradeType.rebalance,
+        reserve_currency=usdc_arbitrum,
+        reserve_currency_price=1.0,
+    )
+
+    # 3. Inject bridge trades
+    result = inject_cctp_bridge_trades(
+        state=state,
+        trades=[vault_buy],
+        strategy_universe=universe,
+        primary_chain_id=PRIMARY_CHAIN_ID,
+        ts=TS,
+        reserve_asset=usdc_arbitrum,
+    )
+
+    # 4. No bridge trades injected
+    bridge_trades = [t for t in result if t.pair.is_cctp_bridge()]
+    assert len(bridge_trades) == 0
+
+    # 5. The returned list is the same as the input
+    assert result == [vault_buy]
+
+
+def test_multiple_satellite_chains(
+    usdc_arbitrum: AssetIdentifier,
+    cctp_pair_base: TradingPairIdentifier,
+    cctp_pair_avalanche: TradingPairIdentifier,
+    vault_pair_base: TradingPairIdentifier,
+    vault_pair_avalanche: TradingPairIdentifier,
+):
+    """Verify correct bridge injection for trades on multiple satellite chains.
+
+    1. Create a state with reserves
+    2. Create a vault buy on Base ($3000) and a vault buy on Avalanche ($2000)
+    3. Call inject_cctp_bridge_trades with both bridge pairs in the universe
+    4. Assert two bridge trades were injected (one per satellite chain)
+    5. Assert the Base bridge-out is for $3000 and the Avalanche bridge-out is for $2000
+    """
+    # 1. Create state
+    state = _make_state_with_reserves(usdc_arbitrum)
+    universe = _make_mock_universe([
+        cctp_pair_base,
+        cctp_pair_avalanche,
+        vault_pair_base,
+        vault_pair_avalanche,
+    ])
+
+    # 2. Create vault buys on two satellite chains
+    _, base_buy, _ = state.create_trade(
+        strategy_cycle_at=TS,
+        pair=vault_pair_base,
+        quantity=None,
+        reserve=Decimal(3000),
+        assumed_price=1.0,
+        trade_type=TradeType.rebalance,
+        reserve_currency=usdc_arbitrum,
+        reserve_currency_price=1.0,
+    )
+
+    _, avax_buy, _ = state.create_trade(
+        strategy_cycle_at=TS,
+        pair=vault_pair_avalanche,
+        quantity=None,
+        reserve=Decimal(2000),
+        assumed_price=1.0,
+        trade_type=TradeType.rebalance,
+        reserve_currency=usdc_arbitrum,
+        reserve_currency_price=1.0,
+    )
+
+    # 3. Inject bridge trades
+    result = inject_cctp_bridge_trades(
+        state=state,
+        trades=[base_buy, avax_buy],
+        strategy_universe=universe,
+        primary_chain_id=PRIMARY_CHAIN_ID,
+        ts=TS,
+        reserve_asset=usdc_arbitrum,
+    )
+
+    # 4. Assert two bridge trades were injected
+    bridge_trades = [t for t in result if t.pair.is_cctp_bridge()]
+    assert len(bridge_trades) == 2
+
+    # 5. Assert correct amounts per chain
+    base_bridge = [t for t in bridge_trades if t.pair.get_destination_chain_id() == BASE_CHAIN_ID]
+    avax_bridge = [t for t in bridge_trades if t.pair.get_destination_chain_id() == AVALANCHE_CHAIN_ID]
+
+    assert len(base_bridge) == 1
+    assert len(avax_bridge) == 1
+
+    assert base_bridge[0].is_buy()
+    assert base_bridge[0].planned_reserve == Decimal("3000")
+
+    assert avax_bridge[0].is_buy()
+    assert avax_bridge[0].planned_reserve == Decimal("2000")

--- a/tests/ethereum/test_cctp_custody_resolver.py
+++ b/tests/ethereum/test_cctp_custody_resolver.py
@@ -1,0 +1,268 @@
+"""Test CCTP custody address resolver for multichain mint recipients.
+
+Verifies that the CCTP bridge routing correctly resolves the
+mint_recipient address based on trade direction and deployment type
+(Lagoon vault with per-chain Safes vs hot wallet).
+
+Pure unit tests -- no RPC connections or Anvil forks needed.
+"""
+
+import datetime
+from dataclasses import dataclass
+from decimal import Decimal
+from unittest.mock import MagicMock
+
+import pytest
+
+from tradeexecutor.ethereum.ethereum_protocol_adapters import _make_cctp_custody_resolver
+from tradeexecutor.state.identifier import (
+    AssetIdentifier,
+    TradingPairIdentifier,
+    TradingPairKind,
+)
+from tradeexecutor.state.state import State
+from tradeexecutor.state.trade import TradeType
+
+
+ARBITRUM_CHAIN_ID = 42161
+BASE_CHAIN_ID = 8453
+
+PRIMARY_SAFE = "0xaaaa000000000000000000000000000000000001"
+SATELLITE_BASE_SAFE = "0xbbbb000000000000000000000000000000000002"
+HOT_WALLET = "0xcccc000000000000000000000000000000000003"
+
+
+@dataclass
+class FakeSatelliteVault:
+    """Minimal stand-in for AutomatedSafe with only the attribute we need."""
+    safe_address: str
+
+
+@pytest.fixture()
+def satellite_vaults() -> dict:
+    """Satellite vaults keyed by chain_id, mimicking the execution model layout."""
+    return {
+        BASE_CHAIN_ID: FakeSatelliteVault(safe_address=SATELLITE_BASE_SAFE),
+    }
+
+
+@pytest.fixture()
+def usdc_arbitrum() -> AssetIdentifier:
+    """USDC on Arbitrum (primary chain)."""
+    return AssetIdentifier(
+        chain_id=ARBITRUM_CHAIN_ID,
+        address="0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
+        token_symbol="USDC",
+        decimals=6,
+    )
+
+
+@pytest.fixture()
+def usdc_base() -> AssetIdentifier:
+    """USDC on Base (satellite chain)."""
+    return AssetIdentifier(
+        chain_id=BASE_CHAIN_ID,
+        address="0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+        token_symbol="USDC",
+        decimals=6,
+    )
+
+
+@pytest.fixture()
+def cctp_pair(usdc_arbitrum: AssetIdentifier, usdc_base: AssetIdentifier) -> TradingPairIdentifier:
+    """CCTP bridge pair: Arbitrum (quote/primary) -> Base (base/satellite)."""
+    return TradingPairIdentifier(
+        base=usdc_base,
+        quote=usdc_arbitrum,
+        pool_address="0x28b5a0e9C621a5BadaA536219b3a228C8168cf5d",
+        exchange_address="0x28b5a0e9C621a5BadaA536219b3a228C8168cf5d",
+        fee=0,
+        kind=TradingPairKind.cctp_bridge,
+        other_data={"bridge_protocol": "cctp"},
+    )
+
+
+def test_resolver_returns_satellite_safe_for_satellite_chain(satellite_vaults: dict):
+    """Test that the resolver returns the satellite Safe for a satellite chain_id.
+
+    1. Build a resolver with satellite vaults and a primary custody address.
+    2. Query the resolver for the Base chain_id.
+    3. Verify the satellite Safe address is returned, not the primary.
+    """
+    # 1. Build a resolver with satellite vaults and a primary custody address.
+    resolver = _make_cctp_custody_resolver(
+        satellite_vaults=satellite_vaults,
+        primary_custody_address=PRIMARY_SAFE,
+        fallback_address=HOT_WALLET,
+    )
+    assert resolver is not None
+
+    # 2. Query the resolver for the Base chain_id.
+    result = resolver(BASE_CHAIN_ID)
+
+    # 3. Verify the satellite Safe address is returned, not the primary.
+    assert result == SATELLITE_BASE_SAFE
+
+
+def test_resolver_returns_primary_for_primary_chain(satellite_vaults: dict):
+    """Test that the resolver falls back to the primary address for a chain without a satellite.
+
+    1. Build a resolver with a satellite only on Base.
+    2. Query the resolver for the Arbitrum chain_id (primary chain, no satellite).
+    3. Verify the primary custody address is returned.
+    """
+    # 1. Build a resolver with a satellite only on Base.
+    resolver = _make_cctp_custody_resolver(
+        satellite_vaults=satellite_vaults,
+        primary_custody_address=PRIMARY_SAFE,
+        fallback_address=HOT_WALLET,
+    )
+    assert resolver is not None
+
+    # 2. Query the resolver for the Arbitrum chain_id (primary chain, no satellite).
+    result = resolver(ARBITRUM_CHAIN_ID)
+
+    # 3. Verify the primary custody address is returned.
+    assert result == PRIMARY_SAFE
+
+
+def test_resolver_returns_fallback_for_hot_wallet():
+    """Test that the resolver returns the fallback (hot wallet) when no satellites or primary are set.
+
+    1. Build a resolver with no satellites and no primary.
+    2. Verify None is returned (hot wallet path uses tx_builder fallback).
+    3. Build a resolver with primary_custody_address only.
+    4. Query for any chain_id and verify primary is returned.
+    """
+    # 1. Build a resolver with no satellites and no primary.
+    resolver = _make_cctp_custody_resolver(
+        satellite_vaults=None,
+        primary_custody_address=None,
+        fallback_address=HOT_WALLET,
+    )
+
+    # 2. Verify None is returned (hot wallet path uses tx_builder fallback).
+    assert resolver is None
+
+    # 3. Build a resolver with primary_custody_address only.
+    resolver_primary = _make_cctp_custody_resolver(
+        satellite_vaults=None,
+        primary_custody_address=PRIMARY_SAFE,
+        fallback_address=HOT_WALLET,
+    )
+    assert resolver_primary is not None
+
+    # 4. Query for any chain_id and verify primary is returned.
+    assert resolver_primary(BASE_CHAIN_ID) == PRIMARY_SAFE
+    assert resolver_primary(ARBITRUM_CHAIN_ID) == PRIMARY_SAFE
+
+
+def test_resolver_raises_when_no_address_available():
+    """Test that the resolver raises ValueError when no address can be found.
+
+    1. Build a resolver with empty satellite_vaults dict and no primary or fallback.
+    2. Query for a chain_id with no matching entry.
+    3. Verify ValueError is raised because no address can be resolved.
+    """
+    # 1. Build a resolver with empty satellite_vaults dict and no primary or fallback.
+    # Note: {} is not None, so a resolver closure is still created.
+    resolver = _make_cctp_custody_resolver(
+        satellite_vaults={},
+        primary_custody_address=None,
+        fallback_address=None,
+    )
+    assert resolver is not None
+
+    # 2. Query for a chain_id with no matching entry.
+    # 3. Verify ValueError is raised because no address can be resolved.
+    with pytest.raises(ValueError, match="No custody address for chain"):
+        resolver(BASE_CHAIN_ID)
+
+
+def test_direction_aware_mint_recipient(
+    satellite_vaults: dict,
+    cctp_pair: TradingPairIdentifier,
+    usdc_arbitrum: AssetIdentifier,
+):
+    """Test that setup_trades resolves the correct mint recipient based on trade direction.
+
+    We mock the heavy eth_defi imports and tx_builder to isolate the
+    resolver logic inside setup_trades.
+
+    1. Create a CctpBridgeRouting with a custody_address_resolver.
+    2. Create a buy trade (bridge-out: Arbitrum -> Base) and verify mint_recipient = satellite Safe.
+    3. Create a sell trade (bridge-back: Base -> Arbitrum) and verify mint_recipient = primary Safe.
+    """
+    from tradeexecutor.ethereum.cctp.routing import CctpBridgeRouting
+
+    resolver = _make_cctp_custody_resolver(
+        satellite_vaults=satellite_vaults,
+        primary_custody_address=PRIMARY_SAFE,
+        fallback_address=HOT_WALLET,
+    )
+
+    web3config = MagicMock()
+    mock_web3 = MagicMock()
+    web3config.get_connection.return_value = mock_web3
+
+    # 1. Create a CctpBridgeRouting with a custody_address_resolver.
+    routing = CctpBridgeRouting(web3config, custody_address_resolver=resolver)
+    assert routing.custody_address_resolver is resolver
+
+    state = State()
+    state.portfolio.initialise_reserves(usdc_arbitrum)
+    reserve = state.portfolio.get_default_reserve_position()
+    reserve.quantity = Decimal(10000)
+    reserve.reserve_token_price = 1.0
+
+    ts = datetime.datetime(2025, 1, 1)
+
+    # --- Buy trade (bridge-out) ---
+
+    # 2. Create a buy trade (bridge-out: Arbitrum -> Base) and verify mint_recipient = satellite Safe.
+    _, buy_trade, _ = state.create_trade(
+        strategy_cycle_at=ts,
+        pair=cctp_pair,
+        quantity=None,
+        reserve=Decimal(1000),
+        assumed_price=1.0,
+        trade_type=TradeType.rebalance,
+        reserve_currency=usdc_arbitrum,
+        reserve_currency_price=1.0,
+    )
+    state.start_execution(ts, buy_trade)
+
+    # For the buy direction, mint_dest_chain_id = pair.base.chain_id = Base
+    assert buy_trade.is_buy()
+    buy_mint_dest = cctp_pair.base.chain_id
+    assert resolver(buy_mint_dest) == SATELLITE_BASE_SAFE
+
+    # --- Sell trade (bridge-back) ---
+
+    # First complete the buy so we can create a sell
+    buy_trade.mark_broadcasted(ts)
+    state.mark_trade_success(
+        executed_at=ts,
+        trade=buy_trade,
+        executed_price=1.0,
+        executed_amount=Decimal(1000),
+        executed_reserve=Decimal(1000),
+        lp_fees=0,
+        native_token_price=0,
+    )
+
+    # 3. Create a sell trade (bridge-back: Base -> Arbitrum) and verify mint_recipient = primary Safe.
+    _, sell_trade, _ = state.create_trade(
+        strategy_cycle_at=ts,
+        pair=cctp_pair,
+        quantity=Decimal(-1000),
+        reserve=None,
+        assumed_price=1.0,
+        trade_type=TradeType.rebalance,
+        reserve_currency=usdc_arbitrum,
+        reserve_currency_price=1.0,
+    )
+
+    assert sell_trade.is_sell()
+    sell_mint_dest = cctp_pair.quote.chain_id
+    assert resolver(sell_mint_dest) == PRIMARY_SAFE

--- a/tests/ethereum/test_cctp_in_transit_lifecycle.py
+++ b/tests/ethereum/test_cctp_in_transit_lifecycle.py
@@ -1,0 +1,364 @@
+"""Test the cctp_in_transit lifecycle: valuation, executor halt, and startup retry.
+
+Verifies that:
+
+- ``get_in_transit_value()`` correctly sums planned_reserve of in-transit trades
+- ``calculate_total_equity()`` includes in-transit value
+- ``calculate_total_equity_chain()`` attributes in-transit value to the
+  destination chain
+- The sequential executor halts and expires remaining planned trades when
+  a CCTP bridge trade enters cctp_in_transit status
+- Orphan positions created by expired trades are cleaned up
+- ``check_and_retry_cctp_in_transit()`` resolves in-transit trades on startup
+"""
+
+import datetime
+from decimal import Decimal
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from tradeexecutor.state.blockhain_transaction import BlockchainTransaction
+from tradeexecutor.state.identifier import (
+    AssetIdentifier,
+    TradingPairIdentifier,
+    TradingPairKind,
+)
+from tradeexecutor.state.state import State
+from tradeexecutor.state.trade import TradeExecution, TradeStatus, TradeType
+from tradeexecutor.strategy.execution_model import ExecutionHaltableIssue
+
+
+USDC_ARBITRUM_ADDRESS = "0xaf88d065e77c8cC2239327C5EDb3A432268e5831"
+USDC_BASE_ADDRESS = "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913"
+
+
+@pytest.fixture()
+def usdc_arbitrum() -> AssetIdentifier:
+    """USDC on Arbitrum."""
+    return AssetIdentifier(
+        chain_id=42161,
+        address=USDC_ARBITRUM_ADDRESS,
+        token_symbol="USDC",
+        decimals=6,
+    )
+
+
+@pytest.fixture()
+def usdc_base() -> AssetIdentifier:
+    """USDC on Base."""
+    return AssetIdentifier(
+        chain_id=8453,
+        address=USDC_BASE_ADDRESS,
+        token_symbol="USDC",
+        decimals=6,
+    )
+
+
+@pytest.fixture()
+def cctp_pair(usdc_arbitrum: AssetIdentifier, usdc_base: AssetIdentifier) -> TradingPairIdentifier:
+    """CCTP bridge pair: Arbitrum -> Base."""
+    return TradingPairIdentifier(
+        base=usdc_base,
+        quote=usdc_arbitrum,
+        pool_address="0x28b5a0e9C621a5BadaA536219b3a228C8168cf5d",
+        exchange_address="0x28b5a0e9C621a5BadaA536219b3a228C8168cf5d",
+        fee=0,
+        kind=TradingPairKind.cctp_bridge,
+        other_data={"bridge_protocol": "cctp"},
+    )
+
+
+def _create_bridge_trade(
+    state: State,
+    cctp_pair: TradingPairIdentifier,
+    reserve_asset: AssetIdentifier,
+    reserve_amount: Decimal,
+    ts: datetime.datetime,
+) -> TradeExecution:
+    """Helper to create a bridge-out (buy) trade."""
+    _, trade, _ = state.create_trade(
+        strategy_cycle_at=ts,
+        pair=cctp_pair,
+        quantity=None,
+        reserve=reserve_amount,
+        assumed_price=1.0,
+        trade_type=TradeType.rebalance,
+        reserve_currency=reserve_asset,
+        reserve_currency_price=1.0,
+    )
+    return trade
+
+
+def test_in_transit_value_included_in_equity(
+    cctp_pair: TradingPairIdentifier,
+    usdc_arbitrum: AssetIdentifier,
+):
+    """Verify that in-transit value is included in portfolio equity calculations.
+
+    1. Create a state with reserves and a bridge-out (buy) trade
+    2. Advance trade to broadcasted, then mark it cctp_in_transit
+    3. Verify get_in_transit_value() returns the planned_reserve amount
+    4. Verify calculate_total_equity() includes the in-transit value
+    5. Verify calculate_total_equity_chain() attributes in-transit value
+       to the destination chain
+    """
+    state = State()
+    ts = datetime.datetime(2025, 1, 1)
+
+    # 1. Create a state with reserves and a bridge-out (buy) trade
+    state.portfolio.initialise_reserves(usdc_arbitrum)
+    reserve = state.portfolio.get_default_reserve_position()
+    reserve.quantity = Decimal(10_000)
+    reserve.reserve_token_price = 1.0
+
+    trade = _create_bridge_trade(state, cctp_pair, usdc_arbitrum, Decimal(500), ts)
+
+    # 2. Advance trade to broadcasted, then mark it cctp_in_transit
+    state.start_execution(ts, trade)
+    trade.mark_broadcasted(ts)
+
+    # Add fake blockchain transactions for mark_bridge_in_transit
+    approve_tx = BlockchainTransaction()
+    approve_tx.tx_hash = "0xapprove"
+    burn_tx = BlockchainTransaction()
+    burn_tx.tx_hash = "0xburn123"
+    trade.blockchain_transactions = [approve_tx, burn_tx]
+
+    state.mark_bridge_in_transit(ts, trade)
+    assert trade.get_status() == TradeStatus.cctp_in_transit
+
+    # 3. Verify get_in_transit_value() returns the planned_reserve amount
+    in_transit = state.portfolio.get_in_transit_value()
+    assert in_transit == pytest.approx(500.0)
+
+    # 4. Verify calculate_total_equity() includes the in-transit value
+    # Reserves started at 10,000 but 500 was allocated to the trade via
+    # start_execution, so cash is 9,500. Position equity for the bridge
+    # position is 0 (no successful trades yet). In-transit = 500.
+    total_equity = state.portfolio.calculate_total_equity()
+    assert total_equity == pytest.approx(10_000.0)
+
+    # 5. Verify calculate_total_equity_chain() attributes in-transit value
+    #    to the destination chain
+    chain_equity = state.portfolio.calculate_total_equity_chain()
+    from tradingstrategy.chain import ChainId
+    # In-transit value should appear under destination chain (Base = 8453)
+    assert chain_equity.get(ChainId.base, 0) == pytest.approx(500.0)
+    # Reserves remain on Arbitrum
+    assert chain_equity.get(ChainId.arbitrum, 0) == pytest.approx(9_500.0)
+
+
+def test_executor_halt_expires_remaining_trades(
+    cctp_pair: TradingPairIdentifier,
+    usdc_arbitrum: AssetIdentifier,
+):
+    """Verify that a cctp_in_transit trade halts the batch and expires remaining trades.
+
+    We mock _execute_trade_batch to simulate the first trade entering
+    cctp_in_transit status, then verify the sequential executor:
+
+    1. Create state with reserves and three bridge trades
+    2. Mock _execute_trade_batch so the first trade enters cctp_in_transit
+    3. Create a second (planned) trade that should be expired
+    4. Create a third (planned) trade on a fresh position that should
+       be expired and the orphan position cleaned up
+    5. Run _execute_trades_sequentially and catch ExecutionHaltableIssue
+    6. Verify the first trade is still in cctp_in_transit
+    7. Verify remaining planned trades are expired
+    8. Verify orphan positions with only expired trades are removed
+    """
+    from tradeexecutor.ethereum.execution import EthereumExecution
+
+    state = State()
+    ts = datetime.datetime(2025, 1, 1)
+
+    # 1. Create state with reserves
+    state.portfolio.initialise_reserves(usdc_arbitrum)
+    reserve = state.portfolio.get_default_reserve_position()
+    reserve.quantity = Decimal(10_000)
+    reserve.reserve_token_price = 1.0
+
+    # Create the bridge trade (first in sequence)
+    bridge_trade = _create_bridge_trade(state, cctp_pair, usdc_arbitrum, Decimal(500), ts)
+
+    # Create a second planned trade (to be expired)
+    second_trade = _create_bridge_trade(state, cctp_pair, usdc_arbitrum, Decimal(200), ts)
+
+    # Create a third planned trade on a fresh pair (orphan position candidate)
+    # Use the same pair for simplicity — it ends up on the same position
+    # so create a distinct pair to get a distinct position
+    other_pair = TradingPairIdentifier(
+        base=AssetIdentifier(
+            chain_id=8453,
+            address="0x0000000000000000000000000000000000000099",
+            token_symbol="USDC2",
+            decimals=6,
+        ),
+        quote=usdc_arbitrum,
+        pool_address="0x0000000000000000000000000000000000000088",
+        exchange_address="0x0000000000000000000000000000000000000088",
+        fee=0,
+        kind=TradingPairKind.cctp_bridge,
+        other_data={"bridge_protocol": "cctp"},
+    )
+    _, third_trade, _ = state.create_trade(
+        strategy_cycle_at=ts,
+        pair=other_pair,
+        quantity=None,
+        reserve=Decimal(100),
+        assumed_price=1.0,
+        trade_type=TradeType.rebalance,
+        reserve_currency=usdc_arbitrum,
+        reserve_currency_price=1.0,
+    )
+    third_position_id = third_trade.position_id
+
+    # Record the position ID of the third trade before execution
+    assert third_position_id in state.portfolio.open_positions
+
+    trades = [bridge_trade, second_trade, third_trade]
+
+    # 2. Mock _execute_trade_batch so the first trade enters cctp_in_transit
+    def mock_execute_batch(routing_model, batch_state, batch_trades, rebroadcast):
+        for t in batch_trades:
+            if t.trade_id == bridge_trade.trade_id:
+                # Simulate burn confirmed but attestation timed out
+                t.mark_broadcasted(ts)
+                approve_tx = BlockchainTransaction()
+                approve_tx.tx_hash = "0xapprove"
+                burn_tx = BlockchainTransaction()
+                burn_tx.tx_hash = "0xburn"
+                t.blockchain_transactions = [approve_tx, burn_tx]
+                batch_state.mark_bridge_in_transit(ts, t)
+
+    # Build a mock EthereumExecution using MagicMock with spec
+    # because web3 is a read-only property on EthereumExecution
+    executor = MagicMock(spec=EthereumExecution)
+    executor.max_slippage = None
+    executor._execute_trade_batch = mock_execute_batch
+    # Bind the real method to our mock so logic executes
+    executor._execute_trades_sequentially = EthereumExecution._execute_trades_sequentially.__get__(executor)
+    executor._log_trade_outcome = EthereumExecution._log_trade_outcome
+
+    mock_routing_model = MagicMock()
+    mock_routing_state = MagicMock()
+
+    # 5. Run _execute_trades_sequentially and catch ExecutionHaltableIssue
+    with pytest.raises(ExecutionHaltableIssue, match="CCTP bridge in transit"):
+        executor._execute_trades_sequentially(
+            ts=ts,
+            state=state,
+            trades=trades,
+            routing_model=mock_routing_model,
+            routing_state=mock_routing_state,
+            check_balances=False,
+            rebroadcast=False,
+            triggered=False,
+        )
+
+    # 6. Verify the first trade is still in cctp_in_transit
+    assert bridge_trade.get_status() == TradeStatus.cctp_in_transit
+
+    # 7. Verify remaining planned trades are expired
+    assert second_trade.get_status() == TradeStatus.expired
+    assert third_trade.get_status() == TradeStatus.expired
+
+    # 8. Verify orphan position (third_trade's position) is removed
+    #    since it had zero quantity and all trades expired
+    assert third_position_id not in state.portfolio.open_positions
+
+
+def test_startup_retry_resolves_in_transit(
+    cctp_pair: TradingPairIdentifier,
+    usdc_arbitrum: AssetIdentifier,
+):
+    """Verify that check_and_retry_cctp_in_transit resolves an in-transit trade.
+
+    1. Create state with a bridge-out trade in cctp_in_transit status
+    2. Mock attestation to return successfully
+    3. Mock receiveMessage broadcast and receipt to succeed
+    4. Call check_and_retry_cctp_in_transit
+    5. Verify the trade transitions to success
+    6. Verify cctp_in_transit_at is cleared
+    7. Verify the trade is in the returned resolved list
+    """
+    from tradeexecutor.ethereum.cctp.retry import check_and_retry_cctp_in_transit
+
+    state = State()
+    ts = datetime.datetime(2025, 1, 1)
+
+    # 1. Create state with a bridge-out trade in cctp_in_transit status
+    state.portfolio.initialise_reserves(usdc_arbitrum)
+    reserve = state.portfolio.get_default_reserve_position()
+    reserve.quantity = Decimal(10_000)
+    reserve.reserve_token_price = 1.0
+
+    trade = _create_bridge_trade(state, cctp_pair, usdc_arbitrum, Decimal(500), ts)
+    state.start_execution(ts, trade)
+    trade.mark_broadcasted(ts)
+
+    # Add fake blockchain transactions
+    approve_tx = BlockchainTransaction()
+    approve_tx.tx_hash = "0xapprove"
+    burn_tx = BlockchainTransaction()
+    burn_tx.tx_hash = "0xburn_abc"
+    trade.blockchain_transactions = [approve_tx, burn_tx]
+
+    state.mark_bridge_in_transit(ts, trade)
+    assert trade.get_status() == TradeStatus.cctp_in_transit
+
+    # Build mock dependencies
+    mock_execution_model = MagicMock()
+    mock_execution_model.tx_builder.hot_wallet.account = MagicMock()
+
+    mock_web3config = MagicMock()
+    mock_dest_web3 = MagicMock()
+    mock_web3config.get_connection.return_value = mock_dest_web3
+
+    # 2. Mock attestation to return successfully
+    mock_attestation = MagicMock()
+    mock_attestation.message = b"\x01" * 32
+    mock_attestation.attestation = b"\x02" * 32
+
+    # 3. Mock receiveMessage broadcast and receipt to succeed
+    mock_receive_tx = BlockchainTransaction()
+    mock_receive_tx.tx_hash = "0xcccc000000000000000000000000000000000000000000000000000000000099"
+    mock_receive_tx.signed_bytes = "0xcafe"
+
+    mock_dest_web3.eth.wait_for_transaction_receipt.return_value = {"status": 1}
+
+    # 4. Call check_and_retry_cctp_in_transit with all mocks
+    #    The retry module imports these inside the function body, so
+    #    we patch them at their origin packages.
+    with (
+        patch("eth_defi.cctp.attestation.fetch_attestation", return_value=mock_attestation),
+        patch("eth_defi.cctp.transfer._resolve_cctp_domain", return_value=3),
+        patch("eth_defi.cctp.transfer.get_message_transmitter_v2", return_value=MagicMock()),
+        patch("eth_defi.cctp.receive.prepare_receive_message", return_value=MagicMock()),
+        patch("eth_defi.hotwallet.HotWallet") as MockHW,
+        patch("tradeexecutor.ethereum.tx.HotWalletTransactionBuilder") as MockTxBuilder,
+    ):
+        mock_hw_instance = MagicMock()
+        MockHW.return_value = mock_hw_instance
+
+        mock_builder_instance = MagicMock()
+        mock_builder_instance.sign_transaction.return_value = mock_receive_tx
+        MockTxBuilder.return_value = mock_builder_instance
+
+        resolved = check_and_retry_cctp_in_transit(
+            state=state,
+            execution_model=mock_execution_model,
+            web3config=mock_web3config,
+            attestation_timeout=5.0,
+        )
+
+    # 5. Verify the trade transitions to success
+    assert trade.get_status() == TradeStatus.success
+
+    # 6. Verify cctp_in_transit_at is cleared
+    assert trade.cctp_in_transit_at is None
+
+    # 7. Verify the trade is in the returned resolved list
+    assert len(resolved) == 1
+    assert resolved[0].trade_id == trade.trade_id

--- a/tests/ethereum/test_cctp_settlement.py
+++ b/tests/ethereum/test_cctp_settlement.py
@@ -241,7 +241,10 @@ def test_settle_trade_receive_revert(
     mock_receive_tx.signed_bytes = "0xcafe"
 
     # 4. Set the receive receipt status to 0 (revert)
-    mock_dest_web3.eth.wait_for_transaction_receipt.return_value = {"status": 0}
+    mock_dest_web3.eth.wait_for_transaction_receipt.return_value = {
+        "status": 0, "blockNumber": 200, "blockHash": b"\x00" * 32,
+        "gasUsed": 100_000, "effectiveGasPrice": 1_000_000_000,
+    }
 
     with (
         patch("tradeexecutor.ethereum.cctp.routing.fetch_block_timestamp", return_value=mock_ts),
@@ -314,7 +317,10 @@ def test_settle_trade_success_flow(
     mock_receive_tx.signed_bytes = "0xcafe"
 
     # 4. Set the receive receipt status to 1 (success)
-    mock_dest_web3.eth.wait_for_transaction_receipt.return_value = {"status": 1}
+    mock_dest_web3.eth.wait_for_transaction_receipt.return_value = {
+        "status": 1, "blockNumber": 200, "blockHash": b"\x00" * 32,
+        "gasUsed": 100_000, "effectiveGasPrice": 1_000_000_000,
+    }
 
     with (
         patch("tradeexecutor.ethereum.cctp.routing.fetch_block_timestamp", return_value=mock_ts),

--- a/tests/ethereum/test_cctp_settlement.py
+++ b/tests/ethereum/test_cctp_settlement.py
@@ -1,0 +1,348 @@
+"""Test CCTP bridge multi-phase settlement logic.
+
+Verifies that ``CctpBridgeRouting.settle_trade()`` correctly handles:
+
+- Attestation timeout (trade marked in-transit)
+- ``receiveMessage`` revert (trade marked in-transit)
+- Full success flow (burn + attestation + receive all succeed)
+
+All web3 and eth_defi calls are mocked — these tests exercise state
+transitions, not actual blockchain interaction.
+"""
+
+import datetime
+from decimal import Decimal
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from tradeexecutor.ethereum.cctp.routing import CctpBridgeRouting
+from tradeexecutor.ethereum.web3config import Web3Config
+from tradeexecutor.state.blockhain_transaction import (
+    BlockchainTransaction,
+    BlockchainTransactionType,
+)
+from tradeexecutor.state.identifier import (
+    AssetIdentifier,
+    TradingPairIdentifier,
+    TradingPairKind,
+)
+from tradeexecutor.state.state import State
+from tradeexecutor.state.trade import TradeExecution, TradeStatus, TradeType
+
+
+USDC_ARBITRUM_ADDRESS = "0xaf88d065e77c8cC2239327C5EDb3A432268e5831"
+USDC_BASE_ADDRESS = "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913"
+
+
+@pytest.fixture()
+def usdc_arbitrum() -> AssetIdentifier:
+    """USDC on Arbitrum."""
+    return AssetIdentifier(
+        chain_id=42161,
+        address=USDC_ARBITRUM_ADDRESS,
+        token_symbol="USDC",
+        decimals=6,
+    )
+
+
+@pytest.fixture()
+def usdc_base() -> AssetIdentifier:
+    """USDC on Base."""
+    return AssetIdentifier(
+        chain_id=8453,
+        address=USDC_BASE_ADDRESS,
+        token_symbol="USDC",
+        decimals=6,
+    )
+
+
+@pytest.fixture()
+def cctp_pair(usdc_arbitrum: AssetIdentifier, usdc_base: AssetIdentifier) -> TradingPairIdentifier:
+    """CCTP bridge pair: Arbitrum -> Base."""
+    return TradingPairIdentifier(
+        base=usdc_base,
+        quote=usdc_arbitrum,
+        pool_address="0x28b5a0e9C621a5BadaA536219b3a228C8168cf5d",
+        exchange_address="0x28b5a0e9C621a5BadaA536219b3a228C8168cf5d",
+        fee=0,
+        kind=TradingPairKind.cctp_bridge,
+        other_data={"bridge_protocol": "cctp"},
+    )
+
+
+def _create_broadcasted_bridge_trade(
+    state: State,
+    cctp_pair: TradingPairIdentifier,
+    reserve_asset: AssetIdentifier,
+    reserve_amount: Decimal,
+    ts: datetime.datetime,
+) -> TradeExecution:
+    """Create a bridge-out (buy) trade in broadcasted state with fake burn tx.
+
+    Returns a trade that has:
+
+    - Two ``BlockchainTransaction`` objects (approve + burn)
+    - The burn tx has ``function_selector='depositForBurn'`` and ``type=hot_wallet``
+    - The trade is in broadcasted status
+    """
+    _, trade, _ = state.create_trade(
+        strategy_cycle_at=ts,
+        pair=cctp_pair,
+        quantity=None,
+        reserve=reserve_amount,
+        assumed_price=1.0,
+        trade_type=TradeType.rebalance,
+        reserve_currency=reserve_asset,
+        reserve_currency_price=1.0,
+    )
+
+    approve_tx = BlockchainTransaction()
+    approve_tx.tx_hash = "0xaaaa000000000000000000000000000000000000000000000000000000000001"
+    approve_tx.function_selector = "approve"
+    approve_tx.type = BlockchainTransactionType.hot_wallet
+    approve_tx.signed_bytes = "0xdead"
+
+    burn_tx = BlockchainTransaction()
+    burn_tx.tx_hash = "0xbbbb000000000000000000000000000000000000000000000000000000000002"
+    burn_tx.function_selector = "depositForBurn"
+    burn_tx.type = BlockchainTransactionType.hot_wallet
+    burn_tx.signed_bytes = "0xbeef"
+
+    trade.blockchain_transactions = [approve_tx, burn_tx]
+
+    state.start_execution(ts, trade)
+    trade.mark_broadcasted(ts)
+
+    return trade
+
+
+@pytest.fixture()
+def bridge_state_and_trade(
+    cctp_pair: TradingPairIdentifier,
+    usdc_arbitrum: AssetIdentifier,
+) -> tuple[State, TradeExecution]:
+    """State with reserves and a broadcasted bridge-out trade."""
+    state = State()
+    ts = datetime.datetime(2025, 1, 1)
+
+    state.portfolio.initialise_reserves(usdc_arbitrum)
+    reserve = state.portfolio.get_default_reserve_position()
+    reserve.quantity = Decimal(10_000)
+    reserve.reserve_token_price = 1.0
+
+    trade = _create_broadcasted_bridge_trade(
+        state, cctp_pair, usdc_arbitrum, Decimal(500), ts,
+    )
+    return state, trade
+
+
+def _make_routing(web3config: Web3Config | None = None) -> CctpBridgeRouting:
+    """Build a CctpBridgeRouting with a mock web3config and fake hot wallet."""
+    if web3config is None:
+        web3config = MagicMock(spec=Web3Config)
+
+    routing = CctpBridgeRouting(
+        web3config=web3config,
+        attestation_timeout=5.0,
+    )
+
+    mock_hw = MagicMock()
+    mock_hw.account = MagicMock()
+    routing._hot_wallet = mock_hw
+
+    return routing
+
+
+def test_settle_trade_attestation_timeout(
+    bridge_state_and_trade: tuple[State, TradeExecution],
+):
+    """Verify that an attestation timeout marks the trade as cctp_in_transit.
+
+    1. Build a CctpBridgeRouting with mocked dependencies
+    2. Mock fetch_attestation to raise TimeoutError
+    3. Mock fetch_block_timestamp and _resolve_cctp_domain
+    4. Call settle_trade with a successful burn receipt
+    5. Assert the trade is marked cctp_in_transit
+    6. Assert metadata (chain IDs, burn tx hash) is stored
+    """
+    state, trade = bridge_state_and_trade
+    routing = _make_routing()
+
+    # 1. Receipts dict keyed by HexBytes of burn tx hash
+    from hexbytes import HexBytes
+    receipts = {
+        HexBytes("0xbbbb000000000000000000000000000000000000000000000000000000000002"): {"status": 1, "blockNumber": 100},
+    }
+
+    mock_ts = datetime.datetime(2025, 1, 1, 0, 5)
+
+    # 2. Mock fetch_attestation to raise TimeoutError
+    # 3. Mock fetch_block_timestamp and _resolve_cctp_domain
+    with (
+        patch("tradeexecutor.ethereum.cctp.routing.fetch_block_timestamp", return_value=mock_ts),
+        patch("eth_defi.cctp.attestation.fetch_attestation", side_effect=TimeoutError("timed out")),
+        patch("eth_defi.cctp.transfer._resolve_cctp_domain", return_value=3),
+    ):
+        mock_web3 = MagicMock()
+        # 4. Call settle_trade with a successful burn receipt
+        routing.settle_trade(mock_web3, state, trade, receipts)
+
+    # 5. Assert the trade is marked cctp_in_transit
+    assert trade.get_status() == TradeStatus.cctp_in_transit
+    assert trade.cctp_in_transit_at == mock_ts
+
+    # 6. Assert metadata (chain IDs, burn tx hash) is stored
+    assert trade.other_data["cctp_source_chain_id"] == 42161
+    assert trade.other_data["cctp_dest_chain_id"] == 8453
+    assert trade.other_data["cctp_burn_tx_hash"] == "0xbbbb000000000000000000000000000000000000000000000000000000000002"
+
+
+def test_settle_trade_receive_revert(
+    bridge_state_and_trade: tuple[State, TradeExecution],
+):
+    """Verify that a receiveMessage revert marks the trade as cctp_in_transit.
+
+    1. Build routing with mocked web3config that returns a destination web3
+    2. Mock fetch_attestation to return a successful attestation
+    3. Mock the destination chain tx building and broadcast
+    4. Set the receive receipt status to 0 (revert)
+    5. Call settle_trade
+    6. Assert the trade is marked cctp_in_transit (not success, not failed)
+    7. Assert a receiveMessage tx was appended to blockchain_transactions
+    """
+    state, trade = bridge_state_and_trade
+    assert len(trade.blockchain_transactions) == 2
+
+    mock_dest_web3 = MagicMock()
+    mock_dest_web3.eth.chain_id = 8453
+
+    mock_web3config = MagicMock(spec=Web3Config)
+    mock_web3config.get_connection.return_value = mock_dest_web3
+
+    routing = _make_routing(web3config=mock_web3config)
+
+    from hexbytes import HexBytes
+    receipts = {
+        HexBytes("0xbbbb000000000000000000000000000000000000000000000000000000000002"): {"status": 1, "blockNumber": 100},
+    }
+
+    mock_ts = datetime.datetime(2025, 1, 1, 0, 5)
+
+    mock_attestation = MagicMock()
+    mock_attestation.message = b"\x01" * 32
+    mock_attestation.attestation = b"\x02" * 32
+
+    # 3. Mock the destination chain tx building and broadcast
+    mock_receive_tx = BlockchainTransaction()
+    mock_receive_tx.tx_hash = "0xcccc000000000000000000000000000000000000000000000000000000000003"
+    mock_receive_tx.function_selector = "receiveMessage"
+    mock_receive_tx.type = BlockchainTransactionType.hot_wallet
+    mock_receive_tx.signed_bytes = "0xcafe"
+
+    # 4. Set the receive receipt status to 0 (revert)
+    mock_dest_web3.eth.wait_for_transaction_receipt.return_value = {"status": 0}
+
+    with (
+        patch("tradeexecutor.ethereum.cctp.routing.fetch_block_timestamp", return_value=mock_ts),
+        patch("eth_defi.cctp.attestation.fetch_attestation", return_value=mock_attestation),
+        patch("eth_defi.cctp.transfer._resolve_cctp_domain", return_value=3),
+        patch("eth_defi.cctp.transfer.get_message_transmitter_v2", return_value=MagicMock()),
+        patch("eth_defi.cctp.receive.prepare_receive_message", return_value=MagicMock()),
+        patch("eth_defi.hotwallet.HotWallet") as MockHW,
+        patch("tradeexecutor.ethereum.tx.HotWalletTransactionBuilder") as MockTxBuilder,
+    ):
+        mock_hw_instance = MagicMock()
+        MockHW.return_value = mock_hw_instance
+
+        mock_builder_instance = MagicMock()
+        mock_builder_instance.sign_transaction.return_value = mock_receive_tx
+        MockTxBuilder.return_value = mock_builder_instance
+
+        mock_web3 = MagicMock()
+
+        # 5. Call settle_trade
+        routing.settle_trade(mock_web3, state, trade, receipts)
+
+    # 6. Assert the trade is marked cctp_in_transit (not success, not failed)
+    assert trade.get_status() == TradeStatus.cctp_in_transit
+    assert trade.cctp_in_transit_at == mock_ts
+
+    # 7. Assert a receiveMessage tx was appended to blockchain_transactions
+    assert len(trade.blockchain_transactions) == 3
+    assert trade.blockchain_transactions[2].tx_hash == "0xcccc000000000000000000000000000000000000000000000000000000000003"
+
+
+def test_settle_trade_success_flow(
+    bridge_state_and_trade: tuple[State, TradeExecution],
+):
+    """Verify the full success flow: burn confirmed, attestation received, receiveMessage succeeds.
+
+    1. Build routing with mocked web3config
+    2. Mock fetch_attestation to return a successful attestation
+    3. Mock the destination chain tx building and broadcast
+    4. Set the receive receipt status to 1 (success)
+    5. Call settle_trade
+    6. Assert the trade is marked success with 1:1 price
+    7. Assert a receiveMessage tx was appended and the trade has 3 txs total
+    """
+    state, trade = bridge_state_and_trade
+
+    mock_dest_web3 = MagicMock()
+    mock_dest_web3.eth.chain_id = 8453
+
+    mock_web3config = MagicMock(spec=Web3Config)
+    mock_web3config.get_connection.return_value = mock_dest_web3
+
+    routing = _make_routing(web3config=mock_web3config)
+
+    from hexbytes import HexBytes
+    receipts = {
+        HexBytes("0xbbbb000000000000000000000000000000000000000000000000000000000002"): {"status": 1, "blockNumber": 100},
+    }
+
+    mock_ts = datetime.datetime(2025, 1, 1, 0, 5)
+
+    mock_attestation = MagicMock()
+    mock_attestation.message = b"\x01" * 32
+    mock_attestation.attestation = b"\x02" * 32
+
+    mock_receive_tx = BlockchainTransaction()
+    mock_receive_tx.tx_hash = "0xdddd000000000000000000000000000000000000000000000000000000000004"
+    mock_receive_tx.function_selector = "receiveMessage"
+    mock_receive_tx.type = BlockchainTransactionType.hot_wallet
+    mock_receive_tx.signed_bytes = "0xcafe"
+
+    # 4. Set the receive receipt status to 1 (success)
+    mock_dest_web3.eth.wait_for_transaction_receipt.return_value = {"status": 1}
+
+    with (
+        patch("tradeexecutor.ethereum.cctp.routing.fetch_block_timestamp", return_value=mock_ts),
+        patch("eth_defi.cctp.attestation.fetch_attestation", return_value=mock_attestation),
+        patch("eth_defi.cctp.transfer._resolve_cctp_domain", return_value=3),
+        patch("eth_defi.cctp.transfer.get_message_transmitter_v2", return_value=MagicMock()),
+        patch("eth_defi.cctp.receive.prepare_receive_message", return_value=MagicMock()),
+        patch("eth_defi.hotwallet.HotWallet") as MockHW,
+        patch("tradeexecutor.ethereum.tx.HotWalletTransactionBuilder") as MockTxBuilder,
+    ):
+        mock_hw_instance = MagicMock()
+        MockHW.return_value = mock_hw_instance
+
+        mock_builder_instance = MagicMock()
+        mock_builder_instance.sign_transaction.return_value = mock_receive_tx
+        MockTxBuilder.return_value = mock_builder_instance
+
+        mock_web3 = MagicMock()
+
+        # 5. Call settle_trade
+        routing.settle_trade(mock_web3, state, trade, receipts)
+
+    # 6. Assert the trade is marked success with 1:1 price
+    assert trade.get_status() == TradeStatus.success
+    assert trade.executed_price == pytest.approx(1.0)
+    assert trade.executed_quantity == trade.planned_quantity
+    assert trade.executed_reserve == trade.planned_reserve
+
+    # 7. Assert a receiveMessage tx was appended and the trade has 3 txs total
+    assert len(trade.blockchain_transactions) == 3
+    assert trade.blockchain_transactions[2].tx_hash == "0xdddd000000000000000000000000000000000000000000000000000000000004"

--- a/tests/test_cctp_in_transit_status.py
+++ b/tests/test_cctp_in_transit_status.py
@@ -1,0 +1,288 @@
+"""Test CCTP in-transit trade status and related helper methods.
+
+Verifies that:
+- The new ``cctp_in_transit`` status is correctly resolved by ``get_status()``
+- ``mark_expired()`` only works on planned trades
+- ``get_execution_sort_position()`` places bridge trades in the correct phases
+- ``mark_bridge_in_transit()`` sets metadata and locks bridge-back capital
+"""
+
+import datetime
+from decimal import Decimal
+
+import pytest
+
+from tradeexecutor.state.blockhain_transaction import BlockchainTransaction
+from tradeexecutor.state.identifier import (
+    AssetIdentifier,
+    TradingPairIdentifier,
+    TradingPairKind,
+)
+from tradeexecutor.state.state import State
+from tradeexecutor.state.trade import TradeExecution, TradeStatus, TradeType
+
+
+USDC_ARBITRUM_ADDRESS = "0xaf88d065e77c8cC2239327C5EDb3A432268e5831"
+USDC_BASE_ADDRESS = "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913"
+
+
+@pytest.fixture()
+def usdc_arbitrum() -> AssetIdentifier:
+    """USDC on Arbitrum."""
+    return AssetIdentifier(
+        chain_id=42161,
+        address=USDC_ARBITRUM_ADDRESS,
+        token_symbol="USDC",
+        decimals=6,
+    )
+
+
+@pytest.fixture()
+def usdc_base() -> AssetIdentifier:
+    """USDC on Base."""
+    return AssetIdentifier(
+        chain_id=8453,
+        address=USDC_BASE_ADDRESS,
+        token_symbol="USDC",
+        decimals=6,
+    )
+
+
+@pytest.fixture()
+def cctp_pair(usdc_arbitrum: AssetIdentifier, usdc_base: AssetIdentifier) -> TradingPairIdentifier:
+    """CCTP bridge pair: Arbitrum -> Base."""
+    return TradingPairIdentifier(
+        base=usdc_base,
+        quote=usdc_arbitrum,
+        pool_address="0x28b5a0e9C621a5BadaA536219b3a228C8168cf5d",
+        exchange_address="0x28b5a0e9C621a5BadaA536219b3a228C8168cf5d",
+        fee=0,
+        kind=TradingPairKind.cctp_bridge,
+        other_data={"bridge_protocol": "cctp"},
+    )
+
+
+def _create_bridge_trade(
+    state: State,
+    cctp_pair: TradingPairIdentifier,
+    reserve_asset: AssetIdentifier,
+    reserve_amount: Decimal,
+    ts: datetime.datetime,
+    *,
+    sell: bool = False,
+) -> TradeExecution:
+    """Helper to create a bridge-out (buy) or bridge-back (sell) trade."""
+    if sell:
+        quantity = -reserve_amount
+        reserve = None
+    else:
+        quantity = None
+        reserve = reserve_amount
+
+    _, trade, _ = state.create_trade(
+        strategy_cycle_at=ts,
+        pair=cctp_pair,
+        quantity=quantity,
+        reserve=reserve,
+        assumed_price=1.0,
+        trade_type=TradeType.rebalance,
+        reserve_currency=reserve_asset,
+        reserve_currency_price=1.0,
+    )
+    return trade
+
+
+def test_get_status_cctp_in_transit(
+    cctp_pair: TradingPairIdentifier,
+    usdc_arbitrum: AssetIdentifier,
+):
+    """Test that get_status() returns cctp_in_transit and that executed_at wins.
+
+    1. Create a bridge-out trade and advance it to broadcasted
+    2. Set cctp_in_transit_at and verify status is cctp_in_transit
+    3. Set executed_at and verify status is success (executed_at takes priority)
+    """
+    state = State()
+    ts = datetime.datetime(2025, 1, 1)
+
+    state.portfolio.initialise_reserves(usdc_arbitrum)
+    reserve = state.portfolio.get_default_reserve_position()
+    reserve.quantity = Decimal(10_000)
+    reserve.reserve_token_price = 1.0
+
+    # 1. Create a bridge-out trade and advance it to broadcasted
+    trade = _create_bridge_trade(state, cctp_pair, usdc_arbitrum, Decimal(500), ts)
+    state.start_execution(ts, trade)
+    trade.mark_broadcasted(ts)
+    assert trade.get_status() == TradeStatus.broadcasted
+
+    # 2. Set cctp_in_transit_at and verify status is cctp_in_transit
+    trade.cctp_in_transit_at = ts
+    assert trade.get_status() == TradeStatus.cctp_in_transit
+
+    # 3. Set executed_at and verify status is success (executed_at takes priority)
+    trade.executed_at = ts
+    assert trade.get_status() == TradeStatus.success
+
+
+def test_mark_expired(
+    cctp_pair: TradingPairIdentifier,
+    usdc_arbitrum: AssetIdentifier,
+):
+    """Test that mark_expired() works on planned trades and rejects other statuses.
+
+    1. Create a planned trade
+    2. Verify mark_expired() succeeds on a planned trade
+    3. Create another trade, start it, and verify mark_expired() raises
+    """
+    state = State()
+    ts = datetime.datetime(2025, 1, 1)
+
+    state.portfolio.initialise_reserves(usdc_arbitrum)
+    reserve = state.portfolio.get_default_reserve_position()
+    reserve.quantity = Decimal(10_000)
+    reserve.reserve_token_price = 1.0
+
+    # 1. Create a planned trade
+    trade = _create_bridge_trade(state, cctp_pair, usdc_arbitrum, Decimal(500), ts)
+    assert trade.get_status() == TradeStatus.planned
+
+    # 2. Verify mark_expired() succeeds on a planned trade
+    trade.mark_expired(ts)
+    assert trade.get_status() == TradeStatus.expired
+
+    # 3. Create another trade, start it, and verify mark_expired() raises
+    trade2 = _create_bridge_trade(state, cctp_pair, usdc_arbitrum, Decimal(200), ts)
+    state.start_execution(ts, trade2)
+    with pytest.raises(AssertionError):
+        trade2.mark_expired(ts)
+
+
+def test_get_execution_sort_position_cctp_bridge(
+    cctp_pair: TradingPairIdentifier,
+    usdc_arbitrum: AssetIdentifier,
+):
+    """Test that bridge trades sort to the correct phases.
+
+    1. Create a bridge-out (buy) trade and check sort position is in +30M range
+    2. Create a bridge-back (sell) trade and check sort position is in -30M range
+    3. Verify bridge sell with closing=True still uses bridge phase, not close phase
+    """
+    state = State()
+    ts = datetime.datetime(2025, 1, 1)
+
+    state.portfolio.initialise_reserves(usdc_arbitrum)
+    reserve = state.portfolio.get_default_reserve_position()
+    reserve.quantity = Decimal(10_000)
+    reserve.reserve_token_price = 1.0
+
+    # 1. Create a bridge-out (buy) trade and check sort position is in +30M range
+    buy_trade = _create_bridge_trade(state, cctp_pair, usdc_arbitrum, Decimal(500), ts)
+    buy_sort = buy_trade.get_execution_sort_position()
+    assert buy_sort == buy_trade.trade_id + 30_000_000
+
+    # First bridge-out must complete before we can test bridge-back
+    state.start_execution(ts, buy_trade)
+    buy_trade.mark_broadcasted(ts)
+    state.mark_trade_success(
+        executed_at=ts,
+        trade=buy_trade,
+        executed_price=1.0,
+        executed_amount=Decimal(500),
+        executed_reserve=Decimal(500),
+        lp_fees=0,
+        native_token_price=0,
+    )
+
+    # 2. Create a bridge-back (sell) trade and check sort position is in -30M range
+    sell_trade = _create_bridge_trade(
+        state, cctp_pair, usdc_arbitrum, Decimal(500), ts, sell=True,
+    )
+    sell_sort = sell_trade.get_execution_sort_position()
+    assert sell_sort == -sell_trade.trade_id - 30_000_000
+
+    # 3. Verify bridge sell with closing=True still uses bridge phase, not close phase
+    sell_trade.closing = True
+    closing_sort = sell_trade.get_execution_sort_position()
+    # Must still be in the bridge range, not the generic close range (-100M)
+    assert closing_sort == -sell_trade.trade_id - 30_000_000
+
+
+def test_mark_bridge_in_transit(
+    cctp_pair: TradingPairIdentifier,
+    usdc_arbitrum: AssetIdentifier,
+):
+    """Test that mark_bridge_in_transit() sets metadata and locks bridge-back capital.
+
+    1. Create state with reserves and open a bridge position (bridge-out)
+    2. Create a bridge-back (sell) trade and advance to broadcasted
+    3. Call mark_bridge_in_transit() and verify fields and capital lock
+    4. Verify bridge-out buy path sets chain IDs correctly
+    """
+    state = State()
+    ts = datetime.datetime(2025, 1, 1)
+
+    # 1. Create state with reserves and open a bridge position (bridge-out)
+    state.portfolio.initialise_reserves(usdc_arbitrum)
+    reserve = state.portfolio.get_default_reserve_position()
+    reserve.quantity = Decimal(10_000)
+    reserve.reserve_token_price = 1.0
+
+    buy_trade = _create_bridge_trade(state, cctp_pair, usdc_arbitrum, Decimal(1000), ts)
+    state.start_execution(ts, buy_trade)
+    buy_trade.mark_broadcasted(ts)
+
+    # Add a fake blockchain transaction so mark_bridge_in_transit can extract burn tx
+    approve_tx = BlockchainTransaction()
+    approve_tx.tx_hash = "0xapprove"
+    burn_tx = BlockchainTransaction()
+    burn_tx.tx_hash = "0xburn_abc123"
+    buy_trade.blockchain_transactions = [approve_tx, burn_tx]
+
+    # 4. Verify bridge-out buy path sets chain IDs correctly
+    state.mark_bridge_in_transit(ts, buy_trade)
+    assert buy_trade.cctp_in_transit_at == ts
+    assert buy_trade.get_status() == TradeStatus.cctp_in_transit
+    assert buy_trade.other_data["cctp_burn_tx_hash"] == "0xburn_abc123"
+    assert buy_trade.other_data["cctp_source_chain_id"] == 42161  # Arbitrum (quote)
+    assert buy_trade.other_data["cctp_dest_chain_id"] == 8453  # Base (base)
+
+    # Complete the buy so we have a bridge position
+    buy_trade.cctp_in_transit_at = None  # Reset for completion
+    state.mark_trade_success(
+        executed_at=ts,
+        trade=buy_trade,
+        executed_price=1.0,
+        executed_amount=Decimal(1000),
+        executed_reserve=Decimal(1000),
+        lp_fees=0,
+        native_token_price=0,
+    )
+
+    bridge_position = state.portfolio.get_position_by_id(buy_trade.position_id)
+    assert bridge_position is not None
+    assert bridge_position.bridge_capital_allocated == Decimal(0)
+
+    # 2. Create a bridge-back (sell) trade and advance to broadcasted
+    sell_trade = _create_bridge_trade(
+        state, cctp_pair, usdc_arbitrum, Decimal(500), ts, sell=True,
+    )
+    state.start_execution(ts, sell_trade)
+    sell_trade.mark_broadcasted(ts)
+
+    sell_approve_tx = BlockchainTransaction()
+    sell_approve_tx.tx_hash = "0xsell_approve"
+    sell_burn_tx = BlockchainTransaction()
+    sell_burn_tx.tx_hash = "0xsell_burn_def456"
+    sell_trade.blockchain_transactions = [sell_approve_tx, sell_burn_tx]
+
+    # 3. Call mark_bridge_in_transit() and verify fields and capital lock
+    state.mark_bridge_in_transit(ts, sell_trade)
+    assert sell_trade.cctp_in_transit_at == ts
+    assert sell_trade.get_status() == TradeStatus.cctp_in_transit
+    assert sell_trade.other_data["cctp_burn_tx_hash"] == "0xsell_burn_def456"
+    assert sell_trade.other_data["cctp_source_chain_id"] == 8453  # Base (base for sell)
+    assert sell_trade.other_data["cctp_dest_chain_id"] == 42161  # Arbitrum (quote for sell)
+
+    # Verify bridge-back capital was locked
+    assert bridge_position.bridge_capital_allocated == Decimal(500)

--- a/tradeexecutor/backtest/backtest_execution.py
+++ b/tradeexecutor/backtest/backtest_execution.py
@@ -123,7 +123,15 @@ class BacktestExecution(ExecutionModel):
         #
         base = trade.pair.base
         # quote = trade.pair.quote
-        reserve = trade.reserve_currency
+
+        # For satellite chain trades funded via a CCTP bridge, the on-chain
+        # token spent is the pair's quote token (e.g. USDC on Base), not the
+        # portfolio reserve currency (e.g. USDC on Arbitrum).
+        bridge_position = state.portfolio.get_bridge_position_for_chain(trade.pair.chain_id)
+        if bridge_position is not None:
+            reserve = trade.pair.quote
+        else:
+            reserve = trade.reserve_currency
 
         base_balance = self.wallet.get_balance(base.address)
         # quote_balance = self.wallet.get_balance(quote.address)
@@ -255,6 +263,42 @@ class BacktestExecution(ExecutionModel):
         # so return executed_collateral_quantity here to correctly calculate the price
         return executed_quantity, executed_reserve, executed_collateral_allocation, executed_collateral_consumption
 
+    def simulate_bridge(self, state: State, trade: TradeExecution) -> Tuple[Decimal, Decimal]:
+        """CCTP bridge simulation with a simulated wallet.
+
+        Bridge trades transfer USDC 1:1 between chains. In the simulated
+        wallet we debit the source chain USDC (reserve/quote) and credit the
+        destination chain USDC (base).
+
+        :param state:
+            Backtester state
+
+        :param trade:
+            Trade to be executed (must be a CCTP bridge trade)
+
+        :return:
+            (executed_quantity, executed_reserve) tuple
+        """
+        assert trade.pair.is_cctp_bridge(), f"simulate_bridge(): received a non-bridge trade {trade}"
+
+        base = trade.pair.base        # destination chain USDC
+        reserve = trade.reserve_currency  # source chain USDC
+
+        if trade.is_buy():
+            # Bridge out: burn USDC on source, mint on destination
+            executed_reserve = trade.planned_reserve
+            executed_quantity = trade.planned_quantity
+            self.wallet.update_balance(base, executed_quantity, f"bridge out trade #{trade.trade_id}")
+            self.wallet.update_balance(reserve, -executed_reserve, f"bridge out trade #{trade.trade_id}")
+        else:
+            # Bridge back: burn USDC on destination, mint on source
+            executed_quantity = trade.planned_quantity
+            executed_reserve = abs(Decimal(trade.planned_quantity) * Decimal(trade.planned_price))
+            self.wallet.update_balance(base, executed_quantity, f"bridge back trade #{trade.trade_id}")
+            self.wallet.update_balance(reserve, executed_reserve, f"bridge back trade #{trade.trade_id}")
+
+        return executed_quantity, executed_reserve
+
     def simulate_trade(
         self,
         ts: datetime.datetime,
@@ -300,7 +344,8 @@ class BacktestExecution(ExecutionModel):
                 executed_quantity, executed_reserve, sell_amount_epsilon_fix = self.simulate_spot(state, trade)
             elif trade.is_leverage():
                 executed_quantity, executed_reserve, executed_collateral_allocation, executed_collateral_consumption = self.simulate_leverage(state, trade)
-
+            elif trade.pair.is_cctp_bridge():
+                executed_quantity, executed_reserve = self.simulate_bridge(state, trade)
             else:
                 raise NotImplementedError(f"Does not know how to simulate: {trade}")
 
@@ -352,6 +397,129 @@ class BacktestExecution(ExecutionModel):
 
         return executed_quantity, executed_reserve, executed_collateral_allocation, executed_collateral_consumption
 
+    def _execute_trades_sequentially(
+        self,
+        ts: datetime.datetime,
+        state: State,
+        trades: list[TradeExecution],
+        routing_model,
+        routing_state,
+        check_balances: bool,
+        triggered: bool,
+    ):
+        """Execute trades one at a time for CCTP-dependent batches.
+
+        Each trade is started, simulated, and settled before the next
+        trade begins. This ensures bridge positions exist before
+        satellite vault deposits try to allocate from them.
+
+        The normal batch path calls ``start_execution_all()`` which
+        allocates capital for every trade upfront. That fails when a
+        satellite trade needs ``get_bridge_position_for_chain()`` to
+        find a bridge position that has not been created yet.
+
+        :param ts:
+            Strategy cycle timestamp
+
+        :param state:
+            Current backtesting state
+
+        :param trades:
+            Trades to execute, already sorted by execution sort position
+
+        :param routing_model:
+            The routing model (calculates prices)
+
+        :param routing_state:
+            Routing state for the current execution
+
+        :param check_balances:
+            Whether to check wallet balances during setup
+
+        :param triggered:
+            True if this execution is from stop loss trigger checks
+        """
+
+        # Calculate prices for all trades upfront — this does not allocate capital
+        routing_model.setup_trades(
+            state,
+            routing_state,
+            trades,
+            check_balances=check_balances,
+        )
+
+        # Re-sort so bridge trades execute before the satellite trades that
+        # depend on them.  Bridge-out buys go first (sort key 0), everything
+        # else keeps its original execution sort position (bumped by 1 so it
+        # always comes after bridges).
+        def _sequential_sort_key(t):
+            if t.pair.is_cctp_bridge() and t.is_buy():
+                return (0, t.trade_id)
+            elif t.pair.is_cctp_bridge() and t.is_sell():
+                # Bridge-backs go last (return capital to source)
+                return (2, t.trade_id)
+            else:
+                return (1, t.get_execution_sort_position())
+
+        trades = sorted(trades, key=_sequential_sort_key)
+
+        for idx, trade in enumerate(trades):
+            # Start execution (allocate capital) for this trade only
+            state.start_execution(ts, trade, triggered=triggered)
+
+            # Simulate
+            try:
+                executed_quantity, executed_reserve, executed_collateral_allocation, executed_collateral_consumption = self.simulate_trade(ts, state, idx, trade)
+            except BacktestExecutionFailed as e:
+                logger.info("Simulating %d. trade %s failed: %s", idx + 1, trade.get_short_label(), e)
+                raise BacktestExecutionFailed(f"Trade #{idx + 1} out of {len(trades)} trades failed") from e
+
+            # Settle immediately so the next trade can see the results
+            if executed_quantity:
+                if trade.is_short():
+                    executed_price = trade.planned_price
+                else:
+                    executed_price = float(abs(executed_reserve / executed_quantity))
+            else:
+                executed_price = 0
+
+            state.mark_trade_success(
+                ts,
+                trade,
+                executed_price,
+                executed_quantity,
+                executed_reserve,
+                lp_fees=trade.lp_fees_estimated,
+                native_token_price=1,
+                executed_collateral_allocation=executed_collateral_allocation,
+                executed_collateral_consumption=executed_collateral_consumption,
+            )
+
+        # Verify wallet balances after all trades
+        all_assets = calculate_total_assets(state.portfolio)
+        clean, asset_df = self.wallet.verify_balances(all_assets)
+        if not clean:
+            logger.error("Backtest sync issue (sequential path)")
+            logger.error("All portfolio assets were")
+            for a, v in all_assets.items():
+                logger.error("Asset %s: %s", a, v)
+            logger.error("Trades were")
+            for t in trades:
+                logger.error("Trade: %s", t)
+            logger.error("Positions are")
+            for p in state.portfolio.get_open_and_frozen_positions():
+                logger.error("Position: %s", p)
+
+            error_msg = f"Backtest simulated wallet and portfolio out of sync at {ts} after executing trades:\n{asset_df}"
+            logger.error("Current chain status:\n%s", error_msg)
+
+            raise RuntimeError(error_msg)
+
+        # Set the check point interest balances for new positions
+        set_interest_checkpoint(state, ts, None)
+
+        logger.info("Finished sequential backtest execution for %s", ts)
+
     def execute_trades(
         self,
         ts: datetime.datetime,
@@ -373,6 +541,15 @@ class BacktestExecution(ExecutionModel):
         assert isinstance(ts, datetime.datetime)
         assert isinstance(routing_model, (BacktestRoutingModel, GenericRouting))
         assert isinstance(routing_state, (BacktestRoutingState, GenericRoutingState))
+
+        # When the batch contains CCTP bridge trades, we must execute each
+        # trade sequentially (start -> simulate -> settle) so that bridge
+        # positions exist before satellite trades try to allocate from them.
+        has_bridge_trades = any(t.pair.is_cctp_bridge() for t in trades)
+
+        if has_bridge_trades:
+            self._execute_trades_sequentially(ts, state, trades, routing_model, routing_state, check_balances, triggered)
+            return
 
         state.start_execution_all(ts, trades, max_slippage=0, triggered=triggered)
 

--- a/tradeexecutor/backtest/backtest_execution.py
+++ b/tradeexecutor/backtest/backtest_execution.py
@@ -448,18 +448,26 @@ class BacktestExecution(ExecutionModel):
             check_balances=check_balances,
         )
 
-        # Re-sort so bridge trades execute before the satellite trades that
-        # depend on them.  Bridge-out buys go first (sort key 0), everything
-        # else keeps its original execution sort position (bumped by 1 so it
-        # always comes after bridges).
+        # Sort trades for sequential execution.  The standard sort phases
+        # (PR 1) place bridge-outs at +30M, between regular buys and vault
+        # deposits.  But in a sequential backtest, bridge-out buys must
+        # execute BEFORE any satellite trade that will allocate from the
+        # resulting bridge position.  We use the standard sort as a base
+        # but promote bridge-out buys to run right after all sells/redeems
+        # complete (sort key 0) and demote bridge-backs to run last (after
+        # vault deposits return capital).
         def _sequential_sort_key(t):
-            if t.pair.is_cctp_bridge() and t.is_buy():
-                return (0, t.trade_id)
-            elif t.pair.is_cctp_bridge() and t.is_sell():
-                # Bridge-backs go last (return capital to source)
-                return (2, t.trade_id)
-            else:
-                return (1, t.get_execution_sort_position())
+            base = t.get_execution_sort_position()
+            if t.pair.is_cctp_bridge():
+                if t.is_buy():
+                    # Bridge-out buys: after all sells (negative range)
+                    # but before any regular/vault buys (positive range)
+                    return 0
+                else:
+                    # Bridge-back sells: after vault redeems but before
+                    # bridge-outs.  Use the standard -30M position.
+                    return base
+            return base
 
         trades = sorted(trades, key=_sequential_sort_key)
 

--- a/tradeexecutor/cli/loop.py
+++ b/tradeexecutor/cli/loop.py
@@ -1340,6 +1340,36 @@ class ExecutionLoop:
         else:
             logger.info("Startup accounting check disabled (CHECK_ACCOUNTS=false)")
 
+        # Check for CCTP bridge trades stuck in transit from a previous run.
+        # Must resolve these before starting new cycles, otherwise capital
+        # accounting is incorrect.
+        web3config = getattr(self.execution_model, 'web3config', None)
+        if web3config is not None:
+            from tradeexecutor.ethereum.cctp.retry import check_and_retry_cctp_in_transit
+            resolved = check_and_retry_cctp_in_transit(
+                state=state,
+                execution_model=self.execution_model,
+                web3config=web3config,
+            )
+            if resolved:
+                logger.trade("Resolved %d CCTP in-transit trade(s) on startup", len(resolved))
+                self.store.sync(state)
+
+            # Check if any remain unresolved — halt if so
+            from tradeexecutor.state.trade import TradeStatus
+            unresolved = []
+            for position in state.portfolio.open_positions.values():
+                for trade in position.trades.values():
+                    if trade.get_status() == TradeStatus.cctp_in_transit:
+                        unresolved.append(trade)
+            if unresolved:
+                trade_ids = [t.trade_id for t in unresolved]
+                raise RuntimeError(
+                    f"Cannot start live trading: {len(unresolved)} CCTP bridge trade(s) "
+                    f"still in transit after startup retry. Trade IDs: {trade_ids}. "
+                    f"Resolve manually with trade-executor bridge-retry or receiveMessage."
+                )
+
         # Store summary statistics in memory before doing anything else
         self.refresh_live_run_state(state, visualisation=self.visulisation, universe=universe, cycle_duration=self.cycle_duration)
 

--- a/tradeexecutor/ethereum/cctp/planner.py
+++ b/tradeexecutor/ethereum/cctp/planner.py
@@ -1,0 +1,201 @@
+"""Cross-chain CCTP bridge trade injection planner.
+
+Analyses alpha model rebalance trades and injects the necessary
+CCTP bridge transfers to move capital between chains via the
+primary chain hub.
+
+Hub-and-spoke topology: all capital routes through the primary chain.
+
+- Satellite sells produce excess capital that must be bridged back
+  to the primary chain.
+- Satellite buys require capital to be bridged out from the primary
+  chain.
+
+The planner computes *net* flows per satellite chain to avoid
+unnecessary round-trips when sells and buys partially cancel out.
+"""
+
+import datetime
+import logging
+from collections import defaultdict
+from decimal import Decimal
+
+from tradeexecutor.state.identifier import (
+    AssetIdentifier,
+    TradingPairIdentifier,
+    TradingPairKind,
+)
+from tradeexecutor.state.state import State
+from tradeexecutor.state.trade import TradeExecution, TradeType
+
+logger = logging.getLogger(__name__)
+
+
+def _find_bridge_pair(
+    pairs: list[TradingPairIdentifier],
+    destination_chain_id: int,
+) -> TradingPairIdentifier | None:
+    """Find the CCTP bridge pair targeting a specific destination chain.
+
+    :param pairs:
+        All trading pairs available in the strategy universe.
+
+    :param destination_chain_id:
+        The chain ID of the destination (satellite) chain.
+
+    :return:
+        The bridge pair, or ``None`` if no bridge pair exists for that chain.
+    """
+    for pair in pairs:
+        if pair.kind == TradingPairKind.cctp_bridge and pair.get_destination_chain_id() == destination_chain_id:
+            return pair
+    return None
+
+
+def inject_cctp_bridge_trades(
+    state: State,
+    trades: list[TradeExecution],
+    strategy_universe,
+    primary_chain_id: int,
+    ts: datetime.datetime,
+    reserve_asset: AssetIdentifier,
+) -> list[TradeExecution]:
+    """Inject CCTP bridge trades for cross-chain rebalancing.
+
+    Analyses the trade list from the alpha model and injects bridge
+    trades to move capital between satellite chains and the primary
+    chain. Uses hub-and-spoke topology: all capital routes through
+    the primary chain.
+
+    For each satellite chain:
+
+    - Net sell (more sells than buys): inject a bridge-back
+      (satellite -> primary) for the excess capital.
+
+    - Net buy (more buys than sells): inject a bridge-out
+      (primary -> satellite) for the deficit.
+
+    The injected trades have correct sort positions (via
+    ``get_execution_sort_position()``) so they execute in the right
+    order: vault redeems -> bridge-backs -> bridge-outs -> vault
+    deposits.
+
+    :param state:
+        Current portfolio state.
+
+    :param trades:
+        Trade list from alpha model (vault sells + buys only).
+
+    :param strategy_universe:
+        Trading universe with CCTP bridge pairs available.
+        Must support ``iterate_pairs()`` returning
+        :py:class:`TradingPairIdentifier` instances.
+
+    :param primary_chain_id:
+        Chain ID of the primary chain (hub for all bridges).
+
+    :param ts:
+        Strategy cycle timestamp for the injected trades.
+
+    :param reserve_asset:
+        The portfolio reserve currency asset (e.g. USDC on primary chain).
+
+    :return:
+        Augmented trade list with bridge trades injected.
+        Original trades are not modified.
+    """
+
+    # Pre-fetch all pairs from the universe so we only iterate once
+    all_pairs = list(strategy_universe.iterate_pairs())
+
+    # 1. Group trades by chain and compute net capital flow per satellite chain
+    chain_flows: dict[int, Decimal] = defaultdict(lambda: Decimal(0))
+
+    for trade in trades:
+        trade_chain_id = trade.pair.chain_id
+        if trade_chain_id == primary_chain_id:
+            continue
+
+        if trade.is_sell():
+            # Sell frees up capital — positive flow means excess to bridge back
+            sell_value = trade.planned_reserve if trade.planned_reserve else Decimal(str(trade.get_planned_value()))
+            chain_flows[trade_chain_id] += abs(sell_value)
+        else:
+            # Buy consumes capital — negative flow means deficit to bridge out
+            buy_value = trade.planned_reserve if trade.planned_reserve else Decimal(str(trade.get_planned_value()))
+            chain_flows[trade_chain_id] -= abs(buy_value)
+
+    # 2. Inject bridge trades for each satellite chain with a non-zero net flow
+    bridge_trades: list[TradeExecution] = []
+
+    for chain_id, net_flow in chain_flows.items():
+        if net_flow == 0:
+            continue
+
+        bridge_pair = _find_bridge_pair(all_pairs, chain_id)
+        if bridge_pair is None:
+            logger.warning(
+                "No CCTP bridge pair found for destination chain %d, "
+                "skipping bridge injection",
+                chain_id,
+            )
+            continue
+
+        if net_flow > 0:
+            # Net sell: bridge-back (satellite -> primary)
+            amount = net_flow
+            bridge_position = state.portfolio.get_bridge_position_for_chain(chain_id)
+
+            if bridge_position is not None:
+                available = bridge_position.get_available_bridge_capital()
+                closing = amount >= available
+            else:
+                # No existing bridge position — this is unusual for a bridge-back,
+                # but we still create the trade and let execution handle it
+                closing = False
+                bridge_position = None
+
+            _, trade, _ = state.create_trade(
+                strategy_cycle_at=ts,
+                pair=bridge_pair,
+                quantity=Decimal(str(-amount)),
+                reserve=None,
+                assumed_price=1.0,
+                trade_type=TradeType.rebalance,
+                reserve_currency=reserve_asset,
+                reserve_currency_price=1.0,
+                position=bridge_position,
+                closing=closing,
+            )
+
+            logger.info(
+                "Injected bridge-back sell of %s for chain %d (closing=%s)",
+                amount,
+                chain_id,
+                closing,
+            )
+            bridge_trades.append(trade)
+
+        else:
+            # Net buy: bridge-out (primary -> satellite)
+            amount = abs(net_flow)
+
+            _, trade, _ = state.create_trade(
+                strategy_cycle_at=ts,
+                pair=bridge_pair,
+                quantity=None,
+                reserve=Decimal(str(amount)),
+                assumed_price=1.0,
+                trade_type=TradeType.rebalance,
+                reserve_currency=reserve_asset,
+                reserve_currency_price=1.0,
+            )
+
+            logger.info(
+                "Injected bridge-out buy of %s for chain %d",
+                amount,
+                chain_id,
+            )
+            bridge_trades.append(trade)
+
+    return trades + bridge_trades

--- a/tradeexecutor/ethereum/cctp/retry.py
+++ b/tradeexecutor/ethereum/cctp/retry.py
@@ -1,0 +1,264 @@
+"""CCTP in-transit trade retry on startup.
+
+When the executor process restarts while a CCTP bridge trade is in the
+``cctp_in_transit`` state (burn confirmed, receive pending), this module
+provides a best-effort function to poll Circle's attestation API and
+broadcast ``receiveMessage`` on the destination chain.
+"""
+
+import logging
+import datetime
+
+from eth_defi.compat import native_datetime_utc_now
+
+from tradeexecutor.state.state import State
+from tradeexecutor.state.trade import TradeExecution, TradeStatus
+
+logger = logging.getLogger(__name__)
+
+
+def check_and_retry_cctp_in_transit(
+    state: State,
+    execution_model,
+    web3config,
+    attestation_timeout: float = 300.0,
+) -> list[TradeExecution]:
+    """Check for cctp_in_transit trades and attempt to complete them.
+
+    Called during live execution startup to resolve any bridges
+    that were interrupted by a process restart.
+
+    The function scans all open positions for trades with
+    ``cctp_in_transit`` status.  For each one it:
+
+    1. Reads ``cctp_dest_chain_id`` and ``cctp_burn_tx_hash`` from
+       ``trade.other_data``.
+    2. Inspects ``trade.blockchain_transactions`` to determine whether a
+       ``receiveMessage`` transaction was already attempted.
+    3. If no receive tx exists, polls attestation and broadcasts
+       ``receiveMessage`` on the destination chain.
+    4. If a receive tx exists but was not confirmed, rebroadcasts it.
+    5. On success: clears ``cctp_in_transit_at``, reverses
+       ``bridge_capital_allocated`` for bridge-back sells, and calls
+       ``mark_trade_success``.
+    6. On failure: logs a warning and includes the trade in the
+       returned unresolved list.
+
+    :param state:
+        Current strategy state.
+
+    :param execution_model:
+        The execution model (must have ``tx_builder.hot_wallet``).
+
+    :param web3config:
+        Web3Config with connections to all chains.
+
+    :param attestation_timeout:
+        Maximum seconds to wait for attestation (per trade).
+
+    :return:
+        List of trades that were successfully resolved.
+    """
+    from decimal import Decimal
+
+    from eth_defi.cctp.attestation import fetch_attestation
+    from eth_defi.cctp.receive import prepare_receive_message
+    from eth_defi.cctp.transfer import _resolve_cctp_domain, get_message_transmitter_v2
+    from eth_defi.hotwallet import HotWallet
+    from hexbytes import HexBytes
+    from tradingstrategy.chain import ChainId
+
+    from tradeexecutor.ethereum.tx import HotWalletTransactionBuilder
+
+    resolved: list[TradeExecution] = []
+
+    # 1. Scan all open positions for cctp_in_transit trades
+    in_transit_trades: list[TradeExecution] = []
+    for position in state.portfolio.open_positions.values():
+        for trade in position.trades.values():
+            if trade.get_status() == TradeStatus.cctp_in_transit:
+                in_transit_trades.append(trade)
+
+    if not in_transit_trades:
+        return resolved
+
+    logger.info(
+        "Found %d CCTP in-transit trade(s) on startup, attempting retry",
+        len(in_transit_trades),
+    )
+
+    for trade in in_transit_trades:
+        try:
+            # 2. Read metadata from trade.other_data
+            dest_chain_id = trade.other_data.get("cctp_dest_chain_id")
+            source_chain_id = trade.other_data.get("cctp_source_chain_id")
+            burn_tx_hash = trade.other_data.get("cctp_burn_tx_hash")
+
+            if dest_chain_id is None or burn_tx_hash is None:
+                logger.warning(
+                    "CCTP in-transit trade %s missing metadata, skipping",
+                    trade.trade_id,
+                )
+                continue
+
+            source_domain = _resolve_cctp_domain(source_chain_id)
+            if source_domain is None:
+                logger.warning(
+                    "No CCTP domain for source chain %d, skipping trade %s",
+                    source_chain_id, trade.trade_id,
+                )
+                continue
+
+            dest_web3 = web3config.get_connection(ChainId(dest_chain_id))
+            if dest_web3 is None:
+                logger.warning(
+                    "No web3 connection for dest chain %d, skipping trade %s",
+                    dest_chain_id, trade.trade_id,
+                )
+                continue
+
+            # 3. Inspect blockchain_transactions for existing receive tx
+            has_receive_tx = len(trade.blockchain_transactions) > 2
+            receive_already_confirmed = False
+
+            if has_receive_tx:
+                existing_receive_tx = trade.blockchain_transactions[-1]
+                # Check if it was already confirmed on-chain
+                if existing_receive_tx.tx_hash:
+                    try:
+                        receipt = dest_web3.eth.get_transaction_receipt(
+                            HexBytes(existing_receive_tx.tx_hash)
+                        )
+                        if receipt and receipt["status"] == 1:
+                            receive_already_confirmed = True
+                        elif receipt and receipt["status"] == 0:
+                            # Previous receive reverted, need fresh attempt
+                            has_receive_tx = False
+                    except Exception:
+                        # Tx not found — may need rebroadcast
+                        pass
+
+            if receive_already_confirmed:
+                # Receive already confirmed, just update state
+                ts = native_datetime_utc_now()
+            elif has_receive_tx:
+                # 4. Rebroadcast existing receive tx
+                existing_receive_tx = trade.blockchain_transactions[-1]
+                try:
+                    dest_web3.eth.send_raw_transaction(
+                        HexBytes(existing_receive_tx.signed_bytes)
+                    )
+                    receipt = dest_web3.eth.wait_for_transaction_receipt(
+                        HexBytes(existing_receive_tx.tx_hash),
+                        timeout=120,
+                    )
+                    if receipt["status"] != 1:
+                        logger.warning(
+                            "CCTP receive rebroadcast reverted for trade %s",
+                            trade.trade_id,
+                        )
+                        continue
+                except Exception as e:
+                    logger.warning(
+                        "CCTP receive rebroadcast failed for trade %s: %s",
+                        trade.trade_id, e,
+                    )
+                    continue
+                ts = native_datetime_utc_now()
+            else:
+                # No receive tx yet — poll attestation and broadcast fresh
+                try:
+                    attestation = fetch_attestation(
+                        source_domain=source_domain,
+                        transaction_hash=burn_tx_hash,
+                        timeout=attestation_timeout,
+                    )
+                except TimeoutError:
+                    logger.warning(
+                        "CCTP attestation still pending for trade %s after %.0fs",
+                        trade.trade_id, attestation_timeout,
+                    )
+                    continue
+
+                # 5. Clone hot wallet and broadcast receiveMessage
+                dest_wallet = HotWallet(execution_model.tx_builder.hot_wallet.account)
+                dest_wallet.sync_nonce(dest_web3)
+
+                message_transmitter = get_message_transmitter_v2(dest_web3)
+                receive_fn = prepare_receive_message(
+                    dest_web3,
+                    attestation.message,
+                    attestation.attestation,
+                )
+
+                dest_tx_builder = HotWalletTransactionBuilder(dest_web3, dest_wallet)
+                receive_tx = dest_tx_builder.sign_transaction(
+                    message_transmitter,
+                    receive_fn,
+                    gas_limit=200_000,
+                    asset_deltas=[],
+                    notes=f"CCTP receiveMessage retry chain {source_chain_id} -> {dest_chain_id}",
+                )
+
+                trade.blockchain_transactions.append(receive_tx)
+
+                try:
+                    dest_web3.eth.send_raw_transaction(HexBytes(receive_tx.signed_bytes))
+                    receive_tx.broadcasted_at = native_datetime_utc_now()
+                    receipt = dest_web3.eth.wait_for_transaction_receipt(
+                        HexBytes(receive_tx.tx_hash), timeout=120,
+                    )
+                except Exception as e:
+                    logger.warning(
+                        "CCTP receiveMessage retry broadcast failed for trade %s: %s",
+                        trade.trade_id, e,
+                    )
+                    continue
+
+                if receipt["status"] != 1:
+                    logger.warning(
+                        "CCTP receiveMessage retry reverted for trade %s",
+                        trade.trade_id,
+                    )
+                    continue
+
+                ts = native_datetime_utc_now()
+
+            # 6. Success — clear in-transit and mark trade complete
+            trade.cctp_in_transit_at = None
+
+            # Reverse bridge_capital_allocated for bridge-back sells
+            if trade.is_sell():
+                bridge_position = state.portfolio.get_position_by_id(trade.position_id)
+                if bridge_position is not None:
+                    bridge_position.bridge_capital_allocated -= abs(trade.planned_quantity)
+
+            state.mark_trade_success(
+                ts,
+                trade,
+                executed_price=1.0,
+                executed_amount=trade.planned_quantity,
+                executed_reserve=trade.planned_reserve,
+                lp_fees=0,
+                native_token_price=0,
+            )
+
+            resolved.append(trade)
+            logger.info(
+                "CCTP in-transit trade %s resolved successfully",
+                trade.trade_id,
+            )
+
+        except Exception as e:
+            logger.warning(
+                "Unexpected error retrying CCTP in-transit trade %s: %s",
+                trade.trade_id, e,
+                exc_info=True,
+            )
+
+    logger.info(
+        "CCTP startup retry complete: %d/%d trades resolved",
+        len(resolved), len(in_transit_trades),
+    )
+
+    return resolved

--- a/tradeexecutor/ethereum/cctp/routing.py
+++ b/tradeexecutor/ethereum/cctp/routing.py
@@ -310,6 +310,18 @@ class CctpBridgeRouting(RoutingModel):
             state.mark_bridge_in_transit(ts, trade)
             return
 
+        # Populate confirmation metadata on the receive tx
+        receive_ts = fetch_block_timestamp(dest_web3, receive_receipt["blockNumber"])
+        receive_tx.set_confirmation_information(
+            ts=receive_ts,
+            block_number=receive_receipt["blockNumber"],
+            block_hash=receive_receipt["blockHash"].hex() if isinstance(receive_receipt["blockHash"], bytes) else str(receive_receipt["blockHash"]),
+            realised_gas_units_consumed=receive_receipt["gasUsed"],
+            realised_gas_price=receive_receipt.get("effectiveGasPrice", 0),
+            status=receive_receipt["status"] == 1,
+            revert_reason=None,
+        )
+
         if receive_receipt["status"] != 1:
             logger.warning("CCTP receiveMessage reverted for trade %s", trade.trade_id)
             state.mark_bridge_in_transit(ts, trade)

--- a/tradeexecutor/ethereum/cctp/routing.py
+++ b/tradeexecutor/ethereum/cctp/routing.py
@@ -5,6 +5,7 @@ on the source chain and receive transactions on the destination chain.
 """
 
 import logging
+from typing import Callable
 
 from eth_defi.chain import fetch_block_timestamp
 from eth_defi.compat import native_datetime_utc_now
@@ -35,10 +36,24 @@ class CctpBridgeRouting(RoutingModel):
 
     :param web3config:
         Web3Config with connections to all chains involved in bridging.
+
+    :param custody_address_resolver:
+        Optional callable that maps a chain_id to the custody address on
+        that chain.  For Lagoon/Safe multichain setups each chain has its
+        own Safe; the resolver returns the correct one so that
+        ``depositForBurn`` mints USDC to the right destination.
+        When ``None``, the source chain ``tx_builder`` balance address is
+        used as a fallback (correct for hot-wallet deployments where the
+        same address exists on every chain).
     """
 
-    def __init__(self, web3config: Web3Config):
+    def __init__(
+        self,
+        web3config: Web3Config,
+        custody_address_resolver: Callable[[int], str] | None = None,
+    ):
         self.web3config = web3config
+        self.custody_address_resolver = custody_address_resolver
 
     def create_routing_state(
         self,
@@ -103,9 +118,20 @@ class CctpBridgeRouting(RoutingModel):
 
             amount_raw = int(trade.planned_reserve * (10 ** pair.quote.decimals))
 
-            # Get the address that holds USDC — for vault setups (Lagoon, Enzyme)
-            # this is the Safe/vault custody address, not the ERC-4626 wrapper.
-            token_storage = tx_builder.get_erc_20_balance_address()
+            # Resolve mint recipient based on trade direction.
+            # The destination depends on buy vs sell:
+            # - Buy (forward): mint on base chain (satellite)
+            # - Sell (reverse): mint on quote chain (primary)
+            if trade.is_buy():
+                mint_dest_chain_id = pair.base.chain_id
+            else:
+                mint_dest_chain_id = pair.quote.chain_id
+
+            if self.custody_address_resolver is not None:
+                token_storage = self.custody_address_resolver(mint_dest_chain_id)
+            else:
+                # Fallback: hot wallet address (same on all chains)
+                token_storage = tx_builder.get_erc_20_balance_address()
 
             # Resolve burn token address (source chain USDC)
             burn_token_address = USDC_NATIVE_TOKEN.get(source_chain_id)

--- a/tradeexecutor/ethereum/cctp/routing.py
+++ b/tradeexecutor/ethereum/cctp/routing.py
@@ -45,15 +45,22 @@ class CctpBridgeRouting(RoutingModel):
         When ``None``, the source chain ``tx_builder`` balance address is
         used as a fallback (correct for hot-wallet deployments where the
         same address exists on every chain).
+
+    :param attestation_timeout:
+        Maximum seconds to wait for Circle's Iris API attestation during
+        settlement.  Defaults to 1800 (30 minutes).
     """
 
     def __init__(
         self,
         web3config: Web3Config,
         custody_address_resolver: Callable[[int], str] | None = None,
+        attestation_timeout: float = 1800.0,
     ):
         self.web3config = web3config
         self.custody_address_resolver = custody_address_resolver
+        self.attestation_timeout = attestation_timeout
+        self._hot_wallet = None
 
     def create_routing_state(
         self,
@@ -95,6 +102,8 @@ class CctpBridgeRouting(RoutingModel):
         assert isinstance(routing_state, CctpBridgeRoutingState)
         tx_builder = routing_state.tx_builder
         assert tx_builder is not None, "CctpBridgeRoutingState missing tx_builder"
+
+        self._hot_wallet = tx_builder.hot_wallet
 
         for trade in trades:
             assert trade.pair.is_cctp_bridge(), \
@@ -185,6 +194,14 @@ class CctpBridgeRouting(RoutingModel):
                 dest_chain_id,
             )
 
+    def needs_sequential_trade_execution(self, trades: list[TradeExecution]) -> bool:
+        """CCTP bridges must settle before the next trade starts.
+
+        The attestation wait and ``receiveMessage`` broadcast happen during
+        settlement — later trades may depend on the minted USDC.
+        """
+        return len(trades) > 0
+
     def settle_trade(
         self,
         web3,
@@ -195,30 +212,116 @@ class CctpBridgeRouting(RoutingModel):
     ):
         """Settle a CCTP bridge trade after broadcast.
 
-        CCTP bridge is always 1:1, so we just check the receipt status
-        and mark the trade at face value.
-        """
-        from tradeexecutor.ethereum.execution import report_failure
-        from tradeexecutor.ethereum.swap import get_swap_transactions
+        Performs a multi-phase settlement:
 
+        1. Verify the burn receipt succeeded on the source chain.
+        2. Poll Circle's Iris API for attestation (Phase 2).
+        3. Broadcast ``receiveMessage`` on the destination chain (Phase 3).
+        4. Mark the trade as success only when both burn and receive are confirmed.
+
+        If the attestation times out or ``receiveMessage`` reverts, the trade
+        is marked as in-transit so it can be retried later.
+
+        :param web3:
+            Web3 connection to the **source** chain (where the burn happened).
+
+        :param state:
+            Current strategy state.
+
+        :param trade:
+            The CCTP bridge trade to settle.
+
+        :param receipts:
+            Mapping of tx hash → receipt for broadcasted transactions.
+
+        :param stop_on_execution_failure:
+            If ``True``, raise on failure instead of marking trade failed.
+        """
+        from eth_defi.cctp.attestation import fetch_attestation
+        from eth_defi.cctp.receive import prepare_receive_message
+        from eth_defi.cctp.transfer import _resolve_cctp_domain, get_message_transmitter_v2
+        from eth_defi.hotwallet import HotWallet as EthHotWallet
+        from tradingstrategy.chain import ChainId
+
+        from tradeexecutor.ethereum.swap import get_swap_transactions, report_failure
+        from tradeexecutor.ethereum.tx import HotWalletTransactionBuilder
+
+        # Phase 1: verify burn
         swap_tx = get_swap_transactions(trade)
         receipt = receipts[HexBytes(swap_tx.tx_hash)]
 
-        if receipt["status"] == 1:
-            ts = fetch_block_timestamp(web3, receipt["blockNumber"])
-            state.mark_trade_success(
-                ts,
-                trade,
-                executed_price=1.0,
-                executed_amount=trade.planned_quantity,
-                executed_reserve=trade.planned_reserve,
-                lp_fees=0,
-                native_token_price=0,
-            )
+        if receipt["status"] != 1:
+            report_failure(native_datetime_utc_now(), state, trade, stop_on_execution_failure)
+            return
+
+        ts = fetch_block_timestamp(web3, receipt["blockNumber"])
+
+        # Determine chains
+        pair = trade.pair
+        if trade.is_buy():
+            source_chain_id = pair.quote.chain_id
+            dest_chain_id = pair.base.chain_id
         else:
-            report_failure(
-                native_datetime_utc_now(),
-                state,
-                trade,
-                stop_on_execution_failure,
+            source_chain_id = pair.base.chain_id
+            dest_chain_id = pair.quote.chain_id
+
+        # Phase 2: attestation
+        source_domain = _resolve_cctp_domain(source_chain_id)
+        assert source_domain is not None, f"No CCTP domain for chain {source_chain_id}"
+
+        try:
+            attestation = fetch_attestation(
+                source_domain=source_domain,
+                transaction_hash=swap_tx.tx_hash,
+                timeout=self.attestation_timeout,
             )
+        except TimeoutError:
+            logger.warning("CCTP attestation timed out for trade %s, marking in-transit", trade.trade_id)
+            state.mark_bridge_in_transit(ts, trade)
+            return
+
+        # Phase 3: receiveMessage on destination chain
+        dest_web3 = self.web3config.get_connection(ChainId(dest_chain_id))
+        dest_wallet = EthHotWallet(self._hot_wallet.account)
+        dest_wallet.sync_nonce(dest_web3)
+
+        message_transmitter = get_message_transmitter_v2(dest_web3)
+        receive_fn = prepare_receive_message(dest_web3, attestation.message, attestation.attestation)
+
+        dest_tx_builder = HotWalletTransactionBuilder(dest_web3, dest_wallet)
+        receive_tx = dest_tx_builder.sign_transaction(
+            message_transmitter,
+            receive_fn,
+            gas_limit=200_000,
+            asset_deltas=[],
+            notes=f"CCTP receiveMessage chain {source_chain_id} -> {dest_chain_id}",
+        )
+
+        trade.blockchain_transactions.append(receive_tx)
+
+        try:
+            dest_web3.eth.send_raw_transaction(HexBytes(receive_tx.signed_bytes))
+            receive_tx.broadcasted_at = native_datetime_utc_now()
+            receive_receipt = dest_web3.eth.wait_for_transaction_receipt(
+                HexBytes(receive_tx.tx_hash), timeout=120
+            )
+        except Exception as e:
+            logger.warning("CCTP receiveMessage failed for trade %s: %s", trade.trade_id, e)
+            state.mark_bridge_in_transit(ts, trade)
+            return
+
+        if receive_receipt["status"] != 1:
+            logger.warning("CCTP receiveMessage reverted for trade %s", trade.trade_id)
+            state.mark_bridge_in_transit(ts, trade)
+            return
+
+        # Success: both burn and receive confirmed
+        state.mark_trade_success(
+            ts,
+            trade,
+            executed_price=1.0,
+            executed_amount=trade.planned_quantity,
+            executed_reserve=trade.planned_reserve,
+            lp_fees=0,
+            native_token_price=0,
+        )

--- a/tradeexecutor/ethereum/cctp/routing.py
+++ b/tradeexecutor/ethereum/cctp/routing.py
@@ -56,10 +56,16 @@ class CctpBridgeRouting(RoutingModel):
         web3config: Web3Config,
         custody_address_resolver: Callable[[int], str] | None = None,
         attestation_timeout: float = 1800.0,
+        skip_attestation: bool = False,
     ):
         self.web3config = web3config
         self.custody_address_resolver = custody_address_resolver
         self.attestation_timeout = attestation_timeout
+        #: When True, settle_trade() marks success after burn confirmation
+        #: without polling attestation or broadcasting receiveMessage.
+        #: Used for Anvil fork tests where Circle's Iris API is unavailable
+        #: and the test spoofs the receive via replace_attester_on_fork().
+        self.skip_attestation = skip_attestation
         self._hot_wallet = None
 
     def create_routing_state(
@@ -264,6 +270,20 @@ class CctpBridgeRouting(RoutingModel):
         else:
             source_chain_id = pair.base.chain_id
             dest_chain_id = pair.quote.chain_id
+
+        # Fork/simulation mode: skip attestation and receiveMessage entirely.
+        # The test environment spoofs the receive via replace_attester_on_fork().
+        if self.skip_attestation:
+            state.mark_trade_success(
+                ts,
+                trade,
+                executed_price=1.0,
+                executed_amount=trade.planned_quantity,
+                executed_reserve=trade.planned_reserve,
+                lp_fees=0,
+                native_token_price=0,
+            )
+            return
 
         # Phase 2: attestation
         source_domain = _resolve_cctp_domain(source_chain_id)

--- a/tradeexecutor/ethereum/ethereum_protocol_adapters.py
+++ b/tradeexecutor/ethereum/ethereum_protocol_adapters.py
@@ -1046,11 +1046,18 @@ class EthereumPairConfigurator(PairConfigurator):
             )
             # Skip attestation polling on Anvil forks where Circle's Iris API
             # is unavailable.  The test environment spoofs the receive manually.
+            # Detection order: execution_model flag, web3config flag, Anvil
+            # client version string, UNIT_TESTING env var.
             skip_attestation = False
             if self.execution_model is not None:
                 skip_attestation = getattr(self.execution_model, 'mainnet_fork', False)
             if not skip_attestation and self.web3config is not None:
                 skip_attestation = self.web3config.is_mainnet_fork()
+            if not skip_attestation and self.web3 is not None:
+                try:
+                    skip_attestation = self.web3.client_version.startswith("anvil/")
+                except Exception:
+                    pass
             if not skip_attestation:
                 import os
                 skip_attestation = os.environ.get("UNIT_TESTING", "").lower() in ("true", "1", "yes")

--- a/tradeexecutor/ethereum/ethereum_protocol_adapters.py
+++ b/tradeexecutor/ethereum/ethereum_protocol_adapters.py
@@ -34,6 +34,46 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
+def _make_cctp_custody_resolver(
+    satellite_vaults: dict | None,
+    primary_custody_address: str | None,
+    fallback_address: str | None,
+) -> Callable[[int], str] | None:
+    """Build a chain_id -> custody address resolver for CCTP mint recipients.
+
+    For Lagoon vaults, returns the per-chain Safe address.
+    For hot wallet, returns the same address for all chains.
+
+    :param satellite_vaults:
+        Mapping of chain_id -> AutomatedSafe for satellite chains.
+
+    :param primary_custody_address:
+        The custody address on the primary chain (e.g. the Lagoon Safe).
+
+    :param fallback_address:
+        Address used when no satellite or primary match is found
+        (e.g. the hot wallet address).
+
+    :return:
+        A resolver callable, or ``None`` when no addresses are available.
+    """
+    if satellite_vaults is None and primary_custody_address is None:
+        return None
+
+    def resolver(chain_id: int) -> str:
+        if satellite_vaults:
+            satellite = satellite_vaults.get(chain_id)
+            if satellite is not None:
+                return satellite.safe_address
+        if primary_custody_address is not None:
+            return primary_custody_address
+        if fallback_address is not None:
+            return fallback_address
+        raise ValueError(f"No custody address for chain {chain_id}")
+
+    return resolver
+
+
 def _make_token_delivery_address_resolver(execution_model) -> Callable[[TradingPairIdentifier], str] | None:
     """Resolve the correct token delivery address for a pair.
 
@@ -698,6 +738,7 @@ def create_exchange_account_adapter(
 def create_cctp_bridge_adapter(
     web3config: "Web3Config",
     routing_id: ProtocolRoutingId,
+    custody_address_resolver: Callable[[int], str] | None = None,
 ) -> ProtocolRoutingConfig:
     """Create adapter for CCTP bridge pairs.
 
@@ -708,12 +749,15 @@ def create_cctp_bridge_adapter(
         Web3Config with connections to all chains involved in bridging.
     :param routing_id:
         The protocol routing identifier.
+    :param custody_address_resolver:
+        Optional callable mapping chain_id to the custody address on that
+        chain.  Built by :py:func:`_make_cctp_custody_resolver`.
     """
     from tradeexecutor.ethereum.cctp.pricing import CctpBridgePricingModel
     from tradeexecutor.ethereum.cctp.routing import CctpBridgeRouting
     from tradeexecutor.ethereum.cctp.valuation import CctpBridgeValuationModel
 
-    routing_model = CctpBridgeRouting(web3config)
+    routing_model = CctpBridgeRouting(web3config, custody_address_resolver=custody_address_resolver)
     pricing_model = CctpBridgePricingModel()
     valuation_model = CctpBridgeValuationModel()
 
@@ -953,7 +997,25 @@ class EthereumPairConfigurator(PairConfigurator):
         elif routing_id.router_name == "exchange_account":
             return create_exchange_account_adapter(routing_id, self.account_value_func, web3=self.web3)
         elif routing_id.router_name == "cctp-bridge":
-            return create_cctp_bridge_adapter(self.web3config, routing_id)
+            # Resolve primary custody address from the execution model's
+            # vault (Lagoon Safe) or tx_builder (hot wallet).
+            primary_custody_address = None
+            fallback_address = None
+            if self.execution_model is not None:
+                tx_builder = getattr(self.execution_model, "tx_builder", None)
+                if tx_builder is not None:
+                    vault = getattr(tx_builder, "vault", None)
+                    if vault is not None:
+                        primary_custody_address = vault.safe_address
+                    else:
+                        fallback_address = tx_builder.get_erc_20_balance_address()
+
+            custody_resolver = _make_cctp_custody_resolver(
+                satellite_vaults=self.satellite_vaults or None,
+                primary_custody_address=primary_custody_address,
+                fallback_address=fallback_address,
+            )
+            return create_cctp_bridge_adapter(self.web3config, routing_id, custody_address_resolver=custody_resolver)
         else:
             raise NotImplementedError(f"Cannot route exchange {routing_id}")
 

--- a/tradeexecutor/ethereum/ethereum_protocol_adapters.py
+++ b/tradeexecutor/ethereum/ethereum_protocol_adapters.py
@@ -38,6 +38,7 @@ def _make_cctp_custody_resolver(
     satellite_vaults: dict | None,
     primary_custody_address: str | None,
     fallback_address: str | None,
+    primary_chain_id: int | None = None,
 ) -> Callable[[int], str] | None:
     """Build a chain_id -> custody address resolver for CCTP mint recipients.
 
@@ -54,6 +55,11 @@ def _make_cctp_custody_resolver(
         Address used when no satellite or primary match is found
         (e.g. the hot wallet address).
 
+    :param primary_chain_id:
+        Chain ID of the primary chain.  When set with satellite_vaults,
+        the resolver raises for unknown non-primary destinations instead
+        of silently falling back to the primary address.
+
     :return:
         A resolver callable, or ``None`` when no addresses are available.
     """
@@ -65,6 +71,16 @@ def _make_cctp_custody_resolver(
             satellite = satellite_vaults.get(chain_id)
             if satellite is not None:
                 return satellite.safe_address
+            # If we have satellites configured, only fall back to primary
+            # for the primary chain itself.  An unknown satellite destination
+            # means a misconfigured deployment — raise instead of silently
+            # minting to the wrong Safe.
+            if primary_chain_id is not None and chain_id != primary_chain_id:
+                raise ValueError(
+                    f"No satellite vault configured for chain {chain_id}. "
+                    f"Primary chain is {primary_chain_id}, "
+                    f"configured satellites: {list(satellite_vaults.keys())}"
+                )
         if primary_custody_address is not None:
             return primary_custody_address
         if fallback_address is not None:
@@ -1010,10 +1026,18 @@ class EthereumPairConfigurator(PairConfigurator):
                     else:
                         fallback_address = tx_builder.get_erc_20_balance_address()
 
+            # Determine primary chain ID for strict satellite validation
+            primary_chain_id = None
+            if hasattr(self, 'strategy_universe') and self.strategy_universe is not None:
+                primary_chain = getattr(self.strategy_universe, 'primary_chain', None)
+                if primary_chain is not None:
+                    primary_chain_id = primary_chain.value
+
             custody_resolver = _make_cctp_custody_resolver(
                 satellite_vaults=self.satellite_vaults or None,
                 primary_custody_address=primary_custody_address,
                 fallback_address=fallback_address,
+                primary_chain_id=primary_chain_id,
             )
             return create_cctp_bridge_adapter(self.web3config, routing_id, custody_address_resolver=custody_resolver)
         else:

--- a/tradeexecutor/ethereum/ethereum_protocol_adapters.py
+++ b/tradeexecutor/ethereum/ethereum_protocol_adapters.py
@@ -755,6 +755,7 @@ def create_cctp_bridge_adapter(
     web3config: "Web3Config",
     routing_id: ProtocolRoutingId,
     custody_address_resolver: Callable[[int], str] | None = None,
+    skip_attestation: bool = False,
 ) -> ProtocolRoutingConfig:
     """Create adapter for CCTP bridge pairs.
 
@@ -773,7 +774,11 @@ def create_cctp_bridge_adapter(
     from tradeexecutor.ethereum.cctp.routing import CctpBridgeRouting
     from tradeexecutor.ethereum.cctp.valuation import CctpBridgeValuationModel
 
-    routing_model = CctpBridgeRouting(web3config, custody_address_resolver=custody_address_resolver)
+    routing_model = CctpBridgeRouting(
+        web3config,
+        custody_address_resolver=custody_address_resolver,
+        skip_attestation=skip_attestation,
+    )
     pricing_model = CctpBridgePricingModel()
     valuation_model = CctpBridgeValuationModel()
 
@@ -1039,7 +1044,14 @@ class EthereumPairConfigurator(PairConfigurator):
                 fallback_address=fallback_address,
                 primary_chain_id=primary_chain_id,
             )
-            return create_cctp_bridge_adapter(self.web3config, routing_id, custody_address_resolver=custody_resolver)
+            # Skip attestation polling on Anvil forks where Circle's Iris API
+            # is unavailable.  The test environment spoofs the receive manually.
+            skip_attestation = getattr(self.execution_model, 'mainnet_fork', False)
+            return create_cctp_bridge_adapter(
+                self.web3config, routing_id,
+                custody_address_resolver=custody_resolver,
+                skip_attestation=skip_attestation,
+            )
         else:
             raise NotImplementedError(f"Cannot route exchange {routing_id}")
 

--- a/tradeexecutor/ethereum/ethereum_protocol_adapters.py
+++ b/tradeexecutor/ethereum/ethereum_protocol_adapters.py
@@ -1046,7 +1046,14 @@ class EthereumPairConfigurator(PairConfigurator):
             )
             # Skip attestation polling on Anvil forks where Circle's Iris API
             # is unavailable.  The test environment spoofs the receive manually.
-            skip_attestation = getattr(self.execution_model, 'mainnet_fork', False)
+            skip_attestation = False
+            if self.execution_model is not None:
+                skip_attestation = getattr(self.execution_model, 'mainnet_fork', False)
+            if not skip_attestation and self.web3config is not None:
+                skip_attestation = self.web3config.is_mainnet_fork()
+            if not skip_attestation:
+                import os
+                skip_attestation = os.environ.get("UNIT_TESTING", "").lower() in ("true", "1", "yes")
             return create_cctp_bridge_adapter(
                 self.web3config, routing_id,
                 custody_address_resolver=custody_resolver,

--- a/tradeexecutor/ethereum/execution.py
+++ b/tradeexecutor/ethereum/execution.py
@@ -691,6 +691,28 @@ class EthereumExecution(ExecutionModel):
                     f"remaining_trade_ids={remaining_trade_ids}"
                 )
 
+            if trade.get_status() == TradeStatus.cctp_in_transit:
+                # Expire remaining planned trades and clean up orphan positions
+                for remaining_trade in trades[idx:]:
+                    if remaining_trade.get_status() == TradeStatus.planned:
+                        remaining_trade.mark_expired(native_datetime_utc_now())
+                        # Clean up orphan positions created by now-expired trades
+                        pos = state.portfolio.open_positions.get(remaining_trade.position_id)
+                        if pos is not None and pos.get_quantity() == 0:
+                            all_expired = all(
+                                t.get_status() == TradeStatus.expired
+                                for t in pos.trades.values()
+                            )
+                            if all_expired:
+                                del state.portfolio.open_positions[remaining_trade.position_id]
+
+                remaining_ids = [t.trade_id for t in trades[idx:]]
+                raise ExecutionHaltableIssue(
+                    f"CCTP bridge in transit — halting batch. "
+                    f"In-transit trade_id={trade.trade_id}, "
+                    f"remaining_trade_ids={remaining_ids}"
+                )
+
     def execute_trades(
         self,
         ts: datetime.datetime,

--- a/tradeexecutor/ethereum/rebroadcast.py
+++ b/tradeexecutor/ethereum/rebroadcast.py
@@ -11,7 +11,7 @@ from eth_defi.compat import native_datetime_utc_now
 
 from tradeexecutor.state.blockhain_transaction import BlockchainTransaction
 from tradeexecutor.state.state import State
-from tradeexecutor.state.trade import TradeExecution
+from tradeexecutor.state.trade import TradeExecution, TradeStatus
 from tradeexecutor.strategy.execution_model import ExecutionModel
 from tradeexecutor.strategy.routing import RoutingModel, RoutingState
 from eth_defi.compat import native_datetime_utc_now
@@ -45,6 +45,9 @@ def rebroadcast_all(
 
     for t in all_trades:
         # only rebroadcast trades that are not failed and unfinished
+        # Skip CCTP in-transit trades: they have a dedicated retry path
+        if t.get_status() == TradeStatus.cctp_in_transit:
+            continue
         if t.is_unfinished() and not t.is_failed():
             logger.info("Marking trade %s for rebroadcast", t)
             assert t.blockchain_transactions, f"Trade marked unfinished, did not have any txs: {t}"

--- a/tradeexecutor/state/portfolio.py
+++ b/tradeexecutor/state/portfolio.py
@@ -721,9 +721,24 @@ class Portfolio:
         """
         # Any trading positions we have one
         # spot_values = sum([p.get_equity() for p in self.open_positions.values() if not p.is_leverage()])
-        return self.get_position_equity_and_loan_nav() + self.get_cash()
+        return self.get_position_equity_and_loan_nav() + self.get_cash() + self.get_in_transit_value()
 
     get_total_equity = calculate_total_equity
+
+    def get_in_transit_value(self) -> float:
+        """Get the total value of USDC currently in CCTP transit.
+
+        Sums planned_reserve for all trades in cctp_in_transit status.
+        This value represents USDC burned on-chain but not yet received
+        on the destination chain.
+        """
+        from tradeexecutor.state.trade import TradeStatus
+        total = 0.0
+        for position in self.open_positions.values():
+            for trade in position.trades.values():
+                if trade.get_status() == TradeStatus.cctp_in_transit:
+                    total += float(trade.planned_reserve)
+        return total
 
     def calculate_total_equity_chain(self) -> dict[ChainId, USDollarAmount]:
         """Get the value of the portfolio broken down by chain.
@@ -752,6 +767,16 @@ class Portfolio:
                 continue
             chain = ChainId(p.pair.chain_id)
             result[chain] = result.get(chain, 0) + p.get_equity()
+
+        # In-transit CCTP value attributed to destination chain
+        from tradeexecutor.state.trade import TradeStatus
+        for p in self.open_positions.values():
+            for trade in p.trades.values():
+                if trade.get_status() == TradeStatus.cctp_in_transit:
+                    dest_chain_id = trade.other_data.get("cctp_dest_chain_id")
+                    if dest_chain_id is not None:
+                        chain = ChainId(dest_chain_id)
+                        result[chain] = result.get(chain, 0) + float(trade.planned_reserve)
 
         return result
 

--- a/tradeexecutor/state/position.py
+++ b/tradeexecutor/state/position.py
@@ -2480,7 +2480,14 @@ class TradingPosition(GenericPosition):
             (Asset id, amount) iterables
         """
         assert self.is_open() or self.is_frozen()
-        if self.is_spot():
+        if self.pair.is_cctp_bridge():
+            # Bridge positions hold destination chain USDC.
+            # Only the available (unallocated) portion is still in the wallet;
+            # the rest has been moved to satellite trade positions.
+            available = self.get_available_bridge_capital()
+            if available > 0:
+                yield self.pair.base, available
+        elif self.is_spot():
             yield self.pair.base, self.get_quantity()
         elif self.is_credit_supply():
             yield self.loan.collateral.asset, self.loan.get_collateral_quantity()

--- a/tradeexecutor/state/state.py
+++ b/tradeexecutor/state/state.py
@@ -1030,6 +1030,32 @@ class State:
                 f"Trade failed, allocated reserve was not used:\n{trade}"
             )
 
+    def mark_bridge_in_transit(self, ts: datetime.datetime, trade: TradeExecution):
+        """Mark a CCTP bridge trade as in-transit (burn confirmed, receive pending).
+
+        Does NOT adjust reserves — the burn already consumed them on-chain.
+        For bridge-back sells, locks the burned capital on the bridge position.
+        """
+        assert trade.pair.is_cctp_bridge()
+        trade.cctp_in_transit_at = ts
+
+        # Store metadata for retry
+        burn_tx = trade.blockchain_transactions[1] if len(trade.blockchain_transactions) > 1 else None
+        trade.other_data["cctp_burn_tx_hash"] = burn_tx.tx_hash if burn_tx else None
+        if trade.is_buy():
+            trade.other_data["cctp_source_chain_id"] = trade.pair.quote.chain_id
+            trade.other_data["cctp_dest_chain_id"] = trade.pair.base.chain_id
+        else:
+            trade.other_data["cctp_source_chain_id"] = trade.pair.base.chain_id
+            trade.other_data["cctp_dest_chain_id"] = trade.pair.quote.chain_id
+
+        # For bridge-back sells: lock the burned capital on the bridge position
+        # so get_available_bridge_capital() returns zero for it
+        if trade.is_sell():
+            bridge_position = self.portfolio.get_position_by_id(trade.position_id)
+            if bridge_position is not None:
+                bridge_position.bridge_capital_allocated += abs(trade.planned_quantity)
+
     def update_reserves(self, new_reserves: List[ReservePosition]):
         self.portfolio.update_reserves(new_reserves)
 

--- a/tradeexecutor/state/trade.py
+++ b/tradeexecutor/state/trade.py
@@ -90,10 +90,17 @@ class TradeStatus(enum.Enum):
     #:
     repair_entry = "repair_entry"
 
-    #: Trade is bound to triggers (like partial take profit) 
+    #: Trade is bound to triggers (like partial take profit)
     #: but all trigger was expired
     #:
     expired = "expired"
+
+    #: CCTP bridge burn confirmed on source chain, receive pending on destination chain.
+    #:
+    #: The trade has a dedicated retry path and is not considered "unfinished"
+    #: in the generic sense.
+    #:
+    cctp_in_transit = "cctp_in_transit"
 
 
 class TradeFlag(enum.Enum):
@@ -677,6 +684,10 @@ class TradeExecution:
     #:
     expired_at: Optional[datetime.datetime] = None
 
+    #: CCTP bridge burn confirmed on source chain, receive pending on destination chain.
+    #:
+    cctp_in_transit_at: datetime.datetime | None = None
+
     #: After the trade has been assigned to the execution, track
     #: it's execution sort index here.
     #:
@@ -1079,6 +1090,8 @@ class TradeExecution:
             return TradeStatus.failed
         elif self.executed_at:
             return TradeStatus.success
+        elif self.cctp_in_transit_at:
+            return TradeStatus.cctp_in_transit
         elif self.broadcasted_at:
             return TradeStatus.broadcasted
         elif self.started_at:
@@ -1313,6 +1326,15 @@ class TradeExecution:
         credit_order_bump = 200_000_000
         close_order_bump = 100_000_000
         vault_order_bump = 50_000_000
+        bridge_order_bump = 30_000_000
+
+        if self.pair.is_cctp_bridge():
+            if self.is_sell():
+                # Bridge-backs: after vault withdrawals (-50M), before spot sells
+                return -self.trade_id - bridge_order_bump
+            else:
+                # Bridge-outs: after regular buys, before vault deposits (+50M)
+                return self.trade_id + bridge_order_bump
 
         if self.is_credit_supply() and TradeFlag.close in self.flags:
             # Always withdraw credit to cash in hand first,
@@ -1468,6 +1490,14 @@ class TradeExecution:
         assert self.get_status() in (TradeStatus.broadcasted, TradeStatus.started), f"Cannot mark trade failed if it is not broadcasted or started. Current status: {self.get_status()}"
         assert failed_at.tzinfo is None
         self.failed_at = failed_at
+
+    def mark_expired(self, ts: datetime.datetime):
+        """Mark this trade as expired.
+
+        Only planned trades can be expired (e.g. all triggers have lapsed).
+        """
+        assert self.get_status() == TradeStatus.planned, f"Only planned trades can be expired. Current status: {self.get_status()}"
+        self.expired_at = ts
 
     def set_blockchain_transactions(self, txs: List[BlockchainTransaction]):
         """Set the physical transactions needed to perform this trade."""

--- a/tradeexecutor/strategy/runner.py
+++ b/tradeexecutor/strategy/runner.py
@@ -957,6 +957,21 @@ class StrategyRunner(abc.ABC):
                     max_price_impact=self.max_price_impact,
                 )
 
+                # Inject CCTP bridge trades for cross-chain rebalancing.
+                # Only applies to cross-chain universes with a primary chain set.
+                if hasattr(universe, 'get_reserve_asset') and hasattr(universe, 'primary_chain'):
+                    from tradeexecutor.ethereum.cctp.planner import inject_cctp_bridge_trades
+                    primary_chain = getattr(universe, 'primary_chain', None)
+                    if primary_chain is not None and len(rebalance_trades) > 0:
+                        rebalance_trades = inject_cctp_bridge_trades(
+                            state=state,
+                            trades=rebalance_trades,
+                            strategy_universe=universe,
+                            primary_chain_id=primary_chain.value,
+                            ts=strategy_cycle_timestamp,
+                            reserve_asset=universe.get_reserve_asset(),
+                        )
+
                 # If we have no trades, then we are done
                 # Log what our strategy decided
                 if self.is_progress_report_needed():


### PR DESCRIPTION
## Why

The xchain-master-vault strategy allocates across vaults on 6+ chains. Currently, cross-chain capital movement (vault redeem → CCTP bridge → CCTP bridge → vault deposit) is manually orchestrated in test scripts. This PR automates the full multi-step rebalance within a single strategy cycle using blocking attestation waits.

Lagoon vault (Safe-based) is the primary execution model. Hot wallet is secondary.

## Summary

**State foundation (PR 1)**
- `TradeStatus.cctp_in_transit` — first-class status for "burn confirmed, receive pending"
- `mark_expired(ts)` for cancelling planned trades on halt
- CCTP bridge sort phases (-30M/+30M) in `get_execution_sort_position()` that override the `closing` catch-all
- `State.mark_bridge_in_transit()` with bridge-back capital locking
- Exclude `cctp_in_transit` from generic rebroadcast repair

**Custody resolver (PR 2)**
- Direction-aware `mint_recipient` for `depositForBurn()` — buy resolves satellite Safe, sell resolves primary Safe
- `custody_address_resolver` callable passed to `CctpBridgeRouting` at construction
- Rejects unknown non-primary satellite destinations (strict validation)

**Multi-phase settlement (PR 3)**
- `settle_trade()` extended: burn confirmation → Iris API attestation poll → `receiveMessage` broadcast on destination chain
- Cloned hot wallet per destination chain for nonce safety
- Receive tx appended to `blockchain_transactions` with full confirmation metadata
- Falls back to `cctp_in_transit` on attestation timeout or receive revert

**In-transit lifecycle (PR 4)**
- `Portfolio.get_in_transit_value()` counts burned-but-unreceived USDC
- Total equity and per-chain equity include in-transit value
- Sequential executor halts on in-transit, expires remaining planned trades, removes orphan positions
- Startup retry utility for trades stuck in transit after process restart

**Backtest sequential path (PR 5)**
- Detects CCTP trades and switches to per-trade start/simulate/settle
- Bridge positions exist before satellite vault deposits allocate from them
- `simulate_bridge()` handles bridge wallet simulation
- Non-bridge batches use unchanged batch path

**Bridge trade injection planner (PR 6)**
- Analyses alpha model trades, computes net capital flow per satellite chain
- Injects bridge-back sells or bridge-out buys automatically
- Same-chain sells/buys cancel out (only net amount bridged)
- Wired into `runner.tick()` after `post_process_trade_decision()`

**Integration wiring (fix commit)**
- Planner called from `runner.tick()` for cross-chain universes
- Startup retry called from `run_live()`, halts if unresolved
- Receive tx populated with `set_confirmation_information()` metadata

**Test strategy + docs (PR 7)**
- Deterministic 3-cycle cycling test strategy
- README-cctp.md updated with trade executor integration section

## Lessons learnt

- Worktree-based subagent development has import path issues with shared Poetry virtualenvs — direct branch work is more reliable
- `get_execution_sort_position()` bridge phases need different ordering for live (rebalance flow) vs backtest (sequential dependency) — backtest promotes bridge-outs to sort key 0
- `receiveMessage()` is permissionless so Lagoon receive txs bypass the Safe guard — mixed tx types (`lagoon_vault` burn + `hot_wallet` receive) in `blockchain_transactions` is correct
- Custody resolver must know `primary_chain_id` to reject unknown satellite destinations rather than silently minting to primary Safe