### PR TITLE
fix: Hypercore vault withdrawal commission tolerance and buy capping (#1485)

### DIFF
--- a/tests/hyperliquid/test_hypercore_buy_capping.py
+++ b/tests/hyperliquid/test_hypercore_buy_capping.py
@@ -14,13 +14,13 @@ import pytest
 
 from eth_defi.compat import native_datetime_utc_now
 
+from tradeexecutor.ethereum.execution import EthereumExecution
+from tradeexecutor.state.trade import TradeStatus
 from tradeexecutor.state.types import USDollarAmount
 
 
 def _make_execution_model():
     """Create a minimal EthereumExecution with mocked dependencies."""
-    from tradeexecutor.ethereum.execution import EthereumExecution
-
     model = object.__new__(EthereumExecution)
     model.max_slippage = None
     return model
@@ -99,8 +99,6 @@ def test_vault_buy_expired_when_below_minimum():
     2. Verify the trade is expired (not failed).
     3. Verify orphan pending position cleanup (opening buys live in pending_positions).
     """
-    from tradeexecutor.state.trade import TradeStatus
-
     model = _make_execution_model()
     state = MagicMock()
 

--- a/tests/hyperliquid/test_hypercore_buy_capping.py
+++ b/tests/hyperliquid/test_hypercore_buy_capping.py
@@ -97,7 +97,7 @@ def test_vault_buy_expired_when_below_minimum():
 
     1. Create a buy trade with insufficient capital (only $3 available).
     2. Verify the trade is expired (not failed).
-    3. Verify orphan position cleanup.
+    3. Verify orphan pending position cleanup (opening buys live in pending_positions).
     """
     from tradeexecutor.state.trade import TradeStatus
 
@@ -112,6 +112,15 @@ def test_vault_buy_expired_when_below_minimum():
 
     buy_trade = _make_mock_trade(is_buy=True, planned_reserve=Decimal("50"), trade_id=2)
 
+    # Mock pending position with all trades expired (opening buy).
+    pending_pos = MagicMock()
+    pending_pos.get_quantity.return_value = Decimal(0)
+    expired_trade_mock = MagicMock()
+    expired_trade_mock.get_status.return_value = TradeStatus.expired
+    pending_pos.trades = {1: expired_trade_mock}
+    state.portfolio.pending_positions = {buy_trade.position_id: pending_pos}
+    state.portfolio.open_positions = {}
+
     # 2. Should expire.
     expired = model._maybe_cap_hypercore_vault_buy(
         state, buy_trade, cumulative_vault_sell_shortfall=Decimal("47"),
@@ -119,6 +128,9 @@ def test_vault_buy_expired_when_below_minimum():
 
     assert expired
     buy_trade.mark_expired.assert_called_once()
+
+    # 3. Verify pending position was cleaned up.
+    assert buy_trade.position_id not in state.portfolio.pending_positions
 
 
 def test_non_hypercore_buy_unaffected_by_hypercore_sell_shortfall():

--- a/tests/hyperliquid/test_hypercore_buy_capping.py
+++ b/tests/hyperliquid/test_hypercore_buy_capping.py
@@ -1,0 +1,142 @@
+"""Tests for Hypercore vault buy capping when sell proceeds fall short.
+
+Tests that ``_maybe_cap_hypercore_vault_buy()`` and the shortfall tracking
+in ``_execute_trades_sequentially()`` correctly reduce or expire buy trades
+when preceding vault sell withdrawals return less than planned due to the
+vault leader's performance fee.
+"""
+
+import datetime
+from decimal import Decimal
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from eth_defi.compat import native_datetime_utc_now
+
+from tradeexecutor.state.types import USDollarAmount
+
+
+def _make_execution_model():
+    """Create a minimal EthereumExecution with mocked dependencies."""
+    from tradeexecutor.ethereum.execution import EthereumExecution
+
+    model = object.__new__(EthereumExecution)
+    model.max_slippage = None
+    return model
+
+
+def _make_mock_trade(
+    *,
+    is_buy: bool,
+    planned_reserve: Decimal,
+    is_hyperliquid_vault: bool = True,
+    trade_id: int = 1,
+    position_id: int = 1,
+    chain_id: int = 9999,
+):
+    """Create a mock trade for execution tests."""
+    trade = MagicMock()
+    trade.trade_id = trade_id
+    trade.position_id = position_id
+    trade.is_buy.return_value = is_buy
+    trade.is_failed.return_value = False
+    trade.planned_reserve = planned_reserve
+    trade.planned_quantity = planned_reserve
+    trade.executed_reserve = None
+    trade.other_data = {}
+    trade.pair = MagicMock()
+    trade.pair.is_hyperliquid_vault.return_value = is_hyperliquid_vault
+    trade.pair.chain_id = chain_id
+    trade.reserve_currency = MagicMock()
+    trade.get_planned_value.return_value = float(planned_reserve)
+    trade.pair.get_ticker.return_value = "TEST-USDC"
+    trade.route = "hypercore_vault"
+    trade.get_revert_reason.return_value = None
+    trade.get_status.return_value = MagicMock()
+    trade.flags = set()
+    return trade
+
+
+def test_vault_buy_capped_on_vault_sell_shortfall():
+    """Hypercore vault buy is capped when preceding sells returned less than planned.
+
+    1. Create a sell trade that completed with a shortfall (planned 100, executed 90).
+    2. Create a buy trade that planned to spend 50 but only 40 is available.
+    3. Verify the buy's planned_reserve and planned_quantity are reduced.
+    4. Verify originals are preserved in other_data.
+    """
+    model = _make_execution_model()
+    state = MagicMock()
+
+    # 1. Mock reserves: only 40 available (after sell shortfall).
+    state.portfolio.get_bridge_position_for_chain.return_value = None
+    reserve_pos = MagicMock()
+    reserve_pos.quantity = Decimal("40")
+    state.portfolio.get_reserve_position.return_value = reserve_pos
+
+    buy_trade = _make_mock_trade(is_buy=True, planned_reserve=Decimal("50"), trade_id=2)
+
+    # 2. Cap the buy.
+    expired = model._maybe_cap_hypercore_vault_buy(
+        state, buy_trade, cumulative_vault_sell_shortfall=Decimal("10"),
+    )
+
+    # 3. Verify capping, not expiry.
+    assert not expired
+    assert buy_trade.planned_reserve == Decimal("40")
+    assert buy_trade.planned_quantity == pytest.approx(Decimal("40"), abs=Decimal("0.01"))
+
+    # 4. Verify originals preserved.
+    assert buy_trade.other_data["original_planned_reserve"] == "50"
+    assert buy_trade.other_data["original_planned_quantity"] == "50"
+
+
+def test_vault_buy_expired_when_below_minimum():
+    """Hypercore vault buy is expired when available capital is below $5 minimum.
+
+    1. Create a buy trade with insufficient capital (only $3 available).
+    2. Verify the trade is expired (not failed).
+    3. Verify orphan position cleanup.
+    """
+    from tradeexecutor.state.trade import TradeStatus
+
+    model = _make_execution_model()
+    state = MagicMock()
+
+    # 1. Only $3 available.
+    state.portfolio.get_bridge_position_for_chain.return_value = None
+    reserve_pos = MagicMock()
+    reserve_pos.quantity = Decimal("3")
+    state.portfolio.get_reserve_position.return_value = reserve_pos
+
+    buy_trade = _make_mock_trade(is_buy=True, planned_reserve=Decimal("50"), trade_id=2)
+
+    # 2. Should expire.
+    expired = model._maybe_cap_hypercore_vault_buy(
+        state, buy_trade, cumulative_vault_sell_shortfall=Decimal("47"),
+    )
+
+    assert expired
+    buy_trade.mark_expired.assert_called_once()
+
+
+def test_non_hypercore_buy_unaffected_by_hypercore_sell_shortfall():
+    """Non-Hypercore buys are not capped by Hypercore sell shortfall.
+
+    1. Create a non-Hypercore buy trade (is_hyperliquid_vault=False).
+    2. Verify the capping helper is never invoked for it.
+    """
+    model = _make_execution_model()
+    state = MagicMock()
+
+    buy_trade = _make_mock_trade(
+        is_buy=True,
+        planned_reserve=Decimal("50"),
+        is_hyperliquid_vault=False,
+        trade_id=2,
+    )
+
+    # The predicate should prevent calling the helper.
+    # Verify the guard: is_hyperliquid_vault() returns False.
+    assert not buy_trade.pair.is_hyperliquid_vault()

--- a/tests/hyperliquid/test_hypercore_dual_chain.py
+++ b/tests/hyperliquid/test_hypercore_dual_chain.py
@@ -10,7 +10,19 @@ import logging
 from decimal import Decimal
 from unittest.mock import MagicMock, patch
 
+import pytest
+from hexbytes import HexBytes
+
 from eth_defi.hyperliquid.api import UserVaultEquity
+from eth_defi.hyperliquid.core_writer import compute_spot_to_evm_withdrawal_amount
+
+from tradeexecutor.ethereum.vault.hypercore_routing import (
+    HYPERCORE_WITHDRAWAL_SAFETY_MARGIN_RAW,
+    HypercoreVaultRouting,
+    HypercoreWithdrawalVerificationError,
+    raw_to_usdc,
+    usdc_to_raw,
+)
 
 
 VAULT_ADDR = "0xdfc24b077bc1425ad1dea75bcb6f8158e10df303"
@@ -28,8 +40,6 @@ def _make_equity(equity: Decimal) -> UserVaultEquity:
 
 def _make_routing(simulate=False):
     """Create a minimal HypercoreVaultRouting with mocked dependencies."""
-    from tradeexecutor.ethereum.vault.hypercore_routing import HypercoreVaultRouting
-
     routing = object.__new__(HypercoreVaultRouting)
     routing.web3 = MagicMock()
     routing.lagoon_vault = MagicMock()
@@ -87,7 +97,6 @@ def test_withdrawal_dual_chain_verified(mock_fetch_equity, mock_block_ts):
     state = MagicMock()
     mock_block_ts.return_value = datetime.datetime(2025, 1, 1)
 
-    from hexbytes import HexBytes
     receipts = {HexBytes("0xabc"): {"status": 1, "blockNumber": 100}}
 
     phase2_tx = MagicMock(tx_hash="0xdef")
@@ -128,7 +137,6 @@ def test_withdrawal_dual_chain_mismatch_logs_warning(mock_fetch_equity, mock_blo
     state = MagicMock()
     mock_block_ts.return_value = datetime.datetime(2025, 1, 1)
 
-    from hexbytes import HexBytes
     receipts = {HexBytes("0xabc"): {"status": 1, "blockNumber": 100}}
 
     with caplog.at_level(logging.WARNING):
@@ -168,7 +176,6 @@ def test_withdrawal_equity_check_non_fatal_on_api_failure(mock_fetch_equity, moc
     state = MagicMock()
     mock_block_ts.return_value = datetime.datetime(2025, 1, 1)
 
-    from hexbytes import HexBytes
     receipts = {HexBytes("0xabc"): {"status": 1, "blockNumber": 100}}
 
     with caplog.at_level(logging.WARNING):
@@ -245,12 +252,6 @@ def test_wait_for_usdc_arrival_accepts_follow_up_phase_tolerance():
 
 def test_wait_for_usdc_arrival_timeout():
     """P2: USDC never arrives — raises HypercoreWithdrawalVerificationError."""
-    import pytest
-    from tradeexecutor.ethereum.vault.hypercore_routing import (
-        HypercoreVaultRouting,
-        HypercoreWithdrawalVerificationError,
-    )
-
     routing = _make_routing()
     # Balance never increases
     routing._fetch_safe_evm_usdc_balance = MagicMock(return_value=100_000_000)
@@ -341,11 +342,6 @@ def test_wait_for_perp_withdrawable_balance_rejects_large_shortfall():
     2. Wait for the perp withdrawable balance using the withdrawal verifier.
     3. Verify the helper times out and raises a withdrawal verification error.
     """
-    import pytest
-    from tradeexecutor.ethereum.vault.hypercore_routing import (
-        HypercoreWithdrawalVerificationError,
-    )
-
     routing = _make_routing()
 
     # 1. Create a routing object and mock a large perp withdrawable balance increase with a material shortfall.
@@ -412,12 +408,6 @@ def test_withdrawal_phase1_timeout_uses_vault_equity_fallback(
     2. Return a vault equity snapshot that already matches the expected post-withdrawal residual.
     3. Verify settlement continues to phase 2 and marks the trade successful instead of freezing it.
     """
-    from hexbytes import HexBytes
-
-    from tradeexecutor.ethereum.vault.hypercore_routing import (
-        HypercoreWithdrawalVerificationError,
-    )
-
     routing = _make_routing()
     trade = _make_trade(planned_reserve=Decimal("552.259060"))
     state = MagicMock()
@@ -472,10 +462,6 @@ def test_withdrawal_uses_pre_phase1_perp_baseline_for_fast_settlement(
     2. Store the setup-time perp and vault-equity baselines in ``trade.other_data``.
     3. Verify settlement continues to phase 2 instead of waiting for a second perp increase.
     """
-    from hexbytes import HexBytes
-
-    from tradeexecutor.ethereum.vault.hypercore_routing import raw_to_usdc
-
     routing = _make_routing()
     trade = _make_trade(planned_reserve=Decimal("9.223899"))
     trade.other_data = {
@@ -534,10 +520,7 @@ def test_withdrawal_phase3_uses_fee_adjusted_amount(
     2. Verify phase 3 bridges the fee-adjusted amount instead of the pre-fee desired amount.
     3. Verify EVM-arrival confirmation and trade settlement use the same adjusted amount.
     """
-    from hexbytes import HexBytes
 
-    from tradeexecutor.ethereum.vault.hypercore_routing import raw_to_usdc, usdc_to_raw
-    from eth_defi.hyperliquid.core_writer import compute_spot_to_evm_withdrawal_amount
 
     routing = _make_routing()
     trade = _make_trade(planned_reserve=Decimal("50.0"))
@@ -592,9 +575,6 @@ def test_withdrawal_aborts_if_perp_balance_does_not_appear(
     2. Make the perp-balance wait fail before phase 2 can start.
     3. Verify the trade is failed with stranded-USDC recovery metadata.
     """
-    from tradeexecutor.ethereum.vault.hypercore_routing import HypercoreWithdrawalVerificationError
-    from hexbytes import HexBytes
-
     routing = _make_routing()
     trade = _make_trade(planned_reserve=Decimal("50.0"))
     state = MagicMock()
@@ -643,14 +623,6 @@ def test_withdrawal_phase1_retry_handles_silent_noop_from_equity_drift(
     4. Continue phases 2 and 3 with the retry amount.
     5. Verify the trade succeeds and no stranded-USDC failure is reported.
     """
-    from hexbytes import HexBytes
-
-    from tradeexecutor.ethereum.vault.hypercore_routing import (
-        HYPERCORE_WITHDRAWAL_SAFETY_MARGIN_RAW,
-        HypercoreWithdrawalVerificationError,
-        usdc_to_raw,
-    )
-
     routing = _make_routing()
     trade = _make_trade(planned_reserve=Decimal("11.737146"))
     state = MagicMock()
@@ -762,11 +734,6 @@ def test_wait_for_perp_withdrawable_balance_protocol_vault_stays_tight():
     1. Create the same scenario as the commission-aware test but with no commission rate.
     2. Verify the helper times out because the 8% shortfall exceeds 1% tolerance.
     """
-    import pytest
-    from tradeexecutor.ethereum.vault.hypercore_routing import (
-        HypercoreWithdrawalVerificationError,
-    )
-
     routing = _make_routing()
 
     # 1. Same balance as commission-aware test: 8% short.
@@ -805,7 +772,7 @@ def test_withdrawal_dual_chain_fee_warning(mock_fetch_equity, mock_block_ts, cap
     3. Verify cost breakdown is stored in trade.other_data.
     4. Verify lp_fees kwarg passed to mark_trade_success includes the total cost.
     """
-    from hexbytes import HexBytes
+
 
     routing = _make_routing()
 

--- a/tests/hyperliquid/test_hypercore_dual_chain.py
+++ b/tests/hyperliquid/test_hypercore_dual_chain.py
@@ -725,3 +725,132 @@ def test_withdrawal_phase1_retry_handles_silent_noop_from_equity_drift(
     assert phase1_retry_tx in trade.blockchain_transactions
     state.mark_trade_success.assert_called_once()
     mock_report_failure.assert_not_called()
+
+
+def test_wait_for_perp_withdrawable_balance_commission_aware():
+    """Commission-aware tolerance accepts shortfall within vault performance fee range.
+
+    1. Create a routing object with a large withdrawal and 10% commission rate.
+    2. Mock a perp balance increase that is 8% short (within 10% commission tolerance).
+    3. Verify the wait accepts the balance without timeout.
+    """
+    routing = _make_routing()
+
+    # 1. Mock balance: 570 USDC withdrawal, perp shows 530 (8% short, within 10%).
+    routing._fetch_safe_perp_withdrawable_balance = MagicMock(
+        side_effect=[Decimal("589.56")],
+    )
+
+    # 2. Wait with commission_rate=10%.
+    with patch("tradeexecutor.ethereum.vault.hypercore_routing.time.sleep"):
+        with patch("tradeexecutor.ethereum.vault.hypercore_routing.time.time", side_effect=_monotonic_time()):
+            result = routing._wait_for_perp_withdrawable_balance(
+                baseline_balance=Decimal("59.56"),
+                expected_increase_raw=570_000_000,
+                timeout=30.0,
+                poll_interval=2.0,
+                commission_rate=Decimal("0.10"),
+            )
+
+    # 3. Accepted on first poll (530 increase >= 570 - 57 commission tolerance = 513).
+    assert result == Decimal("589.56")
+
+
+def test_wait_for_perp_withdrawable_balance_protocol_vault_stays_tight():
+    """Protocol vaults (no commission) keep tight 1% tolerance.
+
+    1. Create the same scenario as the commission-aware test but with no commission rate.
+    2. Verify the helper times out because the 8% shortfall exceeds 1% tolerance.
+    """
+    import pytest
+    from tradeexecutor.ethereum.vault.hypercore_routing import (
+        HypercoreWithdrawalVerificationError,
+    )
+
+    routing = _make_routing()
+
+    # 1. Same balance as commission-aware test: 8% short.
+    routing._fetch_safe_perp_withdrawable_balance = MagicMock(
+        return_value=Decimal("589.56"),
+    )
+
+    call_count = [0]
+
+    def fake_time():
+        call_count[0] += 1
+        if call_count[0] <= 2:
+            return 0.0
+        return 999.0
+
+    # 2. Without commission_rate, tolerance is only 1%. 8% shortfall should time out.
+    with patch("tradeexecutor.ethereum.vault.hypercore_routing.time.sleep"):
+        with patch("tradeexecutor.ethereum.vault.hypercore_routing.time.time", side_effect=fake_time):
+            with pytest.raises(HypercoreWithdrawalVerificationError):
+                routing._wait_for_perp_withdrawable_balance(
+                    baseline_balance=Decimal("59.56"),
+                    expected_increase_raw=570_000_000,
+                    timeout=30.0,
+                    poll_interval=2.0,
+                    commission_rate=None,
+                )
+
+
+@patch("tradeexecutor.ethereum.vault.hypercore_routing.get_block_timestamp")
+@patch("tradeexecutor.ethereum.vault.hypercore_routing.fetch_user_vault_equity")
+def test_withdrawal_dual_chain_fee_warning(mock_fetch_equity, mock_block_ts, caplog):
+    """Vault fee detected when equity decreased MORE than USDC received.
+
+    1. Set up a withdrawal where vault equity decreases by 55 but only 50 USDC arrives.
+    2. Verify a "vault fee detected" warning is logged.
+    3. Verify cost breakdown is stored in trade.other_data.
+    4. Verify lp_fees kwarg passed to mark_trade_success includes the total cost.
+    """
+    from hexbytes import HexBytes
+
+    routing = _make_routing()
+
+    # Equity before: 500, after: 445 (decreased by 55, but only 50 received)
+    mock_fetch_equity.side_effect = [
+        _make_equity(Decimal("500.0")),
+        _make_equity(Decimal("445.0")),
+    ]
+
+    trade = _make_trade(planned_reserve=Decimal("50.0"))
+    trade.other_data["hypercore_vault_commission_rate"] = "0.1"
+    state = MagicMock()
+    mock_block_ts.return_value = datetime.datetime(2025, 1, 1)
+
+    receipts = {HexBytes("0xabc"): {"status": 1, "blockNumber": 100}}
+
+    phase2_tx = MagicMock(tx_hash="0xdef")
+    phase3_tx = MagicMock(tx_hash="0x123")
+
+    with caplog.at_level(logging.WARNING):
+        with patch.object(routing, "_fetch_safe_evm_usdc_balance", side_effect=[100_000_000, 150_000_000]):
+            with patch.object(routing, "_fetch_safe_perp_withdrawable_balance", return_value=Decimal("0")):
+                with patch.object(routing, "_fetch_safe_spot_free_usdc_balance", return_value=Decimal("0")):
+                    with patch.object(routing, "_wait_for_perp_withdrawable_balance", return_value=Decimal("50")):
+                        with patch.object(routing, "_wait_for_spot_free_usdc_balance", return_value=Decimal("50")):
+                            with patch.object(routing, "_broadcast_withdrawal_phase2", return_value=(phase2_tx, {"status": 1, "blockNumber": 101})):
+                                with patch.object(routing, "_broadcast_withdrawal_phase3", return_value=(phase3_tx, {"status": 1, "blockNumber": 102})):
+                                    with patch("tradeexecutor.ethereum.vault.hypercore_routing.time.sleep"):
+                                        with patch("tradeexecutor.ethereum.vault.hypercore_routing.time.time", side_effect=_monotonic_time()):
+                                            routing._settle_withdrawal(
+                                                routing.web3, state, trade, receipts,
+                                                stop_on_execution_failure=False,
+                                            )
+
+    # 2. Verify "vault fee detected" warning
+    assert any("vault fee detected" in r.message.lower() for r in caplog.records)
+
+    # 3. Verify cost breakdown in other_data
+    costs = trade.other_data.get("hypercore_withdrawal_costs")
+    assert costs is not None
+    assert costs["commission_rate"] == "0.1"
+    assert Decimal(costs["total_withdrawal_cost"]) == Decimal("5")
+
+    # 4. Verify lp_fees kwarg includes the total cost
+    state.mark_trade_success.assert_called_once()
+    call_kwargs = state.mark_trade_success.call_args
+    lp_fees_value = call_kwargs.kwargs.get("lp_fees") if call_kwargs.kwargs else call_kwargs[1].get("lp_fees")
+    assert abs(lp_fees_value - 5.0) < 0.01

--- a/tradeexecutor/ethereum/execution.py
+++ b/tradeexecutor/ethereum/execution.py
@@ -650,7 +650,7 @@ class EthereumExecution(ExecutionModel):
         # then reserves.
         bridge_position = state.portfolio.get_bridge_position_for_chain(trade.pair.chain_id)
         if bridge_position is not None:
-            available = bridge_position.get_quantity()
+            available = bridge_position.get_available_bridge_capital()
         else:
             try:
                 reserve_pos = state.portfolio.get_reserve_position(trade.reserve_currency)
@@ -685,14 +685,19 @@ class EthereumExecution(ExecutionModel):
                 cumulative_vault_sell_shortfall,
             )
             trade.mark_expired(native_datetime_utc_now())
-            pos = state.portfolio.open_positions.get(trade.position_id)
-            if pos is not None and pos.get_quantity() == 0:
-                all_expired = all(
-                    t.get_status() == TradeStatus.expired
-                    for t in pos.trades.values()
-                )
-                if all_expired:
-                    del state.portfolio.open_positions[trade.position_id]
+            # Clean up the position if all its trades are expired.
+            # Opening buys live in pending_positions until mark_trade_success
+            # moves them; existing positions live in open_positions.
+            for positions_dict in (state.portfolio.pending_positions, state.portfolio.open_positions):
+                pos = positions_dict.get(trade.position_id)
+                if pos is not None and pos.get_quantity() == 0:
+                    all_expired = all(
+                        t.get_status() == TradeStatus.expired
+                        for t in pos.trades.values()
+                    )
+                    if all_expired:
+                        del positions_dict[trade.position_id]
+                    break
             return True
 
     def _execute_trades_sequentially(

--- a/tradeexecutor/ethereum/execution.py
+++ b/tradeexecutor/ethereum/execution.py
@@ -625,6 +625,76 @@ class EthereumExecution(ExecutionModel):
             revert_reason,
         )
 
+    def _maybe_cap_hypercore_vault_buy(
+        self,
+        state: State,
+        trade: "TradeExecution",
+        cumulative_vault_sell_shortfall: Decimal,
+    ) -> bool:
+        """Cap or expire a Hypercore vault buy if sell proceeds fell short.
+
+        Hypercore vault withdrawals incur a leader performance fee (typically
+        10% of profits) that reduces the actual USDC received.  When sells in
+        the same rebalance cycle return less than planned, later buys can
+        exceed available capital.  This helper caps or expires the buy to
+        prevent ``NotEnoughMoney`` failures.
+
+        :return:
+            ``True`` if the trade was expired and should be skipped.
+        """
+        # Matches MINIMUM_VAULT_DEPOSIT (5_000_000 raw) from
+        # eth_defi.hyperliquid.core_writer
+        HYPERCORE_MIN_VAULT_BUY_DECIMAL = Decimal("5")
+
+        # Mirror start_execution()'s funding source: bridge position first,
+        # then reserves.
+        bridge_position = state.portfolio.get_bridge_position_for_chain(trade.pair.chain_id)
+        if bridge_position is not None:
+            available = bridge_position.get_quantity()
+        else:
+            try:
+                reserve_pos = state.portfolio.get_reserve_position(trade.reserve_currency)
+                available = reserve_pos.quantity
+            except KeyError:
+                available = Decimal(0)
+
+        if available >= trade.planned_reserve:
+            return False
+
+        if not hasattr(trade, "other_data") or trade.other_data is None:
+            trade.other_data = {}
+        trade.other_data["original_planned_reserve"] = str(trade.planned_reserve)
+        trade.other_data["original_planned_quantity"] = str(trade.planned_quantity)
+
+        if available >= HYPERCORE_MIN_VAULT_BUY_DECIMAL:
+            ratio = available / trade.planned_reserve
+            logger.warning(
+                "Reducing Hypercore vault buy trade %s planned_reserve from %s to %s USDC "
+                "(ratio %.4f) due to cumulative vault sell commission shortfall of %s USDC",
+                trade.trade_id, trade.planned_reserve, available,
+                ratio, cumulative_vault_sell_shortfall,
+            )
+            trade.planned_quantity = trade.planned_quantity * ratio
+            trade.planned_reserve = available
+            return False
+        else:
+            logger.warning(
+                "Expiring Hypercore vault buy trade %s: available %s USDC below "
+                "minimum %s USDC after cumulative vault sell commission shortfall of %s USDC",
+                trade.trade_id, available, HYPERCORE_MIN_VAULT_BUY_DECIMAL,
+                cumulative_vault_sell_shortfall,
+            )
+            trade.mark_expired(native_datetime_utc_now())
+            pos = state.portfolio.open_positions.get(trade.position_id)
+            if pos is not None and pos.get_quantity() == 0:
+                all_expired = all(
+                    t.get_status() == TradeStatus.expired
+                    for t in pos.trades.values()
+                )
+                if all_expired:
+                    del state.portfolio.open_positions[trade.position_id]
+            return True
+
     def _execute_trades_sequentially(
         self,
         ts: datetime.datetime,
@@ -644,6 +714,8 @@ class EthereumExecution(ExecutionModel):
             f": {reason}" if reason else "",
         )
 
+        cumulative_vault_sell_shortfall = Decimal(0)
+
         for idx, trade in enumerate(trades, start=1):
             logger.info(
                 "Sequential trade execution %d/%d: preparing trade_id=%s planned_value=%.6f pair=%s",
@@ -653,6 +725,17 @@ class EthereumExecution(ExecutionModel):
                 trade.get_planned_value(),
                 trade.pair.get_ticker(),
             )
+
+            # Cap Hypercore vault buys when preceding vault sells returned
+            # less than planned due to performance fees.
+            if (
+                not rebroadcast
+                and trade.pair.is_hyperliquid_vault()
+                and trade.is_buy()
+                and cumulative_vault_sell_shortfall > 0
+            ):
+                if self._maybe_cap_hypercore_vault_buy(state, trade, cumulative_vault_sell_shortfall):
+                    continue
 
             if not rebroadcast:
                 state.start_execution(
@@ -681,6 +764,22 @@ class EthereumExecution(ExecutionModel):
 
             freeze_position_on_failed_trade(ts, state, [trade])
             self._log_trade_outcome(trade)
+
+            # Track Hypercore vault sell shortfall from performance fees.
+            if (
+                trade.pair.is_hyperliquid_vault()
+                and not trade.is_buy()
+                and not trade.is_failed()
+                and trade.executed_reserve is not None
+            ):
+                shortfall = trade.planned_reserve - trade.executed_reserve
+                if shortfall > 0:
+                    cumulative_vault_sell_shortfall += shortfall
+                    logger.info(
+                        "Hypercore vault sell shortfall for trade %s: %s USDC "
+                        "(cumulative: %s USDC)",
+                        trade.trade_id, shortfall, cumulative_vault_sell_shortfall,
+                    )
 
             if trade.is_failed():
                 remaining_trade_ids = [remaining.trade_id for remaining in trades[idx:]]

--- a/tradeexecutor/ethereum/vault/hypercore_routing.py
+++ b/tradeexecutor/ethereum/vault/hypercore_routing.py
@@ -1,6 +1,6 @@
 """Route trades for Hypercore native vaults on HyperEVM.
 
-Hypercore vault deposits/withdrawals use a multi-phase flow:
+Hypercore vault deposits and withdrawals use a multi-phase flow:
 
 **Deposit (buy)**:
 

--- a/tradeexecutor/ethereum/vault/hypercore_routing.py
+++ b/tradeexecutor/ethereum/vault/hypercore_routing.py
@@ -83,7 +83,7 @@ from eth_defi.hyperliquid.session import (
     HyperliquidSession,
     create_hyperliquid_session,
 )
-from eth_defi.hyperliquid.vault import HyperliquidVault
+from eth_defi.hyperliquid.vault import HyperliquidVault, estimate_max_withdrawal_commission
 
 from tradeexecutor.ethereum.swap import report_failure
 from tradeexecutor.state.blockhain_transaction import (
@@ -795,6 +795,11 @@ class HypercoreVaultRouting(RoutingModel):
         if not hasattr(trade, "other_data") or trade.other_data is None:
             trade.other_data = {}
         trade.other_data["hypercore_phase1_vault_equity_usdc"] = str(user_equity.equity)
+        trade.other_data["hypercore_vault_commission_rate"] = (
+            str(getattr(vault_info, "commission_rate", None))
+            if getattr(vault_info, "commission_rate", None) is not None
+            else None
+        )
 
         # Start with the strategy-planned amount. In the common path the live
         # preflight is only a check and this value is returned unchanged.
@@ -1010,12 +1015,15 @@ class HypercoreVaultRouting(RoutingModel):
         expected_increase_raw: int,
         timeout: float = 30.0,
         poll_interval: float = 2.0,
+        commission_rate: Decimal | None = None,
     ) -> Decimal:
         """Poll HyperCore perp withdrawable USDC until the withdrawal reaches perp."""
         expected_increase = raw_to_usdc(expected_increase_raw)
+        max_commission = estimate_max_withdrawal_commission(expected_increase, commission_rate)
         accepted_tolerance = max(
             Decimal("0.10"),
             expected_increase * HYPERCORE_RELATIVE_BALANCE_TOLERANCE,
+            max_commission,
         )
         expected_balance = baseline_balance + expected_increase - accepted_tolerance
         deadline = time.time() + timeout
@@ -1536,6 +1544,20 @@ class HypercoreVaultRouting(RoutingModel):
                     trade=trade,
                     requested_raw=raw_amount,
                     vault_address=vault_address,
+                )
+
+            if not self.simulate:
+                cr = trade.other_data.get("hypercore_vault_commission_rate")
+                cr_dec = Decimal(cr) if cr is not None else None
+                effective_gross = raw_to_usdc(raw_amount)
+                estimated_commission = estimate_max_withdrawal_commission(effective_gross, cr_dec)
+                estimated_net = effective_gross - estimated_commission
+                trade.other_data["estimated_net_withdrawal_reserve"] = str(estimated_net)
+                trade.other_data["estimated_withdrawal_commission"] = str(estimated_commission)
+                logger.info(
+                    "Estimated net withdrawal for trade %s: %s USDC "
+                    "(effective gross %s, estimated commission %s, rate %s)",
+                    trade.trade_id, estimated_net, effective_gross, estimated_commission, cr,
                 )
 
             logger.info(
@@ -2120,6 +2142,22 @@ class HypercoreVaultRouting(RoutingModel):
         In simulate mode, the balance verification is skipped because
         the mock CoreWriter does not actually bridge USDC.
         """
+        # Cost-tracking variables — initialised before the simulate/live
+        # branch so they are always in scope for mark_trade_success.
+        equity_decrease: Decimal | None = None
+        total_withdrawal_cost: Decimal | None = None
+        vault_performance_fee: Decimal | None = None
+        bridge_and_rounding_cost: Decimal | None = None
+        actual_perp_increase_raw: int = 0
+        stored_commission_rate = (
+            trade.other_data.get("hypercore_vault_commission_rate")
+            if hasattr(trade, "other_data") and trade.other_data
+            else None
+        )
+        commission_rate: Decimal | None = (
+            Decimal(stored_commission_rate) if stored_commission_rate is not None else None
+        )
+
         # Capture baseline USDC balance before processing receipt.
         # The withdrawal multicall has already been mined but spotSend's
         # bridge delivery takes 2-10 seconds, so USDC hasn't arrived yet.
@@ -2272,6 +2310,7 @@ class HypercoreVaultRouting(RoutingModel):
                     expected_increase_raw=expected_raw,
                     timeout=30.0,
                     poll_interval=2.0,
+                    commission_rate=commission_rate,
                 )
             except HypercoreWithdrawalVerificationError as e:
                 current_vault_equity: Decimal | None = None
@@ -2390,6 +2429,7 @@ class HypercoreVaultRouting(RoutingModel):
                                 expected_increase_raw=expected_raw,
                                 timeout=30.0,
                                 poll_interval=2.0,
+                                commission_rate=commission_rate,
                             )
                         except HypercoreWithdrawalVerificationError as retry_wait_error:
                             logger.error(
@@ -2682,9 +2722,9 @@ class HypercoreVaultRouting(RoutingModel):
                     vault_address=vault_address,
                     bypass_cache=True,
                 )
-                remaining_equity = eq_after.equity if eq_after else Decimal(0)
 
-                if vault_equity_before_phase1_snapshot is not None:
+                if vault_equity_before_phase1_snapshot is not None and eq_after is not None:
+                    remaining_equity = eq_after.equity
                     equity_decrease = (
                         vault_equity_before_phase1_snapshot - remaining_equity
                     )
@@ -2698,6 +2738,16 @@ class HypercoreVaultRouting(RoutingModel):
                             executed_reserve, equity_decrease, expected_decrease,
                             vault_equity_before_phase1_snapshot, remaining_equity,
                         )
+                    elif equity_decrease > expected_decrease + tolerance:
+                        fee_absorbed = equity_decrease - expected_decrease
+                        logger.warning(
+                            "Withdrawal vault fee detected: HyperCore equity decreased by %s "
+                            "but only %s USDC arrived on EVM. Estimated commission absorbed: "
+                            "%s USDC. Before: %s, after: %s (commission_rate: %s)",
+                            equity_decrease, executed_reserve, fee_absorbed,
+                            vault_equity_before_phase1_snapshot, remaining_equity,
+                            stored_commission_rate,
+                        )
                     else:
                         logger.info(
                             "Withdrawal dual-chain verified: EVM USDC arrived (+%s), "
@@ -2705,7 +2755,15 @@ class HypercoreVaultRouting(RoutingModel):
                             executed_reserve, equity_decrease,
                             vault_equity_before_phase1_snapshot, remaining_equity,
                         )
+                elif vault_equity_before_phase1_snapshot is not None:
+                    remaining_equity = eq_after.equity if eq_after is not None else None
+                    logger.info(
+                        "Withdrawal dual-chain check (no post-withdrawal equity): "
+                        "EVM USDC arrived (+%s), remaining equity: %s",
+                        executed_reserve, remaining_equity,
+                    )
                 else:
+                    remaining_equity = eq_after.equity if eq_after is not None else None
                     logger.info(
                         "Withdrawal dual-chain check (no baseline): "
                         "EVM USDC arrived (+%s), HyperCore equity remaining: %s",
@@ -2716,21 +2774,48 @@ class HypercoreVaultRouting(RoutingModel):
                     "Could not verify vault equity after withdrawal: %s", e,
                 )
 
+            # Compute withdrawal cost breakdown for analytics.
+            if equity_decrease is not None:
+                total_withdrawal_cost = max(equity_decrease - executed_reserve, Decimal(0))
+                perp_increase = raw_to_usdc(actual_perp_increase_raw) if actual_perp_increase_raw > 0 else None
+                if perp_increase is not None:
+                    vault_performance_fee = max(equity_decrease - perp_increase, Decimal(0))
+                    bridge_and_rounding_cost = max(perp_increase - executed_reserve, Decimal(0))
+                else:
+                    vault_performance_fee = total_withdrawal_cost
+                    bridge_and_rounding_cost = Decimal(0)
+
+            if not hasattr(trade, "other_data") or trade.other_data is None:
+                trade.other_data = {}
+            trade.other_data["hypercore_withdrawal_costs"] = {
+                "planned_gross_reserve": str(planned_reserve),
+                "executed_net_reserve": str(executed_reserve),
+                "vault_equity_decreased": str(equity_decrease) if equity_decrease is not None else None,
+                "total_withdrawal_cost": str(total_withdrawal_cost) if total_withdrawal_cost is not None else None,
+                "vault_performance_fee": str(vault_performance_fee) if vault_performance_fee is not None else None,
+                "bridge_and_rounding_cost": str(bridge_and_rounding_cost) if bridge_and_rounding_cost is not None else None,
+                "commission_rate": stored_commission_rate,
+                "estimated_commission": trade.other_data.get("estimated_withdrawal_commission"),
+            }
+
         executed_amount = -executed_reserve  # Negative for sells
 
+        vault_fee = float(total_withdrawal_cost) if total_withdrawal_cost is not None else 0
         state.mark_trade_success(
             ts,
             trade,
             executed_price=1.0,
             executed_amount=executed_amount,
             executed_reserve=executed_reserve,
-            lp_fees=0,
+            lp_fees=vault_fee,
             native_token_price=0,
         )
 
         logger.info(
-            "Hypercore vault withdrawal settled: %s USDC withdrawn (planned %s)",
+            "Hypercore vault withdrawal settled: %s USDC withdrawn (planned %s), "
+            "vault fee %s",
             executed_reserve, planned_reserve,
+            total_withdrawal_cost if total_withdrawal_cost is not None else "unknown",
         )
 
     # ------------------------------------------------------------------


### PR DESCRIPTION
## Why

The `hyper-ai` strategy was hitting 30-second timeouts during Hypercore vault withdrawals because the settlement code expected the full planned USDC to arrive in the perp account, but Hyperliquid vault leaders earn a performance fee (typically 10% of profits) deducted at withdrawal time. This fee reduces the actual USDC received, causing the balance check to never reach the threshold.

Additionally, when vault sells returned less than planned due to the fee, subsequent buys in the same rebalance cycle would attempt to spend more USDC than available, risking `NotEnoughMoney` failures.

## Lessons learnt

- Hyperliquid's `vaultDetails` API exposes the leader fee as `leaderCommission` (e.g. `0.1` for 10%), not `commissionRate` (which is always `None`). Fixed in companion eth_defi PR #1074.
- The worst-case commission (entire withdrawal is profit) is `commission_rate * withdrawal_amount`. In practice only the profit portion is taxed, so the actual fee is lower.
- Vault fee cost should be recorded as `lp_fees` on the trade for accurate PnL accounting, not silently absorbed.

## Summary

### Commission-aware withdrawal tolerance (`hypercore_routing.py`)
- `_wait_for_perp_withdrawable_balance()` now accepts `commission_rate` and widens the accepted tolerance by the worst-case commission estimate
- Store `commission_rate` from `VaultInfo` in `trade.other_data` during `setup_trades` so it is available during settlement
- Compute and store withdrawal cost breakdown (vault performance fee vs bridge/rounding cost) in `trade.other_data["hypercore_withdrawal_costs"]` for analytics
- Record total vault fee as `lp_fees` on the trade for accurate PnL accounting
- Log a "vault fee detected" warning when equity decreases more than USDC received
- Add net withdrawal reserve estimate after commission for monitoring

### Buy capping on sell shortfall (`execution.py`)
- Track cumulative Hypercore vault sell shortfall across the rebalance cycle
- Cap subsequent Hypercore vault buys to available capital when preceding sells returned less than planned
- Expire buys below the minimum vault deposit threshold ($5 USDC) instead of attempting them

### Tests
- `test_wait_for_perp_withdrawable_balance_commission_aware`: 10% commission tolerance accepts 8% shortfall
- `test_wait_for_perp_withdrawable_balance_protocol_vault_stays_tight`: protocol vaults keep tight 1% tolerance
- `test_withdrawal_dual_chain_fee_warning`: vault fee detection and cost breakdown storage
- `test_vault_buy_capped_on_vault_sell_shortfall`: buy reserve reduced to available capital
- `test_vault_buy_expired_when_below_minimum`: buy expired when capital below $5 minimum
- `test_non_hypercore_buy_unaffected_by_hypercore_sell_shortfall`: non-vault buys unaffected

## Related issues and PRs

- eth_defi PR: https://github.com/tradingstrategy-ai/web3-ethereum-defi/pull/1074 (merged)
