### PR TITLE
feat: update xchain-master-vault from 01-initial.ipynb notebook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 
 - Breaking API changes
 
+- Update cross-chain master vault strategy from 01-initial.ipynb notebook with Ethereum/Base/Arbitrum CCTP vault universe (2026-05-29)
+
 - Add `claim-hypercore-vault-dust` CLI command to recover untracked Hypercore vault dust into Lagoon reserves with operator safety guards (2026-04-16)
 
 - Add `--remove-share-price-outliers` flag to `correct-history` CLI command to detect and remove spurious share price data points using rolling median comparison (2026-04-08)

--- a/strategies/xchain-master-vault.py
+++ b/strategies/xchain-master-vault.py
@@ -385,6 +385,13 @@ def decide_trades(input: StrategyInput) -> list[TradeExecution]:
             Candidate signals: {signal_count}
             Total equity: {portfolio.get_total_equity():,.2f} USD
             Cash: {position_manager.get_current_cash():,.2f} USD
+            Redeemable capital: {redeemable_capital:,.2f} USD
+            Locked capital carried forward: {locked_position_value:,.2f} USD
+            Pending redemptions: {position_manager.get_pending_redemptions():,.2f} USD
+            Investable equity: {alpha_model.investable_equity:,.2f} USD
+            Accepted investable equity: {alpha_model.accepted_investable_equity:,.2f} USD
+            Allocated to signals: {alpha_model.get_allocated_value():,.2f} USD
+            Discarded allocation because of lack of lit liquidity: {alpha_model.size_risk_discarded_value:,.2f} USD
             Rebalance volume: {rebalance_volume:,.2f} USD
         """)
 

--- a/strategies/xchain-master-vault.py
+++ b/strategies/xchain-master-vault.py
@@ -1,9 +1,41 @@
-"""Cross-chain master vault strategy.
+"""Cross-chain master vault CCTP strategy.
 
-Based on ``16-backtest-volvol-veto-best-cagr-jan-start.ipynb`` notebook.
+Based on ``01-initial.ipynb`` notebook.
 
-Cross-chain vault allocation with age-ramp weighting, daily rebalancing,
-vol-of-vol veto, stale-data protection, and redemption-aware target sizing.
+Cross-chain vault allocation across Ethereum, Base, and Arbitrum with CCTP
+bridge pairs, age-ramp weighting, daily rebalancing, vol-of-vol veto,
+stale-data protection, and redemption-aware target sizing.
+
+Backtest results (2025-01-02 to 2026-03-10)
+=============================================
+
+Last backtest run: 2026-05-29
+
+Note: CLI summary inflates return to 51% because bridge positions
+(get_value) double-count capital already held in satellite vault
+positions. The equity curve uses calculate_total_equity() which
+correctly returns get_equity()=0 for bridge positions.
+
+=================================  ===========
+Metric                             Strategy
+=================================  ===========
+Start period                       2025-01-02
+End period                         2026-03-10
+Trading period length              432 days
+Cumulative return                  15.20%
+CAGR                               12.70%
+Cash at start                      $100,000.00
+Value at end                       $115,197.08
+Max drawdown                       -0.08%
+Longest DD days                    4
+Volatility (ann.)                  0.43%
+Sharpe                             27.47
+Sortino                            25.84
+Calmar                             161.76
+Total positions                    93
+Won positions                      17
+Lost positions                     1
+=================================  ===========
 """
 
 #
@@ -37,6 +69,7 @@ from tradeexecutor.strategy.chart.standard.alpha_model import (
     missed_vault_deposit_redemption_events,
     missed_vault_deposit_redemption_timeline,
 )
