### PR TITLE
feat: Add cross-chain CCTP bridge support to perform-test-trade and trade-ui

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 
 - Breaking API changes
 
+- Add cross-chain CCTP bridge support to `perform-test-trade` and `trade-ui` for satellite-chain vault pairs (2026-06-03)
+
 - Add `diagnose_hyperliquid_vault_redemption_failure()` to capture full HyperCore state on vault settlement failures, replacing uninformative `revert_reason=None` errors (2026-06-01)
 
 - Update cross-chain master vault strategy from 01-initial.ipynb notebook with Ethereum/Base/Arbitrum CCTP vault universe (2026-05-29)

--- a/tests/mainnet_fork/test_perform_test_trade_crosschain.py
+++ b/tests/mainnet_fork/test_perform_test_trade_crosschain.py
@@ -1,0 +1,583 @@
+"""Test cross-chain test trade orchestration.
+
+Mainnet fork test (Arbitrum + Base) that verifies perform-test-trade
+and trade-ui correctly handle satellite-chain vault pairs by
+automatically injecting CCTP bridge trades.
+
+1. Verify cross-chain detection logic (satellite vs home chain pairs)
+2. Verify bridge pairs are filtered from TUI display
+3. Full round-trip cross-chain test trade on Anvil forks (bridge in → open → close → bridge back)
+4. Buy-only cross-chain test trade (bridge in → open, leave positions open)
+
+Requires ``JSON_RPC_ARBITRUM`` and ``JSON_RPC_BASE`` environment variables.
+"""
+
+import datetime
+import logging
+import os
+from decimal import Decimal
+
+import pytest
+from eth_account import Account
+
+from eth_defi.compat import native_datetime_utc_now
+from eth_defi.hotwallet import HotWallet
+from eth_defi.provider.anvil import fork_network_anvil, AnvilLaunch, set_balance, fund_erc20_on_anvil
+from eth_defi.provider.multi_provider import create_multi_provider_web3
+from eth_defi.token import USDC_NATIVE_TOKEN
+from eth_defi.cctp.constants import TOKEN_MESSENGER_V2
+
+from tradingstrategy.chain import ChainId
+from tradingstrategy.exchange import Exchange, ExchangeType
+from tradingstrategy.timebucket import TimeBucket
+from tradingstrategy.universe import Universe
+
+from tradeexecutor.cli.testtrade import make_test_trade
+from tradeexecutor.cli.trade_ui_tui import PairSelectionApp
+from tradeexecutor.ethereum.ethereum_protocol_adapters import EthereumPairConfigurator
+from tradeexecutor.ethereum.execution import EthereumExecution
+from tradeexecutor.ethereum.hot_wallet_sync_model import HotWalletSyncModel
+from tradeexecutor.ethereum.tx import HotWalletTransactionBuilder
+from tradeexecutor.ethereum.web3config import Web3Config
+from tradeexecutor.state.identifier import AssetIdentifier, TradingPairIdentifier, TradingPairKind
+from tradeexecutor.state.state import State
+from tradeexecutor.strategy.generic.generic_pricing_model import GenericPricing
+from tradeexecutor.strategy.generic.generic_router import GenericRouting
+from tradeexecutor.strategy.trading_strategy_universe import TradingStrategyUniverse, create_pair_universe_from_code
+
+
+JSON_RPC_ARBITRUM = os.environ.get("JSON_RPC_ARBITRUM")
+JSON_RPC_BASE = os.environ.get("JSON_RPC_BASE")
+
+ARBITRUM_CHAIN_ID = 42161
+BASE_CHAIN_ID = 8453
+
+# IPOR Fusion vault on Base — USDC, short lockup
+IPOR_VAULT_ADDRESS = "0x45aa96f0b3188d47a1dafdbefce1db6b37f58216"
+
+DEPOSIT_AMOUNT = Decimal("10")
+TEST_TRADE_AMOUNT = Decimal("3")
+
+#: Pin Base fork to a block where the IPOR Fusion vault has sufficient
+#: deposit headroom (vault's totalSupplyCap fills up quickly).
+BASE_FORK_BLOCK = 45_960_642
+
+pytestmark = pytest.mark.skipif(
+    not JSON_RPC_ARBITRUM or not JSON_RPC_BASE,
+    reason="JSON_RPC_ARBITRUM and JSON_RPC_BASE environment variables required",
+)
+
+
+# --- Fixtures ---
+
+
+@pytest.fixture()
+def arb_anvil() -> AnvilLaunch:
+    launch = fork_network_anvil(JSON_RPC_ARBITRUM)
+    try:
+        yield launch
+    finally:
+        launch.close(log_level=logging.ERROR)
+
+
+@pytest.fixture()
+def base_anvil() -> AnvilLaunch:
+    launch = fork_network_anvil(JSON_RPC_BASE, fork_block_number=BASE_FORK_BLOCK)
+    try:
+        yield launch
+    finally:
+        launch.close(log_level=logging.ERROR)
+
+
+@pytest.fixture()
+def arb_web3(arb_anvil):
+    return create_multi_provider_web3(arb_anvil.json_rpc_url)
+
+
+@pytest.fixture()
+def base_web3(base_anvil):
+    return create_multi_provider_web3(base_anvil.json_rpc_url)
+
+
+@pytest.fixture()
+def web3config(arb_web3, base_web3) -> Web3Config:
+    config = Web3Config()
+    config.connections[ChainId.arbitrum] = arb_web3
+    config.connections[ChainId.base] = base_web3
+    config.default_chain_id = ChainId.arbitrum
+    return config
+
+
+@pytest.fixture()
+def hot_wallet(arb_web3, base_web3) -> HotWallet:
+    """Create hot wallet funded with gas on both chains."""
+    wallet = HotWallet.create_for_testing(arb_web3, eth_amount=100)
+    set_balance(base_web3, wallet.address, 100 * 10**18)
+    return wallet
+
+
+@pytest.fixture()
+def funded_wallet(hot_wallet, arb_web3) -> HotWallet:
+    """Fund the hot wallet with USDC on Arbitrum."""
+    usdc_raw = int(DEPOSIT_AMOUNT * 10**6)
+    fund_erc20_on_anvil(
+        arb_web3,
+        USDC_NATIVE_TOKEN[ARBITRUM_CHAIN_ID],
+        hot_wallet.address,
+        usdc_raw,
+    )
+    return hot_wallet
+
+
+@pytest.fixture()
+def usdc_arb() -> AssetIdentifier:
+    return AssetIdentifier(
+        chain_id=ARBITRUM_CHAIN_ID,
+        address=USDC_NATIVE_TOKEN[ARBITRUM_CHAIN_ID],
+        token_symbol="USDC",
+        decimals=6,
+    )
+
+
+@pytest.fixture()
+def usdc_base() -> AssetIdentifier:
+    return AssetIdentifier(
+        chain_id=BASE_CHAIN_ID,
+        address=USDC_NATIVE_TOKEN[BASE_CHAIN_ID],
+        token_symbol="USDC",
+        decimals=6,
+    )
+
+
+@pytest.fixture()
+def ipor_share_token() -> AssetIdentifier:
+    """IPOR Fusion vault share token (ERC-4626 vault IS its own share token)."""
+    return AssetIdentifier(
+        chain_id=BASE_CHAIN_ID,
+        address=IPOR_VAULT_ADDRESS,
+        token_symbol="ipfUSDC",
+        decimals=18,
+    )
+
+
+@pytest.fixture()
+def bridge_pair(usdc_base, usdc_arb) -> TradingPairIdentifier:
+    """CCTP bridge pair: Arbitrum USDC → Base USDC."""
+    return TradingPairIdentifier(
+        base=usdc_base,
+        quote=usdc_arb,
+        pool_address=TOKEN_MESSENGER_V2,
+        exchange_address=TOKEN_MESSENGER_V2,
+        internal_id=1,
+        internal_exchange_id=1,
+        fee=0.0,
+        kind=TradingPairKind.cctp_bridge,
+        exchange_name="CCTP Bridge",
+        other_data={
+            "bridge_protocol": "cctp",
+            "destination_chain_id": BASE_CHAIN_ID,
+        },
+    )
+
+
+@pytest.fixture()
+def vault_pair(ipor_share_token, usdc_base) -> TradingPairIdentifier:
+    """IPOR Fusion vault pair on Base."""
+    return TradingPairIdentifier(
+        base=ipor_share_token,
+        quote=usdc_base,
+        pool_address=IPOR_VAULT_ADDRESS,
+        exchange_address=IPOR_VAULT_ADDRESS,
+        internal_id=2,
+        internal_exchange_id=2,
+        fee=0.0,
+        kind=TradingPairKind.vault,
+        exchange_name="IPOR Fusion",
+        other_data={
+            "vault_protocol": "ipor_fusion",
+        },
+    )
+
+
+@pytest.fixture()
+def universe(bridge_pair, vault_pair, usdc_arb) -> TradingStrategyUniverse:
+    """Trading universe with CCTP bridge and IPOR vault pairs."""
+    pair_universe = create_pair_universe_from_code(ChainId.arbitrum, [bridge_pair, vault_pair])
+
+    cctp_exchange = Exchange(
+        chain_id=ChainId.arbitrum,
+        chain_slug="arbitrum",
+        exchange_id=1,
+        exchange_slug="cctp-bridge",
+        address=TOKEN_MESSENGER_V2,
+        exchange_type=ExchangeType.uniswap_v2,
+        pair_count=1,
+    )
+
+    vault_exchange = Exchange(
+        chain_id=ChainId.base,
+        chain_slug="base",
+        exchange_id=2,
+        exchange_slug="ipor-fusion",
+        address=IPOR_VAULT_ADDRESS,
+        exchange_type=ExchangeType.erc_4626_vault,
+        pair_count=1,
+    )
+
+    data_universe = Universe(
+        time_bucket=TimeBucket.d1,
+        chains={ChainId.arbitrum, ChainId.base},
+        exchanges={cctp_exchange, vault_exchange},
+        pairs=pair_universe,
+        candles=None,
+        liquidity=None,
+    )
+
+    return TradingStrategyUniverse(
+        data_universe=data_universe,
+        reserve_assets=[usdc_arb],
+    )
+
+
+@pytest.fixture()
+def execution_model(arb_web3, funded_wallet, web3config) -> EthereumExecution:
+    tx_builder = HotWalletTransactionBuilder(arb_web3, funded_wallet)
+    model = EthereumExecution(
+        tx_builder=tx_builder,
+        confirmation_block_count=0,
+        confirmation_timeout=datetime.timedelta(seconds=30),
+        max_slippage=0.05,
+        mainnet_fork=True,
+    )
+    model.web3config = web3config
+    return model
+
+
+@pytest.fixture()
+def sync_model(arb_web3, funded_wallet) -> HotWalletSyncModel:
+    return HotWalletSyncModel(arb_web3, funded_wallet)
+
+
+@pytest.fixture()
+def routing_model(arb_web3, universe, web3config) -> GenericRouting:
+    pair_configurator = EthereumPairConfigurator(
+        arb_web3,
+        universe,
+        web3config=web3config,
+    )
+    return GenericRouting(pair_configurator)
+
+
+@pytest.fixture()
+def state(sync_model, usdc_arb) -> State:
+    state = State()
+    sync_model.init()
+    sync_model.sync_initial(state, reserve_currency=usdc_arb, reserve_token_price=1.0)
+    sync_model.sync_treasury(native_datetime_utc_now(), state, [usdc_arb])
+    return state
+
+
+def _get_total_equity(state: State) -> float:
+    """Calculate total portfolio equity: reserves + all open positions."""
+    reserve_value = sum(float(r.quantity) for r in state.portfolio.reserves.values())
+    position_equity = sum(p.get_equity() for p in state.portfolio.open_positions.values())
+    return reserve_value + position_equity
+
+
+# --- Tests ---
+
+
+def test_crosschain_detection_and_tui_filtering(
+    universe: TradingStrategyUniverse,
+    bridge_pair: TradingPairIdentifier,
+    vault_pair: TradingPairIdentifier,
+):
+    """Verify cross-chain detection logic and TUI bridge pair filtering.
+
+    1. Check bridge pair has correct kind and is detected as CCTP bridge
+    2. Check vault pair on Base has different chain_id from Arbitrum home chain
+    3. Verify multichain detection via universe chains
+    4. Verify bridge pairs are filtered from TUI PairSelectionApp
+    5. Verify chain name resolution works for display
+    """
+
+    # 1. Bridge pair detection
+    assert bridge_pair.kind == TradingPairKind.cctp_bridge
+    assert bridge_pair.is_cctp_bridge()
+
+    # 2. Cross-chain detection: vault on Base vs Arbitrum home
+    home_chain_id = ARBITRUM_CHAIN_ID
+    assert vault_pair.chain_id == BASE_CHAIN_ID
+    assert vault_pair.chain_id != home_chain_id
+    assert not vault_pair.is_cctp_bridge()
+
+    # Bridge pair should NOT be considered cross-chain (it IS the bridge)
+    is_bridge_cross_chain = (
+        not bridge_pair.is_cctp_bridge()
+        and bridge_pair.chain_id != home_chain_id
+    )
+    assert not is_bridge_cross_chain
+
+    # Vault pair on home chain should NOT be cross-chain
+    arb_vault = TradingPairIdentifier(
+        base=AssetIdentifier(chain_id=ARBITRUM_CHAIN_ID, address="0x1234", token_symbol="TEST", decimals=18),
+        quote=AssetIdentifier(chain_id=ARBITRUM_CHAIN_ID, address="0x5678", token_symbol="USDC", decimals=6),
+        pool_address="0x1234",
+        exchange_address="0x1234",
+        internal_id=99,
+        internal_exchange_id=99,
+        fee=0.0,
+        kind=TradingPairKind.vault,
+    )
+    is_arb_vault_cross_chain = (
+        not arb_vault.is_cctp_bridge()
+        and arb_vault.chain_id != home_chain_id
+    )
+    assert not is_arb_vault_cross_chain
+
+    # 3. Multichain detection
+    assert len(universe.data_universe.chains) > 1
+
+    # 4. TUI bridge pair filtering
+    all_pairs = list(universe.iterate_pairs())
+    assert len(all_pairs) == 2
+    # PairSelectionApp filters bridge pairs in __init__
+    filtered = [p for p in all_pairs if not p.is_cctp_bridge()]
+    assert len(filtered) == 1
+    assert filtered[0].kind == TradingPairKind.vault
+
+    # 5. Chain name resolution
+    chain_name = ChainId(vault_pair.base.chain_id).get_name()
+    assert chain_name == "Base"
+
+
+@pytest.mark.timeout(600)
+def test_make_test_trade_crosschain_buy_only(
+    arb_web3,
+    execution_model: EthereumExecution,
+    sync_model: HotWalletSyncModel,
+    routing_model: GenericRouting,
+    state: State,
+    universe: TradingStrategyUniverse,
+    bridge_pair: TradingPairIdentifier,
+    vault_pair: TradingPairIdentifier,
+    web3config: Web3Config,
+):
+    """Cross-chain buy-only test trade: bridge in + open vault position.
+
+    1. Set up routing state
+    2. Verify initial equity matches deposit
+    3. Call make_test_trade with buy_only=True for satellite vault pair
+    4. Verify bridge position created with correct kind
+    5. Verify vault position created on Base
+    6. Verify home reserves decreased by bridge amount
+    7. Verify total equity preserved
+    """
+
+    # 1. Set up routing state and generic pricing model
+    routing_state = routing_model.create_routing_state(
+        universe, {"tx_builder": execution_model.tx_builder},
+    )
+    pricing_model = GenericPricing(routing_model.pair_configurator)
+
+    # 2. Verify initial equity
+    initial_equity = _get_total_equity(state)
+    assert initial_equity == pytest.approx(float(DEPOSIT_AMOUNT), rel=0.01)
+
+    # 3. Call make_test_trade with buy_only for satellite chain pair
+    make_test_trade(
+        web3=arb_web3,
+        execution_model=execution_model,
+        pricing_model=pricing_model,
+        sync_model=sync_model,
+        state=state,
+        universe=universe,
+        routing_model=routing_model,
+        routing_state=routing_state,
+        max_slippage=0.05,
+        amount=TEST_TRADE_AMOUNT,
+        pair=vault_pair,
+        buy_only=True,
+        web3config=web3config,
+    )
+
+    # 4. Verify bridge position created
+    bridge_positions = [
+        p for p in state.portfolio.open_positions.values()
+        if p.pair.kind == TradingPairKind.cctp_bridge
+    ]
+    assert len(bridge_positions) == 1
+    bridge_position = bridge_positions[0]
+    assert float(bridge_position.get_quantity()) == pytest.approx(float(TEST_TRADE_AMOUNT), rel=0.01)
+
+    # 5. Verify vault position created
+    vault_positions = [
+        p for p in state.portfolio.open_positions.values()
+        if p.pair.kind == TradingPairKind.vault
+    ]
+    assert len(vault_positions) == 1
+    assert vault_positions[0].get_quantity() > 0
+
+    # 6. Verify home reserves decreased
+    home_reserve = state.portfolio.get_default_reserve_position()
+    assert float(home_reserve.quantity) == pytest.approx(float(DEPOSIT_AMOUNT - TEST_TRADE_AMOUNT), rel=0.01)
+
+    # 7. Verify total equity preserved (within tolerance for vault share pricing)
+    final_equity = _get_total_equity(state)
+    assert final_equity == pytest.approx(float(DEPOSIT_AMOUNT), rel=0.03)
+
+
+@pytest.mark.timeout(600)
+def test_make_test_trade_crosschain_round_trip(
+    arb_web3,
+    execution_model: EthereumExecution,
+    sync_model: HotWalletSyncModel,
+    routing_model: GenericRouting,
+    state: State,
+    universe: TradingStrategyUniverse,
+    bridge_pair: TradingPairIdentifier,
+    vault_pair: TradingPairIdentifier,
+    web3config: Web3Config,
+):
+    """Full round-trip cross-chain test trade: bridge in → open → close → bridge back.
+
+    1. Set up routing state and pricing
+    2. Call make_test_trade with default mode (open + close) for satellite vault pair
+    3. Verify no open positions remain after round-trip
+    4. Verify capital returned to home reserves
+    5. Verify total equity preserved
+    """
+
+    # 1. Set up routing and generic pricing model
+    routing_state = routing_model.create_routing_state(
+        universe, {"tx_builder": execution_model.tx_builder},
+    )
+    pricing_model = GenericPricing(routing_model.pair_configurator)
+
+    initial_equity = _get_total_equity(state)
+
+    # 2. Call make_test_trade with buy_only first, then close_only
+    #    to inspect state between steps
+    make_test_trade(
+        web3=arb_web3,
+        execution_model=execution_model,
+        pricing_model=pricing_model,
+        sync_model=sync_model,
+        state=state,
+        universe=universe,
+        routing_model=routing_model,
+        routing_state=routing_state,
+        max_slippage=0.05,
+        amount=TEST_TRADE_AMOUNT,
+        pair=vault_pair,
+        web3config=web3config,
+    )
+
+    # 3. Inspect all trades for debugging
+    all_trades = list(state.portfolio.get_all_trades())
+
+    # 3b. No open positions should remain
+    open_positions = list(state.portfolio.open_positions.values())
+    assert len(open_positions) == 0, \
+        f"Expected 0 open positions after round-trip, got {len(open_positions)}: " \
+        f"{[(p.pair.get_ticker(), p.pair.kind.value) for p in open_positions]}"
+
+    # 4. Capital returned to home reserves
+    home_reserve = state.portfolio.get_default_reserve_position()
+    assert float(home_reserve.quantity) > 0
+
+    # 5. Total equity preserved (within tolerance for vault/bridge fees)
+    final_equity = _get_total_equity(state)
+    assert final_equity == pytest.approx(initial_equity, rel=0.05), \
+        f"Equity dropped from {initial_equity} to {final_equity}. " \
+        f"Trades: {len(all_trades)}, " \
+        f"reserve: {float(home_reserve.quantity)}, " \
+        f"closed positions: {len(state.portfolio.closed_positions)}"
+
+
+@pytest.mark.timeout(600)
+def test_make_test_trade_crosschain_close_only(
+    arb_web3,
+    execution_model: EthereumExecution,
+    sync_model: HotWalletSyncModel,
+    routing_model: GenericRouting,
+    state: State,
+    universe: TradingStrategyUniverse,
+    bridge_pair: TradingPairIdentifier,
+    vault_pair: TradingPairIdentifier,
+    web3config: Web3Config,
+):
+    """Close-only cross-chain test trade: open with buy_only, then close separately.
+
+    1. Set up routing state and pricing
+    2. Open positions via make_test_trade with buy_only=True
+    3. Verify open positions exist (bridge + vault)
+    4. Close positions via make_test_trade with close_only=True
+    5. Verify no open positions remain
+    6. Verify capital returned to home reserves
+    7. Verify total equity preserved
+    """
+
+    # 1. Set up routing state and generic pricing model
+    routing_state = routing_model.create_routing_state(
+        universe, {"tx_builder": execution_model.tx_builder},
+    )
+    pricing_model = GenericPricing(routing_model.pair_configurator)
+
+    initial_equity = _get_total_equity(state)
+
+    # 2. Open positions via buy_only
+    make_test_trade(
+        web3=arb_web3,
+        execution_model=execution_model,
+        pricing_model=pricing_model,
+        sync_model=sync_model,
+        state=state,
+        universe=universe,
+        routing_model=routing_model,
+        routing_state=routing_state,
+        max_slippage=0.05,
+        amount=TEST_TRADE_AMOUNT,
+        pair=vault_pair,
+        buy_only=True,
+        web3config=web3config,
+    )
+
+    # 3. Verify open positions exist
+    open_positions = list(state.portfolio.open_positions.values())
+    assert len(open_positions) == 2, \
+        f"Expected 2 open positions (bridge + vault), got {len(open_positions)}"
+    assert any(p.pair.kind == TradingPairKind.cctp_bridge for p in open_positions)
+    assert any(p.pair.kind == TradingPairKind.vault for p in open_positions)
+
+    # 4. Close positions via close_only
+    make_test_trade(
+        web3=arb_web3,
+        execution_model=execution_model,
+        pricing_model=pricing_model,
+        sync_model=sync_model,
+        state=state,
+        universe=universe,
+        routing_model=routing_model,
+        routing_state=routing_state,
+        max_slippage=0.05,
+        amount=TEST_TRADE_AMOUNT,
+        pair=vault_pair,
+        close_only=True,
+        web3config=web3config,
+    )
+
+    # 5. No open positions should remain
+    open_positions = list(state.portfolio.open_positions.values())
+    assert len(open_positions) == 0, \
+        f"Expected 0 open positions after close_only, got {len(open_positions)}: " \
+        f"{[(p.pair.get_ticker(), p.pair.kind.value) for p in open_positions]}"
+
+    # 6. Capital returned to home reserves
+    home_reserve = state.portfolio.get_default_reserve_position()
+    assert float(home_reserve.quantity) > 0
+
+    # 7. Total equity preserved (within tolerance for vault/bridge fees)
+    final_equity = _get_total_equity(state)
+    assert final_equity == pytest.approx(initial_equity, rel=0.05), \
+        f"Equity dropped from {initial_equity} to {final_equity}"

