### PR TITLE
Fix gas distribution source balance guard

### DIFF
--- a/tests/cli/test_cli_distribute_gas_funds.py
+++ b/tests/cli/test_cli_distribute_gas_funds.py
@@ -160,3 +160,40 @@ def test_distribute_gas_funds_dry_run_without_deployed_vault(environment: dict):
     assert "Proposed swaps" in output
     assert "Dry run mode" in output
     prepare_swaps.assert_called_once()
+
+
+def test_distribute_gas_funds_dry_run_fails_when_source_chain_has_no_balance(
+    environment: dict,
+    anvil_arbitrum: AnvilLaunch,
+    hot_wallet_address: str,
+) -> None:
+    """distribute-gas-funds dry-run mode fails early if source chain has no gas balance.
+
+    We mock display and quote functions because the assertion must fire before
+    user-facing output or external Li.Fi quote preparation is attempted.
+
+    1. Set the selected source chain hot wallet native balance to zero.
+    2. Patch the process environment for a dry-run CCTP bridge strategy.
+    3. Run the command and verify the source balance assertion fires before distribution.
+    """
+    web3 = Web3(HTTPProvider(anvil_arbitrum.json_rpc_url))
+
+    # 1. Set the selected source chain hot wallet native balance to zero.
+    web3.provider.make_request("anvil_setBalance", [hot_wallet_address, hex(0)])
+    assert web3.eth.get_balance(hot_wallet_address) == 0
+
+    # 2. Patch the process environment for a dry-run CCTP bridge strategy.
+    # 3. Run the command and verify the source balance assertion fires before distribution.
+    with mock.patch.dict("os.environ", environment, clear=True):
+        with mock.patch("tradeexecutor.cli.commands.distribute_gas_funds.display_balances") as display_balances:
+            with mock.patch("tradeexecutor.cli.commands.distribute_gas_funds.prepare_crosschain_swaps") as prepare_swaps:
+                with pytest.raises(AssertionError) as exc_info:
+                    app(["distribute-gas-funds"], standalone_mode=False)
+
+    message = str(exc_info.value)
+    assert "<missing Parameters.id>" in message
+    assert "Arbitrum" in message
+    assert "chain_id=42161" in message
+    assert hot_wallet_address in message
+    display_balances.assert_not_called()
+    prepare_swaps.assert_not_called()

--- a/tests/cli/test_cli_distribute_gas_funds_source_balance.py
+++ b/tests/cli/test_cli_distribute_gas_funds_source_balance.py
@@ -1,0 +1,40 @@
+"""Test source chain balance checks for distribute-gas-funds."""
+
+from unittest import mock
+
+import pytest
+
+from eth_defi.hotwallet import HotWallet
+
+from tradeexecutor.cli.commands.distribute_gas_funds import assert_source_chain_has_balance
+
+
+def test_assert_source_chain_has_balance_fails_with_strategy_parameter_id() -> None:
+    """Zero source chain gas balance fails early with strategy parameter id context.
+
+    1. Create a hot wallet and a mocked source chain Web3 connection.
+    2. Mock the source chain native balance as zero because bridge transactions need source chain gas.
+    3. Assert the pre-flight check fails before any distribution flow can continue.
+    """
+    wallet = HotWallet.from_private_key("0x" + "1" * 64)
+    source_web3 = mock.Mock()
+    source_web3.eth.get_balance.return_value = 0
+
+    # 1. Create a hot wallet and a mocked source chain Web3 connection.
+    # 2. Mock the source chain native balance as zero because bridge transactions need source chain gas.
+    # 3. Assert the pre-flight check fails before any distribution flow can continue.
+    with pytest.raises(AssertionError) as exc_info:
+        assert_source_chain_has_balance(
+            source_web3=source_web3,
+            wallet=wallet,
+            strategy_parameter_id="xchain-master-vault",
+            source_chain_name="Ethereum",
+            source_chain_id=1,
+        )
+
+    message = str(exc_info.value)
+    assert "xchain-master-vault" in message
+    assert "Ethereum" in message
+    assert "chain_id=1" in message
+    assert wallet.address in message
+    source_web3.eth.get_balance.assert_called_once_with(wallet.address)

--- a/tradeexecutor/cli/commands/distribute_gas_funds.py
+++ b/tradeexecutor/cli/commands/distribute_gas_funds.py
@@ -47,6 +47,33 @@ from eth_defi.compat import native_datetime_utc_now
 logger = logging.getLogger(__name__)
 
 
+def assert_source_chain_has_balance(
+    source_web3,
+    wallet: HotWallet,
+    strategy_parameter_id: str,
+    source_chain_name: str,
+    source_chain_id: int,
+) -> int:
+    """Check the source chain can pay for bridge transaction gas."""
+    balance_wei = source_web3.eth.get_balance(wallet.address)
+    balance_native = Decimal(balance_wei) / Decimal(10**18)
+    assert balance_wei > 0, (
+        f"Cannot distribute gas funds for strategy Parameters.id={strategy_parameter_id!r}: "
+        f"source chain {source_chain_name} (chain_id={source_chain_id}) has zero native token balance "
+        f"for hot wallet {wallet.address}. "
+        "The source chain is selected from universe.get_reserve_asset().chain_id. "
+        "Fund this wallet on the source chain or change the strategy reserve/source configuration "
+        "before running distribute-gas-funds."
+    )
+    logger.info(
+        "Source chain %s (ID: %s) hot wallet balance before gas distribution: %s native",
+        source_chain_name,
+        source_chain_id,
+        balance_native,
+    )
+    return balance_wei
+
+
 @app.command()
 @shared_options.with_json_rpc_options()
 def distribute_gas_funds(
@@ -211,6 +238,14 @@ def distribute_gas_funds(
 
     # Create hot wallet
     wallet = HotWallet.from_private_key(private_key)
+    strategy_parameter_id = mod.parameters.get("id", "<missing Parameters.id>")
+    assert_source_chain_has_balance(
+        source_web3=source_web3,
+        wallet=wallet,
+        strategy_parameter_id=strategy_parameter_id,
+        source_chain_name=source_chain_name,
+        source_chain_id=source_chain_id,
+    )
 
     # Build TopUpConfig for display functions
     config = TopUpConfig(


### PR DESCRIPTION
## Why

`distribute-gas-funds` could prepare LI.FI quotes and only fail during raw transaction broadcast when the selected source chain wallet had no native gas balance. This made the failure late and harder to understand.

## Lessons learnt

The source chain is selected from the strategy universe reserve asset, not from where the hot wallet currently has funds. The command should make this explicit when the source chain cannot pay transaction gas.

## Summary

Added an early source-chain native balance assertion that includes `Parameters.id`, source chain details, and the hot wallet address.

Added focused unit coverage for the assertion message and command-level dry-run coverage to ensure the guard fires before balance display or LI.FI swap preparation.