### PR TITLE
fix: Use fixed gas pricing for HyperCore vault transactions

### DIFF
--- a/tests/ethereum/test_cctp_bridge_planner.py
+++ b/tests/ethereum/test_cctp_bridge_planner.py
@@ -26,6 +26,8 @@ from tradeexecutor.state.state import State
 from tradeexecutor.state.trade import TradeExecution, TradeType
 
 
+from tradingstrategy.chain import ChainId
+
 USDC_ARBITRUM_ADDRESS = "0xaf88d065e77c8cC2239327C5EDb3A432268e5831"
 USDC_BASE_ADDRESS = "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913"
 USDC_AVALANCHE_ADDRESS = "0xB97EF9Ef8734C71904D8002F8b6Bc66Dd9c48a6E"
@@ -33,6 +35,7 @@ USDC_AVALANCHE_ADDRESS = "0xB97EF9Ef8734C71904D8002F8b6Bc66Dd9c48a6E"
 PRIMARY_CHAIN_ID = 42161  # Arbitrum
 BASE_CHAIN_ID = 8453
 AVALANCHE_CHAIN_ID = 43114
+HYPERCORE_CHAIN_ID = ChainId.hypercore.value  # 9999
 
 TS = datetime.datetime(2025, 6, 1)
 
@@ -583,3 +586,74 @@ def test_multiple_satellite_chains(
 
     assert avax_bridge[0].is_buy()
     assert avax_bridge[0].planned_reserve == Decimal("2000")
+
+
+@pytest.fixture()
+def vault_pair_hypercore(usdc_arbitrum: AssetIdentifier) -> TradingPairIdentifier:
+    """A HyperCore vault pair (chain_id 9999)."""
+    vault_token = AssetIdentifier(
+        chain_id=HYPERCORE_CHAIN_ID,
+        address="0x0000000000000000000000000000000000000abc",
+        token_symbol="HCvault",
+        decimals=6,
+    )
+    return TradingPairIdentifier(
+        base=vault_token,
+        quote=AssetIdentifier(
+            chain_id=HYPERCORE_CHAIN_ID,
+            address="0x0000000000000000000000000000000000000def",
+            token_symbol="USDC",
+            decimals=6,
+        ),
+        pool_address="0x0000000000000000000000000000000000000aaa",
+        exchange_address="0x0000000000000000000000000000000000000bbb",
+        fee=0,
+        kind=TradingPairKind.vault,
+    )
+
+
+def test_no_bridge_for_hypercore_vaults(
+    usdc_arbitrum: AssetIdentifier,
+    cctp_pair_base: TradingPairIdentifier,
+    vault_pair_hypercore: TradingPairIdentifier,
+):
+    """Verify that HyperCore vault trades do not trigger CCTP bridge injection.
+
+    HyperCore vaults (chain_id 9999) have their own multi-phase settlement
+    mechanism and do not need CCTP bridging.
+
+    1. Create a state with reserves
+    2. Create a HyperCore vault buy trade (chain_id 9999)
+    3. Call inject_cctp_bridge_trades
+    4. Assert no bridge trades were injected
+    """
+    # 1. Create state
+    state = _make_state_with_reserves(usdc_arbitrum)
+    universe = _make_mock_universe([cctp_pair_base, vault_pair_hypercore])
+
+    # 2. Create a HyperCore vault buy
+    _, vault_buy, _ = state.create_trade(
+        strategy_cycle_at=TS,
+        pair=vault_pair_hypercore,
+        quantity=None,
+        reserve=Decimal(5000),
+        assumed_price=1.0,
+        trade_type=TradeType.rebalance,
+        reserve_currency=usdc_arbitrum,
+        reserve_currency_price=1.0,
+    )
+
+    # 3. Inject bridge trades
+    result = inject_cctp_bridge_trades(
+        state=state,
+        trades=[vault_buy],
+        strategy_universe=universe,
+        primary_chain_id=PRIMARY_CHAIN_ID,
+        ts=TS,
+        reserve_asset=usdc_arbitrum,
+    )
+
+    # 4. No bridge trades injected — HyperCore handles its own settlement
+    bridge_trades = [t for t in result if t.pair.is_cctp_bridge()]
+    assert len(bridge_trades) == 0
+    assert result == [vault_buy]

--- a/tradeexecutor/ethereum/cctp/planner.py
+++ b/tradeexecutor/ethereum/cctp/planner.py
@@ -116,6 +116,11 @@ def inject_cctp_bridge_trades(
         if trade_chain_id == primary_chain_id:
             continue
 
+        # HyperCore vault trades (chain_id 9999) have their own multi-phase
+        # settlement mechanism and do not need CCTP bridging.
+        if trade.pair.is_hyperliquid_vault():
+            continue
+
         if trade.is_sell():
             # Sell frees up capital — positive flow means excess to bridge back
             sell_value = trade.planned_reserve if trade.planned_reserve else Decimal(str(trade.get_planned_value()))

--- a/tradeexecutor/ethereum/vault/hypercore_routing.py
+++ b/tradeexecutor/ethereum/vault/hypercore_routing.py
@@ -47,7 +47,7 @@ from web3 import Web3
 from web3.contract.contract import ContractFunction
 
 from eth_defi.confirmation import wait_and_broadcast_multiple_nodes
-from eth_defi.gas import apply_gas, estimate_gas_price
+from eth_defi.gas import GasPriceMethod, GasPriceSuggestion, apply_gas
 from eth_defi.hotwallet import HotWallet, SignedTransactionWithNonce
 from eth_defi.provider.fallback import get_fallback_provider
 from eth_defi.revert_reason import fetch_transaction_revert_reason
@@ -191,6 +191,24 @@ HYPERCORE_FOLLOW_UP_PHASE_TOLERANCE_RAW = 200_000
 # confirmation window, so larger amounts need more than a fixed-cent
 # tolerance to avoid false failures.
 HYPERCORE_RELATIVE_BALANCE_TOLERANCE = Decimal("0.01")
+
+#: Fixed ``maxFeePerGas`` for HyperEVM transactions (in wei).
+#:
+#: HyperEVM base fees are typically 0.1–0.5 gwei. Using dynamic
+#: ``estimate_gas_price()`` per phase caused phase 3 of trade #842
+#: (2026-06-04) to get a ``maxFeePerGas`` of 0.66 gwei while the chain
+#: needed ~0.65 gwei effective — the tx eventually landed 18 minutes
+#: later but exceeded the 2-minute confirmation timeout, stranding USDC.
+#:
+#: A fixed 4 gwei is ~20× typical base fee and costs <0.003 HYPE per
+#: 650k-gas transaction — negligible.  Overpayment is refunded by EIP-1559.
+HYPERCORE_FIXED_MAX_FEE_PER_GAS = 4_000_000_000  # 4 gwei
+
+#: Fixed ``maxPriorityFeePerGas`` for HyperEVM transactions (in wei).
+#:
+#: HyperEVM does not have a meaningful priority fee market.
+#: A small tip helps with inclusion without overpaying.
+HYPERCORE_FIXED_MAX_PRIORITY_FEE_PER_GAS = 100_000_000  # 0.1 gwei
 
 def usdc_to_raw(amount: Decimal) -> int:
     """Convert a human-readable USDC amount to raw 6-decimal integer."""
@@ -416,6 +434,9 @@ class HypercoreVaultRouting(RoutingModel):
         objects already addressed to the module contract. We sign them directly
         with the deployer hot wallet.
 
+        Uses fixed gas pricing to avoid underpricing during multi-phase
+        settlement.  See :py:data:`HYPERCORE_FIXED_MAX_FEE_PER_GAS`.
+
         :param fn:
             Bound ``ContractFunction`` already wrapped through the trading strategy module.
 
@@ -434,8 +455,44 @@ class HypercoreVaultRouting(RoutingModel):
             "gas": gas_limit,
         })
 