+from tradeexecutor.strategy.chart.standard.cycle_snapshot import latest_cycle_snapshot
 from tradeexecutor.strategy.chart.standard.equity_curve import (
     equity_curve as equity_curve_chart,
     equity_curve_with_drawdown,
@@ -87,45 +120,23 @@ logger = logging.getLogger(__name__)
 
 trading_strategy_engine_version = "0.5"
 
-CHAIN_ID = ChainId.cross_chain
-PRIMARY_CHAIN_ID = ChainId.ethereum
-
-EXCHANGES = ("uniswap-v2", "uniswap-v3")
-
-SUPPORTING_PAIRS = [
-    (ChainId.arbitrum, "uniswap-v3", "WETH", "USDC", 0.0005),
-    (ChainId.ethereum, "uniswap-v3", "WETH", "USDC", 0.0005),
-    (ChainId.ethereum, "uniswap-v3", "WBTC", "USDC", 0.003),
-]
-
 LENDING_RESERVES = None
 
-PREFERRED_STABLECOIN = USDC_NATIVE_TOKEN[PRIMARY_CHAIN_ID].lower()
+SUPPORTING_PAIRS = [
+    (ChainId.ethereum, "uniswap-v3", "WETH", "USDC", 0.0005),
+    (ChainId.ethereum, "uniswap-v3", "WBTC", "USDC", 0.003),
+    (ChainId.arbitrum, "uniswap-v3", "WETH", "USDC", 0.0005),
+    (ChainId.base, "uniswap-v3", "WETH", "USDC", 0.0005),
+]
 
-ALLOWED_VAULT_DENOMINATION_TOKENS = {
-    "USDC",
-    "USDT",
-    "USDC.e",
-    "crvUSD",
-    "USDT0",
-    "USD₮0",
-    "USDt",
-    "USDS",
-}
-
-HAND_CURATED_VAULTS = [
-    # Ethereum
-    (ChainId.ethereum, "0x2e87d6bfa3f2a932e0c70a32607c0b839404984d"),
-    (ChainId.ethereum, "0x438982ea288763370946625fd76c2508ee1fb229"),
-    (ChainId.ethereum, "0x786977528b0265c5c5bc9544ac56c863c03e34d1"),
+SOURCE_VAULTS = [
+    # Ethereum native-USDC vaults
     (ChainId.ethereum, "0x09c4c7b1d2e9aa7506db8b76f1dbbd61c08c114b"),
-    (ChainId.ethereum, "0x01f461a0bbb218bc1943aa027c5bbc424391e541"),
-    (ChainId.ethereum, "0xedc72b49542e4362c677b8369bc23882ed635a75"),
-    (ChainId.ethereum, "0xca790385506b790554571cbc9da73f0130cdcfd5"),
-    (ChainId.ethereum, "0xb250c9e0f7be4cff13f94374c993ac445a1385fe"),
+    (ChainId.ethereum, "0x438982ea288763370946625fd76c2508ee1fb229"),
     (ChainId.ethereum, "0x8df3deba711ae4a9af16cbca5e4fbb1402f036d5"),
+    (ChainId.ethereum, "0xca790385506b790554571cbc9da73f0130cdcfd5"),
     (ChainId.ethereum, "0xe9d33286f0e37f517b1204aa6da085564414996d"),
-    # Base
+    # Base native-USDC vaults
     (ChainId.base, "0xf7e26fa48a568b8b0038e104dfd8abdf0f99074f"),
     (ChainId.base, "0x3094b241aade60f91f1c82b0628a10d9501462f9"),
     (ChainId.base, "0x70fffbacb53ef74903ac074aae769414a70970d1"),
@@ -136,51 +147,16 @@ HAND_CURATED_VAULTS = [
     (ChainId.base, "0xbc10718571fcb3c3f67800e7c0887e450d2ff398"),
     (ChainId.base, "0xefe32813dba3a783059d50e5358b9e3661218dad"),
     (ChainId.base, "0xd5c22fa3f7ee979ed7c28e36669b29797ab277e4"),
-    # Arbitrum
+    # Arbitrum native-USDC vaults
     (ChainId.arbitrum, "0x75288264fdfea8ce68e6d852696ab1ce2f3e5004"),
     (ChainId.arbitrum, "0x58bfc95a864e18e8f3041d2fcd3418f48393fe6a"),
     (ChainId.arbitrum, "0xf63b7f49b4f5dc5d0e7e583cfd79dc64e646320c"),
     (ChainId.arbitrum, "0x1723cb57af58efb35a013870c90fcc3d60174a4e"),
     (ChainId.arbitrum, "0x20d419a8e12c45f88fda7c5760bb6923cee27f98"),
-    (ChainId.arbitrum, "0xc8248953429d707c6a2815653eca89846ffaa63b"),
-    (ChainId.arbitrum, "0x4739e2c293bdcd835829aa7c5d7fbdee93565d1a"),
     (ChainId.arbitrum, "0xd3443ee1e91af28e5fb858fbd0d72a63ba8046e0"),
     (ChainId.arbitrum, "0x0df2e3a0b5997adc69f8768e495fd98a4d00f134"),
-    (ChainId.arbitrum, "0x9fa306b1f4a6a83fec98d8ebbabedff78c407f6b"),
-    # Avalanche
-    (ChainId.avalanche, "0x606fe9a70338e798a292ca22c1f28c829f24048e"),
-    (ChainId.avalanche, "0x4af3abe954259fb70b97c57ebd7ac1eb822028ef"),
-    (ChainId.avalanche, "0x37ca03ad51b8ff79aad35fadacba4cedf0c3e74e"),
-    (ChainId.avalanche, "0x39de0f00189306062d79edec6dca5bb6bfd108f9"),
-    (ChainId.avalanche, "0xeaf77df5d03306bca4ee8b58b6821e6aca76309d"),
-    (ChainId.avalanche, "0x8fc260cd0a00cac30eb1f444b8f1511d71420af9"),
-    (ChainId.avalanche, "0x8f23da78e3f31ab5deb75dc3282198bed630ffde"),
-    (ChainId.avalanche, "0x39288474bc5931d3c4705e866b6e21cc2e47617d"),
-    # HyperEVM
-    (ChainId.hyperliquid, "0x1c5164a764844356d57654ea83f9f1b72cd10db5"),
-    (ChainId.hyperliquid, "0x195eb4d088f222c982282b5dd495e76dba4bc7d1"),
-    (ChainId.hyperliquid, "0x2c910f67dbf81099e6f8e126e7265d7595dc20ad"),
-    (ChainId.hyperliquid, "0xe5add96840f0b908ddeb3bd144c0283ac5ca7ca0"),
-    (ChainId.hyperliquid, "0x9896a8605763106e57a51aa0a97fe8099e806bb3"),
-    (ChainId.hyperliquid, "0x08c00f8279dff5b0cb5a04d349e7d79708ceadf3"),
-    (ChainId.hyperliquid, "0xfc5126377f0efc0041c0969ef9ba903ce67d151e"),
-    (ChainId.hyperliquid, "0x8a862fd6c12f9ad34c9c2ff45ab2b6712e8cea27"),
-    (ChainId.hyperliquid, "0x53a333e51e96fe288bc9add7cdc4b1ead2cd2ffa"),
-    (ChainId.hyperliquid, "0xdc6f4239c1d8d3b955c06cb8f1a6cf18effc5bfe"),
-    # Monad
-    (ChainId.monad, "0xa8665084d8cd6276c00ca97cbc0bf4bc9ae94c79"),
-    (ChainId.monad, "0x8ee9fc28b8da872c38a496e9ddb9700bb7261774"),
-    (ChainId.monad, "0x0da39b740834090c146dc48357f6a435a1bb33b3"),
-    (ChainId.monad, "0x802c91d807a8daca257c4708ab264b6520964e44"),
-    (ChainId.monad, "0x6b343f7b797f1488aa48c49d540690f2b2c89751"),
-    (ChainId.monad, "0x961a59fe249b9795fae7fa35f9e89629689d5278"),
-    (ChainId.monad, "0xf19e8ddc541dee2f4d6796a79b1c1e10a415a0da"),
-    (ChainId.monad, "0x78999cc96d2ba0341588c60ccb0e91c6c33cf371"),
-    (ChainId.monad, "0xbeeff443c3cba3e369da795002243beac311ab83"),
-    (ChainId.monad, "0xbeeff300e9a9caec7beea740ab8758d33b777509"),
 ]
 
-SOURCE_VAULTS = HAND_CURATED_VAULTS
 BENCHMARK_PAIRS = SUPPORTING_PAIRS
 
 #
@@ -192,154 +168,46 @@ class Parameters:
 
     id = "xchain-master-vault"
 
-    #: Daily candles match the validated survivor-first research branch.
     candle_time_bucket = TimeBucket.d1
-    #: Keep daily rebalance cadence from the notebook.
     cycle_duration = CycleDuration.cycle_1d
-    #: Run this strategy as a cross-chain vault universe.
-    chain_id = CHAIN_ID
-    #: Use Ethereum as the primary reserve chain for the cross-chain universe.
-    primary_chain_id = PRIMARY_CHAIN_ID
-    #: Keep the same exchange set as the notebook.
-    exchanges = EXCHANGES
-    #: Allow test-only variants reuse the production universe builder.
+    chain_id = ChainId.cross_chain
+    primary_chain_id = ChainId.ethereum
     supporting_pairs = SUPPORTING_PAIRS
-    #: Allow test-only variants narrow the live vault universe.
     source_vaults = SOURCE_VAULTS
-    #: Allow test-only variants change the reserve chain cleanly.
-    preferred_stablecoin = PREFERRED_STABLECOIN
-    #: Enable shared synthetic forward CCTP bridge generation for satellite chains.
+    preferred_stablecoin = USDC_NATIVE_TOKEN[ChainId.ethereum].lower()
     auto_generate_cctp_bridges = True
 
-    #: Keep the validated 20-vault basket from the notebook.
-    max_assets_in_portfolio = 20
-    #: Keep the validated deployment target from the notebook.
+    backtest_start = datetime.datetime(2025, 1, 1)
+    backtest_end = datetime.datetime(2026, 3, 11)
+    initial_cash = 100_000
+
+    max_assets_in_portfolio = 12
     allocation_pct = 0.98
-    #: Keep the validated concentration cap from the notebook.
     max_concentration_pct = 0.12
-    #: Keep the pool-cap ceiling from the notebook.
     per_position_cap_of_pool_pct = 0.2
-    #: Engine hygiene threshold used across the survivor-first strategies.
     min_portfolio_weight_pct = 0.005
 
-    #: Keep the absolute minimum vault deposit floor from the notebook.
     absolute_min_vault_deposit_usd = 5.0
-    #: Preserve the old 50 USD buy threshold at 100k initial cash.
-    individual_rebalance_min_threshold_of_initial_cash_pct = 0.0005
-    #: Preserve the old 10 USD sell threshold at 100k initial cash.
-    sell_rebalance_min_threshold_of_initial_cash_pct = 0.0001
+    individual_rebalance_min_threshold_usd = 50.0
+    sell_rebalance_min_threshold_usd = 10.0
 
-    #: Keep the survivor-first release TVL floor for the initial cross-chain read.
     min_tvl_usd = 7_500
-    #: Keep the same young-vault-inclusive age floor from the notebook.
     min_age = 0.075
-    #: Keep the surviving signal family unchanged.
     weight_signal = "age_ramp"
-    #: Keep the validated age-ramp period unchanged.
     age_ramp_period = 0.75
 
-    #: Rolling window in days for volatility and vol-of-vol calculations.
     vol_window = 60
-    #: Vol-of-vol percentile threshold for veto.
     volvol_veto_percentile = 0.75
 
-    #: Keep the same mature-universe start as the Jan-start notebook.
-    backtest_start = datetime.datetime(2025, 1, 1)
-    #: Keep the same end date so the result stays comparable.
-    backtest_end = datetime.datetime(2026, 3, 11)
-    #: Use a standard treasury size.
-    initial_cash = 100_000
-    #: Derived at class creation time from the configured initial cash and the 5 USD hard floor.
-    individual_rebalance_min_threshold_usd = max(
-        absolute_min_vault_deposit_usd,
-        initial_cash * individual_rebalance_min_threshold_of_initial_cash_pct,
-    )
-    #: Derived at class creation time from the configured initial cash and the 5 USD hard floor.
-    sell_rebalance_min_threshold_usd = max(
-        absolute_min_vault_deposit_usd,
-        initial_cash * sell_rebalance_min_threshold_of_initial_cash_pct,
-    )
-
-    #: Keep the same data loading window so age and TVL indicators can warm up.
     required_history_period = datetime.timedelta(days=365)
-    #: Route through the default DEX router stack.
     routing = TradeRouting.default
-    #: Keep a live-style slippage assumption aligned with other vault strategies.
     slippage_tolerance_pct = 0.0060
-    #: Assume no liquidity if there is a gap in TVL data.
     assummed_liquidity_when_data_missings_usd = 0.01
 
 
 #
 # Universe creation
 #
-
-
-def create_trading_universe(
-    input: CreateTradingUniverseInput,
-) -> TradingStrategyUniverse:
-    """Create the cross-chain trading universe.
-
-    Keep the backtest trading window fixed to ``Parameters.backtest_start`` /
-    ``Parameters.backtest_end``, but let ``required_history_period`` extend the
-    data-loading window backwards so age and other history-derived indicators
-    can see the full pre-backtest history for the selected vaults.
-    """
-    execution_context = input.execution_context
-    client = input.client
-    timestamp = input.timestamp
-    parameters = input.parameters or Parameters
-    universe_options = input.universe_options
-
-    debug_printer = logger.info if execution_context.live_trading else print
-    chain_id = parameters.primary_chain_id
-
-    if execution_context.live_trading:
-        supporting_pairs = []
-    else:
-        supporting_pairs = parameters.supporting_pairs
-
-    debug_printer(f"Preparing trading universe on chain {chain_id.get_name()}")
-
-    all_pairs_df = client.fetch_pair_universe().to_pandas()
-    pairs_df = filter_for_selected_pairs(all_pairs_df, supporting_pairs)
-    debug_printer(f"We have total {len(all_pairs_df)} pairs in dataset and going to use {len(pairs_df)} pairs for the strategy")
-
-    vault_universe = load_vault_universe_with_metadata(client, vaults=parameters.source_vaults)
-    if parameters.auto_generate_cctp_bridges:
-        vault_universe = vault_universe.limit_to_native_usdc()
-    else:
-        vault_universe = vault_universe.limit_to_denomination(
-            ALLOWED_VAULT_DENOMINATION_TOKENS,
-            check_all_vaults_found=True,
-        )
-    debug_printer(
-        f"Loaded {vault_universe.get_vault_count()} vaults from remote vault metadata, "
-        f"source vaults count: {len(parameters.source_vaults)}"
-    )
-
-    dataset = load_partial_data(
-        client=client,
-        time_bucket=parameters.candle_time_bucket,
-        pairs=pairs_df,
-        execution_context=execution_context,
-        universe_options=universe_options,
-        liquidity=True,
-        liquidity_time_bucket=TimeBucket.d1,
-        lending_reserves=LENDING_RESERVES,
-        vaults=vault_universe,
-        vault_history_source="trading-strategy-website",
-        check_all_vaults_found=True,
-    )
-
-    return TradingStrategyUniverse.create_from_dataset(
-        dataset,
-        reserve_asset=parameters.preferred_stablecoin,
-        forward_fill=True,
-        forward_fill_until=timestamp,
-        primary_chain=parameters.primary_chain_id,
-        auto_generate_cctp_bridges=parameters.auto_generate_cctp_bridges,
-    )
 
 
 def _get_available_supporting_pair_ids(
@@ -355,13 +223,66 @@ def _get_available_supporting_pair_ids(
     return pair_ids
 
 
+def create_trading_universe(
+    input: CreateTradingUniverseInput,
+) -> TradingStrategyUniverse:
+    """Create the cross-chain trading universe."""
+    execution_context = input.execution_context
+    client = input.client
+    timestamp = input.timestamp
+    params = input.parameters or Parameters
+    universe_options = input.universe_options
+
+    debug_printer = logger.info if execution_context.live_trading else print
+    chain_id = params.primary_chain_id
+
+    supporting_pairs = [] if execution_context.live_trading else params.supporting_pairs
+
+    debug_printer(f"Preparing trading universe on chain {chain_id.get_name()}")
+
+    all_pairs_df = client.fetch_pair_universe().to_pandas()
+    pairs_df = filter_for_selected_pairs(all_pairs_df, supporting_pairs)
+    debug_printer(f"We have total {len(all_pairs_df)} pairs in dataset and going to use {len(pairs_df)} pairs for the strategy")
+
+    vault_universe = load_vault_universe_with_metadata(client, vaults=params.source_vaults)
+    if params.auto_generate_cctp_bridges:
+        vault_universe = vault_universe.limit_to_native_usdc()
+    debug_printer(
+        f"Loaded {vault_universe.get_vault_count()} vaults from remote vault metadata, "
+        f"source vaults count: {len(params.source_vaults)}"
+    )
+
+    dataset = load_partial_data(
+        client=client,
+        time_bucket=params.candle_time_bucket,
+        pairs=pairs_df,
+        execution_context=execution_context,
+        universe_options=universe_options,
+        liquidity=True,
+        liquidity_time_bucket=TimeBucket.d1,
+        lending_reserves=LENDING_RESERVES,
+        vaults=vault_universe,
+        vault_history_source="trading-strategy-website",
+        check_all_vaults_found=True,
+    )
+
+    return TradingStrategyUniverse.create_from_dataset(
+        dataset,
+        reserve_asset=params.preferred_stablecoin,
+        forward_fill=True,
+        forward_fill_until=timestamp,
+        primary_chain=params.primary_chain_id,
+        auto_generate_cctp_bridges=params.auto_generate_cctp_bridges,
+    )
+
+
 #
 # Strategy logic
 #
 
 
 def decide_trades(input: StrategyInput) -> list[TradeExecution]:
-    """Run survivor-first capped waterfall sizing with a redemption-aware target value."""
+    """For each strategy tick, generate the list of trades."""
     parameters = input.parameters
     position_manager = input.get_position_manager()
     state = input.state
@@ -369,11 +290,6 @@ def decide_trades(input: StrategyInput) -> list[TradeExecution]:
     indicators = input.indicators
     strategy_universe = input.strategy_universe
 
-    # Guard against allocating based on stale forward-filled vault data.
-    # The framework forward-fill keeps indicators from crashing, but it
-    # also masks stale data: tvl() sees the last real TVL repeated,
-    # age() keeps growing on synthetic rows, and age_ramp_weight()
-    # increases. Bail out before the alpha model uses those values.
     check_stale_vault_data(strategy_universe, timestamp, input.execution_context.mode)
 
     portfolio = position_manager.get_current_portfolio()
@@ -382,10 +298,7 @@ def decide_trades(input: StrategyInput) -> list[TradeExecution]:
     if input.execution_context.mode == ExecutionMode.backtesting and equity < parameters.initial_cash * 0.10:
         return []
 
-    alpha_model = AlphaModel(
-        timestamp,
-        close_position_weight_epsilon=parameters.min_portfolio_weight_pct,
-    )
+    alpha_model = AlphaModel(timestamp, close_position_weight_epsilon=parameters.min_portfolio_weight_pct)
 
     tvl_included_pair_count = indicators.get_indicator_value("tvl_included_pair_count")
     included_pairs = indicators.get_indicator_value("inclusion_criteria", na_conversion=False)
@@ -399,13 +312,7 @@ def decide_trades(input: StrategyInput) -> list[TradeExecution]:
         if vol_of_vol_value is not None and not pd.isna(vol_of_vol_value):
             volvol_values[pair_id] = vol_of_vol_value
 
-    if volvol_values:
-        volvol_threshold = np.percentile(
-            list(volvol_values.values()),
-            parameters.volvol_veto_percentile * 100,
-        )
-    else:
-        volvol_threshold = float("inf")
+    volvol_threshold = np.percentile(list(volvol_values.values()), parameters.volvol_veto_percentile * 100) if volvol_values else float("inf")
 
     vetoed_count = 0
     signal_count = 0
@@ -415,12 +322,10 @@ def decide_trades(input: StrategyInput) -> list[TradeExecution]:
             continue
         if is_quarantined(pair.pool_address, timestamp):
             continue
-
         vol_of_vol_value = volvol_values.get(pair_id)
         if vol_of_vol_value is not None and vol_of_vol_value > volvol_threshold:
             vetoed_count += 1
             continue
-
         age_ramp_weight_value = indicators.get_indicator_value("age_ramp_weight", pair=pair)
         weight_signal_value = age_ramp_weight_value if age_ramp_weight_value is not None else 1.0
         alpha_model.set_signal(pair, weight_signal_value)
@@ -428,10 +333,7 @@ def decide_trades(input: StrategyInput) -> list[TradeExecution]:
 
     locked_position_value = alpha_model.carry_forward_non_redeemable_positions(position_manager)
     redeemable_capital = get_redeemable_portfolio_capital(position_manager)
-    portfolio_target_value = calculate_portfolio_target_value(
-        position_manager,
-        parameters.allocation_pct,
-    )
+    portfolio_target_value = calculate_portfolio_target_value(position_manager, parameters.allocation_pct)
     deployable_target_value = max(portfolio_target_value - locked_position_value, 0.0)
 
     alpha_model.select_top_signals(count=parameters.max_assets_in_portfolio)
@@ -461,12 +363,7 @@ def decide_trades(input: StrategyInput) -> list[TradeExecution]:
     )
     missed_vault_events = alpha_model.get_missed_vault_events()
     if missed_vault_events:
-        state.visualisation.add_calculations(
-            timestamp,
-            {
-                "missed_vault_events": missed_vault_events,
-            },
-        )
+        state.visualisation.add_calculations(timestamp, {"missed_vault_events": missed_vault_events})
 
     if input.is_visualisation_enabled():
         try:
@@ -477,49 +374,24 @@ def decide_trades(input: StrategyInput) -> list[TradeExecution]:
             top_signal = None
 
         rebalance_volume = sum(trade.get_value() for trade in trades)
-        report = dedent_any(
-            f"""
+        report = dedent_any(f"""
             Cycle: #{input.cycle}
-            Rebalanced: {'👍' if alpha_model.is_rebalance_triggered() else '👎'}
+            Rebalanced: {'yes' if alpha_model.is_rebalance_triggered() else 'no'}
             Open/about to open positions: {len(state.portfolio.open_positions)}
-            Max position value change: {alpha_model.max_position_adjust_usd:,.2f} USD
-            Rebalance threshold: {alpha_model.position_adjust_threshold_usd:,.2f} USD
             Trades decided: {len(trades)}
             Pairs meeting inclusion criteria: {len(included_pairs)}
-            Pairs meeting TVL inclusion criteria: {tvl_included_pair_count}
-            Vol-of-vol veto percentile: {parameters.volvol_veto_percentile}
             Vol-of-vol threshold: {volvol_threshold:.6f}
             Vaults vetoed by vol-of-vol: {vetoed_count}
-            Candidate signals created: {signal_count}
-            Selected survivor signals: {len(alpha_model.signals)}
-            Weight signal: {parameters.weight_signal}
-            Age ramp period: {parameters.age_ramp_period}
+            Candidate signals: {signal_count}
             Total equity: {portfolio.get_total_equity():,.2f} USD
             Cash: {position_manager.get_current_cash():,.2f} USD
-            Redeemable capital: {redeemable_capital:,.2f} USD
-            Locked capital carried forward: {locked_position_value:,.2f} USD
-            Pending redemptions: {position_manager.get_pending_redemptions():,.2f} USD
-            Investable equity: {alpha_model.investable_equity:,.2f} USD
-            Accepted investable equity: {alpha_model.accepted_investable_equity:,.2f} USD
-            Allocated to signals: {alpha_model.get_allocated_value():,.2f} USD
-            Discarded allocation because of lack of lit liquidity: {alpha_model.size_risk_discarded_value:,.2f} USD
             Rebalance volume: {rebalance_volume:,.2f} USD
-            """
-        )
+        """)
 
         if top_signal:
-            assert top_signal.position_size_risk
-            report += dedent_any(
-                f"""
-                Top signal pair: {top_signal.pair.get_ticker()}
-                Top signal value: {top_signal.signal}
-                Top signal weight: {top_signal.raw_weight}
-                Top signal weight (normalised): {top_signal.normalised_weight * 100:.2f} % (got {top_signal.position_size_risk.get_relative_capped_amount() * 100:.2f} % of asked size)
-                """
-            )
-
-        for flag, count in alpha_model.get_flag_diagnostics_data().items():
-            report += f"Signals with flag {flag.name}: {count}\n"
+            report += dedent_any(f"""
+                Top signal: {top_signal.pair.get_ticker()} weight={top_signal.normalised_weight * 100:.2f}%
+            """)
 
         state.visualisation.add_message(timestamp, report)
         state.visualisation.set_discardable_data("alpha_model", alpha_model)
@@ -536,18 +408,13 @@ indicators = IndicatorRegistry()
 
 @indicators.define(source=IndicatorSource.tvl)
 def tvl(close: pd.Series) -> pd.Series:
-    """TVL series for a pair.
-
-    Framework forward-fill (via ``create_from_dataset(forward_fill=True,
-    forward_fill_until=timestamp)``) already extends each pair's liquidity
-    data to the decision timestamp. No manual forward-fill needed here
-    because this strategy uses daily candles with daily TVL data.
-    """
+    """TVL series for a pair."""
     return close
 
 
 @indicators.define()
 def age(close: pd.Series) -> pd.Series:
+    """Age of a vault in years since first candle."""
     inception = close.index[0]
     age_years = (close.index - inception) / pd.Timedelta(days=365.25)
     return pd.Series(age_years, index=close.index)
@@ -558,6 +425,7 @@ def tvl_inclusion_criteria(
     min_tvl_usd: USDollarAmount,
     dependency_resolver: IndicatorDependencyResolver,
 ) -> pd.Series:
+    """The pair must have min TVL to be included."""
     series = dependency_resolver.get_indicator_data_pairs_combined(tvl)
     mask = series >= min_tvl_usd
     mask_true_values_only = mask[mask]
@@ -571,6 +439,7 @@ def age_inclusion_criteria(
     min_age: float,
     dependency_resolver: IndicatorDependencyResolver,
 ) -> pd.Series:
+    """The pair must be at least min_age years old."""
     series = dependency_resolver.get_indicator_data_pairs_combined(age)
     mask = series >= min_age
     mask_true_values_only = mask[mask]
@@ -583,6 +452,7 @@ def age_inclusion_criteria(
 def trading_availability_criteria(
     strategy_universe: TradingStrategyUniverse,
 ) -> pd.Series:
+    """Is pair tradeable at each timestamp."""
     candle_series = strategy_universe.data_universe.candles.df["open"]
     return candle_series.groupby(level="timestamp").apply(
         lambda x: x.index.get_level_values("pair_id").tolist()
@@ -590,11 +460,7 @@ def trading_availability_criteria(
 
 
 @indicators.define(
-    dependencies=[
-        tvl_inclusion_criteria,
-        trading_availability_criteria,
-        age_inclusion_criteria,
-    ],
+    dependencies=[tvl_inclusion_criteria, trading_availability_criteria, age_inclusion_criteria],
     source=IndicatorSource.strategy_universe,
 )
 def inclusion_criteria(
@@ -603,41 +469,20 @@ def inclusion_criteria(
     min_age: float,
     dependency_resolver: IndicatorDependencyResolver,
 ) -> pd.Series:
+    """Pairs meeting all of our inclusion criteria."""
     benchmark_pair_ids = _get_available_supporting_pair_ids(strategy_universe)
-
-    tvl_series = dependency_resolver.get_indicator_data(
-        tvl_inclusion_criteria,
-        parameters={"min_tvl_usd": min_tvl_usd},
-    )
+    tvl_series = dependency_resolver.get_indicator_data(tvl_inclusion_criteria, parameters={"min_tvl_usd": min_tvl_usd})
     trading_availability_series = dependency_resolver.get_indicator_data(trading_availability_criteria)
-    age_series = dependency_resolver.get_indicator_data(
-        age_inclusion_criteria,
-        parameters={"min_age": min_age},
-    )
+    age_series = dependency_resolver.get_indicator_data(age_inclusion_criteria, parameters={"min_age": min_age})
 
-    df = pd.DataFrame(
-        {
-            "tvl_pair_ids": tvl_series,
-            "trading_availability_pair_ids": trading_availability_series,
-            "age_pair_ids": age_series,
-        }
-    )
+    df = pd.DataFrame({"tvl_pair_ids": tvl_series, "trading_availability_pair_ids": trading_availability_series, "age_pair_ids": age_series})
     df = df.fillna("").apply(list)
 
     def _combine(row):
-        final_set = (
-            set(row["tvl_pair_ids"])
-            & set(row["trading_availability_pair_ids"])
-            & set(row["age_pair_ids"])
-        )
-        return final_set - benchmark_pair_ids
+        return set(row["tvl_pair_ids"]) & set(row["trading_availability_pair_ids"]) & set(row["age_pair_ids"]) - benchmark_pair_ids
 
     union_criteria = df.apply(_combine, axis=1)
-    full_index = pd.date_range(
-        start=union_criteria.index.min(),
-        end=union_criteria.index.max(),
-        freq=Parameters.candle_time_bucket.to_frequency(),
-    )
+    full_index = pd.date_range(start=union_criteria.index.min(), end=union_criteria.index.max(), freq=Parameters.candle_time_bucket.to_frequency())
     return union_criteria.reindex(full_index, fill_value=[])
 
 
@@ -647,6 +492,7 @@ def age_ramp_weight(
     dependency_resolver: IndicatorDependencyResolver,
     age_ramp_period: float = 1.0,
 ) -> pd.Series:
+    """Younger vaults receive lower weights, ramping up over age_ramp_period years."""
     vault_age = dependency_resolver.get_indicator_data("age", pair=pair)
     return (vault_age / age_ramp_period).clip(upper=1.0).clip(lower=0.05)
 
@@ -686,13 +532,8 @@ def all_criteria_included_pair_count(
     min_age: float,
     dependency_resolver: IndicatorDependencyResolver,
 ) -> pd.Series:
-    series = dependency_resolver.get_indicator_data(
-        "inclusion_criteria",
-        parameters={
-            "min_tvl_usd": min_tvl_usd,
-            "min_age": min_age,
-        },
-    )
+    """Count of pairs meeting all inclusion criteria per timestamp."""
+    series = dependency_resolver.get_indicator_data("inclusion_criteria", parameters={"min_tvl_usd": min_tvl_usd, "min_age": min_age})
     return series.apply(len)
 
 
@@ -701,10 +542,8 @@ def tvl_included_pair_count(
     min_tvl_usd: USDollarAmount,
     dependency_resolver: IndicatorDependencyResolver,
 ) -> pd.Series:
-    series = dependency_resolver.get_indicator_data(
-        "tvl_inclusion_criteria",
-        parameters={"min_tvl_usd": min_tvl_usd},
-    )
+    """Count of pairs meeting TVL inclusion criteria per timestamp."""
+    series = dependency_resolver.get_indicator_data("tvl_inclusion_criteria", parameters={"min_tvl_usd": min_tvl_usd})
     return series.apply(len)
 
 
@@ -713,10 +552,8 @@ def age_included_pair_count(
     min_age: float,
     dependency_resolver: IndicatorDependencyResolver,
 ) -> pd.Series:
-    series = dependency_resolver.get_indicator_data(
-        "age_inclusion_criteria",
-        parameters={"min_age": min_age},
-    )
+    """Count of pairs meeting age inclusion criteria per timestamp."""
+    series = dependency_resolver.get_indicator_data("age_inclusion_criteria", parameters={"min_age": min_age})
     return series.apply(len)
 
 
@@ -724,10 +561,10 @@ def age_included_pair_count(
 def trading_pair_count(
     strategy_universe: TradingStrategyUniverse,
 ) -> pd.Series:
+    """Get number of pairs that trade at each timestamp."""
     benchmark_pair_ids = _get_available_supporting_pair_ids(strategy_universe)
     series = strategy_universe.data_universe.candles.df["open"]
     swap_index = series.index.swaplevel(0, 1)
-
     seen_pairs = set()
     seen_data = {}
     for timestamp, pair_id in swap_index:
@@ -735,7 +572,6 @@ def trading_pair_count(
             continue
         seen_pairs.add(pair_id)
         seen_data[timestamp] = len(seen_pairs)
-
     return pd.Series(seen_data.values(), index=list(seen_data.keys()))
 
 
@@ -761,37 +597,22 @@ def create_indicators(
 
 def equity_curve_with_benchmark(input: ChartInput) -> list[Figure]:
     """Equity curve with ETH benchmark."""
-    return equity_curve_chart(
-        input,
-        benchmark_token_symbols=["ETH"],
-    )
+    return equity_curve_chart(input, benchmark_token_symbols=["ETH"])
 
 
 def inclusion_criteria_check_with_chain(input: ChartInput) -> pd.DataFrame:
     """Inclusion criteria table with chain shown."""
-    return inclusion_criteria_check(
-        input,
-        show_chain=True,
-    )
+    return inclusion_criteria_check(input, show_chain=True)
 
 
 def trading_pair_breakdown_with_chain(input: ChartInput) -> pd.DataFrame:
     """Trading pair breakdown with chain and address."""
-    return trading_pair_breakdown(
-        input,
-        show_chain=True,
-        show_address=True,
-    )
+    return trading_pair_breakdown(input, show_chain=True, show_address=True)
 
 
 def all_vault_positions_by_profit(input: ChartInput) -> pd.DataFrame:
     """Vault positions sorted by profit."""
-    return all_vault_positions(
-        input,
-        sort_by="Profit USD",
-        sort_ascending=False,
-        show_address=True,
-    )
+    return all_vault_positions(input, sort_by="Profit USD", sort_ascending=False, show_address=True)
 
 
 def create_charts(
@@ -820,6 +641,7 @@ def create_charts(
     charts.register(trading_metrics, ChartKind.state_all_pairs)
     charts.register(vault_statistics, ChartKind.state_all_pairs)
     charts.register(all_vault_positions_by_profit, ChartKind.state_all_pairs)
+    charts.register(latest_cycle_snapshot, ChartKind.state_all_pairs)
     return charts
 
 
@@ -831,18 +653,19 @@ tags = {StrategyTag.beta, StrategyTag.deposits_disabled}
 
 name = "Xchain master vault strategy"
 
-short_description = "Cross-chain vault allocation strategy with age-ramp weighting, vol-of-vol veto, and redemption-aware sizing"
+short_description = "Cross-chain vault allocation strategy with age-ramp weighting, vol-of-vol veto, and CCTP bridges"
 
 icon = ""
 
 long_description = """
 # Cross-chain master vault strategy
 
-A diversified yield strategy that allocates across a hand-curated cross-chain vault universe.
+A diversified yield strategy that allocates across native-USDC vaults on Ethereum, Base, and Arbitrum
+using CCTP bridge pairs for cross-chain capital movement.
 
 ## Strategy features
 
-- **Cross-chain allocation**: Invests across Ethereum, Base, Arbitrum, Avalanche, HyperEVM, and Monad
+- **Cross-chain allocation**: Invests across Ethereum, Base, and Arbitrum via CCTP bridges
 - **Age-ramp weighting**: Younger vaults receive lower weights, ramping up over 0.75 years
 - **Vol-of-vol veto**: Excludes vaults whose realised volatility is too unstable versus peers
 - **Daily rebalancing**: Adjusts positions every day using survivor-first capped waterfall sizing
@@ -851,7 +674,7 @@ A diversified yield strategy that allocates across a hand-curated cross-chain va
 
 ## Risk parameters
 
-- Maximum 20 positions at any time
+- Maximum 12 positions at any time
 - 98% allocation target
 - 12% maximum concentration per asset
 - 20% per-position cap of pool TVL


### PR DESCRIPTION
## Why

Transfer the cross-chain master vault strategy from the `01-initial.ipynb` backtesting notebook to the live strategy module. The notebook defines a simpler, more focused vault universe (Ethereum/Base/Arbitrum only) compared to the previous 6-chain version.

## Lessons learnt

- **CLI backtest summary double-counts bridge capital**: The `Value at end` figure uses `get_value()` on bridge positions (which returns the full bridged amount), but `calculate_total_equity()` correctly uses `get_equity()` which returns 0 for bridge positions since that capital is already reflected in satellite vault positions. This inflated the reported return from 15.20% to 51.25%.
- **Bridge position accounting**: CCTP bridge positions have `avg_price=0.0` and `last_token_price=1.0`, causing `get_unrealised_profit_usd()` to show 100% profit. The `get_equity()` method correctly returns 0 for these positions.
- **HTML report generation fails for CCTP strategies**: `format_value()` in `trade_analyser.py` receives `None` from `get_realised_profit_usd()` for bridge positions, causing `BacktestReportRunFailed`.

## Summary

- Updated `strategies/xchain-master-vault.py` from `01-initial.ipynb` notebook
- Vault universe narrowed from 60+ vaults across 6 chains to 22 vaults on Ethereum/Base/Arbitrum
- Added Base WETH/USDC supporting pair for CCTP bridge routing
- `max_assets_in_portfolio` reduced from 20 to 12
- Simplified rebalance thresholds to direct USD values (was computed from initial cash percentage)
- Added `latest_cycle_snapshot` chart registration
- Simplified `decide_trades` diagnostic report
- Removed unused `EXCHANGES`, `ALLOWED_VAULT_DENOMINATION_TOKENS`, `HAND_CURATED_VAULTS` constants
- Backtest result: **15.20% cumulative return (12.70% CAGR)** over 432 days with -0.08% max drawdown