### PR TITLE
Fix liquidity data staleness check ignoring max_data_delay

### DIFF
--- a/tradeexecutor/cli/loop.py
+++ b/tradeexecutor/cli/loop.py
@@ -877,6 +877,7 @@ class ExecutionLoop:
                 rounded_ts,
                 universe,
                 self.max_data_delay,
+                best_before_duration_liquidity=self.max_data_delay,
             )
 
         logger.info("Warmed up universe %s", universe)


### PR DESCRIPTION
## Why

The `hyper-ai` strategy on production was crashing on startup with:

```
DataTooOld: Liquidity data is too old to work with 2023-03-01 00:00:00 - 2026-05-14 00:00:00
```

`check_data_age()` has a hardcoded 2-day default for `best_before_duration_liquidity`, but the caller in `ExecutionLoop.warm_up_live_trading()` only passed `max_data_delay` (60 days) for candle data. When the upstream vault price history parquet was 4 days stale, candles passed but liquidity failed.

## Lessons learnt

- `check_data_age()` has separate tolerance parameters for candle and liquidity data — the liquidity one defaults to 2 days and was never being overridden by the caller
- For vault-only datasets, "liquidity" is really TVL data from the same source as candle data, so it makes no sense to have a tighter tolerance

## Summary

- Pass `max_data_delay` as `best_before_duration_liquidity` in `ExecutionLoop.warm_up_live_trading()` so both checks use the same configured tolerance

🤖 Generated with [Claude Code](https://claude.com/claude-code)