### PR TITLE
feat: Async vault trade lifecycle for Ostium V1.5 and ERC-7540

### DIFF
--- a/scripts/manual-ostium-v15-test-trade.py
+++ b/scripts/manual-ostium-v15-test-trade.py
@@ -29,7 +29,10 @@ Without ``SIMULATE=true``, the script runs against real Arbitrum mainnet.
 Set ``ACTION`` to control what happens:
 
 - ``status``: Show vault state and owner balances (default)
-- ``deposit``: Deposit USDC into the vault (requires confirmation)
+- ``deposit``: Deposit USDC into the vault (requires confirmation).
+  Saves state to ``STATE_FILE`` so ``claim`` can resume later.
+- ``claim``: Load state from ``STATE_FILE`` and run settlement retry
+  to claim any resolved deposits/withdrawals.
 - ``redeem``: Redeem vault shares (requires confirmation)
 
 Environment variables
@@ -39,7 +42,7 @@ Environment variables
     Set to ``true`` to use an Anvil fork with auto-funded test wallet.
 
 ``ACTION``
-    One of: ``status``, ``deposit``, ``redeem``, ``simulate_all``.
+    One of: ``status``, ``deposit``, ``claim``, ``redeem``, ``simulate_all``.
     Default: ``simulate_all`` if SIMULATE, else ``status``.
 
 ``JSON_RPC_ARBITRUM``
@@ -56,6 +59,10 @@ Environment variables
 ``AMOUNT``
     USDC amount for deposit, or OLP share amount for redeem.
     Default: ``5``.
+
+``STATE_FILE``
+    Path to save/load trade-executor state for deposit→claim lifecycle.
+    Default: ``/tmp/ostium-v15-test-trade-state.json``.
 
 Usage
 -----
@@ -75,12 +82,21 @@ Live deposit:
     source .local-test.env && ACTION=deposit AMOUNT=5 \\
     PRIVATE_KEY=GMX_PRIVATE_KEY \\
     poetry run python scripts/manual-ostium-v15-test-trade.py
+
+Claim after settlement (~24h later):
+
+.. code-block:: shell
+
+    source .local-test.env && ACTION=claim \\
+    PRIVATE_KEY=GMX_PRIVATE_KEY \\
+    poetry run python scripts/manual-ostium-v15-test-trade.py
 """
 
 import logging
 import os
 import sys
 from decimal import Decimal
+from pathlib import Path
 
 from eth_defi.compat import native_datetime_utc_now
 from eth_defi.erc_4626.classification import create_vault_instance_autodetect
@@ -224,20 +240,24 @@ def print_vault_state(vault, web3, owner_address=None):
     print()
 
 
-def do_test_trade(web3, hot_wallet, vault, arb_usdc, amount, action="deposit"):
-    """Execute a test trade (deposit or redeem) through the trade-executor pipeline.
+def do_test_trade(web3, hot_wallet, vault, arb_usdc, amount, state_file_path, is_live=False):
+    """Execute a test deposit through the trade-executor pipeline.
 
     Uses PositionManager → EthereumExecution → VaultRouting — the exact same
     code path that the ``start`` CLI command uses for live trading.
+
+    On live mode, saves state to ``state_file_path`` so the ``claim`` action
+    can load it later and run settlement retry after off-chain settlement.
     """
     # Build self-contained universe from on-chain vault data
     strategy_universe, vault_pair = build_universe(vault, arb_usdc)
 
-    # Create execution model (same as CLI start uses)
+    # Create execution model — mainnet_fork=False for live Arbitrum so the
+    # confirmation helper doesn't call Anvil-only evm_mine on slow receipts.
     tx_builder = HotWalletTransactionBuilder(web3, hot_wallet)
     execution_model = EthereumExecution(
         tx_builder,
-        mainnet_fork=True,
+        mainnet_fork=not is_live,
         confirmation_block_count=0,
     )
     sync_model = HotWalletSyncModel(web3, hot_wallet)
@@ -264,40 +284,97 @@ def do_test_trade(web3, hot_wallet, vault, arb_usdc, amount, action="deposit"):
     routing_state = routing_model.create_routing_state(strategy_universe, routing_state_details)
     execution_model.initialize()
 
-    if action == "deposit":
-        # ── DEPOSIT ──────────────────────────────────────────────────
-        print(f"\n--- Depositing {amount} USDC into Ostium vault ---")
-        ts = native_datetime_utc_now()
-        pm = PositionManager(
-            ts, universe=strategy_universe, state=state,
-            pricing_model=pricing_model, default_slippage_tolerance=0.10,
-        )
-        trades = pm.open_spot(vault_pair, value=float(amount))
-        execution_model.execute_trades(ts, state, trades, routing_model, routing_state, check_balances=True)
+    # ── DEPOSIT ──────────────────────────────────────────────────
+    print(f"\n--- Depositing {amount} USDC into Ostium vault ---")
+    ts = native_datetime_utc_now()
+    pm = PositionManager(
+        ts, universe=strategy_universe, state=state,
+        pricing_model=pricing_model, default_slippage_tolerance=0.10,
+    )
+    trades = pm.open_spot(vault_pair, value=float(amount))
+    execution_model.execute_trades(ts, state, trades, routing_model, routing_state, check_balances=True)
 
-        buy_trade = trades[0]
-        status = buy_trade.get_status()
-        print(f"Trade status: {status.value}")
+    buy_trade = trades[0]
+    status = buy_trade.get_status()
+    print(f"Trade status: {status.value}")
 
-        if status == TradeStatus.vault_settlement_pending:
-            print(f"Settlement ID stored in trade.other_data")
-            pending_value = state.portfolio.get_vault_settlement_pending_value()
-            equity = state.portfolio.calculate_total_equity()
-            print(f"Pending value: {pending_value:.2f} USDC")
-            print(f"Total equity:  {equity:.2f} USDC (should ≈ starting)")
-        elif status == TradeStatus.success:
-            print(f"Deposit completed synchronously (unexpected for V1.5)")
-        else:
-            print(f"ERROR: Unexpected status {status.value}")
-            print(f"Revert: {buy_trade.get_revert_reason()}")
-            sys.exit(1)
+    if status == TradeStatus.vault_settlement_pending:
+        print(f"Settlement ID stored in trade.other_data")
+        pending_value = state.portfolio.get_vault_settlement_pending_value()
+        equity = state.portfolio.calculate_total_equity()
+        print(f"Pending value: {pending_value:.2f} USDC")
+        print(f"Total equity:  {equity:.2f} USDC (should ≈ starting)")
 
-        return state, execution_model
-
-    elif action == "redeem":
-        # For redeem, we need an existing position — not implemented as standalone
-        print("ERROR: Use simulate_all for full deposit+redeem cycle")
+        # Save state so the claim action can load it later
+        state.write_json_file(state_file_path)
+        print(f"\nState saved to: {state_file_path}")
+        print(f"After settlement (~24h), claim with: ACTION=claim")
+    elif status == TradeStatus.success:
+        print(f"Deposit completed synchronously (unexpected for V1.5)")
+    else:
+        print(f"ERROR: Unexpected status {status.value}")
+        print(f"Revert: {buy_trade.get_revert_reason()}")
         sys.exit(1)
+
+    return state, execution_model
+
+
+def do_claim(web3, hot_wallet, vault, arb_usdc, state_file_path):
+    """Load saved state and run settlement retry to claim resolved deposits/withdrawals.
+
+    After a live deposit enters vault_settlement_pending, settlement happens
+    off-chain (~24h). This action loads the state saved by the deposit action,
+    runs settlement retry to check on-chain status, and claims if resolved.
+    """
+    if not state_file_path.exists():
+        print(f"ERROR: State file not found: {state_file_path}")
+        print(f"Run ACTION=deposit first to create a pending deposit.")
+        sys.exit(1)
+
+    # Load state with pending vault trades
+    state = State.read_json_file(state_file_path)
+    pending_trades = [
+        t for p in state.portfolio.open_positions.values()
+        for t in p.trades.values()
+        if t.get_status() == TradeStatus.vault_settlement_pending
+    ]
+    if not pending_trades:
+        print("No vault_settlement_pending trades found in state.")
+        print("All trades may have already been resolved.")
+        sys.exit(0)
+
+    print(f"Found {len(pending_trades)} pending vault trade(s)")
+    for t in pending_trades:
+        print(f"  Trade #{t.trade_id}: {t.other_data.get('vault_direction', '?')} — settlement pending")
+
+    # Create execution model for claiming (live mode, no Anvil mine)
+    strategy_universe, _ = build_universe(vault, arb_usdc)
+    tx_builder = HotWalletTransactionBuilder(web3, hot_wallet)
+    execution_model = EthereumExecution(
+        tx_builder,
+        mainnet_fork=False,
+        confirmation_block_count=0,
+    )
+    execution_model.initialize()
+
+    # Run settlement retry — checks on-chain status and broadcasts claim txs
+    resolved = check_and_resolve_vault_settlements(state=state, execution_model=execution_model)
+
+    if resolved:
+        print(f"\nResolved {len(resolved)} trade(s):")
+        for t in resolved:
+            print(f"  Trade #{t.trade_id}: {t.get_status().value}")
+            if t.is_buy():
+                print(f"    Received: {t.executed_quantity} shares")
+            else:
+                print(f"    Received: {t.executed_reserve:.2f} USDC")
+
+        # Save updated state
+        state.write_json_file(state_file_path)
+        print(f"\nState updated: {state_file_path}")
+    else:
+        print("\nNo trades resolved — settlement may not have happened yet.")
+        print("Try again after the next Ostium settlement epoch (~24h).")
 
 
 def do_simulate_all(web3, hot_wallet, vault, arb_usdc, amount):
@@ -432,6 +509,8 @@ simulate = os.environ.get("SIMULATE", "").lower() in ("true", "1", "yes")
 action = os.environ.get("ACTION", "simulate_all" if simulate else "status").lower()
 vault_address = os.environ.get("VAULT_ADDRESS", OSTIUM_VAULT_ADDRESS)
 amount = Decimal(os.environ.get("AMOUNT", "5"))
+# State file persists vault_settlement_pending trade metadata between deposit and claim
+state_file_path = Path(os.environ.get("STATE_FILE", "/tmp/ostium-v15-test-trade-state.json"))
 anvil_launch = None
 
 # Reserve asset identifier for Arbitrum USDC
@@ -482,7 +561,7 @@ try:
         if action == "simulate_all":
             do_simulate_all(web3, hot_wallet, vault, arb_usdc, amount)
         elif action == "deposit":
-            do_test_trade(web3, hot_wallet, vault, arb_usdc, amount, action="deposit")
+            do_test_trade(web3, hot_wallet, vault, arb_usdc, amount, state_file_path, is_live=False)
         elif action == "status":
             pass
         else:
@@ -507,7 +586,7 @@ try:
                     owner = HotWallet.from_private_key(pk).address
             print_vault_state(vault, web3, owner)
 
-        elif action in ("deposit", "redeem"):
+        elif action in ("deposit", "claim", "redeem"):
             private_key = resolve_private_key()
             hot_wallet = HotWallet.from_private_key(private_key)
             hot_wallet.sync_nonce(web3)
@@ -517,17 +596,24 @@ try:
             if action == "deposit":
                 if not confirm(f"Deposit {amount} USDC into Ostium vault via trade-executor?"):
                     sys.exit(0)
