### PR TITLE
fix: Correct trade-ui vault deposit status

### DIFF
--- a/tests/cli/test_trade_ui_deposit_status.py
+++ b/tests/cli/test_trade_ui_deposit_status.py
@@ -1,0 +1,114 @@
+"""Test trade-ui vault deposit status rendering."""
+
+import datetime
+
+from tradeexecutor.cli.trade_ui_tui import _format_deposits_open, _get_deposit_status
+from tradeexecutor.state.identifier import AssetIdentifier, TradingPairIdentifier, TradingPairKind
+
+
+def _make_vault_pair(deposit_closed_reason: str | None = None) -> TradingPairIdentifier:
+    base = AssetIdentifier(
+        chain_id=1,
+        address="0x0000000000000000000000000000000000000001",
+        token_symbol="vUSDC",
+        decimals=18,
+    )
+    quote = AssetIdentifier(
+        chain_id=1,
+        address="0x0000000000000000000000000000000000000002",
+        token_symbol="USDC",
+        decimals=6,
+    )
+    return TradingPairIdentifier(
+        base=base,
+        quote=quote,
+        pool_address=base.address,
+        exchange_address=base.address,
+        internal_id=1,
+        internal_exchange_id=1,
+        fee=0.0,
+        kind=TradingPairKind.vault,
+        exchange_name="vault",
+        other_data={
+            "vault_protocol": "erc4626",
+            "deposit_closed_reason": deposit_closed_reason,
+        },
+    )
+
+
+def test_vault_pair_static_deposit_status_uses_closed_reason() -> None:
+    """Check ERC-4626 vault metadata can close deposits in the TUI fallback path.
+
+    1. Create a non-Hyperliquid vault pair with a deposit closed reason.
+    2. Ask the pair for its static deposit availability.
+    3. Render the TUI deposit status without a pricing model result.
+    4. Verify both paths report deposits as closed.
+    """
+    # 1. Create a non-Hyperliquid vault pair with a deposit closed reason.
+    pair = _make_vault_pair("Max deposit cap reached")
+
+    # 2. Ask the pair for its static deposit availability.
+    can_deposit = pair.can_deposit()
+
+    # 3. Render the TUI deposit status without a pricing model result.
+    rendered = _format_deposits_open(pair)
+
+    # 4. Verify both paths report deposits as closed.
+    assert can_deposit is False
+    assert rendered.plain == "No"
+
+
+def test_trade_ui_deposit_status_uses_live_pricing_model() -> None:
+    """Check trade-ui honours live pricing model deposit gates.
+
+    1. Create a vault pair whose static metadata says deposits are open.
+    2. Create a pricing model that reports deposits as closed.
+    3. Resolve and render the deposit status through the TUI helpers.
+    4. Verify the live closed status wins over static metadata.
+    """
+
+    class ClosedPricingModel:
+        def can_deposit(self, ts: datetime.datetime, pair: TradingPairIdentifier) -> bool:
+            return False
+
+    # 1. Create a vault pair whose static metadata says deposits are open.
+    pair = _make_vault_pair()
+
+    # 2. Create a pricing model that reports deposits as closed.
+    pricing_model = ClosedPricingModel()
+
+    # 3. Resolve and render the deposit status through the TUI helpers.
+    status = _get_deposit_status(pricing_model, pair, datetime.datetime(2026, 6, 3))
+    rendered = _format_deposits_open(pair, status)
+
+    # 4. Verify the live closed status wins over static metadata.
+    assert status is False
+    assert rendered.plain == "No"
+
+
+def test_trade_ui_deposit_status_shows_unknown_when_live_check_fails() -> None:
+    """Check trade-ui does not claim deposits are open after a failed live check.
+
+    1. Create a vault pair whose static metadata has no closed reason.
+    2. Create a pricing model whose live deposit check fails.
+    3. Resolve and render the deposit status through the TUI helpers.
+    4. Verify the UI renders unknown instead of a false open status.
+    """
+
+    class FailingPricingModel:
+        def can_deposit(self, ts: datetime.datetime, pair: TradingPairIdentifier) -> bool:
+            raise RuntimeError("RPC unavailable")
+
+    # 1. Create a vault pair whose static metadata has no closed reason.
+    pair = _make_vault_pair()
+
+    # 2. Create a pricing model whose live deposit check fails.
+    pricing_model = FailingPricingModel()
+
+    # 3. Resolve and render the deposit status through the TUI helpers.
+    status = _get_deposit_status(pricing_model, pair, datetime.datetime(2026, 6, 3))
+    rendered = _format_deposits_open(pair, status)
+
+    # 4. Verify the UI renders unknown instead of a false open status.
+    assert status is None
+    assert rendered.plain == "?"