--- a/tradeexecutor/cli/commands/perform_test_trade.py
+++ b/tradeexecutor/cli/commands/perform_test_trade.py
@@ -23,7 +23,8 @@ from tradingstrategy.chain import ChainId
 from .app import app
 from .pair_mapping import parse_pair_data
 from ..bootstrap import prepare_executor_id, prepare_cache_and_token_cache, create_web3_config, create_state_store, \
-    create_execution_and_sync_model, create_client, configure_default_chain
+    create_execution_and_sync_model, create_client, configure_default_chain, \
+    check_universe_chains_have_rpc, check_universe_chains_have_gas
 from ..log import setup_logging
 from ..slippage import configure_max_slippage_tolerance
 from ..testtrade import make_test_trade
@@ -228,6 +229,13 @@ def perform_test_trade(
         strategy_parameters=mod.parameters,
         execution_model=execution_model,
     )
+
+    # Validate all universe chains have RPC and gas before starting trades.
+    # This prevents bridging USDC to a chain we cannot reach.
+    check_universe_chains_have_rpc(web3config, universe)
+    wallet_address = execution_model.tx_builder.get_gas_wallet_address()
+    min_gas = getattr(execution_model, 'min_balance_threshold', 0)
+    check_universe_chains_have_gas(web3config, universe, wallet_address, min_gas)
 
     if single_pair:
         pair = universe.get_single_pair()