-                state, execution_model = do_test_trade(
-                    web3, hot_wallet, vault, arb_usdc, amount, action="deposit",
+                # Execute deposit — state is saved to STATE_FILE for later claim
+                do_test_trade(
+                    web3, hot_wallet, vault, arb_usdc, amount, state_file_path, is_live=True,
                 )
                 print(f"\nDeposit request submitted. The trade is vault_settlement_pending.")
                 print(f"Settlement happens off-chain every ~24h.")
-                print(f"After settlement, use the trade-executor settlement retry to claim.")
+                print(f"After settlement, claim with:")
+                print(f"  ACTION=claim PRIVATE_KEY=... poetry run python {sys.argv[0]}")
+
+            elif action == "claim":
+                # Load saved state and run settlement retry to claim
+                do_claim(web3, hot_wallet, vault, arb_usdc, state_file_path)
+
             elif action == "redeem":
                 print("ERROR: Live redeem not yet supported as standalone — use the start CLI command")
                 sys.exit(1)
         else:
-            print(f"Unknown ACTION: {action}. Use: status, deposit, redeem, simulate_all")
+            print(f"Unknown ACTION: {action}. Use: status, deposit, claim, redeem, simulate_all")
             sys.exit(1)
 
 finally:

--- a/scripts/manual-ostium-v15-test-trade.py
+++ b/scripts/manual-ostium-v15-test-trade.py
@@ -269,7 +269,24 @@ def do_test_trade(web3, hot_wallet, vault, arb_usdc, amount, state_file_path, is
     )
     pricing_model = GenericPricing(pair_configurator)
 
-    # Initialise state and sync on-chain reserves
+    # Refuse to overwrite a state file that has unresolved pending trades —
+    # a second deposit would lose the first trade's ticket metadata, making
+    # the first deposit unclaimable via the script's claim action.
+    if is_live and state_file_path.exists():
+        existing = State.read_json_file(state_file_path)
+        pending = [
+            t for p in existing.portfolio.open_positions.values()
+            for t in p.trades.values()
+            if t.get_status() == TradeStatus.vault_settlement_pending
+        ]
+        if pending:
+            print(f"ERROR: State file {state_file_path} has {len(pending)} unresolved pending trade(s).")
+            print(f"Run ACTION=claim first, or delete the file to discard the old state.")
+            for t in pending:
+                print(f"  Trade #{t.trade_id}: {t.other_data.get('vault_direction', '?')}")
+            sys.exit(1)
+
+    # Initialise fresh state and sync on-chain reserves
     state = State()
     sync_model.sync_initial(state, reserve_asset=arb_usdc, reserve_token_price=1.0)
     sync_model.sync_treasury(native_datetime_utc_now(), state, supported_reserves=[arb_usdc])

--- a/scripts/manual-ostium-v15-test-trade.py
+++ b/scripts/manual-ostium-v15-test-trade.py
@@ -1,0 +1,536 @@
+"""Manual test trade for Ostium V1.5 async vault using trade-executor internals.
+
+Exercises the full deposit/redeem lifecycle through the trade-executor's
+PositionManager, EthereumExecution, and vault routing — the same code path
+used by the ``start`` and ``perform-test-trade`` CLI commands.
+
+Self-contained: builds the trading universe from the on-chain vault contract
+without requiring a strategy module or TradingStrategy API key.
+
+Simulation mode
+---------------
+
+Set ``SIMULATE=true`` to run on an Anvil mainnet fork with a test wallet.
+The script will:
+1. Fork Arbitrum at a recent block
+2. Fund a test wallet with ETH + USDC
+3. Deposit USDC into Ostium vault (requestDeposit)
+4. Force settlement on Anvil
+5. Claim deposit (settlement retry)
+6. Redeem vault shares (requestWithdraw)
+7. Force settlement(s) for withdrawal
+8. Claim withdrawal (settlement retry)
+9. Verify USDC returned and portfolio accounting
+
+Live mode
+---------
+
+Without ``SIMULATE=true``, the script runs against real Arbitrum mainnet.
+Set ``ACTION`` to control what happens:
+
+- ``status``: Show vault state and owner balances (default)
+- ``deposit``: Deposit USDC into the vault (requires confirmation)
+- ``redeem``: Redeem vault shares (requires confirmation)
+
+Environment variables
+---------------------
+
+``SIMULATE``
+    Set to ``true`` to use an Anvil fork with auto-funded test wallet.
+
+``ACTION``
+    One of: ``status``, ``deposit``, ``redeem``, ``simulate_all``.
+    Default: ``simulate_all`` if SIMULATE, else ``status``.
+
+``JSON_RPC_ARBITRUM``
+    Arbitrum RPC URL.
+
+``PRIVATE_KEY``
+    Private key for signing. Not needed in simulation mode.
+    Can be a name like ``GMX_PRIVATE_KEY`` which will be resolved
+    from the environment.
+
+``VAULT_ADDRESS``
+    Ostium vault address (default: OLP vault).
+
+``AMOUNT``
+    USDC amount for deposit, or OLP share amount for redeem.
+    Default: ``5``.
+
+Usage
+-----
+
+Simulated (Anvil fork):
+
+.. code-block:: shell
+
+    source .local-test.env && SIMULATE=true \\
+    JSON_RPC_ARBITRUM="https://arb1.arbitrum.io/rpc" \\
+    poetry run python scripts/manual-ostium-v15-test-trade.py
+
+Live deposit:
+
+.. code-block:: shell
+
+    source .local-test.env && ACTION=deposit AMOUNT=5 \\
+    PRIVATE_KEY=GMX_PRIVATE_KEY \\
+    poetry run python scripts/manual-ostium-v15-test-trade.py
+"""
+
+import logging
+import os
+import sys
+from decimal import Decimal
+
+from eth_defi.compat import native_datetime_utc_now
+from eth_defi.erc_4626.classification import create_vault_instance_autodetect
+from eth_defi.erc_4626.vault_protocol.gains.vault import OstiumVault, OstiumVersion
+from eth_defi.hotwallet import HotWallet
+from eth_defi.provider.anvil import fork_network_anvil, AnvilLaunch
+from eth_defi.provider.multi_provider import create_multi_provider_web3
+from eth_defi.token import fetch_erc20_details, USDC_NATIVE_TOKEN, USDC_WHALE
+from eth_defi.trace import assert_transaction_success_with_explanation
+
+from tradeexecutor.ethereum.ethereum_protocol_adapters import EthereumPairConfigurator
+from tradeexecutor.ethereum.execution import EthereumExecution
+from tradeexecutor.ethereum.hot_wallet_sync_model import HotWalletSyncModel
+from tradeexecutor.ethereum.tx import HotWalletTransactionBuilder
+from tradeexecutor.ethereum.vault.settlement_retry import check_and_resolve_vault_settlements
+from tradeexecutor.ethereum.vault.vault_utils import translate_vault_to_trading_pair
+from tradeexecutor.state.identifier import AssetIdentifier
+from tradeexecutor.state.state import State
+from tradeexecutor.state.trade import TradeStatus
+from tradeexecutor.strategy.generic.generic_pricing_model import GenericPricing
+from tradeexecutor.strategy.generic.generic_router import GenericRouting
+from tradeexecutor.strategy.pandas_trader.position_manager import PositionManager
+from tradeexecutor.strategy.reverse_universe import create_universe_from_trading_pair_identifiers
+from tradeexecutor.strategy.trading_strategy_universe import TradingStrategyUniverse
+from tradingstrategy.chain import ChainId
+from tradingstrategy.exchange import ExchangeUniverse, Exchange, ExchangeType
+from tradingstrategy.timebucket import TimeBucket
+from tradingstrategy.universe import Universe
+
+
+logging.basicConfig(level=logging.INFO, stream=sys.stderr)
+logger = logging.getLogger(__name__)
+
+
+# ── Default vault address (Ostium OLP on Arbitrum) ───────────────────
+OSTIUM_VAULT_ADDRESS = "0x20d419a8e12c45f88fda7c5760bb6923cee27f98"
+
+
+def confirm(prompt: str) -> bool:
+    """Ask for y/n confirmation before sending a transaction."""
+    answer = input(f"{prompt} [y/N] ").strip().lower()
+    return answer == "y"
+
+
+def resolve_private_key() -> str:
+    """Resolve PRIVATE_KEY from env, supporting indirection (e.g. PRIVATE_KEY=GMX_PRIVATE_KEY)."""
+    raw = os.environ.get("PRIVATE_KEY", "")
+    if not raw:
+        print("ERROR: Set PRIVATE_KEY environment variable")
+        sys.exit(1)
+    # If the value looks like an env var name (no 0x prefix), resolve it
+    if not raw.startswith("0x"):
+        resolved = os.environ.get(raw, "")
+        if resolved:
+            logger.info("Resolved PRIVATE_KEY via %s", raw)
+            return resolved
+        print(f"ERROR: PRIVATE_KEY={raw} but {raw} is not set in environment")
+        sys.exit(1)
+    return raw
+
+
+def build_universe(vault, arb_usdc):
+    """Build a self-contained TradingStrategyUniverse from an on-chain vault.
+
+    No API key or strategy module needed — reads vault metadata directly
+    from the contract and constructs a minimal universe with one pair.
+    """
+    # Translate on-chain vault to a TradingPairIdentifier
+    vault_pair = translate_vault_to_trading_pair(vault)
+
+    # Build exchange universe with a single synthetic exchange entry
+    exchange_universe = ExchangeUniverse(
+        exchanges={
+            1: Exchange(
+                chain_id=ChainId(42161),
+                chain_slug="arbitrum",
+                exchange_id=1,
+                exchange_slug="ostium",
+                address="0x0000000000000000000000000000000000000000",
+                exchange_type=ExchangeType.erc_4626_vault,
+                pair_count=1,
+            ),
+        }
+    )
+
+    pair_universe = create_universe_from_trading_pair_identifiers(
+        [vault_pair],
+        exchange_universe,
+    )
+
+    universe = Universe(
+        time_bucket=TimeBucket.not_applicable,
+        chains={ChainId.arbitrum},
+        pairs=pair_universe,
+        exchange_universe=exchange_universe,
+    )
+
+    return TradingStrategyUniverse(
+        data_universe=universe,
+        reserve_assets=[arb_usdc],
+    ), vault_pair
+
+
+def print_vault_state(vault, web3, owner_address=None):
+    """Print vault state summary — mirrors the eth_defi script output."""
+    block = web3.eth.block_number
+    contract = vault.vault_contract
+
+    print("=" * 70)
+    print("OSTIUM V1.5 VAULT — TRADE-EXECUTOR TEST TRADE")
+    print("=" * 70)
+
+    print(f"\nChain:          Arbitrum (chain ID: {web3.eth.chain_id})")
+    print(f"Block:          {block:,}")
+    print(f"Vault:          {vault.name}")
+    print(f"Address:        {vault.address}")
+    print(f"Share token:    {vault.share_token.symbol}")
+
+    total_assets = vault.fetch_total_assets(block)
+    share_price = vault.fetch_share_price(block)
+    print(f"\nTVL:             {total_assets} {vault.denomination_token.symbol}")
+    print(f"Share price:     {share_price} {vault.denomination_token.symbol}/{vault.share_token.symbol}")
+
+    last_settlement_id = contract.functions.lastSettlementId().call()
+    deposit_target = contract.functions.targetSettlementId(True).call()
+    withdraw_target = contract.functions.targetSettlementId(False).call()
+    print(f"\nLast settlement: {last_settlement_id}")
+    print(f"Deposit target:  {deposit_target}")
+    print(f"Withdraw target: {withdraw_target}")
+
+    if owner_address:
+        eth_balance = web3.from_wei(web3.eth.get_balance(owner_address), "ether")
+        usdc_balance = vault.denomination_token.fetch_balance_of(owner_address)
+        share_balance = vault.share_token.fetch_balance_of(owner_address)
+        print(f"\nOwner: {owner_address}")
+        print(f"  ETH:   {eth_balance}")
+        print(f"  USDC:  {usdc_balance}")
+        print(f"  Shares: {share_balance}")
+
+    print("=" * 70)
+    print()
+
+
+def do_test_trade(web3, hot_wallet, vault, arb_usdc, amount, action="deposit"):
+    """Execute a test trade (deposit or redeem) through the trade-executor pipeline.
+
+    Uses PositionManager → EthereumExecution → VaultRouting — the exact same
+    code path that the ``start`` CLI command uses for live trading.
+    """
+    # Build self-contained universe from on-chain vault data
+    strategy_universe, vault_pair = build_universe(vault, arb_usdc)
+
+    # Create execution model (same as CLI start uses)
+    tx_builder = HotWalletTransactionBuilder(web3, hot_wallet)
+    execution_model = EthereumExecution(
+        tx_builder,
+        mainnet_fork=True,
+        confirmation_block_count=0,
+    )
+    sync_model = HotWalletSyncModel(web3, hot_wallet)
+
+    # Create routing and pricing models
+    routing_model = execution_model.create_default_routing_model(strategy_universe)
+    pair_configurator = EthereumPairConfigurator(
+        web3, strategy_universe, execution_model=execution_model,
+    )
+    pricing_model = GenericPricing(pair_configurator)
+
+    # Initialise state and sync on-chain reserves
+    state = State()
+    sync_model.sync_initial(state, reserve_asset=arb_usdc, reserve_token_price=1.0)
+    sync_model.sync_treasury(native_datetime_utc_now(), state, supported_reserves=[arb_usdc])
+
+    reserve = state.portfolio.get_default_reserve_position()
+    print(f"\nReserve: {float(reserve.quantity):.2f} USDC")
+    starting_equity = state.portfolio.calculate_total_equity()
+    print(f"Starting equity: {starting_equity:.2f} USDC")
+
+    # Create routing state for trade execution
+    routing_state_details = execution_model.get_routing_state_details()
+    routing_state = routing_model.create_routing_state(strategy_universe, routing_state_details)
+    execution_model.initialize()
+
+    if action == "deposit":
+        # ── DEPOSIT ──────────────────────────────────────────────────
+        print(f"\n--- Depositing {amount} USDC into Ostium vault ---")
+        ts = native_datetime_utc_now()
+        pm = PositionManager(
+            ts, universe=strategy_universe, state=state,
+            pricing_model=pricing_model, default_slippage_tolerance=0.10,
+        )
+        trades = pm.open_spot(vault_pair, value=float(amount))
+        execution_model.execute_trades(ts, state, trades, routing_model, routing_state, check_balances=True)
+
+        buy_trade = trades[0]
+        status = buy_trade.get_status()
+        print(f"Trade status: {status.value}")
+
+        if status == TradeStatus.vault_settlement_pending:
+            print(f"Settlement ID stored in trade.other_data")
+            pending_value = state.portfolio.get_vault_settlement_pending_value()
+            equity = state.portfolio.calculate_total_equity()
+            print(f"Pending value: {pending_value:.2f} USDC")
+            print(f"Total equity:  {equity:.2f} USDC (should ≈ starting)")
+        elif status == TradeStatus.success:
+            print(f"Deposit completed synchronously (unexpected for V1.5)")
+        else:
+            print(f"ERROR: Unexpected status {status.value}")
+            print(f"Revert: {buy_trade.get_revert_reason()}")
+            sys.exit(1)
+
+        return state, execution_model
+
+    elif action == "redeem":
+        # For redeem, we need an existing position — not implemented as standalone
+        print("ERROR: Use simulate_all for full deposit+redeem cycle")
+        sys.exit(1)
+
+
+def do_simulate_all(web3, hot_wallet, vault, arb_usdc, amount):
+    """Full simulated deposit → settlement → claim → redeem → settlement → claim cycle.
+
+    Uses force_ostium_v15_settlement() to advance the Ostium settlement epoch
+    on the Anvil fork, then settlement retry to claim.
+    """
+    from eth_defi.erc_4626.vault_protocol.gains.testing import force_ostium_v15_settlement
+
+    # Build universe and execution model
+    strategy_universe, vault_pair = build_universe(vault, arb_usdc)
+    tx_builder = HotWalletTransactionBuilder(web3, hot_wallet)
+    execution_model = EthereumExecution(
+        tx_builder, mainnet_fork=True, confirmation_block_count=0,
+    )
+    sync_model = HotWalletSyncModel(web3, hot_wallet)
+    routing_model = execution_model.create_default_routing_model(strategy_universe)
+    pair_configurator = EthereumPairConfigurator(
+        web3, strategy_universe, execution_model=execution_model,
+    )
+    pricing_model = GenericPricing(pair_configurator)
+
+    # Initialise state
+    state = State()
+    sync_model.sync_initial(state, reserve_asset=arb_usdc, reserve_token_price=1.0)
+    sync_model.sync_treasury(native_datetime_utc_now(), state, supported_reserves=[arb_usdc])
+
+    reserve = state.portfolio.get_default_reserve_position()
+    starting_cash = float(reserve.quantity)
+    starting_equity = state.portfolio.calculate_total_equity()
+    print(f"\nStarting cash:   {starting_cash:.2f} USDC")
+    print(f"Starting equity: {starting_equity:.2f} USDC")
+
+    routing_state_details = execution_model.get_routing_state_details()
+    routing_state = routing_model.create_routing_state(strategy_universe, routing_state_details)
+    execution_model.initialize()
+
+    # ── Step 1: Deposit ──────────────────────────────────────────────
+    print(f"\n{'─' * 70}")
+    print(f"STEP 1: Deposit {amount} USDC → requestDeposit()")
+    ts = native_datetime_utc_now()
+    pm = PositionManager(
+        ts, universe=strategy_universe, state=state,
+        pricing_model=pricing_model, default_slippage_tolerance=0.10,
+    )
+    trades = pm.open_spot(vault_pair, value=float(amount))
+    execution_model.execute_trades(ts, state, trades, routing_model, routing_state, check_balances=True)
+
+    buy_trade = trades[0]
+    assert buy_trade.get_status() == TradeStatus.vault_settlement_pending, \
+        f"Expected vault_settlement_pending, got {buy_trade.get_status()}"
+    print(f"  Status: vault_settlement_pending")
+    print(f"  Pending value: {state.portfolio.get_vault_settlement_pending_value():.2f} USDC")
+
+    # ── Step 2: Force settlement ─────────────────────────────────────
+    print(f"\n{'─' * 70}")
+    print(f"STEP 2: Force settlement on Anvil")
+    owner_address = buy_trade.other_data["vault_owner_address"]
+    force_ostium_v15_settlement(vault, owner_address)
+    print(f"  Settlement forced")
+
+    # ── Step 3: Claim deposit via settlement retry ───────────────────
+    print(f"\n{'─' * 70}")
+    print(f"STEP 3: Settlement retry → claimDeposit()")
+    resolved = check_and_resolve_vault_settlements(state=state, execution_model=execution_model)
+    assert len(resolved) == 1
+    assert buy_trade.get_status() == TradeStatus.success
+    print(f"  Deposit claimed: {buy_trade.executed_quantity} shares")
+    print(f"  Pending value: {state.portfolio.get_vault_settlement_pending_value():.2f} USDC (should be 0)")
+
+    # ── Step 4: Redeem ───────────────────────────────────────────────
+    print(f"\n{'─' * 70}")
+    print(f"STEP 4: Redeem all shares → requestWithdraw()")
+    ts = native_datetime_utc_now()
+    pm = PositionManager(
+        ts, universe=strategy_universe, state=state,
+        pricing_model=pricing_model, default_slippage_tolerance=0.10,
+    )
+    trades = pm.close_all()
+    execution_model.execute_trades(ts, state, trades, routing_model, routing_state, check_balances=True)
+
+    sell_trade = trades[0]
+    assert sell_trade.get_status() == TradeStatus.vault_settlement_pending
+    print(f"  Status: vault_settlement_pending")
+
+    # ── Step 5: Force settlement(s) for withdrawal ───────────────────
+    print(f"\n{'─' * 70}")
+    print(f"STEP 5: Force settlement(s) for withdrawal")
+    withdraw_target = vault.vault_contract.functions.targetSettlementId(False).call()
+    last_id = vault.vault_contract.functions.lastSettlementId().call()
+    settlements_needed = max(withdraw_target - last_id, 1)
+    for i in range(settlements_needed):
+        force_ostium_v15_settlement(vault, owner_address)
+        print(f"  Settlement {i + 1}/{settlements_needed} forced")
+
+    # ── Step 6: Claim withdrawal ─────────────────────────────────────
+    print(f"\n{'─' * 70}")
+    print(f"STEP 6: Settlement retry → claimWithdraw()")
+    resolved = check_and_resolve_vault_settlements(state=state, execution_model=execution_model)
+    assert len(resolved) == 1
+    assert sell_trade.get_status() == TradeStatus.success
+    print(f"  Withdrawal claimed: {sell_trade.executed_reserve:.2f} USDC")
+
+    # ── Final verification ───────────────────────────────────────────
+    print(f"\n{'─' * 70}")
+    print(f"VERIFICATION")
+    final_equity = state.portfolio.calculate_total_equity()
+    final_cash = float(state.portfolio.get_default_reserve_position().quantity)
+    print(f"  Starting equity: {starting_equity:.2f} USDC")
+    print(f"  Final equity:    {final_equity:.2f} USDC")
+    print(f"  Final cash:      {final_cash:.2f} USDC")
+    print(f"  Pending value:   {state.portfolio.get_vault_settlement_pending_value():.2f} USDC")
+    print(f"  Open positions:  {len(state.portfolio.open_positions)}")
+    print(f"  Closed positions: {len(state.portfolio.closed_positions)}")
+
+    equity_diff = abs(final_equity - starting_equity)
+    if equity_diff < starting_equity * 0.02:
+        print(f"\n  ✓ Equity preserved (diff: {equity_diff:.2f} USDC, <2%)")
+    else:
+        print(f"\n  ✗ Equity drift too large: {equity_diff:.2f} USDC ({equity_diff / starting_equity * 100:.1f}%)")
+        sys.exit(1)
+
+    print(f"\n{'=' * 70}")
+    print(f"SIMULATION COMPLETE — all steps passed")
+    print(f"{'=' * 70}")
+
+
+# ── Main ─────────────────────────────────────────────────────────────
+
+simulate = os.environ.get("SIMULATE", "").lower() in ("true", "1", "yes")
+action = os.environ.get("ACTION", "simulate_all" if simulate else "status").lower()
+vault_address = os.environ.get("VAULT_ADDRESS", OSTIUM_VAULT_ADDRESS)
+amount = Decimal(os.environ.get("AMOUNT", "5"))
+anvil_launch = None
+
+# Reserve asset identifier for Arbitrum USDC
+arb_usdc = AssetIdentifier(
+    chain_id=42161,
+    address=USDC_NATIVE_TOKEN[42161],
+    decimals=6,
+    token_symbol="USDC",
+)
+
+try:
+    if simulate:
+        # ── Simulation mode: Anvil fork ──────────────────────────────
+        print("=" * 70)
+        print("OSTIUM V1.5 — TRADE-EXECUTOR TEST TRADE (SIMULATION)")
+        print("=" * 70)
+
+        # Fork Arbitrum and fund a test wallet
+        usdc_whale = USDC_WHALE[42161]
+        anvil_launch = fork_network_anvil(
+            os.environ["JSON_RPC_ARBITRUM"],
+            fork_block_number=470_000_000,
+            unlocked_addresses=[usdc_whale],
+        )
+        web3 = create_multi_provider_web3(
+            anvil_launch.json_rpc_url,
+            default_http_timeout=(3, 250.0),
+            retries=1,
+        )
+
+        hot_wallet = HotWallet.create_for_testing(web3, test_account_n=1, eth_amount=10)
+        hot_wallet.sync_nonce(web3)
+
+        # Fund wallet with USDC
+        usdc = fetch_erc20_details(web3, USDC_NATIVE_TOKEN[42161])
+        fund_amount = max(amount * 10, Decimal(500))
+        tx_hash = usdc.contract.functions.transfer(
+            hot_wallet.address, int(fund_amount * 10**6),
+        ).transact({"from": usdc_whale, "gas": 100_000})
+        assert_transaction_success_with_explanation(web3, tx_hash)
+
+        vault = create_vault_instance_autodetect(web3, vault_address)
+        assert isinstance(vault, OstiumVault)
+        assert vault.version == OstiumVersion.v1_5
+
+        print_vault_state(vault, web3, hot_wallet.address)
+
+        if action == "simulate_all":
+            do_simulate_all(web3, hot_wallet, vault, arb_usdc, amount)
+        elif action == "deposit":
+            do_test_trade(web3, hot_wallet, vault, arb_usdc, amount, action="deposit")
+        elif action == "status":
+            pass
+        else:
+            print(f"Unknown ACTION: {action}")
+            sys.exit(1)
+
+    else:
+        # ── Live mode ────────────────────────────────────────────────
+        web3 = create_multi_provider_web3(os.environ["JSON_RPC_ARBITRUM"])
+        vault = create_vault_instance_autodetect(web3, vault_address)
+        assert isinstance(vault, OstiumVault)
+        assert vault.version == OstiumVersion.v1_5
+
+        if action == "status":
+            # Show vault state — resolve owner from PRIVATE_KEY if available
+            owner = None
+            pk = os.environ.get("PRIVATE_KEY", "")
+            if pk:
+                if not pk.startswith("0x"):
+                    pk = os.environ.get(pk, "")
+                if pk:
+                    owner = HotWallet.from_private_key(pk).address
+            print_vault_state(vault, web3, owner)
+
+        elif action in ("deposit", "redeem"):
+            private_key = resolve_private_key()
+            hot_wallet = HotWallet.from_private_key(private_key)
+            hot_wallet.sync_nonce(web3)
+
+            print_vault_state(vault, web3, hot_wallet.address)
+
+            if action == "deposit":
+                if not confirm(f"Deposit {amount} USDC into Ostium vault via trade-executor?"):
+                    sys.exit(0)
+                state, execution_model = do_test_trade(
+                    web3, hot_wallet, vault, arb_usdc, amount, action="deposit",
+                )
+                print(f"\nDeposit request submitted. The trade is vault_settlement_pending.")
+                print(f"Settlement happens off-chain every ~24h.")
+                print(f"After settlement, use the trade-executor settlement retry to claim.")
+            elif action == "redeem":
+                print("ERROR: Live redeem not yet supported as standalone — use the start CLI command")
+                sys.exit(1)
+        else:
+            print(f"Unknown ACTION: {action}. Use: status, deposit, redeem, simulate_all")
+            sys.exit(1)
+
+finally:
+    if anvil_launch is not None:
+        print("\nShutting down Anvil fork...")
+        anvil_launch.close()

--- a/strategies/test_only/arbitrum-ostium-v15.py
+++ b/strategies/test_only/arbitrum-ostium-v15.py
@@ -1,0 +1,128 @@
+"""Test strategy for Ostium V1.5 async vault deposit/redeem.
+
+- Opens a position on cycle 1 (deposit 50 USDC into Ostium)
+- Closes the position on cycle 2 (redeem all OLP shares)
+
+Used by integration tests that drive the executor tick-by-tick
+with forced Ostium settlement between cycles.
+
+This strategy exercises the async vault flow:
+- open_spot() → requestDeposit() → vault_settlement_pending
+- close_all() → requestWithdraw() → vault_settlement_pending
+- Settlement retry at next tick resolves both
+"""
+import datetime
+
+from tradeexecutor.state.identifier import AssetIdentifier
+from tradeexecutor.strategy.cycle import CycleDuration
+from tradeexecutor.strategy.default_routing_options import TradeRouting
+from tradeexecutor.strategy.execution_context import ExecutionContext
+from tradeexecutor.strategy.pandas_trader.position_manager import PositionManager
+from tradeexecutor.strategy.pandas_trader.strategy_input import StrategyInput
+from tradeexecutor.strategy.parameters import StrategyParameters
+from tradeexecutor.strategy.pandas_trader.indicator import IndicatorSet
+from tradeexecutor.strategy.trading_strategy_universe import TradingStrategyUniverse
+from tradeexecutor.strategy.universe_model import UniverseOptions
+from tradingstrategy.alternative_data.vault import load_single_vault
+from tradingstrategy.chain import ChainId
+from tradingstrategy.client import Client
+from tradingstrategy.exchange import ExchangeUniverse
+from tradingstrategy.pair import PandasPairUniverse
+from tradingstrategy.timebucket import TimeBucket
+from tradingstrategy.universe import Universe
+
+
+trading_strategy_engine_version = "0.5"
+
+
+# Ostium OLP vault on Arbitrum (V1.5 with async deposit/redeem)
+OSTIUM_VAULT_ADDRESS = "0x20d419a8e12c45f88fda7c5760bb6923cee27f98"
+
+
+class Parameters:
+    id = "arbitrum-ostium-v15-test"
+    cycle_duration = CycleDuration.cycle_1s
+    candle_time_bucket = TimeBucket.h1
+    chain_id = ChainId.arbitrum
+    routing = TradeRouting.default
+    slippage_tolerance = 0.05
+    backtest_start = datetime.datetime(2025, 1, 1)
+    backtest_end = datetime.datetime(2025, 6, 1)
+    initial_cash = 500
+    required_history_period = datetime.timedelta(days=1)
+    deposit_value = 50.0
+
+
+def create_trading_universe(
+    timestamp,
+    client: Client,
+    execution_context: ExecutionContext,
+    universe_options: UniverseOptions,
+) -> TradingStrategyUniverse:
+    """Load the Ostium vault as a single-pair universe.
+
+    The vault pair data is loaded from the bundled vault metadata database.
+    No OHLCV candle data is needed — vault strategies use share price only.
+    """
+    # Load Ostium vault metadata from bundled data (no API call needed)
+    vault_exchanges, vault_pairs_df = load_single_vault(
+        ChainId.arbitrum,
+        OSTIUM_VAULT_ADDRESS,
+    )
+
+    exchange_universe = ExchangeUniverse.from_collection(vault_exchanges)
+    pair_universe = PandasPairUniverse(vault_pairs_df, exchange_universe=exchange_universe)
+
+    # Universe.exchanges (Set[Exchange]) must be set explicitly —
+    # without it, pretick_check() fails with "len(None)" because it checks
+    # data_universe.exchanges which defaults to None if not provided.
+    universe = Universe(
+        time_bucket=TimeBucket.not_applicable,
+        chains={ChainId.arbitrum},
+        pairs=pair_universe,
+        exchange_universe=exchange_universe,
+        exchanges=set(vault_exchanges),
+    )
+
+    # USDC on Arbitrum — the vault's denomination/reserve token.
+    # Hardcoded because load_single_vault() doesn't provide a reserve asset directly.
+    reserve_asset = AssetIdentifier(
+        chain_id=42161,
+        address="0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
+        decimals=6,
+        token_symbol="USDC",
+    )
+
+    return TradingStrategyUniverse(
+        data_universe=universe,
+        reserve_assets=[reserve_asset],
+    )
+
+
+def create_indicators(timestamp, parameters, strategy_universe, execution_context):
+    """No indicators needed — vault strategies don't use technical indicators."""
+    return IndicatorSet()
+
+
+def decide_trades(input: StrategyInput) -> list:
+    """Simple two-cycle strategy: deposit on cycle 1, redeem on cycle 2.
+
+    On Anvil, each trade will enter vault_settlement_pending state.
+    The settlement retry module resolves them at the start of the next tick
+    (after force_ostium_v15_settlement() is called externally by the test).
+    """
+    position_manager = input.get_position_manager()
+    parameters = input.parameters
+    pair = input.get_default_pair()
+
+    # Cycle 1: no open positions → deposit into vault
+    if not position_manager.is_any_open():
+        trades = position_manager.open_spot(
+            pair,
+            value=parameters.deposit_value,
+        )
+        return trades
+
+    # Cycle 2+: position exists → redeem all shares from vault
+    trades = position_manager.close_all()
+    return trades

--- a/tests/erc_4626/test_vault_async_cli_commands.py
+++ b/tests/erc_4626/test_vault_async_cli_commands.py
@@ -1,0 +1,264 @@
+"""CLI integration tests for Ostium V1.5 async vault with trade-executor commands.
+
+Tests that the following CLI commands handle async vault trades correctly:
+- ``perform-test-trade``: Opens and closes a vault position with forced settlement on Anvil
+- ``start`` with MAX_CYCLES: Runs decide_trades() which opens/closes vault positions
+- ``check-accounts``: Reports no mismatches during pending settlement
+- ``repair``: Does not touch vault_settlement_pending trades
+
+These tests use the ``arbitrum-ostium-v15.py`` strategy module and verify
+the full CLI pipeline works end-to-end with async vault deposits/redeems.
+"""
+
+import logging
+import os
+from pathlib import Path
+
+import flaky
+import pytest
+from typer.main import get_command
+from web3 import Web3
+
+from eth_defi.hotwallet import HotWallet
+from eth_defi.provider.anvil import fork_network_anvil, AnvilLaunch
+from eth_defi.provider.multi_provider import create_multi_provider_web3
+from eth_defi.token import fetch_erc20_details, USDC_NATIVE_TOKEN, USDC_WHALE
+from eth_defi.trace import assert_transaction_success_with_explanation
+
+from tradeexecutor.cli.main import app
+from tradeexecutor.state.state import State
+from tradeexecutor.state.trade import TradeStatus
+from tradeexecutor.utils.hex import hexbytes_to_hex_str
+
+
+JSON_RPC_ARBITRUM = os.environ.get("JSON_RPC_ARBITRUM")
+TRADING_STRATEGY_API_KEY = os.environ.get("TRADING_STRATEGY_API_KEY")
+
+pytestmark = pytest.mark.skipif(
+    not JSON_RPC_ARBITRUM or not TRADING_STRATEGY_API_KEY,
+    reason="Set JSON_RPC_ARBITRUM and TRADING_STRATEGY_API_KEY to run",
+)
+
+FORK_BLOCK = 470_000_000
+
+
+@pytest.fixture()
+def anvil_arbitrum_fork() -> AnvilLaunch:
+    """Arbitrum fork with unlocked USDC whale."""
+    usdc_whale = USDC_WHALE[42161]
+    launch = fork_network_anvil(
+        JSON_RPC_ARBITRUM,
+        fork_block_number=FORK_BLOCK,
+        unlocked_addresses=[usdc_whale],
+    )
+    try:
+        yield launch
+    finally:
+        launch.close(log_level=logging.ERROR)
+
+
+@pytest.fixture()
+def web3(anvil_arbitrum_fork) -> Web3:
+    return create_multi_provider_web3(
+        anvil_arbitrum_fork.json_rpc_url,
+        default_http_timeout=(3, 250.0),
+        retries=1,
+    )
+
+
+@pytest.fixture()
+def hot_wallet(web3) -> HotWallet:
+    """A test wallet funded with ETH and USDC."""
+    hw = HotWallet.create_for_testing(web3, test_account_n=1, eth_amount=10)
+    hw.sync_nonce(web3)
+
+    usdc = fetch_erc20_details(web3, USDC_NATIVE_TOKEN[42161])
+    tx_hash = usdc.contract.functions.transfer(
+        hw.address, 500 * 10**6,
+    ).transact({"from": USDC_WHALE[42161], "gas": 100_000})
+    assert_transaction_success_with_explanation(web3, tx_hash)
+    return hw
+
+
+@pytest.fixture()
+def strategy_file() -> Path:
+    """The Ostium V1.5 test strategy module."""
+    return Path(os.path.dirname(__file__)) / ".." / ".." / "strategies" / "test_only" / "arbitrum-ostium-v15.py"
+
+
+@pytest.fixture()
+def state_file(tmp_path) -> Path:
+    return tmp_path / "ostium-v15-cli-test.json"
+
+
+@pytest.fixture()
+def environment(
+    anvil_arbitrum_fork,
+    hot_wallet,
+    state_file,
+    strategy_file,
+    persistent_test_client,
+) -> dict:
+    """CLI environment for Ostium V1.5 hot wallet tests."""
+    cache_path = persistent_test_client.transport.cache_path
+    return {
+        "EXECUTOR_ID": "test_vault_async_cli",
+        "NAME": "test_vault_async_cli",
+        "STRATEGY_FILE": strategy_file.as_posix(),
+        "JSON_RPC_ARBITRUM": anvil_arbitrum_fork.json_rpc_url,
+        "STATE_FILE": state_file.as_posix(),
+        "ASSET_MANAGEMENT_MODE": "hot_wallet",
+        "UNIT_TESTING": "true",
+        "LOG_LEVEL": "disabled",
+        "TRADING_STRATEGY_API_KEY": TRADING_STRATEGY_API_KEY,
+        "MAX_DATA_DELAY_MINUTES": str(10 * 60 * 24 * 365),
+        "MIN_GAS_BALANCE": "0.01",
+        "GAS_BALANCE_WARNING_LEVEL": "0.0",
+        "PRIVATE_KEY": hexbytes_to_hex_str(hot_wallet.private_key),
+        "CACHE_PATH": cache_path,
+    }
+
+
+@pytest.mark.skip(reason="perform-test-trade with forced settlement requires unlocked Ostium keeper on Anvil")
+def test_ostium_v15_perform_test_trade(
+    environment: dict,
+    mocker,
+    state_file: Path,
+):
+    """Perform-test-trade CLI opens/closes an Ostium V1.5 position on Anvil.
+
+    1. Init strategy
+    2. Run perform-test-trade (forces settlement on Anvil automatically)
+    3. Verify state file has successful buy+sell trades
+    """
+    # 1. Init
+    mocker.patch.dict("os.environ", environment, clear=True)
+    cli = get_command(app)
+    cli.main(args=["init"], standalone_mode=False)
+
+    # 2. Perform test trade (--all-vaults tests all vault pairs)
+    mocker.patch.dict("os.environ", environment, clear=True)
+    cli.main(args=["perform-test-trade", "--all-vaults"], standalone_mode=False)
+
+    # 3. Verify state
+    state = State.read_json_file(state_file)
+    trades = list(state.portfolio.get_all_trades())
+
+    assert len(trades) >= 1
+    buy_trade = trades[0]
+    assert buy_trade.is_success(), f"Buy trade failed: {buy_trade.get_revert_reason()}"
+    assert buy_trade.executed_quantity > 0
+
+    if len(trades) >= 2:
+        sell_trade = trades[1]
+        assert sell_trade.is_success(), f"Sell trade failed: {sell_trade.get_revert_reason()}"
+
+
+@flaky.flaky
+def test_ostium_v15_start_one_cycle(
+    environment: dict,
+    mocker,
+    state_file: Path,
+):
+    """Run one strategy cycle that deposits into Ostium V1.5 vault.
+
+    1. Init strategy
+    2. Run start with MAX_CYCLES=1
+    3. Verify the buy trade was executed and is either success or vault_settlement_pending
+       (on Anvil, settlement retry should resolve it within the same tick)
+    """
+    # 1. Init
+    mocker.patch.dict("os.environ", environment, clear=True)
+    cli = get_command(app)
+    cli.main(args=["init"], standalone_mode=False)
+
+    # 2. Start with 1 cycle
+    env_cycle = {**environment, "MAX_CYCLES": "1"}
+    mocker.patch.dict("os.environ", env_cycle, clear=True)
+    cli.main(args=["start"], standalone_mode=False)
+
+    # 3. Verify the async vault deposit was executed
+    state = State.read_json_file(state_file)
+    trades = list(state.portfolio.get_all_trades())
+
+    assert len(trades) >= 1
+    buy_trade = trades[0]
+    # Async vault flow: the trade calls requestDeposit() which is confirmed on-chain,
+    # but settlement hasn't happened yet. The trade stays in vault_settlement_pending
+    # until the next tick's settlement retry resolves it (after external settlement).
+    # On Anvil with forced settlement, it might resolve within the same tick cycle.
+    assert buy_trade.get_status() in (TradeStatus.success, TradeStatus.vault_settlement_pending), \
+        f"Unexpected trade status: {buy_trade.get_status()}"
+
+
+@flaky.flaky
+def test_ostium_v15_check_accounts_cli(
+    environment: dict,
+    mocker,
+    state_file: Path,
+):
+    """Run check-accounts after a vault deposit — should report no mismatches.
+
+    1. Init + start (1 cycle to create a pending vault trade)
+    2. Run check-accounts CLI
+    3. Verify exit code 0 (no mismatches)
+    """
+    # 1. Init + one cycle
+    mocker.patch.dict("os.environ", environment, clear=True)
+    cli = get_command(app)
+    cli.main(args=["init"], standalone_mode=False)
+
+    env_cycle = {**environment, "MAX_CYCLES": "1"}
+    mocker.patch.dict("os.environ", env_cycle, clear=True)
+    cli.main(args=["start"], standalone_mode=False)
+
+    # 2. Check accounts — should exit 0 (no mismatches)
+    # When a vault deposit is pending: on-chain USDC is lower (sent to vault via requestDeposit),
+    # and state reserve is also lower (debited at trade start). So on-chain == expected.
+    # Position has quantity 0 (no vault shares yet), on-chain also 0. No mismatch.
+    env_check = {**environment, "SKIP_SAVE": "true"}
+    mocker.patch.dict("os.environ", env_check, clear=True)
+    try:
+        cli.main(args=["check-accounts"], standalone_mode=False)
+    except SystemExit as e:
+        assert e.code == 0, f"check-accounts exited with code {e.code} — accounting mismatch detected"
+
+
+@flaky.flaky
+def test_ostium_v15_repair_cli(
+    environment: dict,
+    mocker,
+    state_file: Path,
+):
+    """Run repair after a vault deposit — should not touch pending trades.
+
+    1. Init + start (1 cycle)
+    2. Run repair CLI
+    3. Verify the pending trade was NOT repaired (still vault_settlement_pending or success)
+    """
+    # 1. Init + one cycle
+    mocker.patch.dict("os.environ", environment, clear=True)
+    cli = get_command(app)
+    cli.main(args=["init"], standalone_mode=False)
+
+    env_cycle = {**environment, "MAX_CYCLES": "1"}
+    mocker.patch.dict("os.environ", env_cycle, clear=True)
+    cli.main(args=["start"], standalone_mode=False)
+
+    # 2. Run repair (AUTO_APPROVE to skip y/n prompt)
+    # The repair command has two paths that could touch our pending vault position:
+    # - find_trades_to_be_repaired(): only selects is_failed() trades → skips pending
+    # - repair_zero_quantity(): position has quantity 0 but we explicitly skip
+    #   positions with vault_settlement_pending trades (fix in repair.py)
+    env_repair = {**environment, "SKIP_SAVE": "true", "AUTO_APPROVE": "true"}
+    mocker.patch.dict("os.environ", env_repair, clear=True)
+    cli.main(args=["repair"], standalone_mode=False)
+
+    # 3. Verify the vault_settlement_pending trade was NOT repaired or closed
+    state = State.read_json_file(state_file)
+    trades = list(state.portfolio.get_all_trades())
+    assert len(trades) >= 1
+    buy_trade = trades[0]
+    # Trade should remain in its original state — repair must not touch it
+    assert buy_trade.get_status() in (TradeStatus.success, TradeStatus.vault_settlement_pending), \
+        f"Repair incorrectly modified trade status to: {buy_trade.get_status()}"

--- a/tests/erc_4626/test_vault_async_lagoon_ostium_v15.py
+++ b/tests/erc_4626/test_vault_async_lagoon_ostium_v15.py
@@ -1,0 +1,443 @@
+"""Integration test: Lagoon vault strategy trading Ostium V1.5 via async settlement.
+
+Deploys a fresh Lagoon vault on an Anvil Arbitrum fork, whitelists the Ostium V1.5
+vault, funds the Lagoon via a depositor, then runs a decide_trades() loop to open
+and close a position through the async settlement cycle.
+
+This tests the full Lagoon execution path (LagoonTransactionBuilder → guard → Safe)
+with async vault support, verifying that portfolio accounting remains correct at
+every step.
+
+Steps:
+1. Deploy Lagoon vault on Arbitrum fork, whitelist Ostium V1.5
+2. Fund the Lagoon vault with USDC via depositor
+3. Sync treasury, verify starting equity
+4. decide_trades() → open Ostium position → execute → vault_settlement_pending
+5. Verify portfolio equity preserved during pending state
+6. Force Ostium settlement on Anvil
+7. check_and_resolve_vault_settlements() → trade success, position open
+8. decide_trades() → close position → execute → vault_settlement_pending
+9. Force settlement(s) for withdrawal
+10. check_and_resolve_vault_settlements() → trade success, position closed
+11. Verify final equity ≈ starting (minus Ostium fees)
+"""
+
+import logging
+import os
+from decimal import Decimal
+
+import flaky
+import pytest
+from web3 import Web3
+
+from eth_defi.compat import native_datetime_utc_now
+from eth_defi.erc_4626.classification import create_vault_instance_autodetect
+from eth_defi.erc_4626.vault_protocol.gains.testing import force_ostium_v15_settlement
+from eth_defi.erc_4626.vault_protocol.gains.vault import OstiumVault, OstiumVersion
+from eth_defi.erc_4626.vault_protocol.lagoon.deployment import (
+    LagoonDeploymentParameters,
+    LagoonAutomatedDeployment,
+    deploy_automated_lagoon_vault,
+)
+from eth_defi.hotwallet import HotWallet
+from eth_defi.provider.anvil import fork_network_anvil, AnvilLaunch
+from eth_defi.provider.multi_provider import create_multi_provider_web3
+from eth_defi.token import fetch_erc20_details, USDC_NATIVE_TOKEN, USDC_WHALE
+from eth_defi.trace import assert_transaction_success_with_explanation
+
+from tradeexecutor.ethereum.ethereum_protocol_adapters import EthereumPairConfigurator
+from tradeexecutor.ethereum.lagoon.execution import LagoonExecution
+from tradeexecutor.ethereum.lagoon.tx import LagoonTransactionBuilder
+from tradeexecutor.ethereum.lagoon.vault import LagoonVaultSyncModel
+from tradeexecutor.ethereum.vault.settlement_retry import check_and_resolve_vault_settlements
+from tradeexecutor.ethereum.vault.vault_utils import translate_vault_to_trading_pair
+from tradeexecutor.state.identifier import AssetIdentifier, TradingPairIdentifier
+from tradeexecutor.state.state import State
+from tradeexecutor.state.trade import TradeStatus
+from tradeexecutor.strategy.generic.generic_pricing_model import GenericPricing
+from tradeexecutor.strategy.generic.generic_router import GenericRouting
+from tradeexecutor.strategy.pandas_trader.position_manager import PositionManager
+from tradeexecutor.strategy.reverse_universe import create_universe_from_trading_pair_identifiers
+from tradeexecutor.strategy.trading_strategy_universe import TradingStrategyUniverse
+from tradingstrategy.chain import ChainId
+from tradingstrategy.exchange import ExchangeUniverse, Exchange, ExchangeType
+from tradingstrategy.timebucket import TimeBucket
+from tradingstrategy.universe import Universe
+
+
+JSON_RPC_ARBITRUM = os.environ.get("JSON_RPC_ARBITRUM")
+pytestmark = pytest.mark.skipif(not JSON_RPC_ARBITRUM, reason="Set JSON_RPC_ARBITRUM to run this test")
+
+OSTIUM_VAULT_ADDRESS = "0x20d419a8e12c45f88fda7c5760bb6923cee27f98"
+FORK_BLOCK = 470_000_000
+
+
+@pytest.fixture()
+def anvil_arbitrum_fork() -> AnvilLaunch:
+    """Arbitrum fork with unlocked USDC whale."""
+    usdc_whale = USDC_WHALE[42161]
+    launch = fork_network_anvil(
+        JSON_RPC_ARBITRUM,
+        fork_block_number=FORK_BLOCK,
+        unlocked_addresses=[usdc_whale],
+    )
+    try:
+        yield launch
+    finally:
+        launch.close(log_level=logging.ERROR)
+
+
+@pytest.fixture()
+def web3(anvil_arbitrum_fork) -> Web3:
+    return create_multi_provider_web3(
+        anvil_arbitrum_fork.json_rpc_url,
+        default_http_timeout=(3, 250.0),
+        retries=1,
+    )
+
+
+@pytest.fixture()
+def deployer_hot_wallet(web3) -> HotWallet:
+    """Deployer wallet for Lagoon vault."""
+    return HotWallet.create_for_testing(web3, eth_amount=1)
+
+
+@pytest.fixture()
+def asset_manager(web3) -> HotWallet:
+    """Asset manager wallet for Lagoon operations."""
+    hw = HotWallet.create_for_testing(web3, eth_amount=5)
+    return hw
+
+
+@pytest.fixture()
+def multisig_owners(web3) -> list:
+    """Safe multisig owners."""
+    return [web3.eth.accounts[2], web3.eth.accounts[3], web3.eth.accounts[4]]
+
+
+@pytest.fixture()
+def depositor(web3) -> str:
+    """User who deposits USDC into Lagoon vault."""
+    account = web3.eth.accounts[5]
+    # Top up depositor with USDC
+    usdc = fetch_erc20_details(web3, USDC_NATIVE_TOKEN[42161])
+    tx_hash = usdc.contract.functions.transfer(
+        account, 500 * 10**6,
+    ).transact({"from": USDC_WHALE[42161], "gas": 100_000})
+    assert_transaction_success_with_explanation(web3, tx_hash)
+    return account
+
+
+@pytest.fixture()
+def ostium_vault(web3) -> OstiumVault:
+    """Ostium V1.5 vault."""
+    vault = create_vault_instance_autodetect(web3, OSTIUM_VAULT_ADDRESS)
+    assert isinstance(vault, OstiumVault)
+    assert vault.version == OstiumVersion.v1_5
+    return vault
+
+
+@pytest.fixture()
+def automated_lagoon_vault(
+    web3,
+    deployer_hot_wallet,
+    asset_manager,
+    multisig_owners,
+    ostium_vault,
+) -> LagoonAutomatedDeployment:
+    """Deploy a Lagoon vault with Ostium V1.5 whitelisted."""
+
+    chain_id = web3.eth.chain_id
+    parameters = LagoonDeploymentParameters(
+        underlying=USDC_NATIVE_TOKEN[chain_id],
+        name="TestOstiumLagoon",
+        symbol="TOST",
+    )
+
+    deploy_info = deploy_automated_lagoon_vault(
+        web3=web3,
+        deployer=deployer_hot_wallet,
+        asset_manager=asset_manager.address,
+        parameters=parameters,
+        safe_owners=multisig_owners,
+        safe_threshold=2,
+        uniswap_v2=None,
+        uniswap_v3=None,
+        any_asset=False,
+        erc_4626_vaults=[ostium_vault],
+        from_the_scratch=True,
+        use_forge=True,
+    )
+
+    # Verify the Ostium vault was whitelisted in the guard
+    module = deploy_info.vault.trading_strategy_module
+    assert module.functions.isAllowedApprovalDestination(ostium_vault.vault_address).call()
+
+    return deploy_info
+
+
+@pytest.fixture()
+def arb_usdc() -> AssetIdentifier:
+    return AssetIdentifier(
+        chain_id=42161,
+        address=USDC_NATIVE_TOKEN[42161],
+        decimals=6,
+        token_symbol="USDC",
+    )
+
+
+@pytest.fixture()
+def vault_pair(ostium_vault: OstiumVault) -> TradingPairIdentifier:
+    return translate_vault_to_trading_pair(ostium_vault)
+
+
+@pytest.fixture()
+def strategy_universe(vault_pair: TradingPairIdentifier, arb_usdc: AssetIdentifier) -> TradingStrategyUniverse:
+    """Universe containing only the Ostium vault pair."""
+
+    exchange_universe = ExchangeUniverse(
+        exchanges={
+            1: Exchange(
+                chain_id=ChainId(42161),
+                chain_slug="arbitrum",
+                exchange_id=1,
+                exchange_slug="ostium",
+                address="0x0000000000000000000000000000000000000000",
+                exchange_type=ExchangeType.erc_4626_vault,
+                pair_count=1,
+            ),
+        }
+    )
+
+    pair_universe = create_universe_from_trading_pair_identifiers(
+        [vault_pair],
+        exchange_universe,
+    )
+
+    universe = Universe(
+        time_bucket=TimeBucket.not_applicable,
+        chains={ChainId.arbitrum},
+        pairs=pair_universe,
+        exchange_universe=exchange_universe,
+    )
+
+    return TradingStrategyUniverse(
+        data_universe=universe,
+        reserve_assets=[arb_usdc],
+    )
+
+
+@pytest.fixture()
+def lagoon_execution_model(
+    web3,
+    automated_lagoon_vault: LagoonAutomatedDeployment,
+    asset_manager: HotWallet,
+) -> LagoonExecution:
+    """Lagoon execution model using TradingStrategyModuleV0."""
+    vault = automated_lagoon_vault.vault
+    return LagoonExecution(
+        vault=vault,
+        tx_builder=LagoonTransactionBuilder(vault, asset_manager),
+        mainnet_fork=True,
+        confirmation_block_count=0,
+    )
+
+
+@pytest.fixture()
+def sync_model(
+    automated_lagoon_vault: LagoonAutomatedDeployment,
+    asset_manager: HotWallet,
+) -> LagoonVaultSyncModel:
+    return LagoonVaultSyncModel(
+        vault=automated_lagoon_vault.vault,
+        hot_wallet=asset_manager,
+        unit_testing=True,
+    )
+
+
+@pytest.fixture()
+def routing_model(lagoon_execution_model, strategy_universe) -> GenericRouting:
+    return lagoon_execution_model.create_default_routing_model(strategy_universe)
+
+
+@pytest.fixture()
+def pricing_model(web3, strategy_universe) -> GenericPricing:
+    pair_configurator = EthereumPairConfigurator(
+        web3,
+        strategy_universe,
+    )
+    return GenericPricing(pair_configurator)
+
+
+@flaky.flaky
+def test_lagoon_ostium_v15_async_lifecycle(
+    web3: Web3,
+    automated_lagoon_vault: LagoonAutomatedDeployment,
+    ostium_vault: OstiumVault,
+    depositor: str,
+    asset_manager: HotWallet,
+    strategy_universe: TradingStrategyUniverse,
+    lagoon_execution_model: LagoonExecution,
+    sync_model: LagoonVaultSyncModel,
+    routing_model: GenericRouting,
+    pricing_model: GenericPricing,
+    vault_pair: TradingPairIdentifier,
+    arb_usdc: AssetIdentifier,
+):
+    """Full Lagoon vault → Ostium V1.5 async deposit/redeem with portfolio accounting.
+
+    1. Deploy Lagoon vault with Ostium whitelisted (fixture)
+    2. Fund Lagoon vault with USDC from depositor
+    3. Sync treasury, verify starting equity
+    4. decide_trades() → open position → execute → vault_settlement_pending
+    5. Verify equity preserved during pending state
+    6. Force Ostium settlement
+    7. Settlement retry → trade success, position open
+    8. decide_trades() → close position → execute → vault_settlement_pending
+    9. Force settlement(s) for withdrawal
+    10. Settlement retry → trade success, position closed
+    11. Verify final equity ≈ starting equity
+    """
+    lagoon_vault = automated_lagoon_vault.vault
+    state = State()
+
+    # 2. Fund Lagoon vault
+    # First post initial zero valuation so deposits are accepted
+    tx_hash = lagoon_vault.post_new_valuation(Decimal(0)).transact({"from": asset_manager.address})
+    assert_transaction_success_with_explanation(web3, tx_hash)
+
+    usdc = fetch_erc20_details(web3, USDC_NATIVE_TOKEN[42161])
+    deposit_amount = 200 * 10**6
+    tx_hash = usdc.contract.functions.approve(lagoon_vault.address, deposit_amount).transact({"from": depositor})
+    assert_transaction_success_with_explanation(web3, tx_hash)
+    tx_hash = lagoon_vault.request_deposit(depositor, deposit_amount).transact({"from": depositor})
+    assert_transaction_success_with_explanation(web3, tx_hash)
+
+    # Settle deposits
+    valuation = Decimal(0)
+    tx_hash = lagoon_vault.post_new_valuation(valuation).transact({"from": asset_manager.address})
+    assert_transaction_success_with_explanation(web3, tx_hash)
+    tx_hash = lagoon_vault.settle_via_trading_strategy_module(valuation).transact({"from": asset_manager.address, "gas": 1_000_000})
+    assert_transaction_success_with_explanation(web3, tx_hash)
+
+    # 3. Sync treasury
+    sync_model.sync_initial(
+        state,
+        reserve_asset=arb_usdc,
+        reserve_token_price=1.0,
+    )
+
+    sync_model.sync_treasury(
+        native_datetime_utc_now(),
+        state,
+        supported_reserves=[arb_usdc],
+        post_valuation=True,
+    )
+
+    # Verify USDC landed in the safe
+    safe_usdc_balance = usdc.fetch_balance_of(lagoon_vault.safe_address)
+    assert safe_usdc_balance > 0, f"Safe has no USDC after deposit settlement"
+
+    # If sync_treasury didn't find balance events, manually set reserves
+    reserve_position = state.portfolio.get_default_reserve_position()
+    if float(reserve_position.quantity) == 0:
+        reserve_position.quantity = safe_usdc_balance
+        reserve_position.reserve_token_price = 1.0
+
+    starting_equity = state.portfolio.calculate_total_equity()
+    assert starting_equity == pytest.approx(float(safe_usdc_balance), abs=2.0)
+
+    # 4. Open position (deposit into Ostium via Lagoon guard)
+    ts = native_datetime_utc_now()
+    position_manager = PositionManager(
+        ts,
+        universe=strategy_universe,
+        state=state,
+        pricing_model=pricing_model,
+        default_slippage_tolerance=0.10,
+    )
+
+    trades = position_manager.open_spot(vault_pair, value=50.0)
+    assert len(trades) == 1
+    buy_trade = trades[0]
+
+    routing_state_details = lagoon_execution_model.get_routing_state_details()
+    routing_state = routing_model.create_routing_state(strategy_universe, routing_state_details)
+    lagoon_execution_model.initialize()
+
+    lagoon_execution_model.execute_trades(
+        ts, state, trades, routing_model, routing_state, check_balances=True,
+    )
+
+    # Verify trade is vault_settlement_pending
+    assert buy_trade.get_status() == TradeStatus.vault_settlement_pending, \
+        f"Expected vault_settlement_pending, got {buy_trade.get_status()}"
+    assert buy_trade.other_data.get("vault_async_flow") is True
+    assert buy_trade.other_data.get("vault_direction") == "deposit"
+
+    # 5. Verify portfolio equity preserved
+    pending_value = state.portfolio.get_vault_settlement_pending_value()
+    assert pending_value == pytest.approx(50.0, abs=2.0)
+    equity_while_pending = state.portfolio.calculate_total_equity()
+    assert equity_while_pending == pytest.approx(starting_equity, abs=5.0)
+
+    # 6. Force Ostium settlement (use asset manager as gas payer — tryNewSettlement is permissionless)
+    force_ostium_v15_settlement(ostium_vault, asset_manager.address)
+
+    # 7. Settlement retry resolves the trade
+    resolved = check_and_resolve_vault_settlements(
+        state=state,
+        execution_model=lagoon_execution_model,
+    )
+    assert len(resolved) == 1
+    assert buy_trade.get_status() == TradeStatus.success
+    assert buy_trade.executed_quantity > 0
+
+    # Position should be open
+    position = state.portfolio.get_position_by_id(buy_trade.position_id)
+    assert position.is_open()
+    assert state.portfolio.get_vault_settlement_pending_value() == pytest.approx(0.0)
+
+    # 8. Close position (redeem from Ostium via Lagoon guard)
+    ts = native_datetime_utc_now()
+    position_manager = PositionManager(
+        ts,
+        universe=strategy_universe,
+        state=state,
+        pricing_model=pricing_model,
+        default_slippage_tolerance=0.10,
+    )
+
+    trades = position_manager.close_all()
+    assert len(trades) == 1
+    sell_trade = trades[0]
+
+    lagoon_execution_model.execute_trades(
+        ts, state, trades, routing_model, routing_state, check_balances=True,
+    )
+
+    assert sell_trade.get_status() == TradeStatus.vault_settlement_pending
+    assert sell_trade.other_data.get("vault_direction") == "redeem"
+
+    # 9. Force settlement(s) for withdrawal
+    withdraw_target = ostium_vault.vault_contract.functions.targetSettlementId(False).call()
+    last_id = ostium_vault.vault_contract.functions.lastSettlementId().call()
+    settlements_needed = max(withdraw_target - last_id, 1)
+    for _ in range(settlements_needed):
+        force_ostium_v15_settlement(ostium_vault, asset_manager.address)
+
+    # 10. Settlement retry resolves withdrawal
+    resolved = check_and_resolve_vault_settlements(
+        state=state,
+        execution_model=lagoon_execution_model,
+    )
+    assert len(resolved) == 1
+    assert sell_trade.get_status() == TradeStatus.success
+    assert sell_trade.executed_reserve > 0
+    assert position.is_closed()
+
+    # 11. Verify final equity
+    final_equity = state.portfolio.calculate_total_equity()
+    assert final_equity == pytest.approx(starting_equity, rel=0.03), \
+        f"Final equity {final_equity} deviates too much from starting {starting_equity}"
+    assert state.portfolio.get_vault_settlement_pending_value() == pytest.approx(0.0)

--- a/tests/erc_4626/test_vault_async_ostium_v15.py
+++ b/tests/erc_4626/test_vault_async_ostium_v15.py
@@ -1,0 +1,436 @@
+"""Integration test for Ostium V1.5 async vault deposit/redemption lifecycle.
+
+Uses a real Anvil fork of Arbitrum with the Ostium V1.5 vault to test the
+full async deposit → settlement → claim → redeem → settlement → claim cycle
+via hot wallet, with portfolio accounting checks at every step.
+
+Steps:
+1. Initialise state with reserves, record starting equity
+2. decide_trades() opens a position (vault deposit)
+3. execute_trades() broadcasts requestDeposit(), marks vault_settlement_pending
+4. Verify portfolio accounting: pending value included in equity
+5. Force settlement on Anvil
+6. Settlement retry → trade success, position open
+7. decide_trades() closes position (vault redeem)
+8. execute_trades() broadcasts requestWithdraw(), marks vault_settlement_pending
+9. Force settlement(s) for withdrawal
+10. Settlement retry → trade success, position closed
+11. Verify final equity approximately equals starting equity
+"""
+
+import logging
+import os
+
+import flaky
+import pytest
+from web3 import Web3
+
+from eth_defi.compat import native_datetime_utc_now
+from eth_defi.erc_4626.classification import create_vault_instance_autodetect
+from eth_defi.erc_4626.vault_protocol.gains.testing import force_ostium_v15_settlement
+from eth_defi.erc_4626.vault_protocol.gains.vault import OstiumVault, OstiumVersion
+from eth_defi.hotwallet import HotWallet
+from eth_defi.provider.anvil import fork_network_anvil, AnvilLaunch
+from eth_defi.provider.multi_provider import create_multi_provider_web3
+from eth_defi.token import fetch_erc20_details, USDC_NATIVE_TOKEN, USDC_WHALE
+from eth_defi.trace import assert_transaction_success_with_explanation
+
+from tradeexecutor.ethereum.ethereum_protocol_adapters import EthereumPairConfigurator
+from tradeexecutor.ethereum.execution import EthereumExecution
+from tradeexecutor.ethereum.hot_wallet_sync_model import HotWalletSyncModel
+from tradeexecutor.ethereum.tx import HotWalletTransactionBuilder
+from tradeexecutor.ethereum.vault.settlement_retry import check_and_resolve_vault_settlements
+from tradeexecutor.ethereum.vault.vault_utils import translate_vault_to_trading_pair
+from tradeexecutor.state.identifier import AssetIdentifier, TradingPairIdentifier
+from tradeexecutor.state.repair import find_trades_to_be_repaired
+from tradeexecutor.state.state import State
+from tradeexecutor.state.trade import TradeStatus
+from tradeexecutor.strategy.account_correction import calculate_account_corrections
+from tradeexecutor.strategy.generic.generic_pricing_model import GenericPricing
+from tradeexecutor.strategy.generic.generic_router import GenericRouting
+from tradeexecutor.strategy.pandas_trader.position_manager import PositionManager
+from tradeexecutor.strategy.reverse_universe import create_universe_from_trading_pair_identifiers
+from tradeexecutor.strategy.trading_strategy_universe import TradingStrategyUniverse
+from tradingstrategy.chain import ChainId
+from tradingstrategy.exchange import ExchangeUniverse, Exchange, ExchangeType
+from tradingstrategy.timebucket import TimeBucket
+from tradingstrategy.universe import Universe
+
+
+JSON_RPC_ARBITRUM = os.environ.get("JSON_RPC_ARBITRUM")
+pytestmark = pytest.mark.skipif(not JSON_RPC_ARBITRUM, reason="Set JSON_RPC_ARBITRUM to run this test")
+
+OSTIUM_VAULT_ADDRESS = "0x20d419a8e12c45f88fda7c5760bb6923cee27f98"
+FORK_BLOCK = 470_000_000
+
+
+@pytest.fixture()
+def anvil_arbitrum_fork() -> AnvilLaunch:
+    """Create an Anvil fork of Arbitrum at a post-V1.5 block."""
+    usdc_whale = USDC_WHALE[42161]
+    launch = fork_network_anvil(
+        JSON_RPC_ARBITRUM,
+        fork_block_number=FORK_BLOCK,
+        unlocked_addresses=[usdc_whale],
+    )
+    try:
+        yield launch
+    finally:
+        launch.close(log_level=logging.ERROR)
+
+
+@pytest.fixture()
+def web3(anvil_arbitrum_fork) -> Web3:
+    return create_multi_provider_web3(
+        anvil_arbitrum_fork.json_rpc_url,
+        default_http_timeout=(3, 250.0),
+        retries=1,
+    )
+
+
+@pytest.fixture()
+def hot_wallet(web3) -> HotWallet:
+    """A test wallet with USDC."""
+    hw = HotWallet.create_for_testing(web3, test_account_n=1, eth_amount=10)
+    hw.sync_nonce(web3)
+
+    usdc = fetch_erc20_details(web3, USDC_NATIVE_TOKEN[42161])
+    tx_hash = usdc.contract.functions.transfer(
+        hw.address, 500 * 10**6,
+    ).transact({"from": USDC_WHALE[42161], "gas": 100_000})
+    assert_transaction_success_with_explanation(web3, tx_hash)
+    return hw
+
+
+@pytest.fixture()
+def ostium_vault(web3) -> OstiumVault:
+    """The Ostium V1.5 vault instance."""
+    vault = create_vault_instance_autodetect(web3, OSTIUM_VAULT_ADDRESS)
+    assert isinstance(vault, OstiumVault)
+    assert vault.version == OstiumVersion.v1_5
+    return vault
+
+
+@pytest.fixture()
+def arb_usdc() -> AssetIdentifier:
+    return AssetIdentifier(
+        chain_id=42161,
+        address=USDC_NATIVE_TOKEN[42161],
+        decimals=6,
+        token_symbol="USDC",
+    )
+
+
+@pytest.fixture()
+def vault_pair(ostium_vault: OstiumVault) -> TradingPairIdentifier:
+    return translate_vault_to_trading_pair(ostium_vault)
+
+
+@pytest.fixture()
+def strategy_universe(vault_pair: TradingPairIdentifier, arb_usdc: AssetIdentifier) -> TradingStrategyUniverse:
+    """A minimal universe containing only the Ostium vault pair."""
+
+    exchange_universe = ExchangeUniverse(
+        exchanges={
+            1: Exchange(
+                chain_id=ChainId(42161),
+                chain_slug="arbitrum",
+                exchange_id=1,
+                exchange_slug="ostium",
+                address="0x0000000000000000000000000000000000000000",
+                exchange_type=ExchangeType.erc_4626_vault,
+                pair_count=1,
+            ),
+        }
+    )
+
+    pair_universe = create_universe_from_trading_pair_identifiers(
+        [vault_pair],
+        exchange_universe,
+    )
+
+    universe = Universe(
+        time_bucket=TimeBucket.not_applicable,
+        chains={ChainId.arbitrum},
+        pairs=pair_universe,
+        exchange_universe=exchange_universe,
+    )
+
+    return TradingStrategyUniverse(
+        data_universe=universe,
+        reserve_assets=[arb_usdc],
+    )
+
+
+@pytest.fixture()
+def execution_model(web3, hot_wallet) -> EthereumExecution:
+    return EthereumExecution(
+        HotWalletTransactionBuilder(web3, hot_wallet),
+        mainnet_fork=True,
+        confirmation_block_count=0,
+    )
+
+
+@pytest.fixture()
+def sync_model(web3, hot_wallet) -> HotWalletSyncModel:
+    return HotWalletSyncModel(web3, hot_wallet)
+
+
+@pytest.fixture()
+def routing_model(execution_model, strategy_universe) -> GenericRouting:
+    return execution_model.create_default_routing_model(strategy_universe)
+
+
+@pytest.fixture()
+def pricing_model(web3, strategy_universe, execution_model) -> GenericPricing:
+    pair_configurator = EthereumPairConfigurator(
+        web3,
+        strategy_universe,
+        execution_model=execution_model,
+    )
+    return GenericPricing(pair_configurator)
+
+
+@flaky.flaky
+def test_ostium_v15_async_deposit_redeem_lifecycle(
+    web3: Web3,
+    hot_wallet: HotWallet,
+    ostium_vault: OstiumVault,
+    strategy_universe: TradingStrategyUniverse,
+    execution_model: EthereumExecution,
+    sync_model: HotWalletSyncModel,
+    routing_model: GenericRouting,
+    pricing_model: GenericPricing,
+    vault_pair: TradingPairIdentifier,
+    arb_usdc: AssetIdentifier,
+):
+    """Full async deposit/redeem lifecycle with portfolio accounting checks at each step.
+
+    1. Initialise state with reserves, record starting equity
+    2. decide_trades() opens a position (vault deposit)
+    3. execute_trades() broadcasts requestDeposit(), marks vault_settlement_pending
+    4. Verify portfolio accounting: pending value included in equity
+    5. Force settlement on Anvil
+    6. Settlement retry resolves buy, position open
+    7. decide_trades() closes position (vault redeem)
+    8. execute_trades() broadcasts requestWithdraw(), marks vault_settlement_pending
+    9. Force settlement(s) for withdrawal
+    10. Settlement retry resolves sell, position closed
+    11. Verify final equity approximately equals starting equity
+    """
+    state = State()
+
+    # 1. Initialise state and sync on-chain reserves
+    sync_model.sync_initial(state, reserve_asset=arb_usdc, reserve_token_price=1.0)
+    sync_model.sync_treasury(native_datetime_utc_now(), state, supported_reserves=[arb_usdc])
+    reserve_position = state.portfolio.get_default_reserve_position()
+    starting_cash = float(reserve_position.quantity)
+    assert starting_cash == pytest.approx(500.0, abs=1.0)
+    starting_equity = state.portfolio.calculate_total_equity()
+
+    # 2. Cycle 1: decide_trades() opens position
+    ts = native_datetime_utc_now()
+    pm = PositionManager(ts, universe=strategy_universe, state=state, pricing_model=pricing_model, default_slippage_tolerance=0.10)
+    trades = pm.open_spot(vault_pair, value=50.0)
+    assert len(trades) == 1
+    buy_trade = trades[0]
+
+    # 3. execute_trades() detects async vault, calls requestDeposit() instead of deposit()
+    # The vault routing layer (vault_routing.py) recognises Ostium V1.5 and routes through
+    # VaultDepositManager.requestDeposit(). On success it calls state.mark_vault_settlement_pending()
+    # which sets vault_settlement_pending_at timestamp and stores ticket metadata in other_data.
+    routing_state_details = execution_model.get_routing_state_details()
+    routing_state = routing_model.create_routing_state(strategy_universe, routing_state_details)
+    execution_model.initialize()
+    execution_model.execute_trades(ts, state, trades, routing_model, routing_state, check_balances=True)
+
+    assert buy_trade.get_status() == TradeStatus.vault_settlement_pending
+    assert buy_trade.other_data["vault_async_flow"] is True
+    assert buy_trade.other_data["vault_direction"] == "deposit"
+
+    # 4. Verify portfolio accounting during pending state
+    # get_vault_settlement_pending_value() counts planned_reserve of pending buy trades
+    # so equity = cash (reduced) + pending_value (50) ≈ starting_equity
+    pending_value = state.portfolio.get_vault_settlement_pending_value()
+    assert pending_value == pytest.approx(50.0, abs=1.0)
+    equity_while_pending = state.portfolio.calculate_total_equity()
+    assert equity_while_pending == pytest.approx(starting_equity, abs=2.0)
+
+    # 5. Force settlement on Anvil (simulates Ostium keeper running a settlement epoch)
+    # In production this happens off-chain every ~24h. On Anvil we can force it.
+    owner_address = buy_trade.other_data["vault_owner_address"]
+    force_ostium_v15_settlement(ostium_vault, owner_address)
+
+    # 6. Settlement retry checks on-chain status and broadcasts claimDeposit()
+    # This is what the runner calls at the start of each tick to resolve pending trades.
+    resolved = check_and_resolve_vault_settlements(state=state, execution_model=execution_model)
+    assert len(resolved) == 1
+    assert buy_trade.get_status() == TradeStatus.success
+    assert buy_trade.executed_quantity > 0
+    position = state.portfolio.get_position_by_id(buy_trade.position_id)
+    assert position.is_open()
+    # After claim, pending value drops to 0 — capital is now in the position
+    assert state.portfolio.get_vault_settlement_pending_value() == pytest.approx(0.0)
+
+    # 7. Cycle 2: decide_trades() closes position (redeem vault shares)
+    ts = native_datetime_utc_now()
+    pm = PositionManager(ts, universe=strategy_universe, state=state, pricing_model=pricing_model, default_slippage_tolerance=0.10)
+    trades = pm.close_all()
+    assert len(trades) == 1
+    sell_trade = trades[0]
+
+    # 8. execute_trades() calls requestWithdraw() for async redeem
+    execution_model.execute_trades(ts, state, trades, routing_model, routing_state, check_balances=True)
+    assert sell_trade.get_status() == TradeStatus.vault_settlement_pending
+    assert sell_trade.other_data["vault_direction"] == "redeem"
+    # Sell trades are NOT counted in pending_value (only buys lock capital)
+    assert state.portfolio.get_vault_settlement_pending_value() == pytest.approx(0.0)
+
+    # 9. Force settlement(s) for withdrawal
+    # Withdrawals may need multiple settlements to reach the target settlement ID
+    withdraw_target = ostium_vault.vault_contract.functions.targetSettlementId(False).call()
+    last_id = ostium_vault.vault_contract.functions.lastSettlementId().call()
+    for _ in range(max(withdraw_target - last_id, 1)):
+        force_ostium_v15_settlement(ostium_vault, owner_address)
+
+    # 10. Settlement retry broadcasts claimWithdraw() and marks trade success
+    resolved = check_and_resolve_vault_settlements(state=state, execution_model=execution_model)
+    assert len(resolved) == 1
+    assert sell_trade.get_status() == TradeStatus.success
+    assert sell_trade.executed_reserve > 0
+    assert position.is_closed()
+
+    # 11. Verify final equity ≈ starting equity (minus Ostium vault fees)
+    final_equity = state.portfolio.calculate_total_equity()
+    assert final_equity == pytest.approx(starting_equity, rel=0.02), \
+        f"Final equity {final_equity} deviates too much from starting {starting_equity}"
+    assert state.portfolio.get_vault_settlement_pending_value() == pytest.approx(0.0)
+    assert state.portfolio.get_in_transit_value() == pytest.approx(0.0)
+
+
+@flaky.flaky
+def test_ostium_v15_check_accounts_during_pending_settlement(
+    web3: Web3,
+    hot_wallet: HotWallet,
+    ostium_vault: OstiumVault,
+    strategy_universe: TradingStrategyUniverse,
+    execution_model: EthereumExecution,
+    sync_model: HotWalletSyncModel,
+    routing_model: GenericRouting,
+    pricing_model: GenericPricing,
+    vault_pair: TradingPairIdentifier,
+    arb_usdc: AssetIdentifier,
+):
+    """Verify check-accounts reports no mismatch when a vault deposit is pending.
+
+    1. Initialise state with reserves
+    2. Execute a vault deposit → trade enters vault_settlement_pending
+    3. Run calculate_account_corrections (same logic as check-accounts CLI)
+    4. Verify no accounting mismatches are reported
+    5. Verify repair does not touch the pending trade
+    """
+    state = State()
+
+    # 1. Initialise state
+    sync_model.sync_initial(state, reserve_asset=arb_usdc, reserve_token_price=1.0)
+    sync_model.sync_treasury(native_datetime_utc_now(), state, supported_reserves=[arb_usdc])
+
+    # 2. Execute vault deposit → pending
+    ts = native_datetime_utc_now()
+    pm = PositionManager(ts, universe=strategy_universe, state=state, pricing_model=pricing_model, default_slippage_tolerance=0.10)
+    trades = pm.open_spot(vault_pair, value=50.0)
+    routing_state_details = execution_model.get_routing_state_details()
+    routing_state = routing_model.create_routing_state(strategy_universe, routing_state_details)
+    execution_model.initialize()
+    execution_model.execute_trades(ts, state, trades, routing_model, routing_state, check_balances=True)
+
+    buy_trade = trades[0]
+    assert buy_trade.get_status() == TradeStatus.vault_settlement_pending
+
+    # 3. Run check-accounts logic (same as check-accounts CLI internally)
+    # Why this should show no mismatch:
+    # - Reserve (USDC): state was debited at trade start, on-chain USDC was sent to vault
+    #   via requestDeposit(). Both reduced by same amount → match.
+    # - Position (vault token): get_quantity() returns 0 (only counts is_success() trades),
+    #   on-chain vault token balance is also 0 (not yet claimed) → match.
+    pair_universe = strategy_universe.data_universe.pairs
+    corrections = list(calculate_account_corrections(
+        pair_universe=pair_universe,
+        reserve_assets=strategy_universe.reserve_assets,
+        state=state,
+        sync_model=sync_model,
+        all_balances=True,
+    ))
+
+    # 4. No accounting mismatches — on-chain balances match state
+    mismatches = [c for c in corrections if c.mismatch]
+    assert len(mismatches) == 0, f"Unexpected accounting mismatches during pending settlement: {mismatches}"
+
+    # 5. Repair does not touch pending trades
+    # - find_trades_to_be_repaired() only targets is_failed() → skips vault_settlement_pending
+    # - repair_zero_quantity() explicitly skips positions with vault_settlement_pending trades
+    repair_trades = find_trades_to_be_repaired(state)
+    assert len(repair_trades) == 0, "Repair should not target vault_settlement_pending trades"
+
+
+@flaky.flaky
+def test_ostium_v15_check_accounts_after_settlement(
+    web3: Web3,
+    hot_wallet: HotWallet,
+    ostium_vault: OstiumVault,
+    strategy_universe: TradingStrategyUniverse,
+    execution_model: EthereumExecution,
+    sync_model: HotWalletSyncModel,
+    routing_model: GenericRouting,
+    pricing_model: GenericPricing,
+    vault_pair: TradingPairIdentifier,
+    arb_usdc: AssetIdentifier,
+):
+    """Verify check-accounts reports no mismatch after settlement resolves a vault deposit.
+
+    1. Initialise state, execute vault deposit → pending
+    2. Force settlement, resolve via settlement retry
+    3. Run check-accounts logic
+    4. Verify balances match (position now holds vault tokens)
+    """
+    state = State()
+
+    # 1. Setup and deposit
+    sync_model.sync_initial(state, reserve_asset=arb_usdc, reserve_token_price=1.0)
+    sync_model.sync_treasury(native_datetime_utc_now(), state, supported_reserves=[arb_usdc])
+
+    ts = native_datetime_utc_now()
+    pm = PositionManager(ts, universe=strategy_universe, state=state, pricing_model=pricing_model, default_slippage_tolerance=0.10)
+    trades = pm.open_spot(vault_pair, value=50.0)
+    routing_state_details = execution_model.get_routing_state_details()
+    routing_state = routing_model.create_routing_state(strategy_universe, routing_state_details)
+    execution_model.initialize()
+    execution_model.execute_trades(ts, state, trades, routing_model, routing_state, check_balances=True)
+
+    buy_trade = trades[0]
+    assert buy_trade.get_status() == TradeStatus.vault_settlement_pending
+
+    # 2. Force settlement and resolve
+    owner_address = buy_trade.other_data["vault_owner_address"]
+    force_ostium_v15_settlement(ostium_vault, owner_address)
+    resolved = check_and_resolve_vault_settlements(state=state, execution_model=execution_model)
+    assert len(resolved) == 1
+    assert buy_trade.get_status() == TradeStatus.success
+
+    # 3. Run check-accounts logic
+    pair_universe = strategy_universe.data_universe.pairs
+    corrections = list(calculate_account_corrections(
+        pair_universe=pair_universe,
+        reserve_assets=strategy_universe.reserve_assets,
+        state=state,
+        sync_model=sync_model,
+        all_balances=True,
+    ))
+
+    # 4. No mismatches — position quantity matches on-chain vault tokens
+    mismatches = [c for c in corrections if c.mismatch]
+    assert len(mismatches) == 0, f"Unexpected accounting mismatches after settlement: {mismatches}"
+
+    # Position should have vault tokens
+    position = state.portfolio.get_position_by_id(buy_trade.position_id)
+    assert position.get_quantity() > 0

--- a/tests/ethereum/test_vault_settlement_lifecycle.py
+++ b/tests/ethereum/test_vault_settlement_lifecycle.py
@@ -1,0 +1,538 @@
+"""Test the vault_settlement_pending lifecycle: accounting, routing, and settlement retry.
+
+Verifies that:
+
+- ``get_vault_settlement_pending_value()`` correctly sums planned_reserve of pending buy trades
+- ``calculate_total_equity()`` includes pending vault settlement value
+- ``settle_trade()`` marks async vault trades as ``vault_settlement_pending``
+- ``check_and_resolve_vault_settlements()`` resolves claimable trades
+- ``check_and_resolve_vault_settlements()`` handles reclaimable trades (mark failed)
+- Serialisation round-trip preserves all ``other_data`` fields
+"""
+
+import datetime
+from decimal import Decimal
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from tradeexecutor.state.blockhain_transaction import BlockchainTransaction
+from tradeexecutor.state.identifier import (
+    AssetIdentifier,
+    TradingPairIdentifier,
+    TradingPairKind,
+)
+from tradeexecutor.state.state import State
+from tradeexecutor.state.trade import TradeExecution, TradeStatus, TradeType
+
+
+USDC_ARBITRUM_ADDRESS = "0xaf88d065e77c8cC2239327C5EDb3A432268e5831"
+OLP_ARBITRUM_ADDRESS = "0x20d419a8e12c45f88fda7c5760bb6923cee27f98"
+
+
+@pytest.fixture()
+def usdc_arbitrum() -> AssetIdentifier:
+    """USDC on Arbitrum."""
+    return AssetIdentifier(
+        chain_id=42161,
+        address=USDC_ARBITRUM_ADDRESS,
+        token_symbol="USDC",
+        decimals=6,
+    )
+
+
+@pytest.fixture()
+def olp_arbitrum() -> AssetIdentifier:
+    """OLP share token on Arbitrum."""
+    return AssetIdentifier(
+        chain_id=42161,
+        address=OLP_ARBITRUM_ADDRESS,
+        token_symbol="oLP",
+        decimals=18,
+    )
+
+
+@pytest.fixture()
+def vault_pair(usdc_arbitrum: AssetIdentifier, olp_arbitrum: AssetIdentifier) -> TradingPairIdentifier:
+    """Ostium vault trading pair."""
+    return TradingPairIdentifier(
+        base=olp_arbitrum,
+        quote=usdc_arbitrum,
+        pool_address=OLP_ARBITRUM_ADDRESS,
+        exchange_address=OLP_ARBITRUM_ADDRESS,
+        fee=0,
+        kind=TradingPairKind.vault,
+    )
+
+
+def _create_vault_buy_trade(
+    state: State,
+    vault_pair: TradingPairIdentifier,
+    reserve_asset: AssetIdentifier,
+    reserve_amount: Decimal,
+    ts: datetime.datetime,
+) -> TradeExecution:
+    """Helper to create a vault deposit (buy) trade."""
+    _, trade, _ = state.create_trade(
+        strategy_cycle_at=ts,
+        pair=vault_pair,
+        quantity=None,
+        reserve=reserve_amount,
+        assumed_price=1.0,
+        trade_type=TradeType.rebalance,
+        reserve_currency=reserve_asset,
+        reserve_currency_price=1.0,
+    )
+    return trade
+
+
+def _create_vault_sell_trade(
+    state: State,
+    vault_pair: TradingPairIdentifier,
+    reserve_asset: AssetIdentifier,
+    quantity: Decimal,
+    ts: datetime.datetime,
+) -> TradeExecution:
+    """Helper to create a vault redeem (sell) trade."""
+    _, trade, _ = state.create_trade(
+        strategy_cycle_at=ts,
+        pair=vault_pair,
+        quantity=-quantity,
+        reserve=None,
+        assumed_price=1.0,
+        trade_type=TradeType.rebalance,
+        reserve_currency=reserve_asset,
+        reserve_currency_price=1.0,
+    )
+    return trade
+
+
+def test_vault_settlement_pending_value_in_equity(
+    vault_pair: TradingPairIdentifier,
+    usdc_arbitrum: AssetIdentifier,
+):
+    """Verify pending vault deposit value is included in portfolio equity.
+
+    1. Create a state with reserves and a vault deposit (buy) trade
+    2. Advance trade to vault_settlement_pending
+    3. Verify get_vault_settlement_pending_value() returns the planned_reserve
+    4. Verify calculate_total_equity() includes the pending value
+    """
+    state = State()
+    ts = datetime.datetime(2025, 1, 1)
+
+    # 1. Create state with reserves and vault buy trade
+    state.portfolio.initialise_reserves(usdc_arbitrum)
+    reserve = state.portfolio.get_default_reserve_position()
+    reserve.quantity = Decimal(10_000)
+    reserve.reserve_token_price = 1.0
+
+    trade = _create_vault_buy_trade(state, vault_pair, usdc_arbitrum, Decimal(500), ts)
+
+    # 2. Advance to vault_settlement_pending
+    state.start_execution(ts, trade)
+    trade.mark_broadcasted(ts)
+
+    # Add fake blockchain transactions
+    approve_tx = BlockchainTransaction()
+    approve_tx.tx_hash = "0xapprove"
+    request_tx = BlockchainTransaction()
+    request_tx.tx_hash = "0xrequest123"
+    trade.blockchain_transactions = [approve_tx, request_tx]
+
+    ticket_data = {
+        "vault_address": OLP_ARBITRUM_ADDRESS,
+        "vault_owner": "0xTestOwner",
+        "vault_to": "0xTestOwner",
+        "vault_raw_amount": 500_000_000,
+        "vault_request_tx_hash": "0xrequest123",
+        "vault_settlement_id": 42,
+    }
+    state.mark_vault_settlement_pending(ts, trade, ticket_data)
+
+    # 3. Verify status and pending value
+    assert trade.get_status() == TradeStatus.vault_settlement_pending
+    pending_value = state.portfolio.get_vault_settlement_pending_value()
+    assert pending_value == pytest.approx(500.0)
+
+    # 4. Verify total equity includes pending value
+    # Reserves: 10,000 - 500 (allocated) = 9,500 cash
+    # Position equity: 0 (no successful trades)
+    # Vault pending: 500
+    total_equity = state.portfolio.calculate_total_equity()
+    assert total_equity == pytest.approx(10_000.0)
+
+
+def test_vault_settlement_pending_sell_not_counted(
+    vault_pair: TradingPairIdentifier,
+    usdc_arbitrum: AssetIdentifier,
+):
+    """Verify pending vault sell trades are NOT counted in pending value.
+
+    1. Create a vault sell (redeem) trade
+    2. Mark as vault_settlement_pending
+    3. Verify get_vault_settlement_pending_value() returns 0
+    """
+    state = State()
+    ts = datetime.datetime(2025, 1, 1)
+
+    # 1. Create state with reserves
+    state.portfolio.initialise_reserves(usdc_arbitrum)
+    reserve = state.portfolio.get_default_reserve_position()
+    reserve.quantity = Decimal(10_000)
+    reserve.reserve_token_price = 1.0
+
+    trade = _create_vault_sell_trade(state, vault_pair, usdc_arbitrum, Decimal(100), ts)
+
+    # 2. Mark as vault_settlement_pending
+    state.start_execution(ts, trade)
+    trade.mark_broadcasted(ts)
+
+    request_tx = BlockchainTransaction()
+    request_tx.tx_hash = "0xrequest_withdraw"
+    trade.blockchain_transactions = [request_tx]
+
+    ticket_data = {
+        "vault_address": OLP_ARBITRUM_ADDRESS,
+        "vault_owner": "0xTestOwner",
+        "vault_to": "0xTestOwner",
+        "vault_raw_amount": 100 * 10**18,
+        "vault_request_tx_hash": "0xrequest_withdraw",
+        "vault_settlement_id": 43,
+    }
+    state.mark_vault_settlement_pending(ts, trade, ticket_data)
+
+    # 3. Verify sell trades are not counted
+    assert trade.get_status() == TradeStatus.vault_settlement_pending
+    pending_value = state.portfolio.get_vault_settlement_pending_value()
+    assert pending_value == pytest.approx(0.0)
+
+
+def test_vault_settlement_pending_metadata_stored(
+    vault_pair: TradingPairIdentifier,
+    usdc_arbitrum: AssetIdentifier,
+):
+    """Verify vault settlement metadata is stored correctly in other_data.
+
+    1. Create a vault buy trade and mark as pending
+    2. Verify all expected metadata fields are present
+    3. Verify metadata survives dict round-trip (JSON serialisation proxy)
+    """
+    state = State()
+    ts = datetime.datetime(2025, 1, 1)
+
+    state.portfolio.initialise_reserves(usdc_arbitrum)
+    reserve = state.portfolio.get_default_reserve_position()
+    reserve.quantity = Decimal(10_000)
+    reserve.reserve_token_price = 1.0
+
+    # 1. Create and mark pending
+    trade = _create_vault_buy_trade(state, vault_pair, usdc_arbitrum, Decimal(100), ts)
+    state.start_execution(ts, trade)
+    trade.mark_broadcasted(ts)
+    trade.blockchain_transactions = [BlockchainTransaction()]
+
+    ticket_data = {
+        "vault_address": OLP_ARBITRUM_ADDRESS,
+        "vault_owner": "0xTestOwner",
+        "vault_to": "0xTestOwner",
+        "vault_raw_amount": 100_000_000,
+        "vault_request_tx_hash": "0xrequest123",
+        "vault_settlement_id": 42,
+    }
+    state.mark_vault_settlement_pending(ts, trade, ticket_data)
+
+    # 2. Verify metadata
+    assert trade.other_data["vault_async_flow"] is True
+    assert trade.other_data["vault_chain_id"] == 42161
+    assert trade.other_data["vault_direction"] == "deposit"
+    assert trade.other_data["vault_address"] == OLP_ARBITRUM_ADDRESS
+    assert trade.other_data["vault_settlement_id"] == 42
+    assert trade.other_data["vault_raw_amount"] == 100_000_000
+
+    # 3. Verify round-trip (JSON compat check)
+    import json
+    serialised = json.dumps(trade.other_data)
+    deserialised = json.loads(serialised)
+    assert deserialised["vault_settlement_id"] == 42
+    assert deserialised["vault_chain_id"] == 42161
+
+
+def test_vault_settlement_retry_claimable(
+    vault_pair: TradingPairIdentifier,
+    usdc_arbitrum: AssetIdentifier,
+):
+    """Verify settlement retry resolves a claimable vault trade.
+
+    1. Create a vault buy trade in vault_settlement_pending state
+    2. Mock the deposit manager to return CLAIMABLE status
+    3. Mock the claim transaction and analysis
+    4. Call check_and_resolve_vault_settlements
+    5. Verify trade is marked as success with correct amounts
+    """
+    from unittest.mock import MagicMock, patch
+    from eth_defi.vault.deposit_redeem import AsyncVaultRequestStatus, DepositRedeemEventAnalysis
+    from tradeexecutor.ethereum.vault.settlement_retry import check_and_resolve_vault_settlements
+
+    state = State()
+    ts = datetime.datetime(2025, 1, 1)
+
+    state.portfolio.initialise_reserves(usdc_arbitrum)
+    reserve = state.portfolio.get_default_reserve_position()
+    reserve.quantity = Decimal(10_000)
+    reserve.reserve_token_price = 1.0
+
+    # 1. Create trade in vault_settlement_pending state
+    trade = _create_vault_buy_trade(state, vault_pair, usdc_arbitrum, Decimal(100), ts)
+    state.start_execution(ts, trade)
+    trade.mark_broadcasted(ts)
+
+    approve_tx = BlockchainTransaction()
+    approve_tx.tx_hash = "0xapprove"
+    request_tx = BlockchainTransaction()
+    request_tx.tx_hash = "0xrequest"
+    trade.blockchain_transactions = [approve_tx, request_tx]
+
+    trade.other_data["vault_async_flow"] = True
+    trade.other_data["vault_chain_id"] = 42161
+    trade.other_data["vault_direction"] = "deposit"
+    trade.other_data["vault_owner_address"] = "0xTestOwner"
+    trade.other_data["vault_raw_amount"] = 100_000_000
+    trade.other_data["vault_address"] = OLP_ARBITRUM_ADDRESS
+    trade.other_data["vault_request_tx_hash"] = "0xrequest"
+    trade.other_data["vault_settlement_id"] = 42
+    trade.other_data["vault_request_tx_count"] = 2
+    trade.vault_settlement_pending_at = ts
+
+    assert trade.get_status() == TradeStatus.vault_settlement_pending
+
+    # 2. Mock deposit manager
+    mock_deposit_manager = MagicMock()
+    mock_deposit_manager.get_deposit_request_status.return_value = AsyncVaultRequestStatus.claimable
+    mock_deposit_manager.reconstruct_deposit_ticket.return_value = MagicMock()
+
+    # Mock finish_deposit returns a contract function
+    mock_func = MagicMock()
+    mock_deposit_manager.finish_deposit.return_value = mock_func
+
+    # Mock analysis
+    mock_analysis = MagicMock(spec=DepositRedeemEventAnalysis)
+    mock_analysis.denomination_amount = Decimal(100)
+    mock_analysis.share_count = Decimal("96.15")
+    mock_deposit_manager.analyse_deposit.return_value = mock_analysis
+
+    # 3. Mock vault and web3
+    mock_vault = MagicMock()
+    mock_vault.get_deposit_manager.return_value = mock_deposit_manager
+    mock_vault.vault_contract = MagicMock()
+
+    mock_web3 = MagicMock()
+    mock_receipt = {"status": 1, "transactionHash": b"\x00" * 32, "blockNumber": 100}
+    mock_web3.eth.send_raw_transaction.return_value = b"\x00" * 32
+    mock_web3.eth.wait_for_transaction_receipt.return_value = mock_receipt
+
+    mock_execution_model = MagicMock()
+    mock_execution_model.web3 = mock_web3
+
+    # Mock tx_builder
+    mock_tx = BlockchainTransaction()
+    mock_tx.tx_hash = "0x" + "ab" * 32
+    mock_tx.signed_bytes = b"\xab" * 32
+    mock_tx.other = {}
+    mock_execution_model.tx_builder.sign_transaction.return_value = mock_tx
+
+    # 4. Patch get_vault_for_pair
+    with patch("tradeexecutor.ethereum.vault.settlement_retry.get_vault_for_pair", return_value=mock_vault):
+        resolved = check_and_resolve_vault_settlements(
+            state=state,
+            execution_model=mock_execution_model,
+        )
+
+    # 5. Verify trade marked as success
+    assert len(resolved) == 1
+    assert trade.get_status() == TradeStatus.success
+    assert trade.vault_settlement_pending_at is None
+    assert trade.executed_reserve == pytest.approx(Decimal(100))
+    assert trade.executed_quantity == pytest.approx(Decimal("96.15"))
+
+
+def test_vault_settlement_retry_pending_skipped(
+    vault_pair: TradingPairIdentifier,
+    usdc_arbitrum: AssetIdentifier,
+):
+    """Verify that trades still pending settlement are skipped (not resolved).
+
+    1. Create a vault buy trade in vault_settlement_pending state
+    2. Mock the deposit manager to return PENDING status
+    3. Call check_and_resolve_vault_settlements
+    4. Verify trade remains in vault_settlement_pending status
+    """
+    from unittest.mock import MagicMock, patch
+    from eth_defi.vault.deposit_redeem import AsyncVaultRequestStatus
+    from tradeexecutor.ethereum.vault.settlement_retry import check_and_resolve_vault_settlements
+
+    state = State()
+    ts = datetime.datetime(2025, 1, 1)
+
+    state.portfolio.initialise_reserves(usdc_arbitrum)
+    reserve = state.portfolio.get_default_reserve_position()
+    reserve.quantity = Decimal(10_000)
+    reserve.reserve_token_price = 1.0
+
+    # 1. Create trade
+    trade = _create_vault_buy_trade(state, vault_pair, usdc_arbitrum, Decimal(100), ts)
+    state.start_execution(ts, trade)
+    trade.mark_broadcasted(ts)
+
+    approve_tx = BlockchainTransaction()
+    approve_tx.tx_hash = "0xapprove"
+    request_tx = BlockchainTransaction()
+    request_tx.tx_hash = "0xrequest"
+    trade.blockchain_transactions = [approve_tx, request_tx]
+
+    trade.other_data["vault_async_flow"] = True
+    trade.other_data["vault_chain_id"] = 42161
+    trade.other_data["vault_direction"] = "deposit"
+    trade.other_data["vault_owner_address"] = "0xTestOwner"
+    trade.other_data["vault_raw_amount"] = 100_000_000
+    trade.other_data["vault_address"] = OLP_ARBITRUM_ADDRESS
+    trade.other_data["vault_request_tx_hash"] = "0xrequest"
+    trade.other_data["vault_settlement_id"] = 42
+    trade.other_data["vault_request_tx_count"] = 2
+    trade.vault_settlement_pending_at = ts
+
+    # 2. Mock deposit manager returning PENDING
+    mock_deposit_manager = MagicMock()
+    mock_deposit_manager.get_deposit_request_status.return_value = AsyncVaultRequestStatus.pending
+    mock_deposit_manager.reconstruct_deposit_ticket.return_value = MagicMock()
+
+    mock_vault = MagicMock()
+    mock_vault.get_deposit_manager.return_value = mock_deposit_manager
+
+    mock_execution_model = MagicMock()
+    mock_execution_model.web3 = MagicMock()
+
+    # 3. Call retry
+    with patch("tradeexecutor.ethereum.vault.settlement_retry.get_vault_for_pair", return_value=mock_vault):
+        resolved = check_and_resolve_vault_settlements(
+            state=state,
+            execution_model=mock_execution_model,
+        )
+
+    # 4. Verify trade still pending
+    assert len(resolved) == 0
+    assert trade.get_status() == TradeStatus.vault_settlement_pending
+    assert trade.vault_settlement_pending_at == ts
+
+
+def test_vault_settlement_retry_reclaimable(
+    vault_pair: TradingPairIdentifier,
+    usdc_arbitrum: AssetIdentifier,
+):
+    """Verify reclaimable vault trades are marked as failed with reserves restored.
+
+    1. Create a vault buy trade in vault_settlement_pending state
+    2. Mock the deposit manager to return RECLAIMABLE status
+    3. Mock the reclaim transaction
+    4. Call check_and_resolve_vault_settlements
+    5. Verify trade is marked as failed
+    6. Verify reserves are restored
+    """
+    from unittest.mock import MagicMock, patch
+    from eth_defi.vault.deposit_redeem import AsyncVaultRequestStatus
+    from tradeexecutor.ethereum.vault.settlement_retry import check_and_resolve_vault_settlements
+
+    state = State()
+    ts = datetime.datetime(2025, 1, 1)
+
+    state.portfolio.initialise_reserves(usdc_arbitrum)
+    reserve = state.portfolio.get_default_reserve_position()
+    reserve.quantity = Decimal(10_000)
+    reserve.reserve_token_price = 1.0
+
+    # 1. Create trade
+    trade = _create_vault_buy_trade(state, vault_pair, usdc_arbitrum, Decimal(100), ts)
+    state.start_execution(ts, trade)
+    trade.mark_broadcasted(ts)
+
+    approve_tx = BlockchainTransaction()
+    approve_tx.tx_hash = "0xapprove"
+    request_tx = BlockchainTransaction()
+    request_tx.tx_hash = "0xrequest"
+    trade.blockchain_transactions = [approve_tx, request_tx]
+
+    trade.other_data["vault_async_flow"] = True
+    trade.other_data["vault_chain_id"] = 42161
+    trade.other_data["vault_direction"] = "deposit"
+    trade.other_data["vault_owner_address"] = "0xTestOwner"
+    trade.other_data["vault_raw_amount"] = 100_000_000
+    trade.other_data["vault_address"] = OLP_ARBITRUM_ADDRESS
+    trade.other_data["vault_request_tx_hash"] = "0xrequest"
+    trade.other_data["vault_settlement_id"] = 42
+    trade.other_data["vault_request_tx_count"] = 2
+    trade.vault_settlement_pending_at = ts
+
+    # Reserve was 10,000 but 100 allocated to trade
+    cash_before = float(state.portfolio.get_cash())
+
+    # 2. Mock deposit manager returning RECLAIMABLE
+    mock_deposit_manager = MagicMock()
+    mock_deposit_manager.get_deposit_request_status.return_value = AsyncVaultRequestStatus.reclaimable
+    mock_deposit_manager.reconstruct_deposit_ticket.return_value = MagicMock()
+
+    mock_reclaim_func = MagicMock()
+    mock_deposit_manager.reclaim_deposit.return_value = mock_reclaim_func
+
+    mock_vault = MagicMock()
+    mock_vault.get_deposit_manager.return_value = mock_deposit_manager
+    mock_vault.vault_contract = MagicMock()
+
+    mock_web3 = MagicMock()
+    mock_receipt = {"status": 1, "transactionHash": b"\x00" * 32, "blockNumber": 100}
+    mock_web3.eth.send_raw_transaction.return_value = b"\x00" * 32
+    mock_web3.eth.wait_for_transaction_receipt.return_value = mock_receipt
+
+    mock_execution_model = MagicMock()
+    mock_execution_model.web3 = mock_web3
+
+    mock_tx = BlockchainTransaction()
+    mock_tx.tx_hash = "0x" + "cd" * 32
+    mock_tx.signed_bytes = b"\xcd" * 32
+    mock_tx.other = {}
+    mock_execution_model.tx_builder.sign_transaction.return_value = mock_tx
+
+    # 4. Call retry
+    with patch("tradeexecutor.ethereum.vault.settlement_retry.get_vault_for_pair", return_value=mock_vault):
+        resolved = check_and_resolve_vault_settlements(
+            state=state,
+            execution_model=mock_execution_model,
+        )
+
+    # 5. Verify trade failed
+    assert len(resolved) == 1
+    assert trade.get_status() == TradeStatus.failed
+    assert trade.vault_settlement_pending_at is None
+
+    # 6. Verify reserves restored (mark_trade_failed calls adjust_reserves for buys)
+    cash_after = float(state.portfolio.get_cash())
+    assert cash_after == pytest.approx(cash_before + 100.0)
+
+
+def test_is_swap_function_includes_async_selectors():
+    """Verify that requestDeposit and requestWithdraw are recognised as swap functions.
+
+    1. Import is_swap_function
+    2. Verify requestDeposit returns True
+    3. Verify requestWithdraw returns True
+    4. Verify unknown functions return False
+    """
+    from tradeexecutor.ethereum.swap import is_swap_function
+
+    # 2. Async deposit request
+    assert is_swap_function("requestDeposit") is True
+
+    # 3. Async withdraw request
+    assert is_swap_function("requestWithdraw") is True
+
+    # 4. Unknown
+    assert is_swap_function("unknownFunction") is False

--- a/tradeexecutor/cli/loop.py
+++ b/tradeexecutor/cli/loop.py
@@ -1371,6 +1371,20 @@ class ExecutionLoop:
                     f"Resolve manually with trade-executor bridge-retry or receiveMessage."
                 )
 
