### PR TITLE
fix: Lagoon commands resolve chain from strategy module

### DIFF
--- a/tradeexecutor/cli/commands/lagoon_deploy_vault.py
+++ b/tradeexecutor/cli/commands/lagoon_deploy_vault.py
@@ -90,7 +90,7 @@ from tradeexecutor.cli.bootstrap import (create_web3_config, prepare_cache,
                                          prepare_token_cache)
 from tradeexecutor.cli.commands import shared_options
 from tradeexecutor.cli.commands.app import app
-from tradeexecutor.cli.commands.lagoon_utils import choose_single_chain, create_hot_wallet
+from tradeexecutor.cli.commands.lagoon_utils import create_hot_wallet
 from tradeexecutor.cli.commands.shared_options import \
     parse_comma_separated_list
 from tradeexecutor.cli.log import setup_logging
@@ -724,7 +724,7 @@ def lagoon_deploy_vault(
         return
 
     # Single-chain deployment path (original flow)
-    choose_single_chain(web3config)
+    web3config.choose_single_chain()
 
     web3 = web3config.get_default()
     chain_id = ChainId(web3.eth.chain_id)

--- a/tradeexecutor/cli/commands/lagoon_first_deposit.py
+++ b/tradeexecutor/cli/commands/lagoon_first_deposit.py
@@ -26,12 +26,13 @@ from tradeexecutor.cli.commands.lagoon_utils import (
     sync_reserve_balance_to_state,
 )
 from tradeexecutor.cli.log import setup_logging
+from tradeexecutor.strategy.strategy_module import read_strategy_module
 
 logger = logging.getLogger(__name__)
 
 
 @app.command()
-@shared_options.with_json_rpc_options(include_chain_name=True)
+@shared_options.with_json_rpc_options()
 def lagoon_first_deposit(
     id: str = shared_options.id,
 
@@ -50,7 +51,6 @@ def lagoon_first_deposit(
     simulate: bool = shared_options.simulate,
 
     deposit_amount: float = Option(..., envvar="DEPOSIT_AMOUNT", help="Amount of denomination token (e.g. USDC) to deposit into the vault."),
-    chain_name: str | None = shared_options.chain_name,
 ):
     """Make the first deposit into a Lagoon vault.
 
@@ -68,6 +68,8 @@ def lagoon_first_deposit(
     assert vault_adapter_address, "VAULT_ADAPTER_ADDRESS is required"
     assert deposit_amount > 0, f"DEPOSIT_AMOUNT must be positive, got {deposit_amount}"
 
+    mod = read_strategy_module(strategy_file)
+
     cache_path, token_cache = prepare_cache_and_token_cache(
         id,
         cache_path,
@@ -75,6 +77,7 @@ def lagoon_first_deposit(
     )
 
     context = create_lagoon_command_context(
+        mod=mod,
         private_key=private_key,
         vault_address=vault_address,
         token_cache=token_cache,

--- a/tradeexecutor/cli/commands/lagoon_redeem.py
+++ b/tradeexecutor/cli/commands/lagoon_redeem.py
@@ -26,12 +26,13 @@ from tradeexecutor.cli.commands.lagoon_utils import (
     sync_reserve_balance_to_state,
 )
 from tradeexecutor.cli.log import setup_logging
+from tradeexecutor.strategy.strategy_module import read_strategy_module
 
 logger = logging.getLogger(__name__)
 
 
 @app.command()
-@shared_options.with_json_rpc_options(include_chain_name=True)
+@shared_options.with_json_rpc_options()
 def lagoon_redeem(
     id: str = shared_options.id,
 
@@ -48,7 +49,6 @@ def lagoon_redeem(
 
     unit_testing: bool = shared_options.unit_testing,
     simulate: bool = shared_options.simulate,
-    chain_name: str | None = shared_options.chain_name,
 ):
     """Redeem all vault shares from a Lagoon vault for the asset manager.
 
@@ -66,6 +66,8 @@ def lagoon_redeem(
     assert vault_address, "VAULT_ADDRESS is required"
     assert vault_adapter_address, "VAULT_ADAPTER_ADDRESS is required"
 
+    mod = read_strategy_module(strategy_file)
+
     cache_path, token_cache = prepare_cache_and_token_cache(
         id,
         cache_path,
@@ -73,6 +75,7 @@ def lagoon_redeem(
     )
 
     context = create_lagoon_command_context(
+        mod=mod,
         private_key=private_key,
         vault_address=vault_address,
         token_cache=token_cache,

--- a/tradeexecutor/cli/commands/lagoon_settle.py
+++ b/tradeexecutor/cli/commands/lagoon_settle.py
@@ -10,8 +10,8 @@ from typing import Optional
 from . import shared_options
 from .app import app
 from ..bootstrap import prepare_executor_id, prepare_cache_and_token_cache, create_web3_config, create_state_store, \
-    create_execution_and_sync_model, create_client
-from .lagoon_utils import choose_single_chain, resolve_state_store
+    create_execution_and_sync_model, create_client, configure_default_chain
+from .lagoon_utils import resolve_state_store
 from ..log import setup_logging
 from ...strategy.approval import UncheckedApprovalModel
 from ...strategy.bootstrap import make_factory_from_strategy_mod
@@ -27,7 +27,7 @@ from eth_defi.compat import native_datetime_utc_now
 
 
 @app.command()
-@shared_options.with_json_rpc_options(include_chain_name=True)
+@shared_options.with_json_rpc_options()
 def lagoon_settle(
     id: str = shared_options.id,
 
@@ -57,7 +57,6 @@ def lagoon_settle(
     unit_testing: bool = shared_options.unit_testing,
     simulate: bool = shared_options.simulate,
     sync_interest: bool = True,
-    chain_name: str | None = shared_options.chain_name,
 ):
     """Settle the Lagoon vault NAV and deposits.
 
@@ -82,7 +81,7 @@ def lagoon_settle(
     if not web3config.has_any_connection():
         raise RuntimeError("Vault deploy requires that you pass JSON-RPC connection to one of the networks")
 
-    choose_single_chain(web3config)
+    configure_default_chain(web3config, mod)
 
     execution_model, sync_model, valuation_model_factory, pricing_model_factory = create_execution_and_sync_model(
         asset_management_mode=asset_management_mode,

--- a/tradeexecutor/cli/commands/lagoon_utils.py
+++ b/tradeexecutor/cli/commands/lagoon_utils.py
@@ -14,9 +14,9 @@ from eth_defi.hotwallet import HotWallet
 from eth_defi.token import TokenDiskCache
 from web3 import Web3
 
-from tradeexecutor.cli.bootstrap import create_state_store, create_web3_config
+from tradeexecutor.cli.bootstrap import configure_default_chain, create_state_store, create_web3_config
 from tradeexecutor.ethereum.token import translate_token_details
-from tradeexecutor.ethereum.web3config import collect_rpc_kwargs
+from tradeexecutor.strategy.strategy_module import StrategyModuleInformation
 from tradeexecutor.utils.key import ensure_0x_prefixed_private_key
 
 
@@ -30,29 +30,22 @@ class LagoonCommandContext:
     vault: LagoonVault
 
 
-def create_single_chain_web3_config(*, simulate: bool = False, chain_name: str | None = None, **rpc_kwargs):
-    """Build a single-chain Web3 config from shared RPC kwargs."""
-    collected = collect_rpc_kwargs(chain_name=chain_name, **rpc_kwargs)
+def create_single_chain_web3_config(*, mod: StrategyModuleInformation, simulate: bool = False, **rpc_kwargs):
+    """Build a single-chain Web3 config from shared RPC kwargs.
+
+    Uses the strategy module's ``get_default_chain_id()`` to select
+    the correct chain when multiple JSON-RPC connections are configured.
+    """
     web3config = create_web3_config(
-        **collected,
+        **rpc_kwargs,
         simulate=simulate,
     )
 
     if not web3config.has_any_connection():
         raise RuntimeError("This command requires that you pass a JSON-RPC connection to one of the networks")
 
-    choose_single_chain(web3config)
+    configure_default_chain(web3config, mod)
     return web3config
-
-
-def choose_single_chain(web3config, default_chain_id=None):
-    """Choose a single chain even if multiple RPC connections are configured."""
-    if default_chain_id is not None:
-        web3config.choose_single_chain(default_chain_id=default_chain_id)
-    elif len(web3config.connections) > 1:
-        web3config.choose_single_chain(default_chain_id=next(iter(web3config.connections.keys())))
-    else:
-        web3config.choose_single_chain()
 
 
 def create_hot_wallet(web3: Web3, private_key: str) -> HotWallet:
@@ -82,17 +75,17 @@ def load_lagoon_vault(
 
 def create_lagoon_command_context(
     *,
+    mod: StrategyModuleInformation,
     private_key: str,
     vault_address: str,
     token_cache: TokenDiskCache | None = None,
     simulate: bool = False,
-    chain_name: str | None = None,
     **rpc_kwargs,
 ) -> LagoonCommandContext:
     """Create the common single-chain context for simple Lagoon commands."""
     web3config = create_single_chain_web3_config(
+        mod=mod,
         simulate=simulate,
-        chain_name=chain_name,
         **rpc_kwargs,
     )
     web3 = web3config.get_default()


### PR DESCRIPTION
## Why

The previous fix (#1469) added `CHAIN_NAME` env var support, but this requires operators to manually set an extra env var. Other commands like `start` and `check-wallet` already resolve the chain automatically from the strategy module's `Parameters.chain_id` / `Parameters.primary_chain_id` via `configure_default_chain()`. The lagoon commands should follow the same pattern.

## Lessons learnt

- `configure_default_chain(web3config, mod)` is the standard pattern for resolving which chain to use — it reads `mod.get_default_chain_id()` which handles both single-chain and cross-chain strategies (falling back to `primary_chain_id` for cross-chain)
- The `choose_single_chain()` wrapper in `lagoon_utils` was a fragile shortcut that picked `next(iter(connections.keys()))` when no chain was specified

## Summary

- `lagoon_utils.py`: Replaced `choose_single_chain()` with `configure_default_chain(web3config, mod)` in `create_single_chain_web3_config()`. Removed the `choose_single_chain()` wrapper function and `chain_name` parameter. `create_lagoon_command_context()` now requires a `mod: StrategyModuleInformation` argument.
- `lagoon_first_deposit.py`: Added `read_strategy_module(strategy_file)` call and passes `mod` to context. Reverted `include_chain_name` and removed `chain_name` parameter.
- `lagoon_redeem.py`: Same as above.
- `lagoon_settle.py`: Already read the strategy module — replaced `choose_single_chain(web3config)` with `configure_default_chain(web3config, mod)`. Reverted decorator and removed `chain_name`.
- `lagoon_deploy_vault.py`: Updated import — calls `web3config.choose_single_chain()` directly (it already uses `include_chain_name=True` which filters RPCs beforehand).

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>