--- a/tradeexecutor/cli/commands/perform_test_trade.py
+++ b/tradeexecutor/cli/commands/perform_test_trade.py
@@ -18,11 +18,12 @@ from typing import Optional
 from typer import Option
 
 from eth_defi.compat import native_datetime_utc_now
+from tradingstrategy.chain import ChainId
 
 from .app import app
-from .pair_mapping import parse_pair_data, construct_identifier_from_pair
+from .pair_mapping import parse_pair_data
 from ..bootstrap import prepare_executor_id, prepare_cache_and_token_cache, create_web3_config, create_state_store, \
-    create_execution_and_sync_model, create_client
+    create_execution_and_sync_model, create_client, configure_default_chain
 from ..log import setup_logging
 from ..slippage import configure_max_slippage_tolerance
 from ..testtrade import make_test_trade
@@ -156,7 +157,7 @@ def perform_test_trade(
     if not web3config.has_any_connection():
         raise RuntimeError("perform-test-trade requires that you pass JSON-RPC connection to one of the networks")
 
-    web3config.choose_single_chain()
+    configure_default_chain(web3config, mod)
 
     max_slippage = configure_max_slippage_tolerance(max_slippage, mod)
 
@@ -276,19 +277,19 @@ def perform_test_trade(
                     buy_only=buy_only,
                     test_short=test_short,
                     amount=Decimal(amount),
+                    web3config=web3config,
                 )
         elif all_pairs:
-            logger.info("Testing all pairs, we have %d pairs", universe.get_pair_count())
+            tradeable_pairs = [p for p in universe.iterate_pairs() if not p.is_cctp_bridge()]
+            logger.info("Testing all pairs, we have %d tradeable pairs (excluding bridge pairs)", len(tradeable_pairs))
 
             if not simulate:
-                assert universe.get_pair_count() < 10, "Too many pairs to test"
+                assert len(tradeable_pairs) < 10, "Too many pairs to test"
 
-            for pair in universe.data_universe.pairs.iterate_pairs():
+            for pair in tradeable_pairs:
 
-                logger.info("Making test trade for %s", pair)
-
-                _p = construct_identifier_from_pair(pair)
-                p = parse_pair_data(_p)
+                chain_name = ChainId(pair.chain_id).get_name()
+                logger.info("Making test trade for %s on %s", pair, chain_name)
 
                 make_test_trade(
                     web3config.get_default(),
@@ -300,10 +301,11 @@ def perform_test_trade(
                     runner.routing_model,
                     routing_state,
                     max_slippage=max_slippage,
-                    pair=p,
+                    pair=pair,
                     buy_only=buy_only,
                     test_short=test_short,
                     amount=Decimal(amount),
+                    web3config=web3config,
                 )
         else:
 
@@ -325,6 +327,7 @@ def perform_test_trade(
                 buy_only=buy_only,
                 test_short=test_short,
                 amount=Decimal(amount),
+                web3config=web3config,
             )
     except OutOfBalance as e:
         raise RuntimeError(f"Failed to a test trade, as we run out of balance. Make sure vault has enough stablecoins deposited for the test trades.") from e

--- a/tradeexecutor/cli/commands/trade_ui.py
+++ b/tradeexecutor/cli/commands/trade_ui.py
@@ -239,9 +239,9 @@ def trade_ui(
     chain_id = ChainId(web3.eth.chain_id)
     is_hyperliquid = chain_id in (ChainId.hyperliquid, ChainId.hyperliquid_testnet)
 
-    # Collect pairs for the TUI
-    pairs = list(universe.iterate_pairs())
-    assert len(pairs) > 0, "Trading universe has no pairs"
+    # Collect pairs for the TUI — filter out CCTP bridge pairs (handled automatically)
+    pairs = [p for p in universe.iterate_pairs() if not p.is_cctp_bridge()]
+    assert len(pairs) > 0, "Trading universe has no tradeable pairs (after filtering bridge pairs)"
 
     # Display TUI and get user selections
     if unit_testing:
@@ -293,6 +293,7 @@ def trade_ui(
             close_only=close_only,
             test_short=test_short,
             amount=amount,
+            web3config=web3config,
         )
     except OutOfBalance as e:
         raise RuntimeError(

--- a/tradeexecutor/cli/commands/trade_ui.py
+++ b/tradeexecutor/cli/commands/trade_ui.py
@@ -38,6 +38,8 @@ from ..bootstrap import (
     create_execution_and_sync_model,
     create_client,
     configure_default_chain,
+    check_universe_chains_have_rpc,
+    check_universe_chains_have_gas,
 )
 from ..log import setup_logging
 from ..slippage import configure_max_slippage_tolerance
@@ -208,6 +210,13 @@ def trade_ui(
         strategy_parameters=mod.parameters,
         execution_model=execution_model,
     )
+
+    # Validate all universe chains have RPC and gas before starting trades.
+    # This prevents bridging USDC to a chain we cannot reach.
+    check_universe_chains_have_rpc(web3config, universe)
+    wallet_address = execution_model.tx_builder.get_gas_wallet_address()
+    min_gas = getattr(execution_model, 'min_balance_threshold', 0)
+    check_universe_chains_have_gas(web3config, universe, wallet_address, min_gas)
 
     runner = run_description.runner
     routing_state, pricing_model, valuation_method = runner.setup_routing(universe)

--- a/tradeexecutor/cli/testtrade.py
+++ b/tradeexecutor/cli/testtrade.py
@@ -372,12 +372,19 @@ def make_test_trade(
 
             pair = translate_trading_pair(raw_pair)
 
-        # Detect if this pair is on a satellite chain (cross-chain trade)
-        home_chain_id = web3config.default_chain_id.value if web3config else web3.eth.chain_id
-        is_cross_chain = (
-            not pair.is_cctp_bridge()
-            and pair.chain_id != home_chain_id
-        )
+        # Detect if this pair is on a satellite chain (cross-chain trade).
+        # Only attempt cross-chain when web3config is explicitly provided
+        # (callers managing bridging themselves pass web3config=None).
+        # Also skip when the default chain is a test chain (Anvil fork)
+        # because the fork chain_id won't match real pair chain_ids.
+        from tradeexecutor.ethereum.web3config import TEST_CHAIN_IDS
+        is_cross_chain = False
+        if web3config is not None and web3config.default_chain_id not in TEST_CHAIN_IDS:
+            home_chain_id = web3config.default_chain_id.value
+            is_cross_chain = (
+                not pair.is_cctp_bridge()
+                and pair.chain_id != home_chain_id
+            )
 
         if is_cross_chain:
             chain_name = ChainId(pair.chain_id).get_name()

--- a/tradeexecutor/cli/testtrade.py
+++ b/tradeexecutor/cli/testtrade.py
@@ -7,7 +7,8 @@ from web3 import Web3
 
 from eth_defi.compat import native_datetime_utc_now
 from eth_defi.provider.anvil import is_anvil, mine
-from tradeexecutor.state.identifier import TradingPairIdentifier
+from tradeexecutor.state.identifier import TradingPairIdentifier, TradingPairKind
+from tradingstrategy.chain import ChainId
 from tradingstrategy.lending import LendingReserveDescription
 from tradingstrategy.universe import Universe
 from tradingstrategy.pair import HumanReadableTradingPairDescription
@@ -32,6 +33,273 @@ from eth_defi.compat import native_datetime_utc_now
 logger = logging.getLogger(__name__)
 
 
+def _materialise_bridge_on_anvil(
+    web3config,
+    routing_model: RoutingModel,
+    bridge_pair: TradingPairIdentifier,
+    dest_chain_id: int,
+    fallback_recipient: str,
+    bridge_trade,
+):
+    """Mint USDC on destination Anvil fork to simulate bridge completion.
+
+    On Anvil forks, CctpBridgeRouting uses skip_attestation=True which marks
+    the bridge trade as success after burn confirmation, but USDC does not
+    physically arrive on the destination chain. This helper materialises
+    the tokens by minting directly on the destination Anvil fork.
+
+    The mint recipient is resolved from the CCTP routing model's
+    custody_address_resolver, matching what CctpBridgeRouting.setup_trades()
+    uses for the real depositForBurn call. For Lagoon/Safe multichain setups
+    this is the per-chain Safe address, not the hot wallet.
+    """
+    from eth_defi.provider.anvil import fund_erc20_on_anvil
+    from eth_defi.token import USDC_NATIVE_TOKEN, fetch_erc20_details
+
+    # Resolve mint recipient from CCTP routing config
+    pair_config = routing_model.pair_configurator.get_config(
+        routing_model.pair_configurator.match_router(bridge_pair)
+    )
+    cctp_routing = pair_config.routing_model
+    if hasattr(cctp_routing, 'custody_address_resolver') and cctp_routing.custody_address_resolver:
+        recipient = cctp_routing.custody_address_resolver(dest_chain_id)
+    else:
+        recipient = fallback_recipient
+
+    dest_web3 = web3config.get_connection(ChainId(dest_chain_id))
+    usdc_address = USDC_NATIVE_TOKEN[dest_chain_id]
+
+    # Derive raw amount from executed trade using token decimals.
+    # fund_erc20_on_anvil uses anvil_setStorageAt which OVERWRITES the balance,
+    # so we must read the existing balance first and add to it.
+    dest_usdc = fetch_erc20_details(dest_web3, usdc_address)
+    bridge_amount_raw = dest_usdc.convert_to_raw(bridge_trade.executed_reserve)
+    existing_balance_raw = dest_usdc.contract.functions.balanceOf(
+        Web3.to_checksum_address(recipient)
+    ).call()
+    total_raw = existing_balance_raw + bridge_amount_raw
+
+    logger.info(
+        "Anvil fork: materialising %s USDC on chain %s for %s (existing balance: %s)",
+        bridge_trade.executed_reserve, ChainId(dest_chain_id).get_name(), recipient,
+        dest_usdc.convert_to_decimals(existing_balance_raw),
+    )
+    fund_erc20_on_anvil(dest_web3, usdc_address, recipient, total_raw)
+
+
+def _make_cross_chain_test_trade(
+    web3: "Web3",
+    web3config,
+    execution_model: ExecutionModel,
+    pricing_model: "PricingModel",
+    sync_model: "SyncModel",
+    state: State,
+    universe: TradingStrategyUniverse,
+    routing_model: RoutingModel,
+    routing_state: RoutingState,
+    position_manager: PositionManager,
+    pair: TradingPairIdentifier,
+    bridge_pair: TradingPairIdentifier,
+    amount: Decimal,
+    max_slippage: float,
+    buy_only: bool,
+    close_only: bool,
+    gas_at_start,
+    hot_wallet,
+    reserve_currency: str,
+    reserve_currency_at_start: float,
+    anvil_time_skip_seconds: int = 24 * 3600,
+):
+    """Cross-chain test trade: bridge in, open position, close position, bridge out.
+
+    Handles satellite-chain pairs by automatically injecting CCTP bridge
+    trades before opening and after closing positions.
+
+    On real mainnet, CctpBridgeRouting.settle_trade() handles attestation
+    and receiveMessage automatically. On Anvil forks, USDC is materialised
+    via fund_erc20_on_anvil() after bridge trades succeed.
+    """
+    from tradeexecutor.strategy.generic.generic_pricing_model import GenericPricing
+
+    assert isinstance(pricing_model, GenericPricing), \
+        f"Cross-chain test trades require GenericPricing, got {type(pricing_model)}"
+    assert hasattr(routing_model, 'pair_configurator'), \
+        f"Cross-chain test trades require GenericRouting with pair_configurator, got {type(routing_model)}"
+
+    # Verify both pairs are routable
+    try:
+        pricing_model.route(bridge_pair)
+        pricing_model.route(pair)
+    except Exception as e:
+        raise RuntimeError(
+            f"Pricing model cannot route cross-chain pairs. "
+            f"Bridge pair: {bridge_pair.get_ticker()}, satellite pair: {pair.get_ticker()}"
+        ) from e
+
+    assert web3config is not None, "Cross-chain test trades require web3config"
+
+    ts = native_datetime_utc_now()
+    chain_name = ChainId(pair.chain_id).get_name()
+    notes = "A test trade created with perform-test-trade command line command"
+    on_anvil = is_anvil(web3)
+    dest_chain_id = pair.chain_id
+
+    if close_only:
+        # Close-only: find existing positions and close them
+        satellite_position = state.portfolio.get_position_by_trading_pair(pair)
+        if satellite_position is None or not satellite_position.is_open():
+            raise RuntimeError(
+                f"Close-only mode but no open position for {pair.get_ticker()} on {chain_name}."
+            )
+
+        bridge_position = state.portfolio.get_bridge_position_for_chain(dest_chain_id)
+        if bridge_position is None or not bridge_position.is_open():
+            raise RuntimeError(
+                f"Close-only mode but no open bridge position for chain {chain_name}."
+            )
+
+        # Step 1: Close satellite position
+        logger.info("Cross-chain close step 1: closing %s on %s", pair.get_ticker(), chain_name)
+        ts = native_datetime_utc_now()
+        position_manager = PositionManager(
+            ts, universe, state, pricing_model,
+            default_slippage_tolerance=max_slippage,
+        )
+        trades = position_manager.close_position(
+            satellite_position, notes=notes, flags={TradeFlag.test_trade},
+        )
+        execution_model.execute_trades(ts, state, trades, routing_model, routing_state)
+        assert trades[0].is_success(), f"Satellite close failed: {trades[0].get_revert_reason()}"
+
+        # Step 2: Bridge back — sized by get_available_bridge_capital()
+        logger.info("Cross-chain close step 2: bridging back from %s", chain_name)
+        ts = native_datetime_utc_now()
+        position_manager = PositionManager(
+            ts, universe, state, pricing_model,
+            default_slippage_tolerance=max_slippage,
+        )
+        bridge_back_trades = position_manager.close_position(
+            bridge_position, notes=notes, flags={TradeFlag.test_trade},
+        )
+        execution_model.execute_trades(ts, state, bridge_back_trades, routing_model, routing_state)
+        assert bridge_back_trades[0].is_success(), \
+            f"Bridge back failed: {bridge_back_trades[0].get_revert_reason()}"
+
+        if on_anvil:
+            home_chain_id = web3config.default_chain_id.value
+            _materialise_bridge_on_anvil(
+                web3config, routing_model, bridge_pair,
+                home_chain_id, hot_wallet.address, bridge_back_trades[0],
+            )
+            sync_model.sync_treasury(
+                native_datetime_utc_now(), state, list(universe.reserve_assets),
+            )
+
+    else:
+        # Buy flow: bridge in, then open satellite position
+
+        # Step 1: Bridge USDC to satellite chain
+        logger.info("Cross-chain step 1: bridge %s USDC to %s via CCTP", amount, chain_name)
+        bridge_trades = position_manager.open_spot(
+            bridge_pair, float(amount), notes=notes, flags={TradeFlag.test_trade},
+        )
+        execution_model.execute_trades(ts, state, bridge_trades, routing_model, routing_state)
+        bridge_buy_trade = bridge_trades[0]
+        assert bridge_buy_trade.is_success(), \
+            f"Bridge in failed: {bridge_buy_trade.get_revert_reason()}"
+
+        # Materialise USDC on Anvil fork
+        if on_anvil:
+            _materialise_bridge_on_anvil(
+                web3config, routing_model, bridge_pair,
+                dest_chain_id, hot_wallet.address, bridge_buy_trade,
+            )
+
+        # Step 2: Open position on satellite chain
+        logger.info("Cross-chain step 2: open %s on %s", pair.get_ticker(), chain_name)
+        ts = native_datetime_utc_now()
+        position_manager = PositionManager(
+            ts, universe, state, pricing_model,
+            default_slippage_tolerance=max_slippage,
+        )
+        satellite_trades = position_manager.open_spot(
+            pair, float(amount), notes=notes, flags={TradeFlag.test_trade},
+        )
+        execution_model.execute_trades(ts, state, satellite_trades, routing_model, routing_state)
+        satellite_buy_trade = satellite_trades[0]
+        assert satellite_buy_trade.is_success(), \
+            f"Satellite open failed: {satellite_buy_trade.get_revert_reason()}"
+
+        satellite_position = state.portfolio.get_position_by_id(satellite_buy_trade.position_id)
+        bridge_position = state.portfolio.get_position_by_id(bridge_buy_trade.position_id)
+
+        long_short_metrics_latest = serialise_long_short_stats_as_json_table(state, None)
+        update_statistics(native_datetime_utc_now(), state.stats, state.portfolio,
+                          ExecutionMode.real_trading, long_short_metrics_latest=long_short_metrics_latest)
+
+        if not buy_only:
+            # Sell flow: close satellite, then bridge back
+
+            if on_anvil:
+                logger.info("Skipping time forward by %d seconds", anvil_time_skip_seconds)
+                dest_web3 = web3config.get_connection(ChainId(dest_chain_id))
+                mine(dest_web3, increase_timestamp=anvil_time_skip_seconds)
+
+            # Step 3: Close satellite position
+            logger.info("Cross-chain step 3: close %s on %s", pair.get_ticker(), chain_name)
+            ts = native_datetime_utc_now()
+            position_manager = PositionManager(
+                ts, universe, state, pricing_model,
+                default_slippage_tolerance=max_slippage,
+            )
+            close_trades = position_manager.close_position(
+                satellite_position, notes=notes, flags={TradeFlag.test_trade},
+            )
+            execution_model.execute_trades(ts, state, close_trades, routing_model, routing_state)
+            assert close_trades[0].is_success(), \
+                f"Satellite close failed: {close_trades[0].get_revert_reason()}"
+
+            # Step 4: Bridge back — sized by get_available_bridge_capital()
+            logger.info("Cross-chain step 4: bridge back from %s", chain_name)
+            ts = native_datetime_utc_now()
+            position_manager = PositionManager(
+                ts, universe, state, pricing_model,
+                default_slippage_tolerance=max_slippage,
+            )
+            bridge_back_trades = position_manager.close_position(
+                bridge_position, notes=notes, flags={TradeFlag.test_trade},
+            )
+            execution_model.execute_trades(
+                ts, state, bridge_back_trades, routing_model, routing_state,
+            )
+            assert bridge_back_trades[0].is_success(), \
+                f"Bridge back failed: {bridge_back_trades[0].get_revert_reason()}"
+
+            if on_anvil:
+                home_chain_id = web3config.default_chain_id.value
+                _materialise_bridge_on_anvil(
+                    web3config, routing_model, bridge_pair,
+                    home_chain_id, hot_wallet.address, bridge_back_trades[0],
+                )
+                sync_model.sync_treasury(
+                    native_datetime_utc_now(), state, list(universe.reserve_assets),
+                )
+
+            long_short_metrics_latest = serialise_long_short_stats_as_json_table(state, None)
+            update_statistics(native_datetime_utc_now(), state.stats, state.portfolio,
+                              ExecutionMode.real_trading, long_short_metrics_latest=long_short_metrics_latest)
+
+    # Final report
+    gas_at_end = hot_wallet.get_native_currency_balance(web3)
+    reserve_currency_at_end = state.portfolio.get_default_reserve_position().get_value()
+
+    logger.info("Cross-chain test trade report")
+    logger.info("  Chain: %s", chain_name)
+    logger.info("  Gas spent: %s", gas_at_start - gas_at_end)
+    logger.info("  Trades done: %d", len(list(state.portfolio.get_all_trades())))
+    logger.info("  Reserves: %s %s (was %s)", reserve_currency_at_end, reserve_currency, reserve_currency_at_start)
+
+
 def make_test_trade(
     web3: Web3,
     execution_model: ExecutionModel,
@@ -49,6 +317,7 @@ def make_test_trade(
     close_only: bool = False,
     test_short: bool = True,
     anvil_time_skip_seconds: int = 24*3600,
+    web3config=None,
 ):
     """Perform a test trade.
 
@@ -80,6 +349,8 @@ def make_test_trade(
 
     reserve_asset = universe.get_reserve_asset()
 
+    is_cross_chain = False
+
     if pair:
         assert not lending_reserve_description
 
@@ -101,23 +372,35 @@ def make_test_trade(
 
             pair = translate_trading_pair(raw_pair)
 
-        logger.info("Getting price for pair %s using %s", pair, pricing_model)
-        # Get estimated price for the asset we are going to buy
-        assumed_price_structure = pricing_model.get_buy_price(
-            ts,
-            pair,
-            amount,
+        # Detect if this pair is on a satellite chain (cross-chain trade)
+        home_chain_id = web3config.default_chain_id.value if web3config else web3.eth.chain_id
+        is_cross_chain = (
+            not pair.is_cctp_bridge()
+            and pair.chain_id != home_chain_id
         )
 
-        logger.info(
-            "Making a test trade on pair: %s, for %f %s price is %f %s/%s",
-            pair,
-            amount,
-            reserve_asset.token_symbol,
-            assumed_price_structure.mid_price,
-            pair.base.token_symbol,
-            reserve_asset.token_symbol,
-        )
+        if is_cross_chain:
+            chain_name = ChainId(pair.chain_id).get_name()
+            logger.info("Cross-chain pair detected: %s on %s (home chain: %s)",
+                        pair.get_ticker(), chain_name, ChainId(home_chain_id).get_name())
+        else:
+            logger.info("Getting price for pair %s using %s", pair, pricing_model)
+            # Get estimated price for the asset we are going to buy
+            assumed_price_structure = pricing_model.get_buy_price(
+                ts,
+                pair,
+                amount,
+            )
+
+            logger.info(
+                "Making a test trade on pair: %s, for %f %s price is %f %s/%s",
+                pair,
+                amount,
+                reserve_asset.token_symbol,
+                assumed_price_structure.mid_price,
+                pair.base.token_symbol,
+                reserve_asset.token_symbol,
+            )
 
     elif lending_reserve_description:
         # Convert description to TradingPairIdentifier used in PositionManager
@@ -181,6 +464,43 @@ def make_test_trade(
         pricing_model,
         default_slippage_tolerance=max_slippage,
     )
+
+    # Cross-chain dispatch: if the target pair is on a satellite chain,
+    # delegate to the cross-chain helper that handles bridge in/out
+    if is_cross_chain:
+        from tradeexecutor.ethereum.cctp.planner import _find_bridge_pair
+
+        all_pairs = list(universe.iterate_pairs())
+        bridge_pair = _find_bridge_pair(all_pairs, pair.chain_id)
+        if bridge_pair is None:
+            raise RuntimeError(
+                f"Cross-chain pair detected on {ChainId(pair.chain_id).get_name()} but no CCTP bridge pair found. "
+                f"Ensure auto_generate_cctp_bridges=True in your strategy."
+            )
+
+        return _make_cross_chain_test_trade(
+            web3=web3,
+            web3config=web3config,
+            execution_model=execution_model,
+            pricing_model=pricing_model,
+            sync_model=sync_model,
+            state=state,
+            universe=universe,
+            routing_model=routing_model,
+            routing_state=routing_state,
+            position_manager=position_manager,
+            pair=pair,
+            bridge_pair=bridge_pair,
+            amount=amount,
+            max_slippage=max_slippage,
+            buy_only=buy_only,
+            close_only=close_only,
+            gas_at_start=gas_at_start,
+            hot_wallet=hot_wallet,
+            reserve_currency=reserve_currency,
+            reserve_currency_at_start=reserve_currency_at_start,
+            anvil_time_skip_seconds=anvil_time_skip_seconds,
+        )
 
     # The message left on the test positions and trades
     notes = "A test trade created with perform-test-trade command line command"

--- a/tradeexecutor/cli/trade_ui_tui.py
+++ b/tradeexecutor/cli/trade_ui_tui.py
@@ -34,6 +34,8 @@ from textual.widgets import (
 from eth_defi.compat import native_datetime_utc_now
 from tradingstrategy.liquidity import LiquidityDataUnavailable
 
+from tradingstrategy.chain import ChainId
+
 from tradeexecutor.state.identifier import TradingPairIdentifier
 from tradeexecutor.state.state import State
 from tradeexecutor.strategy.trading_strategy_universe import TradingStrategyUniverse
@@ -359,6 +361,8 @@ class PairSelectionApp(App):
         pricing_model=None,
     ):
         super().__init__()
+        # Filter out CCTP bridge pairs — they are handled automatically
+        pairs = [p for p in pairs if not p.is_cctp_bridge()]
         self.pairs = pairs
         self.strategy_universe = strategy_universe
         self.state = state
@@ -368,6 +372,9 @@ class PairSelectionApp(App):
         self.gas_balance = gas_balance
         self.is_hyperliquid = is_hyperliquid
         self.pricing_model = pricing_model
+
+        # Detect multichain universe for chain column display
+        self.is_multichain = len(strategy_universe.data_universe.chains) > 1
 
         # Compute TVL values and sort by TVL descending
         self.tvl_values = {
@@ -410,6 +417,8 @@ class PairSelectionApp(App):
     def on_mount(self) -> None:
         table = self.query_one(DataTable)
         table.add_column("#", key="idx", width=5)
+        if self.is_multichain:
+            table.add_column("Chain", key="chain", width=12)
         table.add_column("Symbol", key="symbol", width=40)
         table.add_column("Exchange", key="exchange", width=20)
         table.add_column("Price", key="price", width=14)
@@ -427,17 +436,13 @@ class PairSelectionApp(App):
             position = _get_position_info(self.state, pair)
             lockup = _format_lockup(self.state, pair)
 
-            table.add_row(
-                str(idx),
-                symbol,
-                exchange,
-                price,
-                tvl,
-                deposits,
-                position,
-                lockup,
-                key=str(idx),
-            )
+            row_values = [str(idx)]
+            if self.is_multichain:
+                chain_name = ChainId(pair.base.chain_id).get_name()
+                row_values.append(chain_name)
+            row_values.extend([symbol, exchange, price, tvl, deposits, position, lockup])
+
+            table.add_row(*row_values, key=str(idx))
 
         table.focus()
 


### PR DESCRIPTION
## Why

`perform-test-trade` and `trade-ui` only worked on a single chain. Cross-chain strategies (like `xchain-master-vault.py`) define vaults on satellite chains with CCTP bridge pairs, but the CLI/TUI layer blocked multichain usage by forcing single-chain mode. The routing and execution layers already fully support cross-chain trading — only the presentation layer needed updating.

## Lessons learnt

- On Anvil forks, `fund_erc20_on_anvil()` uses `anvil_setStorageAt` which **overwrites** the balance slot. When materialising bridged USDC, we must read the existing balance and add to it, otherwise prior funds are lost.
- The CCTP bridge mint recipient must be resolved from `custody_address_resolver` (not the hot wallet) to match what `CctpBridgeRouting.setup_trades()` uses — for Lagoon/Safe setups this is the per-chain Safe address.
- Cross-chain detection must happen **before** the buy-price lookup to avoid unnecessary price queries and to correctly handle `close_only` mode.
- Bridge-back sizing uses `position_manager.close_position(bridge_position)` which internally calls `get_available_bridge_capital()` — correctly handles vault rounding, fees, and profit/loss.

## Summary

- **`testtrade.py`**: New `_make_cross_chain_test_trade()` orchestrates bridge in → open satellite position → close → bridge back, with Anvil fork materialisation via `_materialise_bridge_on_anvil()`. Supports `buy_only`, `close_only`, and default (open + close) modes. Cross-chain pairs are auto-detected by comparing `pair.chain_id` to home chain.
- **`perform_test_trade.py`**: Replaced `choose_single_chain()` with `configure_default_chain()` for multichain support. Filters CCTP bridge pairs from `--all-pairs` loop. Added chain-aware logging.
- **`trade_ui.py`**: Passes `web3config` through; filters bridge pairs from pair list.
- **`trade_ui_tui.py`**: Hides bridge pairs from TUI selection. Adds conditional "Chain" column when the universe is multichain.
- **New test file**: `test_perform_test_trade_crosschain.py` with 4 tests (detection/TUI filtering, buy-only, round-trip, close-only) using Arbitrum + Base Anvil forks with IPOR Fusion vault.

🤖 Generated with [Claude Code](https://claude.com/claude-code)