+        # Check for vault trades stuck in settlement pending from a previous run.
+        # Unlike CCTP, do NOT halt on unresolved — vault settlements can take
+        # hours/days and will resolve on a future tick.
+        from tradeexecutor.ethereum.vault.settlement_retry import check_and_resolve_vault_settlements
+        vault_web3config = getattr(self.execution_model, 'web3config', None)
+        vault_resolved = check_and_resolve_vault_settlements(
+            state=state,
+            execution_model=self.execution_model,
+            web3config=vault_web3config,
+        )
+        if vault_resolved:
+            logger.trade("Resolved %d vault settlement pending trade(s) on startup", len(vault_resolved))
+            self.store.sync(state)
+
         # Store summary statistics in memory before doing anything else
         self.refresh_live_run_state(state, visualisation=self.visulisation, universe=universe, cycle_duration=self.cycle_duration)
 

--- a/tradeexecutor/cli/testtrade.py
+++ b/tradeexecutor/cli/testtrade.py
@@ -15,7 +15,7 @@ from tradingstrategy.pair import HumanReadableTradingPairDescription
 from tradingstrategy.exchange import ExchangeUniverse
 
 from tradeexecutor.ethereum.enzyme.vault import EnzymeVaultSyncModel
-from tradeexecutor.state.trade import TradeFlag
+from tradeexecutor.state.trade import TradeFlag, TradeStatus
 from tradeexecutor.state.types import Percent
 from tradeexecutor.statistics.core import update_statistics
 from tradeexecutor.statistics.statistics_table import serialise_long_short_stats_as_json_table
