### PR TITLE
Fix cross-chain nonce warnings in multichain vault deployment

### DIFF
--- a/tradeexecutor/cli/commands/lagoon_deploy_vault.py
+++ b/tradeexecutor/cli/commands/lagoon_deploy_vault.py
@@ -1011,9 +1011,13 @@ def _deploy_multichain(
 
     logger.info("Multichain deployment: chains=%s, strategy=%s", list(chain_web3.keys()), strategy_file)
 
-    # Sync hot wallet nonce on each chain
+    # Create independent HotWallet per chain to avoid cross-chain nonce conflicts
+    # (each chain has its own nonce counter for the same address)
+    chain_hot_wallets: dict[str, HotWallet] = {}
     for slug, web3 in chain_web3.items():
-        hot_wallet.sync_nonce(web3)
+        hw = HotWallet(hot_wallet.account)
+        hw.sync_nonce(web3)
+        chain_hot_wallets[slug] = hw
         web3.middleware_onion.add(construct_sign_and_send_raw_middleware(hot_wallet.account))
         logger.info("  Chain %s: block %d", slug, web3.eth.block_number)
 
@@ -1063,6 +1067,7 @@ def _deploy_multichain(
 
     log_deployment_preflight_report(
         hot_wallet=hot_wallet,
+        chain_hot_wallets=chain_hot_wallets,
         chain_web3=chain_web3,
         fund_name=resolved_fund_name,
         fund_symbol=resolved_fund_symbol,

--- a/tradeexecutor/ethereum/lagoon/preflight_report.py
+++ b/tradeexecutor/ethereum/lagoon/preflight_report.py
@@ -31,6 +31,10 @@ def log_deployment_preflight_report(
     verifier_url: str | None = None,
     # Multichain: per-chain LagoonConfig objects
     chain_configs: dict[str, LagoonConfig] | None = None,
+    # Per-chain HotWallet instances (multichain path); avoids
+    # cross-chain nonce conflicts when the same address is used
+    # on multiple chains with different nonce counters.
+    chain_hot_wallets: dict[str, HotWallet] | None = None,
     # Legacy single-chain fields (when chain_configs is None)
     denomination_token: TokenDetails | None = None,
     any_asset: bool = False,
@@ -111,10 +115,13 @@ def log_deployment_preflight_report(
         logger.info("Chain: %s (id %d)", slug, web3.eth.chain_id)
         logger.info("  Latest block: %s", f"{web3.eth.block_number:,}")
 
-        # Balance & nonce — sync nonce first so the value is up-to-date
-        hot_wallet.sync_nonce(web3)
-        balance = hot_wallet.get_native_currency_balance(web3)
-        logger.info("  Deployer balance: %f, nonce %d", balance, hot_wallet.current_nonce)
+        # Use per-chain HotWallet when available to avoid cross-chain
+        # nonce conflicts; fall back to the shared instance for
+        # single-chain deployments.
+        chain_hw = chain_hot_wallets[slug] if chain_hot_wallets else hot_wallet
+        chain_hw.sync_nonce(web3)
+        balance = chain_hw.get_native_currency_balance(web3)
+        logger.info("  Deployer balance: %f, nonce %d", balance, chain_hw.current_nonce)
 
         if chain_configs and slug in chain_configs:
             _log_chain_config_section(chain_configs[slug], logger)


### PR DESCRIPTION
## Why

During `lagoon-deploy-vault` for multichain deployments, a single `HotWallet` instance was shared across all chains. `HotWallet` maintains a single `current_nonce` internally. When syncing nonce on arbitrum (on-chain nonce=2), the internal counter was set to 2. Then when syncing on ethereum or base (on-chain nonce=0, wallet never transacted there), the guard `0 < 2` triggered spurious "Nonce sync failed" warnings.

This would also cause incorrect nonce values to be displayed in the pre-flight report for some chains.

## Lessons learnt

- `HotWallet` was designed for single-chain use — it has one `current_nonce` field with no chain awareness
- The downstream `deploy_multichain_lagoon_vault()` already creates per-chain `HotWallet` instances internally, but the calling code in `_deploy_multichain()` and `log_deployment_preflight_report()` did not

## Summary

- **`_deploy_multichain()`**: Create a `dict[str, HotWallet]` with independent instances per chain (all sharing the same `account`/private key) instead of reusing a single `HotWallet`
- **`log_deployment_preflight_report()`**: Accept optional `chain_hot_wallets` parameter; use per-chain wallet when available (multichain path), fall back to the shared instance (single-chain path)