-        gas_price_suggestion = estimate_gas_price(self.web3)
+        # Use fixed gas pricing to guarantee inclusion during multi-phase
+        # settlement.  Dynamic estimation caused phase 3 tx drops when the
+        # base fee crept above the per-phase estimate between signing and mining.
+        gas_price_suggestion = GasPriceSuggestion(
+            method=GasPriceMethod.london,
+            base_fee=0,
+            max_priority_fee_per_gas=HYPERCORE_FIXED_MAX_PRIORITY_FEE_PER_GAS,
+            max_fee_per_gas=HYPERCORE_FIXED_MAX_FEE_PER_GAS,
+        )
         apply_gas(tx_data, gas_price_suggestion)
+
+        # Sanity-check: warn if the current base fee exceeds our fixed cap.
+        try:
+            latest_block = self.web3.eth.get_block("latest")
+            current_base_fee = latest_block.get("baseFeePerGas", 0)
+            logger.info(
+                "HyperEVM gas for %s: fixed maxFeePerGas=%d (%.2f gwei), "
+                "fixed maxPriorityFeePerGas=%d (%.2f gwei), "
+                "current baseFee=%d (%.2f gwei)",
+                notes or fn.fn_name,
+                HYPERCORE_FIXED_MAX_FEE_PER_GAS,
+                HYPERCORE_FIXED_MAX_FEE_PER_GAS / 1e9,
+                HYPERCORE_FIXED_MAX_PRIORITY_FEE_PER_GAS,
+                HYPERCORE_FIXED_MAX_PRIORITY_FEE_PER_GAS / 1e9,
+                current_base_fee,
+                current_base_fee / 1e9,
+            )
+            if current_base_fee > HYPERCORE_FIXED_MAX_FEE_PER_GAS:
+                logger.warning(
+                    "HyperEVM base fee %d (%.2f gwei) exceeds fixed maxFeePerGas %d (%.2f gwei). "
+                    "Transaction may not be included. Consider raising HYPERCORE_FIXED_MAX_FEE_PER_GAS.",
+                    current_base_fee,
+                    current_base_fee / 1e9,
+                    HYPERCORE_FIXED_MAX_FEE_PER_GAS,
+                    HYPERCORE_FIXED_MAX_FEE_PER_GAS / 1e9,
+                )
+        except Exception as e:
+            logger.warning("Could not fetch HyperEVM base fee for sanity check: %s", e)
 
         signed_tx = self.deployer.sign_transaction_with_new_nonce(tx_data)
         signed_bytes = hexbytes_to_hex_str(signed_tx.rawTransaction)


