### PR TITLE
fix: Use multi-node broadcast for Hypercore settlement phase transactions

### DIFF
--- a/tradeexecutor/ethereum/vault/hypercore_routing.py
+++ b/tradeexecutor/ethereum/vault/hypercore_routing.py
@@ -49,6 +49,7 @@ from web3.contract.contract import ContractFunction
 from eth_defi.confirmation import wait_and_broadcast_multiple_nodes
 from eth_defi.gas import apply_gas, estimate_gas_price
 from eth_defi.hotwallet import HotWallet, SignedTransactionWithNonce
+from eth_defi.provider.fallback import get_fallback_provider
 from eth_defi.revert_reason import fetch_transaction_revert_reason
 from eth_defi.hyperliquid.api import (
     HypercoreDepositVerificationError,
@@ -98,6 +99,7 @@ from tradeexecutor.strategy.trading_strategy_universe import TradingStrategyUniv
 from tradeexecutor.strategy.universe_model import StrategyExecutionUniverse
 from tradeexecutor.utils.blockchain import get_block_timestamp
 from tradeexecutor.utils.hex import hexbytes_to_hex_str
+from eth_defi.compat import native_datetime_utc_now
 
 from tradeexecutor.ethereum.tx import TransactionBuilder
 from tradeexecutor.state.identifier import TradingPairIdentifier, AssetIdentifier
@@ -496,8 +498,6 @@ class HypercoreVaultRouting(RoutingModel):
             On broadcast or confirmation failure.  The ``tx`` object will have
             error information set before the exception propagates.
         """
-        from tradeexecutor.utils.timestamp import native_datetime_utc_now
-
         signed_tx = SignedTransactionWithNonce(
             rawTransaction=HexBytes(tx.signed_bytes),
             hash=HexBytes(tx.tx_hash),
@@ -513,7 +513,6 @@ class HypercoreVaultRouting(RoutingModel):
         # MEVBlockerProvider → FallbackProvider, so we cover both direct and
         # wrapped setups.  Fall back to single-node only when no fallback
         # provider exists at all (e.g. plain Anvil in tests).
-        from eth_defi.provider.fallback import get_fallback_provider
         has_fallback = True
         try:
             get_fallback_provider(self.web3)

--- a/tradeexecutor/ethereum/vault/hypercore_routing.py
+++ b/tradeexecutor/ethereum/vault/hypercore_routing.py
@@ -49,7 +49,6 @@ from web3.contract.contract import ContractFunction
 from eth_defi.confirmation import wait_and_broadcast_multiple_nodes
 from eth_defi.gas import apply_gas, estimate_gas_price
 from eth_defi.hotwallet import HotWallet, SignedTransactionWithNonce
-from eth_defi.provider.fallback import FallbackProvider
 from eth_defi.revert_reason import fetch_transaction_revert_reason
 from eth_defi.hyperliquid.api import (
     HypercoreDepositVerificationError,
@@ -510,8 +509,19 @@ class HypercoreVaultRouting(RoutingModel):
             source=tx.details,
         )
 
+        # Detect multi-node availability.  get_fallback_provider() unwraps
+        # MEVBlockerProvider → FallbackProvider, so we cover both direct and
+        # wrapped setups.  Fall back to single-node only when no fallback
+        # provider exists at all (e.g. plain Anvil in tests).
+        from eth_defi.provider.fallback import get_fallback_provider
+        has_fallback = True
         try:
-            if isinstance(self.web3.provider, FallbackProvider):
+            get_fallback_provider(self.web3)
+        except AssertionError:
+            has_fallback = False
+
+        try:
+            if has_fallback:
                 receipts = wait_and_broadcast_multiple_nodes(
                     self.web3,
                     [signed_tx],

--- a/tradeexecutor/ethereum/vault/hypercore_routing.py
+++ b/tradeexecutor/ethereum/vault/hypercore_routing.py
@@ -36,6 +36,7 @@ deposit/withdrawal legs, see also:
 
 from __future__ import annotations
 
+import datetime
 import logging
 import time
 from decimal import Decimal
@@ -45,8 +46,11 @@ from hexbytes import HexBytes
 from web3 import Web3
 from web3.contract.contract import ContractFunction
 
+from eth_defi.confirmation import wait_and_broadcast_multiple_nodes
 from eth_defi.gas import apply_gas, estimate_gas_price
-from eth_defi.hotwallet import HotWallet
+from eth_defi.hotwallet import HotWallet, SignedTransactionWithNonce
+from eth_defi.provider.fallback import FallbackProvider
+from eth_defi.revert_reason import fetch_transaction_revert_reason
 from eth_defi.hyperliquid.api import (
     HypercoreDepositVerificationError,
     fetch_perp_clearinghouse_state,
@@ -209,6 +213,20 @@ class HypercoreWithdrawalVerificationError(Exception):
 
 class HypercoreWithdrawalPreflightError(Exception):
     """Raised when a live Hypercore withdrawal is blocked before broadcast."""
+
+
+class SettlementBroadcastError(Exception):
+    """Raised when a settlement phase transaction fails to broadcast or confirm.
+
+    Carries the :py:class:`~tradeexecutor.state.blockhain_transaction.BlockchainTransaction`
+    so callers can always append it to the trade for diagnostics, even when the
+    broadcast itself failed.
+    """
+
+    def __init__(self, tx: "BlockchainTransaction", cause: Exception):
+        super().__init__(str(cause))
+        #: The signed transaction with error info already set.
+        self.tx = tx
 
 
 class HypercoreVaultRoutingState(RoutingState):
@@ -446,6 +464,97 @@ class HypercoreVaultRouting(RoutingModel):
         vault_addr = trade.pair.pool_address
         assert vault_addr, f"No pool_address set for Hypercore vault pair: {trade.pair}"
         return vault_addr
+
+    def _broadcast_and_confirm_settlement_tx(
+        self,
+        tx: BlockchainTransaction,
+        timeout: float = 120,
+    ) -> dict:
+        """Broadcast a settlement phase tx through all RPC nodes and wait for receipt.
+
+        Settlement phase transactions (phase 2/3 of deposits and withdrawals) were
+        previously sent through a single RPC node via ``send_raw_transaction`` +
+        ``wait_for_transaction_receipt``.  If that single node dropped the tx or
+        HyperEVM was momentarily congested, the transaction was never picked up by
+        other nodes and the 120 s timeout expired, stranding USDC.
+
+        This method uses :py:func:`~eth_defi.confirmation.wait_and_broadcast_multiple_nodes`
+        to broadcast through all configured :py:class:`~eth_defi.provider.fallback.FallbackProvider`
+        nodes, matching the reliability of phase 1 broadcasts.
+
+        On success, sets confirmation information on the ``BlockchainTransaction``.
+        On failure, sets error information (``revert_reason``) on the transaction
+        so that :py:meth:`~tradeexecutor.state.trade.TradeExecution.get_revert_reason`
+        returns a meaningful message.
+
+        :param tx:
+            Signed :py:class:`BlockchainTransaction` to broadcast.
+        :param timeout:
+            Maximum seconds to wait for confirmation.
+        :return:
+            Transaction receipt dict.
+        :raises Exception:
+            On broadcast or confirmation failure.  The ``tx`` object will have
+            error information set before the exception propagates.
+        """
+        from tradeexecutor.utils.timestamp import native_datetime_utc_now
+
+        signed_tx = SignedTransactionWithNonce(
+            rawTransaction=HexBytes(tx.signed_bytes),
+            hash=HexBytes(tx.tx_hash),
+            r=0,
+            s=0,
+            v=0,
+            address=tx.from_address,
+            nonce=tx.nonce,
+            source=tx.details,
+        )
+
+        try:
+            if isinstance(self.web3.provider, FallbackProvider):
+                receipts = wait_and_broadcast_multiple_nodes(
+                    self.web3,
+                    [signed_tx],
+                    max_timeout=datetime.timedelta(seconds=timeout),
+                    confirmation_block_count=0,
+                    node_switch_timeout=datetime.timedelta(minutes=1),
+                    check_nonce_validity=False,
+                )
+                receipt = receipts[HexBytes(tx.tx_hash)]
+            else:
+                # Single-provider fallback (e.g. Anvil tests)
+                self.web3.eth.send_raw_transaction(HexBytes(tx.signed_bytes))
+                receipt = self.web3.eth.wait_for_transaction_receipt(
+                    HexBytes(tx.tx_hash), timeout=timeout,
+                )
+        except Exception as e:
+            # Set error info on the tx so get_revert_reason() works
+            tx.revert_reason = f"Settlement tx broadcast/confirmation failed: {e}"
+            tx.status = False
+            raise
+
+        ts = native_datetime_utc_now()
+
+        revert_reason = None
+        if receipt["status"] != 1:
+            try:
+                revert_reason = fetch_transaction_revert_reason(
+                    self.web3, HexBytes(tx.tx_hash),
+                )
+            except Exception:
+                revert_reason = "Transaction reverted (revert reason unavailable)"
+
+        tx.set_confirmation_information(
+            ts=ts,
+            block_number=receipt["blockNumber"],
+            block_hash=receipt["blockHash"].hex(),
+            realised_gas_price=receipt.get("effectiveGasPrice", 0),
+            realised_gas_units_consumed=receipt["gasUsed"],
+            status=receipt["status"] == 1,
+            revert_reason=revert_reason,
+        )
+
+        return receipt
 
     def _get_raw_usdc_amount(self, trade: TradeExecution) -> int:
         """Get the raw USDC amount (6 decimals) for the trade."""
@@ -1341,6 +1450,9 @@ class HypercoreVaultRouting(RoutingModel):
 
         :return:
             Tuple of (BlockchainTransaction, receipt dict).
+        :raises SettlementBroadcastError:
+            If the broadcast or confirmation fails.  The exception carries
+            the signed ``BlockchainTransaction`` with error info.
         """
         fn = build_hypercore_deposit_phase2(
             self.lagoon_vault,
@@ -1352,15 +1464,21 @@ class HypercoreVaultRouting(RoutingModel):
             notes=f"Hypercore deposit phase 2: {raw_amount} raw USDC to vault {vault_address}",
         )
 
-        tx_hash = self.web3.eth.send_raw_transaction(HexBytes(tx.signed_bytes))
-        receipt = self.web3.eth.wait_for_transaction_receipt(tx_hash, timeout=120)
+        try:
+            receipt = self._broadcast_and_confirm_settlement_tx(tx)
+        except Exception as e:
+            raise SettlementBroadcastError(tx, e) from e
         return tx, receipt
 
     def _broadcast_withdrawal_phase2(
         self,
         raw_amount: int,
     ) -> tuple[BlockchainTransaction, dict]:
-        """Build, sign, and broadcast withdrawal phase 2 (perp -> spot)."""
+        """Build, sign, and broadcast withdrawal phase 2 (perp -> spot).
+
+        :raises SettlementBroadcastError:
+            If the broadcast or confirmation fails.
+        """
         fn = build_hypercore_transfer_usd_class_call(
             self.lagoon_vault,
             hypercore_usdc_amount=raw_amount,
@@ -1372,8 +1490,10 @@ class HypercoreVaultRouting(RoutingModel):
             logical_function_name="sendRawAction",
         )
 
-        tx_hash = self.web3.eth.send_raw_transaction(HexBytes(tx.signed_bytes))
-        receipt = self.web3.eth.wait_for_transaction_receipt(tx_hash, timeout=120)
+        try:
+            receipt = self._broadcast_and_confirm_settlement_tx(tx)
+        except Exception as e:
+            raise SettlementBroadcastError(tx, e) from e
         return tx, receipt
 
     def _broadcast_withdrawal_phase1_retry(
@@ -1381,7 +1501,11 @@ class HypercoreVaultRouting(RoutingModel):
         vault_address: str,
         raw_amount: int,
     ) -> tuple[BlockchainTransaction, dict]:
-        """Build, sign, and broadcast a retry of withdrawal phase 1."""
+        """Build, sign, and broadcast a retry of withdrawal phase 1.
+
+        :raises SettlementBroadcastError:
+            If the broadcast or confirmation fails.
+        """
         fn = build_hypercore_withdraw_from_vault_call(
             self.lagoon_vault,
             vault_address=vault_address,
@@ -1393,15 +1517,21 @@ class HypercoreVaultRouting(RoutingModel):
             logical_function_name="sendRawAction",
         )
 
-        tx_hash = self.web3.eth.send_raw_transaction(HexBytes(tx.signed_bytes))
-        receipt = self.web3.eth.wait_for_transaction_receipt(tx_hash, timeout=120)
+        try:
+            receipt = self._broadcast_and_confirm_settlement_tx(tx)
+        except Exception as e:
+            raise SettlementBroadcastError(tx, e) from e
         return tx, receipt
 
     def _broadcast_withdrawal_phase3(
         self,
         raw_amount: int,
     ) -> tuple[BlockchainTransaction, dict]:
-        """Build, sign, and broadcast withdrawal phase 3 (spot -> EVM)."""
+        """Build, sign, and broadcast withdrawal phase 3 (spot -> EVM).
+
+        :raises SettlementBroadcastError:
+            If the broadcast or confirmation fails.
+        """
         fn = build_hypercore_send_asset_to_evm_call(
             self.lagoon_vault,
             evm_usdc_amount=raw_amount,
@@ -1412,8 +1542,10 @@ class HypercoreVaultRouting(RoutingModel):
             logical_function_name="sendRawAction",
         )
 
-        tx_hash = self.web3.eth.send_raw_transaction(HexBytes(tx.signed_bytes))
-        receipt = self.web3.eth.wait_for_transaction_receipt(tx_hash, timeout=120)
+        try:
+            receipt = self._broadcast_and_confirm_settlement_tx(tx)
+        except Exception as e:
+            raise SettlementBroadcastError(tx, e) from e
         return tx, receipt
 
     def _settle_deposit_simulate(
@@ -1599,8 +1731,9 @@ class HypercoreVaultRouting(RoutingModel):
 
         try:
             phase2_tx, phase2_receipt = self._broadcast_phase2(trade, vault_address, deposit_raw)
-        except Exception as e:
-            logger.error("Phase 2 broadcast failed: %s", e)
+        except SettlementBroadcastError as e:
+            logger.error("Phase 2 broadcast failed: %s", e.__cause__)
+            trade.blockchain_transactions.append(e.tx)
             self._mark_stranded_usdc(trade, deposit_raw, "hypercore_spot")
             report_failure(ts, state, trade, stop_on_execution_failure)
             return
@@ -1936,12 +2069,13 @@ class HypercoreVaultRouting(RoutingModel):
                                 vault_address=vault_address,
                                 raw_amount=retry_raw,
                             )
-                        except Exception as retry_error:
+                        except SettlementBroadcastError as retry_error:
                             logger.error(
                                 "Withdrawal phase 1 retry broadcast failed for trade %s: %s",
                                 trade.trade_id,
-                                retry_error,
+                                retry_error.__cause__,
                             )
+                            trade.blockchain_transactions.append(retry_error.tx)
                             report_failure(ts, state, trade, stop_on_execution_failure)
                             return
 
@@ -2028,8 +2162,9 @@ class HypercoreVaultRouting(RoutingModel):
 
             try:
                 phase2_tx, phase2_receipt = self._broadcast_withdrawal_phase2(expected_raw)
-            except Exception as e:
-                logger.error("Withdrawal phase 2 broadcast failed: %s", e)
+            except SettlementBroadcastError as e:
+                logger.error("Withdrawal phase 2 broadcast failed: %s", e.__cause__)
+                trade.blockchain_transactions.append(e.tx)
                 self._mark_stranded_usdc(trade, expected_raw, "hypercore_perp")
                 report_failure(ts, state, trade, stop_on_execution_failure)
                 return
@@ -2138,15 +2273,16 @@ class HypercoreVaultRouting(RoutingModel):
 
             try:
                 phase3_tx, phase3_receipt = self._broadcast_withdrawal_phase3(phase3_raw)
-            except Exception as e:
+            except SettlementBroadcastError as e:
                 logger.error(
                     "Withdrawal phase 3 broadcast failed for trade %s: %s. "
                     "Requested %d raw, attempted %d raw after bridge-fee headroom",
                     trade.trade_id,
-                    e,
+                    e.__cause__,
                     expected_raw,
                     phase3_raw,
                 )
+                trade.blockchain_transactions.append(e.tx)
                 self._mark_stranded_usdc(trade, expected_raw, "hypercore_spot")
                 report_failure(ts, state, trade, stop_on_execution_failure)
                 return


### PR DESCRIPTION
## Why

Production failure on HyperAI (2026-05-22): trade #666 (Crypto Plaza vault withdrawal) failed with `revert_reason=None`, stranding 10.77 USDC in HyperCore perp and halting the entire 8-trade sequential rebalance.

Root cause: Hypercore settlement phase transactions (phase 2/3 of deposits and withdrawals) were broadcast through a **single RPC node** via `send_raw_transaction()` + `wait_for_transaction_receipt(timeout=120)`. Phase 1 already used robust multi-node broadcasting via `wait_and_broadcast_multiple_nodes()` through all configured FallbackProvider nodes.

When the single RPC node for the phase 2 `transferUsdClass(perp→spot)` transaction dropped the tx or HyperEVM was momentarily congested, the transaction was never picked up by other nodes and the 120s timeout expired. Additionally, the failed `BlockchainTransaction` was never recorded on the trade, so `get_revert_reason()` returned `None` — making the failure opaque to operators.

## Lessons learnt

- Settlement phase broadcasts must match the reliability of phase 1 broadcasts — single-node `send_raw_transaction` is fragile on HyperEVM where congestion can cause individual RPCs to drop transactions.
- When a broadcast exception prevents `_broadcast_*` methods from returning the `BlockchainTransaction`, it is lost and never recorded on the trade. This makes `get_revert_reason()` return `None`, obscuring the actual failure from operators and monitoring.
- The `SettlementBroadcastError` pattern (exception carries the tx object) cleanly separates tx-build from broadcast while ensuring the tx is always available for diagnostics.

## Summary

- Added `_broadcast_and_confirm_settlement_tx()` helper that uses `wait_and_broadcast_multiple_nodes()` through all FallbackProvider nodes (falls back to single-node for Anvil tests). On success, sets `set_confirmation_information()` on the tx including revert reason. On failure, sets `tx.revert_reason` and `tx.status = False` before re-raising.
- Added `SettlementBroadcastError` exception that carries the signed `BlockchainTransaction` with error info, so callers can always append it to the trade.
- Updated all 4 `_broadcast_*` methods (`_broadcast_phase2`, `_broadcast_withdrawal_phase2`, `_broadcast_withdrawal_phase1_retry`, `_broadcast_withdrawal_phase3`) to use multi-node broadcast and wrap failures in `SettlementBroadcastError`.
- Updated all 4 caller sites in `_settle_deposit` and `_settle_withdrawal` to catch `SettlementBroadcastError`, append `e.tx` to `trade.blockchain_transactions`, and log `e.__cause__` for the actual error detail.