### PR TITLE
fix: Correct trade-ui vault deposit status for ERC-4626 vaults

### DIFF
--- a/tests/cli/test_trade_ui_deposit_status.py
+++ b/tests/cli/test_trade_ui_deposit_status.py
@@ -1,0 +1,92 @@
+"""Test trade-ui vault deposit status for xchain-master-vault ERC-4626 pairs.
+
+Before this fix, non-Hyperliquid vault pairs always showed Deposits: Yes
+because ``TradingPairIdentifier.can_deposit()`` only checked
+``deposit_closed_reason`` for Hyperliquid vaults, and the TUI never
+consulted the live pricing model.
+"""
+
+import datetime
+
+from tradeexecutor.cli.trade_ui_tui import (
+    _format_deposits_open,
+    _get_deposit_status,
+)
+from tradeexecutor.state.identifier import (
+    AssetIdentifier,
+    TradingPairIdentifier,
+    TradingPairKind,
+)
+
+
+def _make_erc4626_vault_pair(
+    *,
+    chain_id: int = 8453,
+    vault_address: str = "0x0000000000000000000000000000000000000001",
+    vault_name: str = "Test USDC Vault",
+    protocol_slug: str = "lagoon-finance",
+    deposit_closed_reason: str | None = None,
+    internal_id: int = 1,
+) -> TradingPairIdentifier:
+    """Create a vault pair resembling xchain-master-vault ERC-4626 vaults."""
+    base = AssetIdentifier(
+        chain_id=chain_id,
+        address=vault_address,
+        token_symbol="vUSDC",
+        decimals=18,
+    )
+    quote = AssetIdentifier(
+        chain_id=chain_id,
+        address="0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+        token_symbol="USDC",
+        decimals=6,
+    )
+    return TradingPairIdentifier(
+        base=base,
+        quote=quote,
+        pool_address=vault_address,
+        exchange_address="0x0000000000000000000000000000000000000000",
+        internal_id=internal_id,
+        internal_exchange_id=1,
+        fee=0.0,
+        kind=TradingPairKind.vault,
+        exchange_name=protocol_slug,
+        other_data={
+            "vault_protocol": "erc4626",
+            "vault_name": vault_name,
+            "deposit_closed_reason": deposit_closed_reason,
+        },
+    )
+
+
+def test_tui_erc4626_deposit_status_respects_closed_reason() -> None:
+    """ERC-4626 vaults with deposit_closed_reason show "No" in the TUI.
+
+    This is the regression test for the core bug: before the fix,
+    ``can_deposit()`` always returned True for non-Hyperliquid vaults,
+    so the TUI showed Deposits: Yes even for capped vaults.
+
+    1. Create two ERC-4626 vault pairs mimicking the xchain-master-vault
+       multi-chain universe: one open on Base, one closed on Ethereum.
+    2. Resolve deposit status through the TUI helpers (static fallback path).
+    3. Verify the open vault renders "Yes" and the closed vault renders "No".
+    """
+    # 1. Create two ERC-4626 vault pairs: one open, one closed.
+    open_vault = _make_erc4626_vault_pair(
+        chain_id=8453, vault_name="Open Base Vault",
+        deposit_closed_reason=None, internal_id=1,
+    )
+    closed_vault = _make_erc4626_vault_pair(
+        chain_id=1, vault_name="Capped ETH Vault",
+        deposit_closed_reason="Max deposit cap reached", internal_id=2,
+    )
+
+    # 2. Resolve deposit status through the TUI helpers (static fallback path).
+    open_status = _get_deposit_status(None, open_vault)
+    closed_status = _get_deposit_status(None, closed_vault)
+
+    # 3. Verify the open vault renders "Yes" and the closed vault renders "No".
+    assert open_status is True
+    assert closed_status is False
+    assert _format_deposits_open(open_vault, open_status).plain == "Yes"
+    assert _format_deposits_open(closed_vault, closed_status).plain == "No"

--- a/tradeexecutor/cli/trade_ui_tui.py
+++ b/tradeexecutor/cli/trade_ui_tui.py
@@ -42,6 +42,34 @@ from tradeexecutor.strategy.trading_strategy_universe import TradingStrategyUniv
 
 logger = logging.getLogger(__name__)
 
+# Sentinel to distinguish "no live status was queried" (fall back to pair
+# metadata) from an explicit ``None`` (live check failed → show unknown).
+_NO_LIVE_STATUS = object()
+
+
+def _get_deposit_status(pricing_model, pair: TradingPairIdentifier, ts: datetime.datetime | None = None) -> bool | None:
+    """Get the current deposit status for a vault pair.
+
+    Uses the live pricing model when available, falling back to the
+    data-pipeline metadata snapshot stored on the pair.
+
+    Returns ``True`` (open), ``False`` (closed), or ``None`` (unknown /
+    live check failed).
+    """
+    if not pair.is_vault():
+        return None
+
+    if pricing_model is not None:
+        try:
+            return pricing_model.can_deposit(ts, pair)
+        except Exception as e:
+            logger.warning("Could not get live deposit status for %s, showing unknown: %s", pair, e)
+            if pair.get_deposit_closed_reason() is not None:
+                return False
+            return None
+
+    return pair.can_deposit()
+
 
 def _get_tvl_value(strategy_universe: TradingStrategyUniverse, pair: TradingPairIdentifier, tvl_now) -> float | None:
     """Look up raw TVL value for a pair."""
