### PR TITLE
fix: Add CHAIN_NAME support to lagoon CLI commands

### DIFF
--- a/tradeexecutor/cli/commands/lagoon_first_deposit.py
+++ b/tradeexecutor/cli/commands/lagoon_first_deposit.py
@@ -31,7 +31,7 @@ logger = logging.getLogger(__name__)
 
 
 @app.command()
-@shared_options.with_json_rpc_options()
+@shared_options.with_json_rpc_options(include_chain_name=True)
 def lagoon_first_deposit(
     id: str = shared_options.id,
 
@@ -50,6 +50,7 @@ def lagoon_first_deposit(
     simulate: bool = shared_options.simulate,
 
     deposit_amount: float = Option(..., envvar="DEPOSIT_AMOUNT", help="Amount of denomination token (e.g. USDC) to deposit into the vault."),
+    chain_name: str | None = shared_options.chain_name,
 ):
     """Make the first deposit into a Lagoon vault.
 

--- a/tradeexecutor/cli/commands/lagoon_redeem.py
+++ b/tradeexecutor/cli/commands/lagoon_redeem.py
@@ -31,7 +31,7 @@ logger = logging.getLogger(__name__)
 
 
 @app.command()
-@shared_options.with_json_rpc_options()
+@shared_options.with_json_rpc_options(include_chain_name=True)
 def lagoon_redeem(
     id: str = shared_options.id,
 
@@ -48,6 +48,7 @@ def lagoon_redeem(
 
     unit_testing: bool = shared_options.unit_testing,
     simulate: bool = shared_options.simulate,
+    chain_name: str | None = shared_options.chain_name,
 ):
     """Redeem all vault shares from a Lagoon vault for the asset manager.
 

--- a/tradeexecutor/cli/commands/lagoon_settle.py
+++ b/tradeexecutor/cli/commands/lagoon_settle.py
@@ -27,7 +27,7 @@ from eth_defi.compat import native_datetime_utc_now
 
 
 @app.command()
-@shared_options.with_json_rpc_options()
+@shared_options.with_json_rpc_options(include_chain_name=True)
 def lagoon_settle(
     id: str = shared_options.id,
 
@@ -57,6 +57,7 @@ def lagoon_settle(
     unit_testing: bool = shared_options.unit_testing,
     simulate: bool = shared_options.simulate,
     sync_interest: bool = True,
+    chain_name: str | None = shared_options.chain_name,
 ):
     """Settle the Lagoon vault NAV and deposits.
 


### PR DESCRIPTION
## Why

When multiple JSON-RPC endpoints are configured (e.g. cross-chain strategies with Ethereum, Arbitrum, Base), `lagoon-first-deposit`, `lagoon-redeem`, and `lagoon-settle` picked the first chain in the connections dict (Ethereum) instead of the vault's actual chain. This caused `asset()` to return a zero address because the vault contract doesn't exist on the wrong chain, resulting in:

```
RuntimeError: Vault 0xF68d... denomination token is None — asset() returned zero address or token lookup failed.
```

`lagoon-deploy-vault` already had `include_chain_name=True` and worked correctly — the other three commands were missing it.

## Lessons learnt

- When adding new CLI commands that operate on a single chain but share the multi-chain RPC configuration, always include `chain_name` support via `with_json_rpc_options(include_chain_name=True)`
- The `choose_single_chain()` fallback of `next(iter(connections.keys()))` is fragile — it picks whichever chain was inserted first into the dict

## Summary

- Added `include_chain_name=True` to `@shared_options.with_json_rpc_options()` decorator on `lagoon-first-deposit`, `lagoon-redeem`, and `lagoon-settle`
- Added `chain_name: str | None = shared_options.chain_name` parameter to each command so the `CHAIN_NAME` env var filters RPCs to the correct chain before `choose_single_chain()` runs

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>