### PR TITLE
Fix NameError in close_position_with_empty_trade error message

### DIFF
--- a/tradeexecutor/state/repair.py
+++ b/tradeexecutor/state/repair.py
@@ -477,7 +477,7 @@ def close_position_with_empty_trade(portfolio: Portfolio, p: TradingPosition) ->
 
     opening_trade = p.get_first_trade()
 
-    assert opening_trade.is_success(), f"Cannot make a repairing trade, because opening trade {t} was not success"
+    assert opening_trade.is_success(), f"Cannot make a repairing trade, because opening trade {opening_trade} was not success"
 
     # We copy any price structure from opening trade, though it should be meaningfull
     position, counter_trade, created = portfolio.create_trade(


### PR DESCRIPTION
## Why

`close_position_with_empty_trade()` in `repair.py` crashes with `NameError: name 't' is not defined` when the assert on line 480 fails. The f-string references an undefined variable `t` instead of `opening_trade`.

## Lessons learnt

- Copy-paste errors in assert messages can mask the real failure with a secondary `NameError`.

## Summary

- Fixed the f-string in the assert message at `repair.py:480` to reference `opening_trade` instead of the undefined `t`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)