### PR TITLE
feat: add cycle snapshot chart and analysis helpers

### DIFF
--- a/tradeexecutor/analysis/cycle_messages.py
+++ b/tradeexecutor/analysis/cycle_messages.py
@@ -1,0 +1,58 @@
+"""Parse structured data from strategy cycle visualisation messages.
+
+Strategy ``decide_trades`` implementations write free-text reports into
+``state.visualisation.messages``.  The helpers here extract typed values
+back out so notebooks and charts can display them without duplicating
+regex logic.
+"""
+import datetime
+import re
+from typing import Iterable
+
+import pandas as pd
+
+from tradeexecutor.state.state import State
+
+
+def extract_usd_value(text: str, label: str) -> float:
+    """Extract a ``label: 1,234.56 USD`` value from a cycle message.
+
+    :return: The parsed float, or ``nan`` if the label is absent.
+    """
+    match = re.search(rf"{re.escape(label)}: ([0-9,]+(?:\.[0-9]+)?) USD", text)
+    return float(match.group(1).replace(",", "")) if match else float("nan")
+
+
+def extract_int_value(text: str, label: str) -> int:
+    """Extract a ``label: 42`` integer from a cycle message.
+
+    :return: The parsed int, or ``0`` if the label is absent.
+    """
+    match = re.search(rf"{re.escape(label)}: ([0-9]+)", text)
+    return int(match.group(1)) if match else 0
+
+
+def build_selection_diagnostics(state: State) -> pd.DataFrame:
+    """Build a per-cycle DataFrame of signal selection counts.
+
+    Parses ``Open/about to open positions``, ``Candidate signals created``,
+    and ``Selected survivor signals`` from each cycle message.
+
+    :return:
+        DataFrame indexed by timestamp with columns: open_positions,
+        candidate_signals_created, selected_survivor_signals.
+    """
+    rows = []
+    for unix_ts, messages in sorted(state.visualisation.messages.items(), key=lambda item: item[0]):
+        if not messages:
+            continue
+        message = "\n".join(messages)
+        rows.append({
+            "timestamp": datetime.datetime.utcfromtimestamp(unix_ts),
+            "open_positions": extract_int_value(message, "Open/about to open positions"),
+            "candidate_signals_created": extract_int_value(message, "Candidate signals created"),
+            "selected_survivor_signals": extract_int_value(message, "Selected survivor signals"),
+        })
+    return pd.DataFrame(rows).set_index("timestamp") if rows else pd.DataFrame(
+        columns=["open_positions", "candidate_signals_created", "selected_survivor_signals"]
+    )

--- a/tradeexecutor/analysis/position.py
+++ b/tradeexecutor/analysis/position.py
@@ -338,3 +338,38 @@ def build_chain_exposure_snapshot(
     chain_exposure_df["weight"] = chain_exposure_df["value_usd"] / total if total > 0 else 0
 
     return positions_df, chain_exposure_df
+
+
+def position_duration_summary(
+    state,
+    backtest_end: datetime.datetime | None = None,
+) -> dict:
+    """Compute position duration statistics from a backtest state.
+
+    :param state:
+        Completed backtest state.
+
+    :param backtest_end:
+        End timestamp for open positions that have no ``closed_at``.
+        Defaults to now if not given.
+
+    :return:
+        Dict with keys: position_count, positions_lt_3d,
+        share_positions_lt_3d, median_position_days.
+    """
+    if backtest_end is None:
+        backtest_end = datetime.datetime.now(datetime.timezone.utc).replace(tzinfo=None)
+
+    positions = [p for p in state.portfolio.get_all_positions() if not p.is_credit_supply()]
+    durations = []
+    for position in positions:
+        closed_at = position.closed_at if position.closed_at is not None else backtest_end
+        durations.append((closed_at - position.opened_at).total_seconds() / 86400)
+
+    duration_series = pd.Series(durations, dtype="float64")
+    return {
+        "position_count": len(positions),
+        "positions_lt_3d": int((duration_series < 3).sum()),
+        "share_positions_lt_3d": float((duration_series < 3).mean()) if len(duration_series) else float("nan"),
+        "median_position_days": float(duration_series.median()) if len(duration_series) else float("nan"),
+    }

--- a/tradeexecutor/strategy/chart/standard/cycle_snapshot.py
+++ b/tradeexecutor/strategy/chart/standard/cycle_snapshot.py
@@ -1,0 +1,50 @@
+"""Latest cycle cash, allocation, and redemption snapshot."""
+
+import pandas as pd
+
+from tradeexecutor.analysis.cycle_messages import extract_usd_value
+from tradeexecutor.strategy.chart.definition import ChartInput
+
+
+def latest_cycle_snapshot(input: ChartInput) -> pd.DataFrame:
+    """Cash, allocation, and redemption breakdown for the most recent cycle.
+
+    Parses the last strategy cycle message for equity, cash, redeemable
+    capital, investable equity, and allocation figures.  Combines with
+    alpha-model accepted-size data when available.
+    """
+    state = input.state
+
+    message_map = state.visualisation.get_messages_tail(2)
+    if not message_map:
+        return pd.DataFrame(columns=["Metric", "Value"])
+
+    latest_cycle_label = list(message_map.keys())[0]
+    latest_message = list(message_map.values())[0]
+
+    total_equity = extract_usd_value(latest_message, "Total equity")
+    cash = extract_usd_value(latest_message, "Cash")
+    redeemable_capital = extract_usd_value(latest_message, "Redeemable capital")
+    pending_redemptions = extract_usd_value(latest_message, "Pending redemptions")
+    investable = extract_usd_value(latest_message, "Investable equity")
+    accepted_investable = extract_usd_value(latest_message, "Accepted investable equity")
+    allocated_to_signals = extract_usd_value(latest_message, "Allocated to signals")
+    discarded_lit_liquidity = extract_usd_value(latest_message, "Discarded allocation because of lack of lit liquidity")
+
+    rows = [
+        ("Final cycle", latest_cycle_label),
+        ("Total equity USD", total_equity),
+        ("Cash USD", cash),
+        ("Cash % of equity", cash / total_equity if total_equity else float("nan")),
+        ("Redeemable capital USD", redeemable_capital),
+        ("Pending redemptions USD", pending_redemptions),
+        ("Investable equity USD", investable),
+        ("Accepted investable equity USD", accepted_investable),
+        ("Accepted / investable %", accepted_investable / investable if investable else float("nan")),
+        ("Allocated to signals USD", allocated_to_signals),
+        ("Discarded because of lit liquidity USD", discarded_lit_liquidity),
+        ("Unaccepted investable USD", investable - accepted_investable),
+        ("Unaccepted / investable %", (investable - accepted_investable) / investable if investable else float("nan")),
+    ]
+
+    return pd.DataFrame(rows, columns=["Metric", "Value"])


### PR DESCRIPTION
## Summary

- New `tradeexecutor/analysis/cycle_messages.py` — reusable helpers to parse structured values from strategy cycle visualisation messages (`extract_usd_value()`, `extract_int_value()`, `build_selection_diagnostics()`)
- New `tradeexecutor/strategy/chart/standard/cycle_snapshot.py` — `latest_cycle_snapshot()` standard chart showing cash, allocation, and redemption breakdown for the most recent cycle
- Extended `tradeexecutor/analysis/position.py` — `position_duration_summary()` for position duration statistics

Extracted from inline notebook code in the xchain cross-chain backtest notebooks. Replaces regex-parsing boilerplate that was duplicated across multiple notebooks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)