### PR TITLE
feat: add CCTP bridge analysis helpers and chain exposure snapshot

### DIFF
--- a/tradeexecutor/analysis/cctp.py
+++ b/tradeexecutor/analysis/cctp.py
@@ -1,0 +1,120 @@
+"""CCTP bridge trade analysis for cross-chain vault strategies."""
+from typing import Iterable
+
+import pandas as pd
+
+from tradeexecutor.state.trade import TradeExecution
+
+
+def build_bridge_trade_dataframe(
+    bridge_trades: Iterable[TradeExecution],
+) -> pd.DataFrame:
+    """Build a DataFrame of CCTP bridge trades with direction, chain, and value.
+
+    :param bridge_trades:
+        Trades where ``trade.pair.is_cctp_bridge()`` is True.
+
+    :return:
+        DataFrame sorted by opened_at with columns: trade_id, opened_at,
+        executed_at, direction, source_chain_id, destination_chain_id,
+        value_usd, quantity, status, position_id.
+    """
+    rows = []
+    for trade in bridge_trades:
+        rows.append({
+            "trade_id": trade.trade_id,
+            "opened_at": trade.opened_at,
+            "executed_at": trade.executed_at,
+            "direction": "bridge out" if trade.is_buy() else "bridge back",
+            "source_chain_id": trade.pair.get_source_chain_id(),
+            "destination_chain_id": trade.pair.get_destination_chain_id(),
+            "value_usd": trade.get_value(),
+            "quantity": float(trade.executed_quantity or 0),
+            "status": trade.get_status().value,
+            "position_id": trade.position_id,
+        })
+    df = pd.DataFrame(rows)
+    if not df.empty:
+        df = df.sort_values(["opened_at", "trade_id"])
+    return df
+
+
+def build_bridge_trade_summary(
+    bridge_df: pd.DataFrame,
+) -> pd.DataFrame:
+    """Summarise CCTP bridge trades by destination chain and direction.
+
+    :param bridge_df:
+        Output of :py:func:`build_bridge_trade_dataframe`.
+
+    :return:
+        DataFrame grouped by destination_chain_id and direction with
+        trade count, total value, and first/last trade timestamps.
+    """
+    if bridge_df.empty:
+        return pd.DataFrame(
+            columns=["destination_chain_id", "direction", "trades", "value_usd", "first_trade", "last_trade"],
+        )
+    return bridge_df.groupby(["destination_chain_id", "direction"]).agg(
+        trades=("trade_id", "count"),
+        value_usd=("value_usd", "sum"),
+        first_trade=("opened_at", "min"),
+        last_trade=("opened_at", "max"),
+    ).reset_index()
+
+
+def assert_bridge_coverage(
+    trades: Iterable[TradeExecution],
+    primary_chain_id: int,
+) -> pd.DataFrame:
+    """Assert every cycle with satellite vault trades also has CCTP bridge trades.
+
+    This validates the bridge-trade injection path: when the strategy
+    allocates to vaults on satellite chains, CCTP bridge trades must be
+    generated in the same cycle to fund the deposits.
+
+    :param trades:
+        All trades from the backtest portfolio.
+
+    :param primary_chain_id:
+        Chain ID of the primary reserve chain (e.g. ``ChainId.ethereum.value``).
+
+    :return:
+        Per-cycle summary DataFrame with trade counts.
+
+    :raise AssertionError:
+        If any cycle has satellite vault trades but no bridge trades.
+    """
+    rows = []
+    for trade in trades:
+        rows.append({
+            "cycle": trade.strategy_cycle_at,
+            "trade_id": trade.trade_id,
+            "kind": trade.pair.kind.value,
+            "chain_id": trade.pair.chain_id,
+            "is_bridge": trade.pair.is_cctp_bridge(),
+            "is_satellite_vault": trade.pair.kind.is_vault() and trade.pair.chain_id != primary_chain_id,
+            "value_usd": trade.get_value(),
+            "status": trade.get_status().value,
+        })
+
+    trade_df = pd.DataFrame(rows)
+    cycle_df = trade_df.groupby("cycle").agg(
+        trades=("trade_id", "count"),
+        bridge_trades=("is_bridge", "sum"),
+        satellite_vault_trades=("is_satellite_vault", "sum"),
+        traded_value_usd=("value_usd", "sum"),
+    ).reset_index()
+
+    cycles_with_satellite_vaults = cycle_df[cycle_df["satellite_vault_trades"] > 0]
+    cycles_missing_bridges = cycles_with_satellite_vaults[
+        cycles_with_satellite_vaults["bridge_trades"] == 0
+    ]
+
+    assert len(cycles_with_satellite_vaults) > 0, "Expected satellite vault trades"
+    assert len(cycles_missing_bridges) == 0, (
+        f"{len(cycles_missing_bridges)} cycle(s) have satellite vault trades "
+        f"but no CCTP bridge trades:\n{cycles_missing_bridges}"
+    )
+
+    return cycle_df