### PR DESCRIPTION
## Why

Trade #842 (Sell Crypto Plaza, 2026-06-04) failed because the phase 3 `spotSend` transaction was underpriced. Dynamic `estimate_gas_price()` gave it 0.66 gwei `maxFeePerGas`, but the chain needed ~0.65 gwei effective. The tx eventually landed 18 minutes later (confirmed on-chain at block 36,915,957 with status=1), but exceeded the 2-minute confirmation timeout — stranding 13.46 USDC in HyperCore spot and freezing the position.

Each of the 3 withdrawal phases estimated gas independently, causing prices to vary from 0.28 to 0.83 gwei across phases within the same trade.

Additionally, the CCTP bridge planner was logging a harmless but noisy warning every cycle because HyperCore vault trades (chain_id 9999) were being treated as satellite chain trades needing CCTP bridging.

## Lessons learnt

- HyperEVM gas prices are low (~0.1–0.5 gwei) but can spike enough to delay transactions when using dynamic estimation with a 12% buffer.
- The cost of overpaying gas on HyperEVM is negligible (650k gas × 4 gwei = 0.0026 HYPE per tx), while the cost of underpricing is trade failure and stranded USDC.
- The phase 3 transaction that "failed" actually landed on-chain successfully 18 minutes later — the position was frozen unnecessarily.

## Summary

- Replace dynamic `estimate_gas_price()` in `_sign_module_call()` with fixed 4 gwei `maxFeePerGas` and 0.1 gwei `maxPriorityFeePerGas` for all HyperEVM vault transactions. EIP-1559 refunds unused gas fee above the effective price.
- Add gas price logging at every settlement phase: logs the fixed maxFeePerGas, fixed priority fee, and current base fee. Warns if base fee exceeds the fixed cap.
- Skip HyperCore vault trades in the CCTP bridge planner — they have their own multi-phase settlement and don't need CCTP bridging.
- Add test for HyperCore vault CCTP exclusion.