### PR TITLE
Add missed vault availability analysis

### DIFF
--- a/strategies/xchain-master-vault.py
+++ b/strategies/xchain-master-vault.py
@@ -32,7 +32,10 @@ from tradeexecutor.state.trade import TradeExecution
 from tradeexecutor.state.types import USDollarAmount
 from tradeexecutor.strategy.alpha_model import AlphaModel
 from tradeexecutor.strategy.chart.definition import ChartInput, ChartKind, ChartRegistry
-from tradeexecutor.strategy.chart.standard.alpha_model import alpha_model_diagnostics
+from tradeexecutor.strategy.chart.standard.alpha_model import (
+    alpha_model_diagnostics,
+    missed_vault_deposit_redemption_events,
+)
 from tradeexecutor.strategy.chart.standard.equity_curve import (
     equity_curve as equity_curve_chart,
     equity_curve_with_drawdown,
@@ -452,6 +455,14 @@ def decide_trades(input: StrategyInput) -> list[TradeExecution]:
         sell_rebalance_min_threshold=parameters.sell_rebalance_min_threshold_usd,
         execution_context=input.execution_context,
     )
+    missed_vault_events = alpha_model.get_missed_vault_events()
+    if missed_vault_events:
+        state.visualisation.add_calculations(
+            timestamp,
+            {
+                "missed_vault_events": missed_vault_events,
+            },
+        )
 
     if input.is_visualisation_enabled():
         try:
@@ -799,6 +810,7 @@ def create_charts(
     charts.register(positions_at_end, ChartKind.state_all_pairs)
     charts.register(last_messages, ChartKind.state_all_pairs)
     charts.register(alpha_model_diagnostics, ChartKind.state_all_pairs)
+    charts.register(missed_vault_deposit_redemption_events, ChartKind.state_all_pairs)
     charts.register(trading_pair_breakdown_with_chain, ChartKind.state_all_pairs)
     charts.register(trading_metrics, ChartKind.state_all_pairs)
     charts.register(vault_statistics, ChartKind.state_all_pairs)

--- a/strategies/xchain-master-vault.py
+++ b/strategies/xchain-master-vault.py
@@ -35,6 +35,7 @@ from tradeexecutor.strategy.chart.definition import ChartInput, ChartKind, Chart
 from tradeexecutor.strategy.chart.standard.alpha_model import (
     alpha_model_diagnostics,
     missed_vault_deposit_redemption_events,
+    missed_vault_deposit_redemption_timeline,
 )
 from tradeexecutor.strategy.chart.standard.equity_curve import (
     equity_curve as equity_curve_chart,
@@ -811,6 +812,7 @@ def create_charts(
     charts.register(last_messages, ChartKind.state_all_pairs)
     charts.register(alpha_model_diagnostics, ChartKind.state_all_pairs)
     charts.register(missed_vault_deposit_redemption_events, ChartKind.state_all_pairs)
+    charts.register(missed_vault_deposit_redemption_timeline, ChartKind.state_all_pairs)
     charts.register(trading_pair_breakdown_with_chain, ChartKind.state_all_pairs)
     charts.register(trading_metrics, ChartKind.state_all_pairs)
     charts.register(vault_statistics, ChartKind.state_all_pairs)

--- a/tests/strategy/test_generic_pricing_model.py
+++ b/tests/strategy/test_generic_pricing_model.py
@@ -27,6 +27,36 @@ def test_pricing_model_tradeability_defaults_to_true():
     assert pricing_model.is_tradeable(None, pair=None) is True
 
 
+def test_generic_pricing_delegates_can_deposit():
+    """Check GenericPricing keeps the route-specific deposit gate intact.
+
+    1. Build a child pricing model that reports deposits as closed.
+    2. Route all pairs from GenericPricing to that child pricing model.
+    3. Verify GenericPricing returns the child model's deposit availability.
+    """
+
+    class ClosedDepositPricingModel(DummyPricingModel):
+        def can_deposit(self, ts, pair) -> bool:
+            return False
+
+    child_pricing = ClosedDepositPricingModel()
+
+    class FakePairConfigurator:
+        def get_pricing(self, pair):
+            return child_pricing
+
+    pricing_model = GenericPricing(FakePairConfigurator())
+
+    # 1. Build a child pricing model that reports deposits as closed.
+    pair = object()
+
+    # 2. Route all pairs from GenericPricing to that child pricing model.
+    can_deposit = pricing_model.can_deposit(None, pair)
+
+    # 3. Verify GenericPricing returns the child model's deposit availability.
+    assert can_deposit is False
+
+
 def test_ethereum_generic_pricing_factory_passes_execution_model(monkeypatch):
     captured: dict[str, object] = {}
 

--- a/tests/test_rebalance.py
+++ b/tests/test_rebalance.py
@@ -10,6 +10,7 @@ import datetime
 import random
 from decimal import Decimal
 
+import pandas as pd
 import pytest
 from hexbytes import HexBytes
 
@@ -30,7 +31,11 @@ from tradeexecutor.state.blockhain_transaction import BlockchainTransaction
 from tradeexecutor.state.reserve import ReservePosition
 from tradeexecutor.state.identifier import AssetIdentifier, TradingPairIdentifier, TradingPairKind
 from tradeexecutor.state.types import USDollarPrice, USDollarAmount
-from tradeexecutor.analysis.vault_missed_events import analyse_missed_vault_deposit_redemption_events
+from tradeexecutor.analysis.vault_missed_events import (
+    analyse_missed_vault_deposit_redemption_event_timeline,
+    analyse_missed_vault_deposit_redemption_events,
+    format_missed_vault_deposit_redemption_events,
+)
 from tradeexecutor.strategy import size_risk_model
 from tradeexecutor.strategy.alpha_model import AlphaModel, TradingPairSignalFlags
 from tradeexecutor.strategy.fixed_size_risk import FixedSizeRiskModel
@@ -2540,6 +2545,67 @@ def test_analyse_missed_vault_deposit_redemption_events(start_ts: datetime.datet
     assert rows["Vault B"]["Missed deposit US dollar"] == pytest.approx(0.0)
     assert rows["Vault B"]["Missed redemption count"] == 1
     assert rows["Vault B"]["Missed redemption US dollar"] == pytest.approx(300.0)
+
+
+def test_analyse_missed_vault_deposit_redemption_event_timeline(start_ts: datetime.datetime) -> None:
+    """Check missed vault event timeline analysis and currency table formatting.
+
+    1. Store compact missed vault events for two strategy cycles.
+    2. Build the missed event timeline from state visualisation calculations.
+    3. Verify events are grouped by cycle, vault, and event type.
+    4. Format the summary table and verify dollar values are rendered as currency.
+    """
+    state = State()
+
+    # 1. Store compact missed vault events for two strategy cycles.
+    state.visualisation.add_calculations(
+        start_ts,
+        {
+            "missed_vault_events": [
+                {
+                    "vault_name": "Vault A",
+                    "event_type": "deposit",
+                    "missed_usd": 1000.0,
+                },
+                {
+                    "vault_name": "Vault A",
+                    "event_type": "deposit",
+                    "missed_usd": 250.0,
+                },
+            ],
+        },
+    )
+    state.visualisation.add_calculations(
+        start_ts + datetime.timedelta(days=1),
+        {
+            "missed_vault_events": [
+                {
+                    "vault_name": "Vault B",
+                    "event_type": "redemption",
+                    "missed_usd": 300.0,
+                },
+            ],
+        },
+    )
+
+    # 2. Build the missed event timeline from state visualisation calculations.
+    timeline_df = analyse_missed_vault_deposit_redemption_event_timeline(state)
+
+    # 3. Verify events are grouped by cycle, vault, and event type.
+    rows = timeline_df.set_index(["Timestamp", "Event type", "Vault name"]).to_dict("index")
+    deposit_row = rows[(pd.Timestamp(start_ts), "deposit", "Vault A")]
+    redemption_row = rows[(pd.Timestamp(start_ts + datetime.timedelta(days=1)), "redemption", "Vault B")]
+    assert deposit_row["Missed event count"] == 2
+    assert deposit_row["Missed US dollar"] == pytest.approx(1250.0)
+    assert redemption_row["Missed event count"] == 1
+    assert redemption_row["Missed US dollar"] == pytest.approx(300.0)
+
+    # 4. Format the summary table and verify dollar values are rendered as currency.
+    summary_df = analyse_missed_vault_deposit_redemption_events(state)
+    html = format_missed_vault_deposit_redemption_events(summary_df).to_html()
+    assert "$1,250.00" in html
+    assert "$300.00" in html
+    assert "1.250000e+03" not in html
 
 
 def test_update_old_weights_reads_position_value_once(

--- a/tests/test_rebalance.py
+++ b/tests/test_rebalance.py
@@ -30,6 +30,7 @@ from tradeexecutor.state.blockhain_transaction import BlockchainTransaction
 from tradeexecutor.state.reserve import ReservePosition
 from tradeexecutor.state.identifier import AssetIdentifier, TradingPairIdentifier, TradingPairKind
 from tradeexecutor.state.types import USDollarPrice, USDollarAmount
+from tradeexecutor.analysis.vault_missed_events import analyse_missed_vault_deposit_redemption_events
 from tradeexecutor.strategy import size_risk_model
 from tradeexecutor.strategy.alpha_model import AlphaModel, TradingPairSignalFlags
 from tradeexecutor.strategy.fixed_size_risk import FixedSizeRiskModel
@@ -1705,6 +1706,16 @@ def test_alpha_model_carries_forward_locked_hypercore_vault(
     assert len(locked_signal.redemption_check_results) == 1
     assert locked_signal.redemption_check_results[0].stage == RedemptionCheckStage.carry_forward
     assert locked_signal.redemption_check_results[0].reason_code == RedemptionBlockReason.user_lockup_not_expired
+    assert locked_signal.other_data["missed_redemption_usd"] == pytest.approx(5000.0)
+    assert alpha_model.get_missed_vault_events() == [
+        {
+            "vault_name": locked_signal.pair.get_vault_name() or locked_signal.pair.get_ticker(),
+            "pair_ticker": locked_signal.pair.get_ticker(),
+            "vault_address": locked_signal.pair.pool_address,
+            "event_type": "redemption",
+            "missed_usd": 5000.0,
+        }
+    ]
 
     restored_signal = locked_signal.__class__.from_json(locked_signal.to_json())
     assert len(restored_signal.redemption_check_results) == 1
@@ -1826,7 +1837,10 @@ def test_alpha_model_skips_sell_rebalance_for_non_redeemable_position(
     # 3. Verify the sell rebalance is skipped and the signal stores the sell-stage diagnostics.
     assert trades == []
     assert signal.position_adjust_ignored is True
+    assert signal.position_adjust_usd == pytest.approx(0.0)
+    assert signal.position_adjust_quantity == pytest.approx(0.0)
     assert TradingPairSignalFlags.cannot_redeem in signal.flags
+    assert signal.other_data["missed_redemption_usd"] == pytest.approx(4000.0)
     assert len(signal.redemption_check_results) == 1
     assert signal.redemption_check_results[0].stage == RedemptionCheckStage.sell_rebalance
     assert signal.redemption_check_results[0].reason_code == RedemptionBlockReason.user_lockup_not_expired
@@ -1896,6 +1910,163 @@ def _patch_hypercore_pricing(
             else original_get_sell_price(ts, pair, quantity)
         ),
     )
+
+
+def test_alpha_model_skips_buy_when_vault_deposits_closed(
+    start_ts: datetime.datetime,
+    strategy_universe: TradingStrategyUniverse,
+    pricing_model: BacktestPricing,
+    usdc: AssetIdentifier,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Check AlphaModel does not add capital to a vault whose deposits are closed.
+
+    1. Build an empty portfolio with free USDC and one Hypercore vault buy signal.
+    2. Mock the pricing model so the vault has deterministic pricing but closed deposits.
+    3. Verify no buy trade is generated and the signal records the deposit block.
+    """
+    state = State()
+    state.portfolio.reserves = {
+        usdc: ReservePosition(
+            asset=usdc,
+            quantity=Decimal(2500),
+            last_sync_at=start_ts,
+            reserve_token_price=USDollarAmount(1.0),
+            last_pricing_at=start_ts,
+            initial_deposit=Decimal(2500),
+        )
+    }
+    hypercore_vault_pair = create_hypercore_vault_pair(
+        quote=usdc,
+        vault_address=HLP_VAULT_ADDRESS["mainnet"],
+        internal_id=102,
+    )
+
+    # 1. Build an empty portfolio with free USDC and one Hypercore vault buy signal.
+    position_manager = PositionManager(
+        start_ts + datetime.timedelta(days=1),
+        strategy_universe.data_universe,
+        state,
+        pricing_model,
+    )
+    _patch_hypercore_pricing(monkeypatch, pricing_model, hypercore_vault_pair)
+
+    # 2. Mock the pricing model so the vault has deterministic pricing but closed deposits.
+    # PricingModel is the shared live/backtest gate for venue-specific deposit availability.
+    monkeypatch.setattr(
+        pricing_model,
+        "can_deposit",
+        lambda ts, pair: pair != hypercore_vault_pair,
+    )
+
+    alpha_model = AlphaModel(timestamp=position_manager.timestamp)
+    alpha_model.set_signal(hypercore_vault_pair, 1.0)
+    alpha_model.select_top_signals(count=5)
+    alpha_model.assign_weights(method=weight_passthrouh)
+    alpha_model.normalise_weights(max_weight=1.0)
+    alpha_model.update_old_weights(state.portfolio, ignore_credit=False)
+    alpha_model.calculate_target_positions(position_manager, investable_equity=2500.0)
+
+    trades = alpha_model.generate_rebalance_trades_and_triggers(
+        position_manager,
+        min_trade_threshold=0.01,
+        individual_rebalance_min_threshold=0.01,
+        sell_rebalance_min_threshold=0.01,
+    )
+
+    signal = alpha_model.get_signal_by_pair(hypercore_vault_pair)
+    assert signal is not None
+
+    # 3. Verify no buy trade is generated and the signal records the deposit block.
+    assert trades == []
+    assert signal.position_adjust_ignored is True
+    assert TradingPairSignalFlags.cannot_deposit in signal.flags
+    assert TradingPairSignalFlags.cannot_redeem not in signal.flags
+    assert signal.other_data["missed_deposit_usd"] == pytest.approx(2500.0)
+    missed_events = alpha_model.get_missed_vault_events()
+    assert missed_events == [
+        {
+            "vault_name": signal.pair.get_vault_name() or signal.pair.get_ticker(),
+            "pair_ticker": signal.pair.get_ticker(),
+            "vault_address": signal.pair.pool_address,
+            "event_type": "deposit",
+            "missed_usd": 2500.0,
+        }
+    ]
+
+
+def test_alpha_model_allows_sell_when_vault_deposits_closed_but_redemptions_open(
+    start_ts: datetime.datetime,
+    strategy_universe: TradingStrategyUniverse,
+    pricing_model: BacktestPricing,
+    usdc: AssetIdentifier,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Check a deposit-closed vault can still be reduced when redemptions are open.
+
+    1. Create an open Hypercore vault position that needs to be reduced.
+    2. Mock deposits as closed but redemptions as open for the same vault.
+    3. Verify the alpha model emits a sell and does not mark the signal deposit-blocked.
+    """
+    state = State()
+    hypercore_vault_pair = _create_hypercore_position_for_rebalance_test(state, start_ts, usdc)
+
+    # 1. Create an open Hypercore vault position that needs to be reduced.
+    position_manager = PositionManager(
+        start_ts + datetime.timedelta(days=1),
+        strategy_universe.data_universe,
+        state,
+        pricing_model,
+    )
+    _patch_hypercore_pricing(monkeypatch, pricing_model, hypercore_vault_pair)
+
+    # 2. Mock deposits as closed but redemptions as open for the same vault.
+    # This separates the buy-side deposit gate from the sell-side redemption gate.
+    monkeypatch.setattr(
+        pricing_model,
+        "can_deposit",
+        lambda ts, pair: pair != hypercore_vault_pair,
+    )
+    monkeypatch.setattr(
+        pricing_model,
+        "check_redemption",
+        lambda ts, pair, **kwargs: RedemptionCheckResult(
+            timestamp=ts,
+            stage=kwargs["stage"],
+            can_redeem=True,
+            pair_ticker=pair.get_ticker(),
+            vault_address=pair.pool_address,
+            safe_address="0x0000000000000000000000000000000000000abc",
+            max_withdrawable=None,
+            max_redemption=None,
+            message="Vault redemptions are open",
+        ),
+    )
+
+    alpha_model = AlphaModel(timestamp=position_manager.timestamp)
+    alpha_model.set_signal(hypercore_vault_pair, 1.0)
+    alpha_model.select_top_signals(count=5)
+    alpha_model.assign_weights(method=weight_passthrouh)
+    alpha_model.normalise_weights(max_weight=1.0)
+    alpha_model.update_old_weights(state.portfolio, ignore_credit=False)
+    alpha_model.calculate_target_positions(position_manager, investable_equity=20.0)
+
+    trades = alpha_model.generate_rebalance_trades_and_triggers(
+        position_manager,
+        min_trade_threshold=0.01,
+        individual_rebalance_min_threshold=0.01,
+        sell_rebalance_min_threshold=0.01,
+    )
+
+    signal = alpha_model.get_signal_by_pair(hypercore_vault_pair)
+    assert signal is not None
+
+    # 3. Verify the alpha model emits a sell and does not mark the signal deposit-blocked.
+    assert len(trades) == 1
+    assert trades[0].is_sell()
+    assert TradingPairSignalFlags.cannot_deposit not in signal.flags
+    assert TradingPairSignalFlags.cannot_redeem not in signal.flags
+    assert alpha_model.get_missed_vault_events() == []
 
 
 def test_alpha_model_caps_profitable_hypercore_sell_before_trade_generation(
@@ -2309,6 +2480,66 @@ def test_generic_pricing_delegates_check_redemption_with_diagnostics(
     assert len(blocked_results) == 1
     assert blocked_results[0].reason_code == RedemptionBlockReason.user_lockup_not_expired
     assert blocked_results[0].message == "Hypercore user lockup has not expired yet"
+
+
+def test_analyse_missed_vault_deposit_redemption_events(start_ts: datetime.datetime) -> None:
+    """Check missed vault deposit and redemption event analysis table.
+
+    1. Store compact missed vault events for two strategy cycles.
+    2. Build the missed event analysis table from state visualisation calculations.
+    3. Verify deposit and redemption counts and US dollar sums are grouped by vault name.
+    """
+    state = State()
+
+    # 1. Store compact missed vault events for two strategy cycles.
+    state.visualisation.add_calculations(
+        start_ts,
+        {
+            "missed_vault_events": [
+                {
+                    "vault_name": "Vault A",
+                    "event_type": "deposit",
+                    "missed_usd": 100.0,
+                },
+                {
+                    "vault_name": "Vault A",
+                    "event_type": "redemption",
+                    "missed_usd": 40.0,
+                },
+            ],
+        },
+    )
+    state.visualisation.add_calculations(
+        start_ts + datetime.timedelta(days=1),
+        {
+            "missed_vault_events": [
+                {
+                    "vault_name": "Vault A",
+                    "event_type": "deposit",
+                    "missed_usd": 25.0,
+                },
+                {
+                    "vault_name": "Vault B",
+                    "event_type": "redemption",
+                    "missed_usd": 300.0,
+                },
+            ],
+        },
+    )
+
+    # 2. Build the missed event analysis table from state visualisation calculations.
+    df = analyse_missed_vault_deposit_redemption_events(state)
+
+    # 3. Verify deposit and redemption counts and US dollar sums are grouped by vault name.
+    rows = df.set_index("Vault name").to_dict("index")
+    assert rows["Vault A"]["Missed deposit count"] == 2
+    assert rows["Vault A"]["Missed deposit US dollar"] == pytest.approx(125.0)
+    assert rows["Vault A"]["Missed redemption count"] == 1
+    assert rows["Vault A"]["Missed redemption US dollar"] == pytest.approx(40.0)
+    assert rows["Vault B"]["Missed deposit count"] == 0
+    assert rows["Vault B"]["Missed deposit US dollar"] == pytest.approx(0.0)
+    assert rows["Vault B"]["Missed redemption count"] == 1
+    assert rows["Vault B"]["Missed redemption US dollar"] == pytest.approx(300.0)
 
 
 def test_update_old_weights_reads_position_value_once(

--- a/tradeexecutor/analysis/vault_missed_events.py
+++ b/tradeexecutor/analysis/vault_missed_events.py
@@ -1,6 +1,7 @@
 """Analyse missed vault deposit and redemption opportunities."""
 
 import pandas as pd
+from pandas.io.formats.style import Styler
 
 from tradeexecutor.state.state import State
 
@@ -11,6 +12,15 @@ MISSED_VAULT_EVENT_COLUMNS = [
     "Missed deposit US dollar",
     "Missed redemption count",
     "Missed redemption US dollar",
+]
+
+
+MISSED_VAULT_EVENT_TIMELINE_COLUMNS = [
+    "Timestamp",
+    "Event type",
+    "Vault name",
+    "Missed event count",
+    "Missed US dollar",
 ]
 
 
@@ -35,12 +45,34 @@ def _normalise_event_type(value: object) -> str | None:
     return str(value).lower()
 
 
+def _normalise_timestamp(value: object) -> pd.Timestamp | None:
+    """Normalise persisted calculation timestamps for timeline charts."""
+    if value is None:
+        return None
+    if isinstance(value, (int, float)):
+        return pd.Timestamp(value, unit="s")
+    return pd.Timestamp(value)
+
+
 def _iter_persisted_missed_vault_events(state: State):
     """Yield missed vault event rows persisted in visualisation calculations."""
     for calculations in state.visualisation.calculations.values():
         events = calculations.get("missed_vault_events", [])
         for event in events:
             yield event
+
+
+def _iter_persisted_missed_vault_events_with_timestamp(state: State):
+    """Yield missed vault event rows and the cycle timestamp that stored them."""
+    for timestamp, calculations in state.visualisation.calculations.items():
+        events = calculations.get("missed_vault_events", [])
+        for event in events:
+            event_timestamp = (
+                _read_attr_or_key(event, "timestamp")
+                or _read_attr_or_key(event, "cycle")
+                or timestamp
+            )
+            yield _normalise_timestamp(event_timestamp), event
 
 
 def _iter_latest_missed_vault_events(state: State):
@@ -52,6 +84,16 @@ def _iter_latest_missed_vault_events(state: State):
     get_missed_vault_events = getattr(alpha_model, "get_missed_vault_events", None)
     if get_missed_vault_events is not None:
         yield from get_missed_vault_events()
+
+
+def _get_vault_name(event: object) -> str:
+    """Get the best available vault label for a missed event."""
+    return (
+        _read_attr_or_key(event, "vault_name")
+        or _read_attr_or_key(event, "pair_ticker")
+        or _read_attr_or_key(event, "vault_address")
+        or "Unknown vault"
+    )
 
 
 def analyse_missed_vault_deposit_redemption_events(
@@ -69,12 +111,7 @@ def analyse_missed_vault_deposit_redemption_events(
         if event_type not in {"deposit", "redemption"}:
             continue
 
-        vault_name = (
-            _read_attr_or_key(event, "vault_name")
-            or _read_attr_or_key(event, "pair_ticker")
-            or _read_attr_or_key(event, "vault_address")
-            or "Unknown vault"
-        )
+        vault_name = _get_vault_name(event)
         missed_usd = float(_read_attr_or_key(event, "missed_usd", 0.0) or 0.0)
         row = totals.setdefault(
             vault_name,
@@ -110,4 +147,62 @@ def analyse_missed_vault_deposit_redemption_events(
             "Vault name",
         ],
         ascending=[False, False, True],
+    ).reset_index(drop=True)
+
+
+def format_missed_vault_deposit_redemption_events(df: pd.DataFrame) -> Styler:
+    """Format the missed vault event table for notebook and web output."""
+    return df.style.format(
+        {
+            "Missed deposit count": "{:,.0f}",
+            "Missed deposit US dollar": "${:,.2f}",
+            "Missed redemption count": "{:,.0f}",
+            "Missed redemption US dollar": "${:,.2f}",
+        },
+    )
+
+
+def analyse_missed_vault_deposit_redemption_event_timeline(
+    state: State,
+) -> pd.DataFrame:
+    """Create a timeline table of missed vault deposit and redemption events."""
+    rows = []
+
+    for timestamp, event in _iter_persisted_missed_vault_events_with_timestamp(state):
+        event_type = _normalise_event_type(_read_attr_or_key(event, "event_type"))
+        if event_type not in {"deposit", "redemption"}:
+            continue
+
+        rows.append(
+            {
+                "Timestamp": timestamp,
+                "Event type": event_type,
+                "Vault name": _get_vault_name(event),
+                "Missed event count": 1,
+                "Missed US dollar": float(_read_attr_or_key(event, "missed_usd", 0.0) or 0.0),
+            }
+        )
+
+    if not rows:
+        return pd.DataFrame(columns=MISSED_VAULT_EVENT_TIMELINE_COLUMNS)
+
+    df = pd.DataFrame(rows, columns=MISSED_VAULT_EVENT_TIMELINE_COLUMNS)
+    return df.groupby(
+        [
+            "Timestamp",
+            "Event type",
+            "Vault name",
+        ],
+        as_index=False,
+    ).agg(
+        {
+            "Missed event count": "sum",
+            "Missed US dollar": "sum",
+        },
+    ).sort_values(
+        [
+            "Timestamp",
+            "Event type",
+            "Vault name",
+        ],
     ).reset_index(drop=True)

--- a/tradeexecutor/analysis/vault_missed_events.py
+++ b/tradeexecutor/analysis/vault_missed_events.py
@@ -1,0 +1,113 @@
+"""Analyse missed vault deposit and redemption opportunities."""
+
+import pandas as pd
+
+from tradeexecutor.state.state import State
+
+
+MISSED_VAULT_EVENT_COLUMNS = [
+    "Vault name",
+    "Missed deposit count",
+    "Missed deposit US dollar",
+    "Missed redemption count",
+    "Missed redemption US dollar",
+]
+
+
+def _read_attr_or_key(value: object, key: str, default=None):
+    """Read a field from either a dataclass-like object or a plain dict."""
+    if value is None:
+        return default
+
+    if isinstance(value, dict):
+        return value.get(key, default)
+
+    return getattr(value, key, default)
+
+
+def _normalise_event_type(value: object) -> str | None:
+    """Normalise missed event type values."""
+    if value is None:
+        return None
+    enum_value = getattr(value, "value", None)
+    if enum_value is not None:
+        value = enum_value
+    return str(value).lower()
+
+
+def _iter_persisted_missed_vault_events(state: State):
+    """Yield missed vault event rows persisted in visualisation calculations."""
+    for calculations in state.visualisation.calculations.values():
+        events = calculations.get("missed_vault_events", [])
+        for event in events:
+            yield event
+
+
+def _iter_latest_missed_vault_events(state: State):
+    """Yield missed vault event rows from the latest in-memory alpha model."""
+    alpha_model = state.visualisation.discardable_data.get("alpha_model")
+    if alpha_model is None:
+        return
+
+    get_missed_vault_events = getattr(alpha_model, "get_missed_vault_events", None)
+    if get_missed_vault_events is not None:
+        yield from get_missed_vault_events()
+
+
+def analyse_missed_vault_deposit_redemption_events(
+    state: State,
+) -> pd.DataFrame:
+    """Create a table of missed vault deposit and redemption events."""
+    totals: dict[str, dict[str, float | int]] = {}
+
+    events = list(_iter_persisted_missed_vault_events(state))
+    if not events:
+        events = list(_iter_latest_missed_vault_events(state))
+
+    for event in events:
+        event_type = _normalise_event_type(_read_attr_or_key(event, "event_type"))
+        if event_type not in {"deposit", "redemption"}:
+            continue
+
+        vault_name = (
+            _read_attr_or_key(event, "vault_name")
+            or _read_attr_or_key(event, "pair_ticker")
+            or _read_attr_or_key(event, "vault_address")
+            or "Unknown vault"
+        )
+        missed_usd = float(_read_attr_or_key(event, "missed_usd", 0.0) or 0.0)
+        row = totals.setdefault(
+            vault_name,
+            {
+                "Missed deposit count": 0,
+                "Missed deposit US dollar": 0.0,
+                "Missed redemption count": 0,
+                "Missed redemption US dollar": 0.0,
+            },
+        )
+
+        if event_type == "deposit":
+            row["Missed deposit count"] += 1
+            row["Missed deposit US dollar"] += missed_usd
+        elif event_type == "redemption":
+            row["Missed redemption count"] += 1
+            row["Missed redemption US dollar"] += missed_usd
+
+    if not totals:
+        return pd.DataFrame(columns=MISSED_VAULT_EVENT_COLUMNS)
+
+    df = pd.DataFrame(
+        [
+            {"Vault name": vault_name, **row}
+            for vault_name, row in totals.items()
+        ],
+        columns=MISSED_VAULT_EVENT_COLUMNS,
+    )
+    return df.sort_values(
+        [
+            "Missed redemption US dollar",
+            "Missed deposit US dollar",
+            "Vault name",
+        ],
+        ascending=[False, False, True],
+    ).reset_index(drop=True)

--- a/tradeexecutor/strategy/alpha_model.py
+++ b/tradeexecutor/strategy/alpha_model.py
@@ -96,6 +96,9 @@ class TradingPairSignalFlags(enum.Enum):
     #: This signal was carried forward because the current position cannot be redeemed now.
     cannot_redeem = "cannot_redeem"
 
+    #: This signal was skipped because the venue currently does not accept deposits.
+    cannot_deposit = "cannot_deposit"
+
 
 @dataclass_json
 @dataclass(slots=True)
@@ -860,6 +863,11 @@ class AlphaModel:
         """Attach diagnostics and emit one searchable blocked-redemption log line."""
         signal.flags.add(TradingPairSignalFlags.cannot_redeem)
         signal.set_redemption_check_result(redemption_result)
+        if "missed_redemption_usd" not in signal.other_data:
+            if signal.position_adjust_usd < 0:
+                signal.other_data["missed_redemption_usd"] = abs(signal.position_adjust_usd)
+            elif current_value is not None:
+                signal.other_data["missed_redemption_usd"] = float(current_value)
 
         logger.info(
             "REDEMPTION_DIAGNOSTIC stage=%s pair_ticker=%s vault_address=%s safe_address=%s reason_code=%s current_value=%s position_recorded_lockup_expires_at=%s user_lockup_expires_at=%s max_withdrawable=%s max_redemption=%s message=%s",
@@ -1731,6 +1739,19 @@ class AlphaModel:
             signal.position_adjust_ignored = True
             return True
 
+        if (
+            signal.position_adjust_usd > 0
+            and not position_manager.pricing_model.can_deposit(self.timestamp, signal.pair)
+        ):
+            logger.info(
+                "Skipping buy-side rebalance for %s because deposits are not open",
+                signal.pair,
+            )
+            signal.position_adjust_ignored = True
+            signal.flags.add(TradingPairSignalFlags.cannot_deposit)
+            signal.other_data["missed_deposit_usd"] = signal.position_adjust_usd
+            return True
+
         if individual_rebalance_min_threshold:
             trade_size = abs(signal.position_adjust_usd)
             if signal.position_adjust_usd < 0:
@@ -1795,6 +1816,7 @@ class AlphaModel:
             redemption_results[signal.pair.internal_id] = redemption_result
 
             if not redemption_result.can_redeem:
+                signal.other_data["missed_redemption_usd"] = abs(signal.position_adjust_usd)
                 signal.position_adjust_usd = 0.0
                 signal.position_adjust_quantity = 0.0
                 signal.position_adjust_ignored = True
@@ -1846,6 +1868,9 @@ class AlphaModel:
                 current_position.pair,
             )
             signal.position_adjust_ignored = True
+            signal.other_data["missed_redemption_usd"] = abs(dollar_diff)
+            signal.position_adjust_usd = 0.0
+            signal.position_adjust_quantity = 0.0
             self._mark_signal_cannot_redeem(
                 signal,
                 redemption_result,
@@ -2118,6 +2143,37 @@ class AlphaModel:
 
         # Return all rebalance trades
         return trades
+
+    def get_missed_vault_events(self) -> list[dict]:
+        """Return compact missed vault deposit/redemption diagnostics for this cycle."""
+        rows = []
+        for signal in self.iterate_signals():
+            if not signal.pair.kind.is_vault():
+                continue
+
+            base_row = {
+                "vault_name": signal.pair.get_vault_name() or signal.pair.get_ticker(),
+                "pair_ticker": signal.pair.get_ticker(),
+                "vault_address": signal.pair.pool_address,
+            }
+
+            missed_deposit_usd = signal.other_data.get("missed_deposit_usd")
+            if missed_deposit_usd:
+                rows.append({
+                    **base_row,
+                    "event_type": "deposit",
+                    "missed_usd": float(missed_deposit_usd),
+                })
+
+            missed_redemption_usd = signal.other_data.get("missed_redemption_usd")
+            if missed_redemption_usd:
+                rows.append({
+                    **base_row,
+                    "event_type": "redemption",
+                    "missed_usd": float(missed_redemption_usd),
+                })
+
+        return rows
 
     def get_flag_diagnostics_data(self) -> dict:
         """Get statistics explanation to add to the report of alpha model thinking.

--- a/tradeexecutor/strategy/chart/standard/alpha_model.py
+++ b/tradeexecutor/strategy/chart/standard/alpha_model.py
@@ -1,7 +1,15 @@
 """Alpha model charts and diagnostics."""
 
 import pandas as pd
-from tradeexecutor.analysis.vault_missed_events import analyse_missed_vault_deposit_redemption_events
+import plotly.express as px
+from pandas.io.formats.style import Styler
+from plotly.graph_objects import Figure
+
+from tradeexecutor.analysis.vault_missed_events import (
+    analyse_missed_vault_deposit_redemption_event_timeline,
+    analyse_missed_vault_deposit_redemption_events,
+    format_missed_vault_deposit_redemption_events,
+)
 from tradeexecutor.strategy.alpha_model import format_signals
 from tradeexecutor.strategy.chart.definition import ChartInput
 
@@ -20,6 +28,47 @@ def alpha_model_diagnostics(
     return df
 
 
-def missed_vault_deposit_redemption_events(input: ChartInput) -> pd.DataFrame:
+def missed_vault_deposit_redemption_events(input: ChartInput) -> Styler:
     """Missed vault deposit and redemption event summary."""
-    return analyse_missed_vault_deposit_redemption_events(input.state)
+    df = analyse_missed_vault_deposit_redemption_events(input.state)
+    return format_missed_vault_deposit_redemption_events(df)
+
+
+def missed_vault_deposit_redemption_timeline(input: ChartInput) -> Figure:
+    """Missed vault deposit and redemption events over time."""
+    df = analyse_missed_vault_deposit_redemption_event_timeline(input.state)
+
+    if df.empty:
+        fig = Figure()
+        fig.update_layout(
+            title="Missed vault deposit and redemption events over time",
+            xaxis_title="Time",
+            yaxis_title="Missed US dollar",
+            template="plotly_dark",
+        )
+        return fig
+
+    fig = px.bar(
+        df,
+        x="Timestamp",
+        y="Missed US dollar",
+        color="Vault name",
+        facet_row="Event type",
+        barmode="stack",
+        title="Missed vault deposit and redemption events over time",
+        labels={
+            "Timestamp": "Time",
+            "Missed US dollar": "Missed US dollar",
+            "Vault name": "Vault",
+            "Event type": "Event type",
+            "Missed event count": "Missed events",
+        },
+        hover_data={
+            "Missed event count": True,
+            "Missed US dollar": ":$,.2f",
+        },
+        template="plotly_dark",
+    )
+    fig.update_yaxes(tickprefix="$", separatethousands=True)
+    fig.update_layout(legend_title_text="Vault", bargap=0.05)
+    return fig

--- a/tradeexecutor/strategy/chart/standard/alpha_model.py
+++ b/tradeexecutor/strategy/chart/standard/alpha_model.py
@@ -1,6 +1,7 @@
 """Alpha model charts and diagnostics."""
 
 import pandas as pd
+from tradeexecutor.analysis.vault_missed_events import analyse_missed_vault_deposit_redemption_events
 from tradeexecutor.strategy.alpha_model import format_signals
 from tradeexecutor.strategy.chart.definition import ChartInput
 
@@ -17,3 +18,8 @@ def alpha_model_diagnostics(
         return pd.DataFrame([])
     df = format_signals(alpha_model, signal_type="all")
     return df
+
+
+def missed_vault_deposit_redemption_events(input: ChartInput) -> pd.DataFrame:
+    """Missed vault deposit and redemption event summary."""
+    return analyse_missed_vault_deposit_redemption_events(input.state)


### PR DESCRIPTION
## Why
Vault allocation can miss deposits when a vault is closed to new capital and miss redemptions when existing capital cannot be redeemed. We need this visible in analysis and notebook output, and blocked redemptions must not remain counted as available rebalance balance.

## Lessons learnt
Backtest pricing defaults unknown deposit and redemption limits to open, so deterministic fixtures are useful for exercising closed-vault behaviour. The alpha model already had redemption diagnostics, but deposit closures needed a compact per-cycle event format to support aggregate tables and timeline charts.

## Summary
- Added alpha-model missed deposit/redemption event diagnostics and zeroed blocked redemption adjustments.
- Added tradeexecutor.analysis table output for missed vault deposit and redemption events with currency formatting.
- Added a stacked missed-vault event timeline chart coloured by vault.
- Registered the new analysis outputs in the xchain master vault strategy and rendered them from the CCTP notebook.
- Added focused unit coverage for deposit-closed, redemption-closed, generic pricing delegation, table formatting, and timeline analysis.