--- a/tradeexecutor/analysis/position.py
+++ b/tradeexecutor/analysis/position.py
@@ -288,3 +288,53 @@ def display_position_valuations(positions: Iterable[TradingPosition]) -> pd.Data
         df = df.set_index("Id")
         df = df.replace({pd.NaT: ""})
     return df
+
+
+def build_chain_exposure_snapshot(
+    positions: Iterable[TradingPosition],
+) -> tuple[pd.DataFrame, pd.DataFrame]:
+    """Build a per-position and per-chain exposure summary from open positions.
+
+    Bridge positions (CCTP) are excluded so the result shows only
+    vault/spot exposure.
+
+    :param positions:
+        Open and frozen positions, e.g. from
+        ``state.portfolio.get_open_and_frozen_positions()``.
+
+    :return:
+        Tuple of (positions_df, chain_exposure_df).
+
+        *positions_df* has columns: position_id, chain_id, pair, value_usd,
+        opened_at — one row per non-bridge position, sorted by value descending.
+
+        *chain_exposure_df* has columns: chain_id, positions, value_usd,
+        weight — one row per chain.
+    """
+    rows = []
+    for position in positions:
+        if position.pair.is_cctp_bridge():
+            continue
+        rows.append({
+            "position_id": position.position_id,
+            "chain_id": position.pair.chain_id,
+            "pair": position.pair.get_ticker(),
+            "value_usd": position.get_value(),
+            "opened_at": position.opened_at,
+        })
+
+    positions_df = pd.DataFrame(rows)
+    if positions_df.empty:
+        chain_exposure_df = pd.DataFrame(columns=["chain_id", "positions", "value_usd", "weight"])
+        return positions_df, chain_exposure_df
+
+    positions_df = positions_df.sort_values("value_usd", ascending=False)
+
+    chain_exposure_df = positions_df.groupby("chain_id").agg(
+        positions=("position_id", "count"),
+        value_usd=("value_usd", "sum"),
+    ).reset_index()
+    total = chain_exposure_df["value_usd"].sum()
+    chain_exposure_df["weight"] = chain_exposure_df["value_usd"] / total if total > 0 else 0
+
+    return positions_df, chain_exposure_df


### PR DESCRIPTION
## Summary

- New `tradeexecutor/analysis/cctp.py` with reusable CCTP bridge trade analysis:
  - `build_bridge_trade_dataframe()` — per-trade DataFrame with direction, chains, value
  - `build_bridge_trade_summary()` — grouped summary by destination chain and direction
  - `assert_bridge_coverage()` — validates every satellite-vault cycle has CCTP bridge trades
- Extended `tradeexecutor/analysis/position.py`:
  - `build_chain_exposure_snapshot()` — end-of-run per-chain position count, value, and weight

Extracted from inline notebook code in the xchain2 cross-chain backtest notebooks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)