### PR TITLE
fix: Repair command crashes when no unfinished trades exist

### DIFF
--- a/tradeexecutor/ethereum/execution.py
+++ b/tradeexecutor/ethereum/execution.py
@@ -724,6 +724,9 @@ class EthereumExecution(ExecutionModel):
         rebroadcast=False,
         triggered=False,
     ):
+        if not trades:
+            return
+
         for t in trades:
             assert not t.pair.is_exchange_account(), \
                 f"Unsupported: exchange account trades must not reach execute_trades(). Trade: {t}"

--- a/tradeexecutor/ethereum/rebroadcast.py
+++ b/tradeexecutor/ethereum/rebroadcast.py
@@ -69,6 +69,9 @@ def rebroadcast_all(
 
     logger.info("%d unfinished trades, %d total trades", len(trades), len(all_trades))
 
+    if not trades:
+        return trades, txs
+
     execution_model.execute_trades(
         native_datetime_utc_now(),
         state,


### PR DESCRIPTION
## Why

The `repair` CLI command crashes with `AttributeError: 'NoneType' object has no attribute 'address'` when there are no unfinished trades to rebroadcast. `rebroadcast_all()` unconditionally calls `execute_trades()` even with an empty trades list, which then tries to fetch the reserve asset for on-chain balance checks. Vault strategies (e.g. Lagoon) may not have reserves populated, so `get_default_reserve_asset()` returns `None` and the subsequent `asset.address` access crashes.

## Lessons learnt

- `get_default_reserve_asset()` returns `(None, 1.0)` when the portfolio has no reserve positions — callers must guard against this.
- The repair/rebroadcast path should not enter the execution pipeline at all when there are no trades to process.

## Summary

- Added early return in `rebroadcast_all()` when the trades list is empty — avoids entering the execution pipeline unnecessarily.
- Added early return in `EthereumExecution.execute_trades()` when trades list is empty — defence in depth against any other caller passing an empty list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)