### PR TITLE
fix: Repair command resolves chain from strategy module instead of choose_single_chain

### DIFF
--- a/tradeexecutor/cli/commands/repair.py
+++ b/tradeexecutor/cli/commands/repair.py
@@ -12,7 +12,7 @@ from eth_defi.compat import native_datetime_utc_now
 
 from . import shared_options
 from .app import app
-from ..bootstrap import prepare_executor_id, create_state_store, create_execution_and_sync_model, prepare_cache, create_web3_config, create_client
+from ..bootstrap import prepare_executor_id, create_state_store, create_execution_and_sync_model, prepare_cache, create_web3_config, create_client, configure_default_chain
 from ..log import setup_logging
 from ...ethereum.rebroadcast import rebroadcast_all
 from ...ethereum.velvet.execution import VelvetExecution
@@ -103,13 +103,10 @@ def repair(
 
     assert web3config, "No RPC endpoints given. A working JSON-RPC connection is needed for check-wallet"
 
-    # Check that we are connected to the chain strategy assumes
-    web3config.set_default_chain(mod.get_default_chain_id())
-
     if not web3config.has_any_connection():
-        raise RuntimeError("Vault deploy requires that you pass JSON-RPC connection to one of the networks")
+        raise RuntimeError("Repair requires that you pass JSON-RPC connection to one of the networks")
 
-    web3config.choose_single_chain()
+    configure_default_chain(web3config, mod)
 
     execution_model, sync_model, valuation_model_factory, pricing_model_factory = create_execution_and_sync_model(
         asset_management_mode=asset_management_mode,


### PR DESCRIPTION
## Why

The `repair` command calls `web3config.choose_single_chain()` which asserts exactly one chain connection. Multichain strategies (e.g. master-vault-v2 spanning Ethereum, Arbitrum, and Base) fail with:

```
AssertionError: Expected a single web3 connection, got JSON-RPC for chains [<ChainId.ethereum: 1>, <ChainId.arbitrum: 42161>, <ChainId.base: 8453>]
```

This is the same issue that was fixed for lagoon commands in #1470.

## Lessons learnt

- All commands that previously used `choose_single_chain()` should be audited for multichain compatibility
- `configure_default_chain()` is the standard pattern: it reads the chain from the strategy module's parameters and falls back to `choose_single_chain()` only when the strategy doesn't specify a chain

## Summary

- Replace `web3config.set_default_chain()` + `web3config.choose_single_chain()` with `configure_default_chain(web3config, mod)` in the repair command
- Same pattern as #1470 for lagoon commands