@@ -300,6 +300,50 @@ def _make_cross_chain_test_trade(
     logger.info("  Reserves: %s %s (was %s)", reserve_currency_at_end, reserve_currency, reserve_currency_at_start)
 
 
+def _force_vault_settlement_and_resolve(web3, state, trade, execution_model):
+    """Force settlement on Anvil for an async vault test trade and resolve it.
+
+    Uses protocol-specific settlement forcing (e.g. tryNewSettlement for Ostium V1.5,
+    force_lagoon_settle for ERC-7540) then runs the generic settlement retry.
+    """
+    from eth_defi.erc_4626.vault_protocol.gains.vault import OstiumVault, OstiumVersion
+    from eth_defi.erc_4626.vault_protocol.gains.testing import force_ostium_v15_settlement
+    from tradeexecutor.ethereum.vault.vault_routing import get_vault_for_pair
+    from tradeexecutor.ethereum.vault.settlement_retry import check_and_resolve_vault_settlements
+
+    vault = get_vault_for_pair(web3, trade.pair)
+    owner = trade.other_data.get("vault_owner_address")
+
+    # Protocol-specific settlement forcing
+    if isinstance(vault, OstiumVault) and vault.version == OstiumVersion.v1_5:
+        # May need multiple settlements for withdrawal
+        direction = trade.other_data.get("vault_direction", "deposit")
+        settlements_needed = 1
+        if direction == "redeem":
+            withdraw_target = vault.vault_contract.functions.targetSettlementId(False).call()
+            last_id = vault.vault_contract.functions.lastSettlementId().call()
+            settlements_needed = max(withdraw_target - last_id, 1)
+        for _ in range(settlements_needed):
+            force_ostium_v15_settlement(vault, owner)
+    else:
+        # ERC-7540 (Lagoon) — use force_lagoon_settle if available
+        from eth_defi.erc_4626.vault_protocol.lagoon.vault import LagoonVault
+        if isinstance(vault, LagoonVault):
+            from eth_defi.erc_4626.vault_protocol.lagoon.testing import force_lagoon_settle
+            # Need the vault manager address — for test trades this is typically the owner
+            force_lagoon_settle(vault, owner)
+
+    # Now run the generic settlement retry
+    resolved = check_and_resolve_vault_settlements(
+        state=state,
+        execution_model=execution_model,
+    )
+    if resolved:
+        logger.info("Test trade vault settlement resolved: %d trade(s)", len(resolved))
+    else:
+        logger.warning("Test trade vault settlement NOT resolved after forcing — may need manual intervention")
+
+
 def make_test_trade(
     web3: Web3,
     execution_model: ExecutionModel,
@@ -566,6 +610,22 @@ def make_test_trade(
 
         assert trade.is_test()
         assert position.is_test()
+
+        # For async vaults (Ostium V1.5, ERC-7540), the trade enters
+        # vault_settlement_pending after execute. On Anvil we can force
+        # settlement and resolve; on mainnet we just report the status.
+        if trade.get_status() == TradeStatus.vault_settlement_pending:
+            from eth_defi.provider.anvil import is_anvil
+            if is_anvil(web3):
+                logger.info("Test trade #%d is vault_settlement_pending on Anvil, forcing settlement...", trade.trade_id)
+                _force_vault_settlement_and_resolve(web3, state, trade, execution_model)
+            else:
+                logger.info(
+                    "Test trade #%d is vault_settlement_pending — settlement happens off-chain. "
+                    "Re-run perform-test-trade after settlement to complete the cycle.",
+                    trade.trade_id,
+                )
+                return
 
         if not trade.is_success() or not position.is_open():
             # Alot of diagnostics to debug Arbitrum / WBTC issues

--- a/tradeexecutor/cli/testtrade.py
+++ b/tradeexecutor/cli/testtrade.py
@@ -614,8 +614,8 @@ def make_test_trade(
         # For async vaults (Ostium V1.5, ERC-7540), the trade enters
         # vault_settlement_pending after execute. On Anvil we can force
         # settlement and resolve; on mainnet we just report the status.
+        # is_anvil is already imported at module level
         if trade.get_status() == TradeStatus.vault_settlement_pending:
-            from eth_defi.provider.anvil import is_anvil
             if is_anvil(web3):
                 logger.info("Test trade #%d is vault_settlement_pending on Anvil, forcing settlement...", trade.trade_id)
                 _force_vault_settlement_and_resolve(web3, state, trade, execution_model)

--- a/tradeexecutor/ethereum/swap.py
+++ b/tradeexecutor/ethereum/swap.py
@@ -25,9 +25,12 @@ def is_swap_function(name: str):
         # Aave
         "supply",
         "withdraw",
-        # ERC-4626
+        # ERC-4626 synchronous
         "deposit",
         "redeem",
+        # ERC-4626 async (Ostium V1.5, ERC-7540)
+        "requestDeposit",
+        "requestWithdraw",
         # CCTP bridge
         "depositForBurn",
     }

--- a/tradeexecutor/ethereum/vault/settlement_retry.py
+++ b/tradeexecutor/ethereum/vault/settlement_retry.py
@@ -1,0 +1,329 @@
+"""Async vault settlement retry module.
+
+When the executor process restarts or a new tick fires while an async
+vault trade is in ``vault_settlement_pending`` state (request confirmed,
+claim pending), this module polls the vault's deposit manager for
+settlement status and broadcasts the claim/reclaim transaction.
+
+Works with any vault protocol that implements the generic
+:py:class:`~eth_defi.vault.deposit_redeem.VaultDepositManager` interface
+(Ostium V1.5, ERC-7540 Lagoon, etc.) — no protocol-specific imports.
+"""
+
+import logging
+from itertools import chain as ichain
+
+from eth_defi.compat import native_datetime_utc_now
+from eth_defi.vault.deposit_redeem import (
+    AsyncVaultRequestStatus,
+    DepositRedeemEventAnalysis,
+)
+from hexbytes import HexBytes
+
+from tradeexecutor.ethereum.vault.vault_routing import get_vault_for_pair
+from tradeexecutor.state.state import State
+from tradeexecutor.state.trade import TradeExecution, TradeStatus
+
+logger = logging.getLogger(__name__)
+
+
+def check_and_resolve_vault_settlements(
+    state: State,
+    execution_model,
+    web3config=None,
+) -> list[TradeExecution]:
+    """Check for vault_settlement_pending trades and attempt to complete them.
+
+    Called during live execution startup and on each tick to resolve
+    async vault trades that are awaiting settlement.
+
+    The function scans all open and pending positions for trades with
+    ``vault_settlement_pending`` status. For each one it:
+
+    1. Reads routing metadata from ``trade.other_data``.
+    2. Reconstructs the protocol-specific ticket via the deposit manager.
+    3. Checks settlement status via the generic enum interface.
+    4. If claimable: signs and broadcasts the claim transaction.
+    5. Analyses the claim result and calls ``mark_trade_success``.
+    6. If reclaimable: signs and broadcasts the reclaim transaction,
+       then calls ``mark_trade_failed``.
+
+    :param state:
+        Current strategy state.
+
+    :param execution_model:
+        The execution model (must have ``tx_builder``).
+
+    :param web3config:
+        Optional Web3Config for multi-chain setups.
+        Falls back to ``execution_model.web3`` if None.
+
+    :return:
+        List of trades that were successfully resolved.
+    """
+    resolved: list[TradeExecution] = []
+
+    # Scan both open and pending positions
+    pending_trades: list[TradeExecution] = []
+    all_positions = ichain(
+        state.portfolio.open_positions.values(),
+        state.portfolio.pending_positions.values(),
+    )
+    for position in all_positions:
+        for trade in position.trades.values():
+            if trade.get_status() == TradeStatus.vault_settlement_pending:
+                pending_trades.append(trade)
+
+    if not pending_trades:
+        return resolved
+
+    logger.info(
+        "Found %d vault settlement pending trade(s), checking status",
+        len(pending_trades),
+    )
+
+    for trade in pending_trades:
+        try:
+            _resolve_single_vault_trade(state, trade, execution_model, web3config, resolved)
+        except Exception as e:
+            logger.warning(
+                "Failed to resolve vault settlement for trade #%d: %s",
+                trade.trade_id, e,
+                exc_info=True,
+            )
+
+    return resolved
+
+
+def _resolve_single_vault_trade(
+    state: State,
+    trade: TradeExecution,
+    execution_model,
+    web3config,
+    resolved: list[TradeExecution],
+):
+    """Attempt to resolve a single vault settlement pending trade."""
+
+    from tradingstrategy.chain import ChainId
+
+    # Read metadata
+    vault_chain_id = trade.other_data.get("vault_chain_id")
+    direction = trade.other_data.get("vault_direction")
+
+    if vault_chain_id is None or direction is None:
+        logger.warning(
+            "Vault settlement pending trade #%d missing metadata (chain_id=%s, direction=%s), skipping",
+            trade.trade_id, vault_chain_id, direction,
+        )
+        return
+
+    # Get web3 connection
+    if web3config is not None:
+        web3 = web3config.get_connection(ChainId(vault_chain_id))
+    else:
+        web3 = execution_model.web3
+
+    if web3 is None:
+        logger.warning(
+            "No web3 connection for chain %d, skipping vault trade #%d",
+            vault_chain_id, trade.trade_id,
+        )
+        return
+
+    # Get vault and deposit manager
+    vault = get_vault_for_pair(web3, trade.pair)
+    deposit_manager = vault.get_deposit_manager()
+
+    # Reconstruct ticket
+    if direction == "deposit":
+        ticket = deposit_manager.reconstruct_deposit_ticket(trade.other_data)
+    else:
+        ticket = deposit_manager.reconstruct_redemption_ticket(trade.other_data)
+
+    # STEP A: Check for existing post-request tx (idempotent handling)
+    request_tx_count = trade.other_data.get("vault_request_tx_count", 1)
+    has_existing_post_tx = len(trade.blockchain_transactions) > request_tx_count
+    tx_already_confirmed = False
+    confirmed_receipt = None
+    is_reclaim_tx = False
+
+    if has_existing_post_tx:
+        existing_tx = trade.blockchain_transactions[-1]
+        is_reclaim_tx = existing_tx.other.get("vault_settlement_action") == "reclaim"
+
+        if existing_tx.tx_hash:
+            try:
+                confirmed_receipt = web3.eth.get_transaction_receipt(
+                    HexBytes(existing_tx.tx_hash)
+                )
+                if confirmed_receipt and confirmed_receipt["status"] == 1:
+                    tx_already_confirmed = True
+                elif confirmed_receipt and confirmed_receipt["status"] == 0:
+                    # Reverted — pop and try fresh
+                    trade.blockchain_transactions.pop()
+                    has_existing_post_tx = False
+            except Exception:
+                pass
+
+        if has_existing_post_tx and not tx_already_confirmed:
+            # Rebroadcast
+            try:
+                web3.eth.send_raw_transaction(HexBytes(existing_tx.signed_bytes))
+                confirmed_receipt = web3.eth.wait_for_transaction_receipt(
+                    HexBytes(existing_tx.tx_hash), timeout=120,
+                )
+                if confirmed_receipt["status"] == 1:
+                    tx_already_confirmed = True
+                else:
+                    trade.blockchain_transactions.pop()
+                    has_existing_post_tx = False
+            except Exception as e:
+                logger.warning(
+                    "Vault claim rebroadcast failed for trade #%d: %s",
+                    trade.trade_id, e,
+                )
+                return
+
+    if not tx_already_confirmed:
+        # STEP B: Check settlement status
+        if direction == "deposit":
+            status = deposit_manager.get_deposit_request_status(ticket)
+        else:
+            status = deposit_manager.get_redemption_request_status(ticket)
+
+        if status == AsyncVaultRequestStatus.pending:
+            logger.info(
+                "Vault trade #%d still pending settlement (direction=%s)",
+                trade.trade_id, direction,
+            )
+            return
+        elif status == AsyncVaultRequestStatus.none:
+            logger.warning(
+                "Unexpected NONE status for vault trade #%d (direction=%s)",
+                trade.trade_id, direction,
+            )
+            return
+
+        # STEP C: Sign and broadcast claim/reclaim
+        if status == AsyncVaultRequestStatus.claimable:
+            if direction == "deposit":
+                func = deposit_manager.finish_deposit(ticket)
+            else:
+                func = deposit_manager.finish_redemption(ticket)
+            is_reclaim_tx = False
+        elif status == AsyncVaultRequestStatus.reclaimable:
+            if direction == "deposit":
+                func = deposit_manager.reclaim_deposit(ticket)
+            else:
+                func = deposit_manager.reclaim_withdrawal(ticket)
+            if func is None:
+                logger.error(
+                    "Protocol does not support reclaim for trade #%d",
+                    trade.trade_id,
+                )
+                return
+            is_reclaim_tx = True
+        else:
+            return
+
+        # Sync nonce before signing (may be stale from prior txs)
+        tx_builder = execution_model.tx_builder
+        if hasattr(tx_builder, 'hot_wallet'):
+            tx_builder.hot_wallet.sync_nonce(web3)
+
+        action_label = "reclaim" if is_reclaim_tx else "claim"
+        new_tx = tx_builder.sign_transaction(
+            contract=vault.vault_contract,
+            args_bound_func=func,
+            gas_limit=1_000_000,
+            asset_deltas=[],
+            notes=f"Vault {action_label} for trade #{trade.trade_id} ({direction})",
+        )
+        new_tx.other["vault_settlement_action"] = action_label
+        trade.blockchain_transactions.append(new_tx)
+
+        # Broadcast and wait
+        try:
+            web3.eth.send_raw_transaction(HexBytes(new_tx.signed_bytes))
+            new_tx.broadcasted_at = native_datetime_utc_now()
+            confirmed_receipt = web3.eth.wait_for_transaction_receipt(
+                HexBytes(new_tx.tx_hash), timeout=120,
+            )
+        except Exception as e:
+            logger.warning(
+                "Vault %s broadcast failed for trade #%d: %s",
+                action_label, trade.trade_id, e,
+            )
+            return
+
+        if confirmed_receipt["status"] != 1:
+            logger.warning(
+                "Vault %s tx reverted for trade #%d",
+                action_label, trade.trade_id,
+            )
+            trade.blockchain_transactions.pop()
+            return
+
+    # STEP D: Analyse confirmed tx and update trade state
+    ts = native_datetime_utc_now()
+    tx_hash = HexBytes(confirmed_receipt["transactionHash"])
+
+    if is_reclaim_tx:
+        # Reclaim — mark trade as failed, restore reserves
+        trade.vault_settlement_pending_at = None
+        state.mark_trade_failed(ts, trade)
+        logger.info(
+            "Vault trade #%d reclaimed successfully (direction=%s)",
+            trade.trade_id, direction,
+        )
+    else:
+        # Claim — analyse result and mark success
+        if direction == "deposit":
+            analysis = deposit_manager.analyse_deposit(tx_hash, ticket)
+        else:
+            analysis = deposit_manager.analyse_redemption(tx_hash, ticket)
+
+        if not isinstance(analysis, DepositRedeemEventAnalysis):
+            logger.error(
+                "Vault claim analysis failed for trade #%d: %s",
+                trade.trade_id, analysis,
+            )
+            return
+
+        if direction == "deposit":
+            executed_reserve = analysis.denomination_amount
+            executed_amount = analysis.share_count
+            price = float(executed_reserve / executed_amount) if executed_amount else 0
+        else:
+            executed_amount = -analysis.share_count
+            executed_reserve = analysis.denomination_amount
+            price = float(executed_reserve / analysis.share_count) if analysis.share_count else 0
+
+        # Clear pending status before marking success
+        trade.vault_settlement_pending_at = None
+
+        state.mark_trade_success(
+            ts,
+            trade,
+            executed_price=price,
+            executed_amount=executed_amount,
+            executed_reserve=executed_reserve,
+            lp_fees=0,
+            native_token_price=0,
+        )
+
+        # Handle partial deposit refunds
+        if direction == "deposit" and executed_reserve < trade.planned_reserve:
+            refund_amount = trade.planned_reserve - executed_reserve
+            state.portfolio.adjust_reserves(
+                trade.reserve_currency,
+                refund_amount,
+                f"Vault partial deposit refund: trade #{trade.trade_id}",
+            )
+
+        logger.info(
+            "Vault trade #%d settled successfully (direction=%s, amount=%s, reserve=%s, price=%s)",
+            trade.trade_id, direction, executed_amount, executed_reserve, price,
+        )
+
+    resolved.append(trade)

--- a/tradeexecutor/ethereum/vault/vault_routing.py
+++ b/tradeexecutor/ethereum/vault/vault_routing.py
@@ -288,30 +288,35 @@ class VaultRouting(RoutingModel):
             target_vault.vault_address,
             swap_amount,
         )
-        request_call = deposit_request.funcs[0]
 
-        # Mark trade for async handling
+        # Mark trade for async handling — store both raw and decimal amounts
+        # so we can reconstruct the request during settle_trade() parsing
         trade.other_data["vault_async_flow"] = True
         trade.other_data["vault_raw_amount"] = deposit_request.raw_amount
+        trade.other_data["vault_deposit_amount"] = str(swap_amount)
         trade.other_data["vault_owner_address"] = address
 
-        tx_1 = tx_builder.sign_transaction(
+        # Sign approve tx first
+        txs = [tx_builder.sign_transaction(
             contract=target_vault.denomination_token.contract,
             args_bound_func=approve_call,
             gas_limit=500_000,
             asset_deltas=[],
             notes=trade.notes,
-        )
-        tx_2 = tx_builder.sign_transaction(
-            contract=target_vault.vault_contract,
-            args_bound_func=request_call,
-            gas_limit=self.vault_interaction_gas_limit,
-            asset_deltas=[],
-            notes=trade.notes,
-        )
+        )]
 
-        trade.other_data["vault_request_tx_count"] = 2
-        return [tx_1, tx_2]
+        # Sign all request funcs (most adapters have 1, but support multiple)
+        for func in deposit_request.funcs:
+            txs.append(tx_builder.sign_transaction(
+                contract=target_vault.vault_contract,
+                args_bound_func=func,
+                gas_limit=self.vault_interaction_gas_limit,
+                asset_deltas=[],
+                notes=trade.notes,
+            ))
+
+        trade.other_data["vault_request_tx_count"] = len(txs)
+        return txs
 
     def _build_async_redeem_txs(
         self,
@@ -328,23 +333,28 @@ class VaultRouting(RoutingModel):
             owner=address,
             shares=swap_amount,
         )
-        request_call = redemption_request.funcs[0]
 
-        # Mark trade for async handling
+        # Mark trade for async handling — store both raw and decimal amounts.
+        # We store vault_redeem_shares (Decimal) for adapters like Lagoon that
+        # assert `not raw_shares` and require the decimal form for reconstruction.
         trade.other_data["vault_async_flow"] = True
         trade.other_data["vault_raw_amount"] = redemption_request.raw_shares
+        trade.other_data["vault_redeem_shares"] = str(swap_amount)
         trade.other_data["vault_owner_address"] = address
 
-        tx_1 = tx_builder.sign_transaction(
-            contract=target_vault.vault_contract,
-            args_bound_func=request_call,
-            gas_limit=self.vault_interaction_gas_limit,
-            asset_deltas=[],
-            notes=trade.notes,
-        )
+        # Sign all request funcs (most adapters have 1, but support multiple)
+        txs = []
+        for func in redemption_request.funcs:
+            txs.append(tx_builder.sign_transaction(
+                contract=target_vault.vault_contract,
+                args_bound_func=func,
+                gas_limit=self.vault_interaction_gas_limit,
+                asset_deltas=[],
+                notes=trade.notes,
+            ))
 
-        trade.other_data["vault_request_tx_count"] = 1
-        return [tx_1]
+        trade.other_data["vault_request_tx_count"] = len(txs)
+        return txs
 
     def setup_trades(
         self,
@@ -410,6 +420,8 @@ class VaultRouting(RoutingModel):
             tx_hashes = [HexBytes(tx.tx_hash) for tx in trade.blockchain_transactions if tx.tx_hash]
 
             if direction == "deposit":
+                # Reconstruct deposit request using raw_amount (int) —
+                # all adapters support this path for deposits.
                 deposit_request = deposit_manager.create_deposit_request(
                     owner=owner_address,
                     raw_amount=trade.other_data["vault_raw_amount"],
@@ -417,10 +429,21 @@ class VaultRouting(RoutingModel):
                 ticket = deposit_request.parse_deposit_transaction(tx_hashes)
                 ticket_data = deposit_manager.serialize_deposit_ticket(ticket)
             else:
-                redemption_request = deposit_manager.create_redemption_request(
-                    owner=owner_address,
-                    raw_shares=trade.other_data["vault_raw_amount"],
-                )
+                # Reconstruct redemption request using shares (Decimal) —
+                # Lagoon asserts `not raw_shares` so we must pass the decimal form.
+                # Fall back to raw_shares for adapters that only support raw form.
+                redeem_shares_str = trade.other_data.get("vault_redeem_shares")
+                if redeem_shares_str:
+                    redemption_request = deposit_manager.create_redemption_request(
+                        owner=owner_address,
+                        shares=Decimal(redeem_shares_str),
+                    )
+                else:
+                    # Legacy path: older trades stored only vault_raw_amount
+                    redemption_request = deposit_manager.create_redemption_request(
+                        owner=owner_address,
+                        raw_shares=trade.other_data["vault_raw_amount"],
+                    )
                 ticket = redemption_request.parse_redeem_transaction(tx_hashes)
                 ticket_data = deposit_manager.serialize_redemption_ticket(ticket)
 

--- a/tradeexecutor/ethereum/vault/vault_routing.py
+++ b/tradeexecutor/ethereum/vault/vault_routing.py
@@ -15,7 +15,7 @@ from eth_defi.erc_4626.profit_and_loss import estimate_4626_recent_profitability
 from eth_defi.erc_4626.vault import ERC4626Vault
 from eth_defi.token import fetch_erc20_details, TokenDiskCache
 from eth_defi.trade import TradeSuccess
-
+from eth_defi.vault.deposit_redeem import VaultDepositManager
 
 from tradeexecutor.ethereum.swap import get_swap_transactions, report_failure
 from tradeexecutor.ethereum.token_cache import get_default_token_cache
@@ -222,6 +222,19 @@ class VaultRouting(RoutingModel):
 
         asset_deltas = trade.calculate_asset_deltas()
 
+        deposit_manager = target_vault.get_deposit_manager()
+
+        # Async vault flow (Ostium V1.5, ERC-7540 Lagoon)
+        if trade.is_buy() and not deposit_manager.has_synchronous_deposit():
+            return self._build_async_deposit_txs(
+                tx_builder, target_vault, deposit_manager, trade, address, swap_amount,
+            )
+        elif trade.is_sell() and not deposit_manager.has_synchronous_redemption():
+            return self._build_async_redeem_txs(
+                tx_builder, target_vault, deposit_manager, trade, address, swap_amount,
+            )
+
+        # Synchronous vault flow (standard ERC-4626)
         if trade.is_buy():
             approve_call, swap_call = approve_and_deposit_4626(
                 vault=target_vault,
@@ -255,6 +268,83 @@ class VaultRouting(RoutingModel):
             notes=trade.notes,
         )
         return [tx_1, tx_2]
+
+    def _build_async_deposit_txs(
+        self,
+        tx_builder: TransactionBuilder,
+        target_vault: ERC4626Vault,
+        deposit_manager: VaultDepositManager,
+        trade: TradeExecution,
+        address: HexAddress,
+        swap_amount: Decimal,
+    ) -> list[BlockchainTransaction]:
+        """Build approve + requestDeposit transactions for async vault deposit."""
+
+        deposit_request = deposit_manager.create_deposit_request(
+            owner=address,
+            amount=swap_amount,
+        )
+        approve_call = target_vault.denomination_token.approve(
+            target_vault.vault_address,
+            swap_amount,
+        )
+        request_call = deposit_request.funcs[0]
+
+        # Mark trade for async handling
+        trade.other_data["vault_async_flow"] = True
+        trade.other_data["vault_raw_amount"] = deposit_request.raw_amount
+        trade.other_data["vault_owner_address"] = address
+
+        tx_1 = tx_builder.sign_transaction(
+            contract=target_vault.denomination_token.contract,
+            args_bound_func=approve_call,
+            gas_limit=500_000,
+            asset_deltas=[],
+            notes=trade.notes,
+        )
+        tx_2 = tx_builder.sign_transaction(
+            contract=target_vault.vault_contract,
+            args_bound_func=request_call,
+            gas_limit=self.vault_interaction_gas_limit,
+            asset_deltas=[],
+            notes=trade.notes,
+        )
+
+        trade.other_data["vault_request_tx_count"] = 2
+        return [tx_1, tx_2]
+
+    def _build_async_redeem_txs(
+        self,
+        tx_builder: TransactionBuilder,
+        target_vault: ERC4626Vault,
+        deposit_manager: VaultDepositManager,
+        trade: TradeExecution,
+        address: HexAddress,
+        swap_amount: Decimal,
+    ) -> list[BlockchainTransaction]:
+        """Build requestWithdraw transaction for async vault redemption."""
+
+        redemption_request = deposit_manager.create_redemption_request(
+            owner=address,
+            shares=swap_amount,
+        )
+        request_call = redemption_request.funcs[0]
+
+        # Mark trade for async handling
+        trade.other_data["vault_async_flow"] = True
+        trade.other_data["vault_raw_amount"] = redemption_request.raw_shares
+        trade.other_data["vault_owner_address"] = address
+
+        tx_1 = tx_builder.sign_transaction(
+            contract=target_vault.vault_contract,
+            args_bound_func=request_call,
+            gas_limit=self.vault_interaction_gas_limit,
+            asset_deltas=[],
+            notes=trade.notes,
+        )
+
+        trade.other_data["vault_request_tx_count"] = 1
+        return [tx_1]
 
     def setup_trades(
         self,
@@ -299,15 +389,6 @@ class VaultRouting(RoutingModel):
         )
         logger.info(f"Settling vault trade: #{trade.trade_id} for {vault}")
 
-        base_token_details = fetch_erc20_details(
-            web3,
-            trade.pair.base.checksum_address,
-            cache=self.token_cache,
-            chain_id=trade.pair.base.chain_id,
-        )
-        # quote_token_details = fetch_erc20_details(web3, trade.pair.quote.checksum_address)
-        reserve = trade.reserve_currency
-
         swap_tx = get_swap_transactions(trade)
 
         try:
@@ -315,6 +396,49 @@ class VaultRouting(RoutingModel):
         except KeyError as e:
             raise KeyError(f"Could not find hash: {swap_tx.tx_hash} in {receipts}") from e
 
+        ts = get_block_timestamp(web3, receipt["blockNumber"])
+
+        # Async vault flow — parse request event and mark as pending settlement
+        if trade.other_data.get("vault_async_flow"):
+            if receipt["status"] == 0:
+                report_failure(ts, state, trade, stop_on_execution_failure)
+                return
+
+            deposit_manager = vault.get_deposit_manager()
+            direction = trade.other_data.get("vault_direction", "deposit" if trade.is_buy() else "redeem")
+            owner_address = HexAddress(trade.other_data["vault_owner_address"])
+            tx_hashes = [HexBytes(tx.tx_hash) for tx in trade.blockchain_transactions if tx.tx_hash]
+
+            if direction == "deposit":
+                deposit_request = deposit_manager.create_deposit_request(
+                    owner=owner_address,
+                    raw_amount=trade.other_data["vault_raw_amount"],
+                )
+                ticket = deposit_request.parse_deposit_transaction(tx_hashes)
+                ticket_data = deposit_manager.serialize_deposit_ticket(ticket)
+            else:
+                redemption_request = deposit_manager.create_redemption_request(
+                    owner=owner_address,
+                    raw_shares=trade.other_data["vault_raw_amount"],
+                )
+                ticket = redemption_request.parse_redeem_transaction(tx_hashes)
+                ticket_data = deposit_manager.serialize_redemption_ticket(ticket)
+
+            state.mark_vault_settlement_pending(ts, trade, ticket_data)
+            logger.info(
+                "Vault trade #%d marked as settlement pending (direction=%s, ticket=%s)",
+                trade.trade_id, direction, ticket_data,
+            )
+            return
+
+        # Synchronous vault flow — analyse the deposit/redeem result
+        base_token_details = fetch_erc20_details(
+            web3,
+            trade.pair.base.checksum_address,
+            cache=self.token_cache,
+            chain_id=trade.pair.base.chain_id,
+        )
+        reserve = trade.reserve_currency
         direction = "deposit" if trade.is_buy() else "redeem"
 
         try:
@@ -328,8 +452,6 @@ class VaultRouting(RoutingModel):
         except Exception as e:
             raise RuntimeError(f"Failed to analyse vault tx: {swap_tx.wrapped_function_selector}: {swap_tx.tx_hash} direction: {direction}, receipt: {receipt}, vault: {vault}") from e
 
-        ts = get_block_timestamp(web3, receipt["blockNumber"])
-
         if isinstance(result, TradeSuccess):
 
             path = result.path
@@ -342,17 +464,14 @@ class VaultRouting(RoutingModel):
             if trade.is_buy():
                 assert path[0] == expected_quote_addr, f"Was expecting the route path to start with quote token {trade.pair.quote}, got path {result.path}"
 
-                # price = result.get_human_price(quote_token_details.address == result.token0.address)
                 executed_reserve = result.amount_in / Decimal(10 ** reserve.decimals)
                 executed_amount = result.amount_out / Decimal(10 ** base_token_details.decimals)
 
                 price = executed_reserve / executed_amount
 
             else:
-                # Ordered other way around
                 assert path[0] == base_token_details.address.lower(), f"Path is {path}, base token is {base_token_details}"
                 assert path[-1] == expected_quote_addr, f"Path is {path}, expected quote token {trade.pair.quote}"
-                # price = result.get_human_price(quote_token_details.address == result.token0.address)
                 executed_amount = -result.amount_in / Decimal(10 ** base_token_details.decimals)
                 executed_reserve = result.amount_out / Decimal(10 ** reserve.decimals)
                 price = -executed_reserve / executed_amount
@@ -361,7 +480,6 @@ class VaultRouting(RoutingModel):
 
             logger.info("Executed amount: %s, executed reserve: %s, price: %s", executed_amount, executed_reserve, price)
 
-            # Mark as success
             state.mark_trade_success(
                 ts,
                 trade,

--- a/tradeexecutor/state/portfolio.py
+++ b/tradeexecutor/state/portfolio.py
@@ -721,7 +721,7 @@ class Portfolio:
         """
         # Any trading positions we have one
         # spot_values = sum([p.get_equity() for p in self.open_positions.values() if not p.is_leverage()])
-        return self.get_position_equity_and_loan_nav() + self.get_cash() + self.get_in_transit_value()
+        return self.get_position_equity_and_loan_nav() + self.get_cash() + self.get_in_transit_value() + self.get_vault_settlement_pending_value()
 
     get_total_equity = calculate_total_equity
 
@@ -737,6 +737,23 @@ class Portfolio:
         for position in self.open_positions.values():
             for trade in position.trades.values():
                 if trade.get_status() == TradeStatus.cctp_in_transit:
+                    total += float(trade.planned_reserve)
+        return total
+
+    def get_vault_settlement_pending_value(self) -> float:
+        """Get total value of capital locked in pending async vault deposit requests.
+
+        Only counts BUYS (requestDeposit), not sells (requestWithdraw).
+        For sells, the position's share equity already covers the value.
+        Scans both open_positions and pending_positions.
+        """
+        from itertools import chain as ichain
+        from tradeexecutor.state.trade import TradeStatus
+        total = 0.0
+        all_positions = ichain(self.open_positions.values(), self.pending_positions.values())
+        for position in all_positions:
+            for trade in position.trades.values():
+                if trade.get_status() == TradeStatus.vault_settlement_pending and trade.is_buy():
                     total += float(trade.planned_reserve)
         return total
 

--- a/tradeexecutor/state/position.py
+++ b/tradeexecutor/state/position.py
@@ -24,7 +24,7 @@ from tradeexecutor.state.interest import Interest
 from tradeexecutor.state.loan import Loan
 from tradeexecutor.state.position_internal_share_price import PositionInternalSharePriceState
 from tradeexecutor.state.trade import TradeType, TradeFlag
-from tradeexecutor.state.trade import TradeExecution
+from tradeexecutor.state.trade import TradeExecution, TradeStatus
 from tradeexecutor.state.trigger import Trigger
 from tradeexecutor.state.types import USDollarAmount, BPS, USDollarPrice, Percent, LeverageMultiplier, LegacyDataException
 from tradeexecutor.state.valuation import ValuationUpdate
@@ -735,9 +735,17 @@ class TradingPosition(GenericPosition):
             ])
 
         live = self.get_quantity()  # What was the position quantity before executing any of planned trades
-        # Temporary logging to track down SAND token errors
-        # logger.info("get_available_trading_quantity(): Figuring out available position size to trade. Planned quantity: %s, live quantity: %s", planned, live)
-        return planned + live
+
+        # Async vault sell trades (vault_settlement_pending) have already submitted
+        # a requestWithdraw() on-chain but aren't counted by get_quantity() (only is_success counts).
+        # Subtract their quantity so strategies don't submit duplicate withdrawal requests.
+        vault_pending_sells = sum_decimal([
+            t.get_position_quantity()
+            for t in self.trades.values()
+            if t.get_status() == TradeStatus.vault_settlement_pending and t.is_sell()
+        ])
+
+        return planned + live + vault_pending_sells
 
     def get_current_price(self) -> USDollarAmount:
         """Get the price of the base asset based on the latest valuation."""

--- a/tradeexecutor/state/repair.py
+++ b/tradeexecutor/state/repair.py
@@ -840,7 +840,14 @@ def repair_tx_not_generated(state: State, interactive=True):
 
 def repair_zero_quantity(state: State, interactive=True):
     """Scan for positions that failed to open and need to be cleaned up."""
-    zero_quantity_positions = [p for p in state.portfolio.get_open_positions() if p.get_quantity() == 0]
+    zero_quantity_positions = [
+        p for p in state.portfolio.get_open_positions()
+        if p.get_quantity() == 0
+        # Async vault positions (Ostium V1.5, ERC-7540) have quantity 0 while
+        # awaiting settlement — they are NOT broken and must not be repaired.
+        # Settlement retry will resolve them on the next tick.
+        and not any(t.get_status() == TradeStatus.vault_settlement_pending for t in p.trades.values())
+    ]
     if not zero_quantity_positions:
         print("No zero quantity positions found")
         return

--- a/tradeexecutor/state/state.py
+++ b/tradeexecutor/state/state.py
@@ -1056,6 +1056,29 @@ class State:
             if bridge_position is not None:
                 bridge_position.bridge_capital_allocated += abs(trade.planned_quantity)
 
+    def mark_vault_settlement_pending(
+        self,
+        ts: datetime.datetime,
+        trade: TradeExecution,
+        ticket_data: dict,
+    ):
+        """Mark a vault trade as pending settlement (request confirmed, claim pending).
+
+        Does NOT adjust reserves — they were already debited at trade start.
+        Stores serialised ticket data from deposit_manager.serialize_deposit/redemption_ticket().
+
+        :param ticket_data:
+            Dict from deposit_manager.serialize_deposit_ticket() or
+            deposit_manager.serialize_redemption_ticket().
+            Protocol-specific fields (e.g. settlement_id) are included by the adapter.
+        """
+        trade.vault_settlement_pending_at = ts
+        trade.other_data["vault_async_flow"] = True
+        trade.other_data["vault_chain_id"] = trade.pair.chain_id
+        trade.other_data["vault_direction"] = "deposit" if trade.is_buy() else "redeem"
+        # Merge adapter-serialised ticket data into other_data
+        trade.other_data.update(ticket_data)
+
     def update_reserves(self, new_reserves: List[ReservePosition]):
         self.portfolio.update_reserves(new_reserves)
 

--- a/tradeexecutor/state/trade.py
+++ b/tradeexecutor/state/trade.py
@@ -102,6 +102,15 @@ class TradeStatus(enum.Enum):
     #:
     cctp_in_transit = "cctp_in_transit"
 
+    #: ERC-4626 vault deposit/redeem request confirmed, awaiting settlement.
+    #:
+    #: The trade has a dedicated retry path (settlement retry module) and
+    #: is not considered "unfinished" in the generic sense.
+    #:
+    #: Used for async vaults like Ostium V1.5 and ERC-7540 (Lagoon).
+    #:
+    vault_settlement_pending = "vault_settlement_pending"
+
 
 class TradeFlag(enum.Enum):
     """Trade execution flags.
@@ -688,6 +697,10 @@ class TradeExecution:
     #:
     cctp_in_transit_at: datetime.datetime | None = None
 
+    #: ERC-4626 vault deposit/redeem request confirmed, awaiting settlement.
+    #:
+    vault_settlement_pending_at: datetime.datetime | None = None
+
     #: After the trade has been assigned to the execution, track
     #: it's execution sort index here.
     #:
@@ -1090,6 +1103,8 @@ class TradeExecution:
             return TradeStatus.failed
         elif self.executed_at:
             return TradeStatus.success
+        elif self.vault_settlement_pending_at:
+            return TradeStatus.vault_settlement_pending
         elif self.cctp_in_transit_at:
             return TradeStatus.cctp_in_transit
         elif self.broadcasted_at:

--- a/tradeexecutor/strategy/runner.py
+++ b/tradeexecutor/strategy/runner.py
@@ -863,6 +863,18 @@ class StrategyRunner(abc.ABC):
                     post_valuation=True,
                 )
 
+            # Resolve any pending async vault settlements (Ostium V1.5, ERC-7540 Lagoon)
+            with self.timed_task_context_manager("settle_pending_vault_trades"):
+                from tradeexecutor.ethereum.vault.settlement_retry import check_and_resolve_vault_settlements
+                web3config = getattr(self.execution_model, 'web3config', None)
+                vault_resolved = check_and_resolve_vault_settlements(
+                    state=state,
+                    execution_model=self.execution_model,
+                    web3config=web3config,
+                )
+                if vault_resolved:
+                    logger.info("Resolved %d pending vault settlement(s)", len(vault_resolved))
+
             closed_dust_trades = close_hypercore_dust_positions(state.portfolio)
             if closed_dust_trades:
                 logger.info(


### PR DESCRIPTION
## Why

Ostium V1.5 (and future ERC-7540 vaults) disabled synchronous `deposit()`/`redeem()` functions, replacing them with an async flow: `requestDeposit()` → off-chain settlement → `claimDeposit()`. The trade-executor needs to handle this multi-step lifecycle where trades are "in flight" between request and claim.

This PR builds on the eth_defi layer (merged in PR #1067) to integrate async vault support into the full trade-executor pipeline: state machine, routing, settlement retry, and all CLI commands.

## Summary

### State machine
- New `TradeStatus.vault_settlement_pending` with dedicated `vault_settlement_pending_at` timestamp
- `get_vault_settlement_pending_value()` counts pending buy capital in portfolio equity
- `mark_vault_settlement_pending()` stores serialised ticket metadata in `trade.other_data`

### Vault routing (`vault_routing.py`)
- Detects async vaults via `deposit_manager.is_async_deposit_vault()`
- Routes to `requestDeposit()`/`requestWithdraw()` instead of `deposit()`/`redeem()`
- Marks trades `vault_settlement_pending` on successful request confirmation

### Settlement retry module (`settlement_retry.py`)
- `check_and_resolve_vault_settlements()` scans all pending trades each tick
- Reconstructs tickets from `trade.other_data`, checks on-chain settlement status
- Claims resolved deposits/withdrawals, or reclaims failed ones
- Generic adapter interface — works with Ostium V1.5 and future ERC-7540 vaults

### CLI pipeline
- **`start`**: settlement retry runs at tick start (before `decide_trades`)
- **`check-accounts`**: correctly handles pending state (no false accounting mismatches)
- **`repair`**: skips positions with `vault_settlement_pending` trades (fix for `repair_zero_quantity`)
- **`perform-test-trade`**: forces settlement on Anvil; logs guidance on mainnet

### Test strategy module
- `strategies/test_only/arbitrum-ostium-v15.py` — minimal vault-only strategy for CLI-driven testing

### Tests (14 total)
- **Unit tests** (7): state machine, accounting, settlement retry logic, swap detection
- **Hot wallet integration** (3): full deposit→settle→claim→redeem→settle→claim lifecycle with accounting checks at each step
- **Lagoon vault integration** (1): end-to-end through Lagoon Safe + guard + Ostium
- **CLI integration** (3): `start`, `check-accounts`, `repair` commands with pending vault trades

## Lessons learnt

- `Universe.exchanges` (the `Set[Exchange]` field) must be set explicitly when constructing universes manually — `pretick_check()` calls `len(data_universe.exchanges)` which is None by default
- `CONFIRMATION_BLOCK_COUNT=0` env var triggers an assertion in the live trading loop (only valid via the test trade path which auto-detects Anvil)
- `repair_zero_quantity()` must be aware of async vault positions — they legitimately have quantity 0 while awaiting settlement
- Portfolio accounting works correctly during pending state because reserves are debited at trade start (before `mark_vault_settlement_pending`), so on-chain USDC matches state USDC