@@ -66,18 +94,21 @@ def _format_tvl(tvl: float | None) -> Text:
     return Text(f"${tvl:,.0f}", justify="right")
 
 
-def _format_deposits_open(pair: TradingPairIdentifier) -> Text:
+def _format_deposits_open(pair: TradingPairIdentifier, deposit_status=_NO_LIVE_STATUS) -> Text:
     """Format the deposit status for a vault pair.
 
     Non-vault pairs show a dash.  Vault pairs show ``Yes`` / ``No``
-    based on :py:meth:`TradingPairIdentifier.can_deposit`.
+    based on the live pricing model status or pair metadata.
     """
     if not pair.is_vault():
         return Text("-", style="dim", justify="center")
-    if pair.can_deposit():
+    if deposit_status is _NO_LIVE_STATUS:
+        deposit_status = pair.can_deposit()
+    if deposit_status is None:
+        return Text("?", style="yellow", justify="center")
+    if deposit_status:
         return Text("Yes", style="green", justify="center")
-    reason = pair.get_deposit_closed_reason() or "closed"
-    return Text(f"No", style="red bold", justify="center")
+    return Text("No", style="red bold", justify="center")
 
 
 def _get_price(pricing_model, pair: TradingPairIdentifier, ts: datetime.datetime | None = None) -> float | None:
@@ -391,12 +422,15 @@ class PairSelectionApp(App):
         # Non-vault pairs would trigger on-chain price queries that fail
         # or retry endlessly on Anvil forks.
         self.prices = {}
+        self.deposit_statuses = {}
         price_ts = native_datetime_utc_now()
         for pair in self.sorted_pairs:
             if pair.is_vault():
                 self.prices[id(pair)] = _get_price(pricing_model, pair, ts=price_ts)
+                self.deposit_statuses[id(pair)] = _get_deposit_status(pricing_model, pair, ts=price_ts)
             else:
                 self.prices[id(pair)] = None
+                self.deposit_statuses[id(pair)] = None
 
         # Result set by the trade dialog
         self.selected_pair: TradingPairIdentifier | None = None
@@ -432,7 +466,7 @@ class PairSelectionApp(App):
             exchange = pair.exchange_name or ""
             price = _format_price(self.prices.get(id(pair)))
             tvl = _format_tvl(self.tvl_values.get(id(pair)))
-            deposits = _format_deposits_open(pair)
+            deposits = _format_deposits_open(pair, self.deposit_statuses.get(id(pair)))
             position = _get_position_info(self.state, pair)
             lockup = _format_lockup(self.state, pair)
 

--- a/tradeexecutor/state/identifier.py
+++ b/tradeexecutor/state/identifier.py
@@ -960,15 +960,12 @@ class TradingPairIdentifier:
         instead.
 
         - Asserts this pair is a vault.
-        - For Hyperliquid vaults, checks ``deposit_closed_reason`` in
-          :py:attr:`other_data`.
-        - For other vault types returns ``True`` (no static metadata
-          available yet).
+        - Checks ``deposit_closed_reason`` in :py:attr:`other_data`.
+        - If the data-pipeline metadata does not expose a closed reason,
+          treats deposits as open.
         """
         assert self.is_vault(), f"Not a vault pair: {self}"
-        if self.is_hyperliquid_vault():
-            return self.other_data.get("deposit_closed_reason") is None
-        return True
+        return self.other_data.get("deposit_closed_reason") is None
 
     def get_vault_metadata(self) -> "VaultMetadata | None":
         """Get the full vault metadata object.


### PR DESCRIPTION
## Why

trade-ui showed `Deposits: Yes` for every ERC-4626 vault in the xchain-master-vault universe, even when the vault had `deposit_closed_reason` set (e.g. "Max deposit cap reached"). Two bugs:

1. `TradingPairIdentifier.can_deposit()` only checked `deposit_closed_reason` for Hyperliquid vaults — all other vault types unconditionally returned `True`.
2. The TUI never consulted the live pricing model's `can_deposit()` (which calls `maxDeposit()` on-chain), relying solely on the broken static check.

Verified against the live Trading Strategy database: 5 of 22 vaults in the xchain-master-vault universe (Everstone, AQRU Maple, HYPE++, Wrapped Senior ArcadiaV2, Senior ArcadiaV2) now correctly show deposits as closed.

## Lessons learnt

- `deposit_closed_reason` was already populated for all vault types via `dex_data_translation.py`, but `can_deposit()` had a Hyperliquid-only gate that ignored it for ERC-4626 vaults.
- The TUI display layer and the pricing model layer had completely separate deposit check paths with no shared tests, so pricing model tests passing gave false confidence.
- Static metadata should be checked uniformly across vault types — protocol-specific branching belongs in the pricing model, not in the identifier.

## Summary

- `identifier.py`: Check `deposit_closed_reason` for all vault types in `can_deposit()`, not just Hyperliquid.
- `trade_ui_tui.py`: Add `_get_deposit_status()` to query live pricing model first, fall back to static metadata. Show `?` when live check fails instead of false `Yes`.
- `test_trade_ui_deposit_status.py`: Regression test with ERC-4626 vault pairs modelling the xchain-master-vault multi-chain universe.

Supersedes #1478.

🤖 Generated with [Claude Code](https://claude.com/claude-code)