--- a/tests/mainnet_fork/test_repair_frozen_credit_position.py
+++ b/tests/mainnet_fork/test_repair_frozen_credit_position.py
@@ -65,7 +65,7 @@ def environment(
     environment = {
         "STRATEGY_FILE": strategy_file.as_posix(),
         "PRIVATE_KEY": hexbytes_to_hex_str(secrets.token_bytes(32)),
-        "JSON_RPC_ANVIL": anvil.json_rpc_url,
+        "JSON_RPC_POLYGON": anvil.json_rpc_url,
         "STATE_FILE": state_file.as_posix(),
         "ASSET_MANAGEMENT_MODE": "enzyme",
         "UNIT_TESTING": "true",

--- a/tradeexecutor/cli/trade_ui_tui.py
+++ b/tradeexecutor/cli/trade_ui_tui.py
@@ -42,6 +42,10 @@ from tradeexecutor.strategy.trading_strategy_universe import TradingStrategyUniv
 
 logger = logging.getLogger(__name__)
 
+# Distinguish omitted status (fall back to pair metadata) from explicit
+# None (live deposit check failed and the UI should show unknown).
+UNKNOWN_DEPOSIT_STATUS = object()
+
 
 def _get_tvl_value(strategy_universe: TradingStrategyUniverse, pair: TradingPairIdentifier, tvl_now) -> float | None:
     """Look up raw TVL value for a pair."""
@@ -66,18 +70,42 @@ def _format_tvl(tvl: float | None) -> Text:
     return Text(f"${tvl:,.0f}", justify="right")
 
 
-def _format_deposits_open(pair: TradingPairIdentifier) -> Text:
+def _get_deposit_status(pricing_model, pair: TradingPairIdentifier, ts: datetime.datetime | None = None) -> bool | None:
+    """Get the current deposit status for a vault pair.
+
+    Uses the live pricing model when available, falling back to the
+    data-pipeline metadata snapshot stored on the pair.
+    """
+    if not pair.is_vault():
+        return None
+
+    if pricing_model is not None:
+        try:
+            return pricing_model.can_deposit(ts, pair)
+        except Exception as e:
+            logger.warning("Could not get live deposit status for %s, showing unknown: %s", pair, e)
+            if pair.get_deposit_closed_reason() is not None:
+                return False
+            return None
+
+    return pair.can_deposit()
+
+
+def _format_deposits_open(pair: TradingPairIdentifier, deposit_status=UNKNOWN_DEPOSIT_STATUS) -> Text:
     """Format the deposit status for a vault pair.
 
     Non-vault pairs show a dash.  Vault pairs show ``Yes`` / ``No``
-    based on :py:meth:`TradingPairIdentifier.can_deposit`.
+    based on the live pricing model status or pair metadata.
     """
     if not pair.is_vault():
         return Text("-", style="dim", justify="center")
-    if pair.can_deposit():
+    if deposit_status is UNKNOWN_DEPOSIT_STATUS:
+        deposit_status = pair.can_deposit()
+    if deposit_status is None:
+        return Text("?", style="yellow", justify="center")
+    if deposit_status:
         return Text("Yes", style="green", justify="center")
-    reason = pair.get_deposit_closed_reason() or "closed"
-    return Text(f"No", style="red bold", justify="center")
+    return Text("No", style="red bold", justify="center")
 
 
 def _get_price(pricing_model, pair: TradingPairIdentifier, ts: datetime.datetime | None = None) -> float | None:
@@ -391,12 +419,15 @@ class PairSelectionApp(App):
         # Non-vault pairs would trigger on-chain price queries that fail
         # or retry endlessly on Anvil forks.
         self.prices = {}
+        self.deposit_statuses = {}
         price_ts = native_datetime_utc_now()
         for pair in self.sorted_pairs:
             if pair.is_vault():
                 self.prices[id(pair)] = _get_price(pricing_model, pair, ts=price_ts)
+                self.deposit_statuses[id(pair)] = _get_deposit_status(pricing_model, pair, ts=price_ts)
             else:
                 self.prices[id(pair)] = None
+                self.deposit_statuses[id(pair)] = None
 
         # Result set by the trade dialog
         self.selected_pair: TradingPairIdentifier | None = None
@@ -432,7 +463,7 @@ class PairSelectionApp(App):
             exchange = pair.exchange_name or ""
             price = _format_price(self.prices.get(id(pair)))
             tvl = _format_tvl(self.tvl_values.get(id(pair)))
-            deposits = _format_deposits_open(pair)
+            deposits = _format_deposits_open(pair, self.deposit_statuses.get(id(pair)))
             position = _get_position_info(self.state, pair)
             lockup = _format_lockup(self.state, pair)
 

--- a/tradeexecutor/state/identifier.py
+++ b/tradeexecutor/state/identifier.py
@@ -960,15 +960,12 @@ class TradingPairIdentifier:
         instead.
 
         - Asserts this pair is a vault.
-        - For Hyperliquid vaults, checks ``deposit_closed_reason`` in
-          :py:attr:`other_data`.
-        - For other vault types returns ``True`` (no static metadata
-          available yet).
+        - Checks ``deposit_closed_reason`` in :py:attr:`other_data`.
+        - If the data-pipeline metadata does not expose a closed reason,
+          treats deposits as open.
         """
         assert self.is_vault(), f"Not a vault pair: {self}"
-        if self.is_hyperliquid_vault():
-            return self.other_data.get("deposit_closed_reason") is None
-        return True
+        return self.other_data.get("deposit_closed_reason") is None
 
     def get_vault_metadata(self) -> "VaultMetadata | None":
         """Get the full vault metadata object.
@@ -1473,4 +1470,3 @@ class AssetWithTrackedValue:
         self.quantity = quantity
         self.interest_rate_at_open = None
         self.last_interest_rate = None
-


### PR DESCRIPTION
## Why

trade-ui showed deposits as open for every xchain master vault, even when live ERC-4626 maxDeposit() returned zero. The TUI was using static pair metadata instead of the live pricing-model deposit gate, and the static fallback ignored deposit_closed_reason for non-Hyperliquid vaults.

## Lessons learnt

The Deposits column needs to follow the same deposit availability path as trade execution where possible. Static vault metadata is still useful as a fallback, but unknown live checks should not be rendered as open.

## Summary

- Use pricing_model.can_deposit() to populate trade-ui vault deposit status when a pricing model is available.
- Render unknown live deposit checks as ? instead of falsely showing Yes.
- Honour deposit_closed_reason for all vault pairs in the static TradingPairIdentifier.can_deposit() fallback.
- Add focused tests for closed ERC-4626 metadata, live pricing-model gating, and failed live checks.