### PR TITLE
fix: Detect and close phantom Hypercore vault positions from untracked withdrawals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 
 - Breaking API changes
 
+- Fix phantom Hypercore vault positions from untracked withdrawals: detect and close positions where the Hyperliquid API reports zero equity but state has positive deposited USDC (2026-06-08)
+
 - Fix CCTP bridge USDC decimals: resolve token decimals from pair universe instead of trusting `reserve_asset.decimals` which could be wrong (18 instead of 6) in ERC-4626 vault pair universes (2026-06-03)
 
 - Add cross-chain CCTP bridge support to `perform-test-trade` and `trade-ui` for satellite-chain vault pairs (2026-06-03)

--- a/tests/hyperliquid/test_hypercore_accounting.py
+++ b/tests/hyperliquid/test_hypercore_accounting.py
@@ -47,6 +47,7 @@ from tradeexecutor.strategy.execution_model import AssetManagementMode
 from tradeexecutor.strategy.execution_context import unit_test_execution_context
 from tradeexecutor.strategy.runner import StrategyRunner
 from tradeexecutor.strategy.sync_model import OnChainBalance
+from tradeexecutor.visual.equity_curve import calculate_compounding_unrealised_trading_profitability
 
 
 def test_valuation_computes_per_unit_price():
@@ -1072,3 +1073,268 @@ def test_close_hypercore_dust_positions_closes_duplicate_residual_state() -> Non
     assert live_position.position_id in state.portfolio.open_positions
     assert live_position.position_id not in state.portfolio.closed_positions
     assert created_trades[0].trade_type == TradeType.repair
+
+
+def test_correct_accounts_closes_phantom_position_from_untracked_withdrawal() -> None:
+    """Test that correct-accounts detects and closes a phantom Hypercore vault position.
+
+    A phantom position occurs when a Hypercore vault withdrawal completed
+    on Hyperliquid but the executor failed to confirm it (timeout/restart
+    during the 3-phase settlement). The repair command zeroes out the
+    unconfirmed trade, leaving the state with positive quantity but zero
+    on-chain equity.
+
+    1. Create an open Hypercore vault position with 304 USDC deposited.
+    2. Record reserve quantity after setup.
+    3. Mock Hyperliquid equity API to return 0 (no position found).
+    4. Run the Hypercore account correction sync helper.
+    5. Verify the position is closed with a zero-proceeds repair trade.
+    6. Verify reserves were not changed (USDC reconciliation is deferred).
+    7. Verify equity curve calculation does not crash.
+    """
+
+    # 1. Create an open Hypercore vault position with 304 USDC deposited.
+    reserve_asset = AssetIdentifier(
+        chain_id=999,
+        address="0xb88339cb7199b77e23db6e890353e22632ba630f",
+        token_symbol="USDC",
+        decimals=6,
+    )
+    pair = create_hypercore_vault_pair(
+        quote=reserve_asset,
+        vault_address="0xf6f3d773e11023e3e686cbda883ecba631fefc15",
+    )
+    state = State()
+    state.portfolio.initialise_reserves(reserve_asset, reserve_token_price=1.0)
+    state.portfolio.adjust_reserves(reserve_asset, Decimal("500"), "Initial reserve")
+    position, trade, _created = state.create_trade(
+        strategy_cycle_at=datetime.datetime(2026, 3, 30),
+        pair=pair,
+        quantity=None,
+        reserve=Decimal("304"),
+        assumed_price=1.0,
+        trade_type=TradeType.rebalance,
+        reserve_currency=reserve_asset,
+        reserve_currency_price=1.0,
+        notes="Open Hypercore vault position (simulating YEELON deposit)",
+    )
+    state.mark_trade_success(
+        executed_at=datetime.datetime(2026, 3, 30, 0, 1),
+        trade=trade,
+        executed_price=1.0,
+        executed_amount=Decimal("304"),
+        executed_reserve=Decimal("304"),
+        lp_fees=0,
+        native_token_price=0,
+        force=True,
+    )
+    assert position.get_quantity() == Decimal("304")
+    assert position.is_open()
+
+    # 2. Record reserve quantity after setup.
+    reserve_position = state.portfolio.get_default_reserve_position()
+    reserves_after_setup = reserve_position.quantity
+
+    # 3. Mock Hyperliquid equity API to return 0 (no position found).
+    universe = MagicMock()
+    dex_pair = object()
+    universe.data_universe.pairs.iterate_pairs.return_value = [dex_pair]
+    sync_model = MagicMock()
+    sync_model.get_token_storage_address.return_value = "0xa8F8DEbb722c6174B814b432169BF569603F673F"
+    web3 = MagicMock()
+    web3.eth.chain_id = 999
+
+    with (
+        patch("tradeexecutor.strategy.trading_strategy_universe.translate_trading_pair", return_value=pair),
+        patch("tradeexecutor.strategy.account_correction.translate_trading_pair", return_value=pair),
+        patch("eth_defi.hyperliquid.session.create_hyperliquid_session", return_value=MagicMock()),
+        patch(
+            "tradeexecutor.ethereum.vault.hypercore_vault.create_hypercore_vault_value_func",
+            return_value=lambda pair: Decimal("0"),
+        ),
+    ):
+        # 4. Run the Hypercore account correction sync helper.
+        _sync_hypercore_vault_positions(
+            asset_management_mode=AssetManagementMode.lagoon,
+            universe=universe,
+            sync_model=sync_model,
+            web3=web3,
+            state=state,
+        )
+
+    # 5. Verify the position is closed with a zero-proceeds repair trade.
+    assert position.position_id in state.portfolio.closed_positions
+    assert position.position_id not in state.portfolio.open_positions
+    assert position.get_quantity() == Decimal(0)
+
+    last_trade = list(position.trades.values())[-1]
+    assert last_trade.trade_type == TradeType.repair
+    assert last_trade.executed_quantity == Decimal("-304")
+    assert last_trade.executed_reserve == Decimal(0)
+    assert last_trade.is_success()
+
+    # 6. Verify reserves were not changed (USDC reconciliation is deferred).
+    assert reserve_position.quantity == reserves_after_setup
+
+    # 7. Verify equity curve calculation does not crash.
+    result = calculate_compounding_unrealised_trading_profitability(state)
+    assert result is not None
+
+
+def test_correct_accounts_closes_phantom_position_already_valued_at_zero() -> None:
+    """Test that correct-accounts closes a phantom position even when already valued at zero.
+
+    In production, the valuator tick runs before correct-accounts and sets
+    last_token_price=0.0 when the Hyperliquid API returns zero equity. This
+    makes old_value=0 and diff=0. The phantom position detection must still
+    fire despite the diff==0 condition.
+
+    1. Create an open Hypercore vault position with 304 USDC deposited.
+    2. Set last_token_price=0.0 to simulate a prior valuator tick.
+    3. Record reserve quantity after setup.
+    4. Mock Hyperliquid equity API to return 0.
+    5. Run the Hypercore account correction sync helper.
+    6. Verify the position is closed despite diff==0.
+    7. Verify reserves were not changed.
+    """
+
+    # 1. Create an open Hypercore vault position with 304 USDC deposited.
+    reserve_asset = AssetIdentifier(
+        chain_id=999,
+        address="0xb88339cb7199b77e23db6e890353e22632ba630f",
+        token_symbol="USDC",
+        decimals=6,
+    )
+    pair = create_hypercore_vault_pair(
+        quote=reserve_asset,
+        vault_address="0xf6f3d773e11023e3e686cbda883ecba631fefc15",
+    )
+    state = State()
+    state.portfolio.initialise_reserves(reserve_asset, reserve_token_price=1.0)
+    state.portfolio.adjust_reserves(reserve_asset, Decimal("500"), "Initial reserve")
+    position, trade, _created = state.create_trade(
+        strategy_cycle_at=datetime.datetime(2026, 3, 30),
+        pair=pair,
+        quantity=None,
+        reserve=Decimal("304"),
+        assumed_price=1.0,
+        trade_type=TradeType.rebalance,
+        reserve_currency=reserve_asset,
+        reserve_currency_price=1.0,
+    )
+    state.mark_trade_success(
+        executed_at=datetime.datetime(2026, 3, 30, 0, 1),
+        trade=trade,
+        executed_price=1.0,
+        executed_amount=Decimal("304"),
+        executed_reserve=Decimal("304"),
+        lp_fees=0,
+        native_token_price=0,
+        force=True,
+    )
+
+    # 2. Set last_token_price=0.0 to simulate a prior valuator tick.
+    position.last_token_price = 0.0
+    position.revalue_base_asset(datetime.datetime(2026, 6, 8), 0.0)
+
+    # 3. Record reserve quantity after setup.
+    reserve_position = state.portfolio.get_default_reserve_position()
+    reserves_after_setup = reserve_position.quantity
+
+    # 4. Mock Hyperliquid equity API to return 0.
+    universe = MagicMock()
+    dex_pair = object()
+    universe.data_universe.pairs.iterate_pairs.return_value = [dex_pair]
+    sync_model = MagicMock()
+    sync_model.get_token_storage_address.return_value = "0xa8F8DEbb722c6174B814b432169BF569603F673F"
+    web3 = MagicMock()
+    web3.eth.chain_id = 999
+
+    with (
+        patch("tradeexecutor.strategy.trading_strategy_universe.translate_trading_pair", return_value=pair),
+        patch("tradeexecutor.strategy.account_correction.translate_trading_pair", return_value=pair),
+        patch("eth_defi.hyperliquid.session.create_hyperliquid_session", return_value=MagicMock()),
+        patch(
+            "tradeexecutor.ethereum.vault.hypercore_vault.create_hypercore_vault_value_func",
+            return_value=lambda pair: Decimal("0"),
+        ),
+    ):
+        # 5. Run the Hypercore account correction sync helper.
+        _sync_hypercore_vault_positions(
+            asset_management_mode=AssetManagementMode.lagoon,
+            universe=universe,
+            sync_model=sync_model,
+            web3=web3,
+            state=state,
+        )
+
+    # 6. Verify the position is closed despite diff==0.
+    assert position.position_id in state.portfolio.closed_positions
+    assert position.position_id not in state.portfolio.open_positions
+    assert position.get_quantity() == Decimal(0)
+
+    last_trade = list(position.trades.values())[-1]
+    assert last_trade.trade_type == TradeType.repair
+    assert last_trade.executed_quantity == Decimal("-304")
+
+    # 7. Verify reserves were not changed.
+    assert reserve_position.quantity == reserves_after_setup
+
+
+def test_valuation_accepts_zero_price() -> None:
+    """Test that the valuation PnL calculation accepts a zero valuation price.
+
+    A valuation price of 0.0 is valid when a Hypercore vault position has
+    lost all value (trading losses or untracked withdrawal). The code must
+    use ``is not None`` checks instead of truthiness to avoid crashing on
+    zero prices.
+
+    1. Create a mock position with last_token_price=0.0 and positive quantity.
+    2. Call get_unrealised_and_realised_profit_percent().
+    3. Verify no AssertionError is raised and the result is sensible.
+    """
+
+    # 1. Create a mock position with last_token_price=0.0 and positive quantity.
+    reserve_asset = AssetIdentifier(
+        chain_id=999,
+        address="0xb88339cb7199b77e23db6e890353e22632ba630f",
+        token_symbol="USDC",
+        decimals=6,
+    )
+    pair = create_hypercore_vault_pair(
+        quote=reserve_asset,
+        vault_address="0xf6f3d773e11023e3e686cbda883ecba631fefc15",
+    )
+    state = State()
+    state.portfolio.initialise_reserves(reserve_asset, reserve_token_price=1.0)
+    state.portfolio.adjust_reserves(reserve_asset, Decimal("500"), "Initial reserve")
+    position, trade, _created = state.create_trade(
+        strategy_cycle_at=datetime.datetime(2026, 3, 30),
+        pair=pair,
+        quantity=None,
+        reserve=Decimal("100"),
+        assumed_price=1.0,
+        trade_type=TradeType.rebalance,
+        reserve_currency=reserve_asset,
+        reserve_currency_price=1.0,
+    )
+    state.mark_trade_success(
+        executed_at=datetime.datetime(2026, 3, 30, 0, 1),
+        trade=trade,
+        executed_price=1.0,
+        executed_amount=Decimal("100"),
+        executed_reserve=Decimal("100"),
+        lp_fees=0,
+        native_token_price=0,
+        force=True,
+    )
+
+    # Simulate zero valuation (total loss)
+    position.last_token_price = 0.0
+
+    # 2. Call get_unrealised_and_realised_profit_percent().
+    # This previously crashed with AssertionError because 0.0 is falsy.
+    result = position.get_unrealised_and_realised_profit_percent()
+
+    # 3. Verify no AssertionError is raised and the result is sensible.
+    assert result is not None

--- a/tests/hyperliquid/test_hypercore_phantom_position_sample_state.py
+++ b/tests/hyperliquid/test_hypercore_phantom_position_sample_state.py
@@ -1,0 +1,194 @@
+"""Integration test for phantom Hypercore vault position correction.
+
+Reproduces the YEELON incident from hyper-ai-5.json: two Hypercore vault
+withdrawals completed on Hyperliquid but the executor failed to confirm
+them, leaving a phantom position with quantity=304 USDC but zero on-chain
+equity.  The valuator then set last_token_price=0.0 and the ``start``
+command crashed on ``assert valuation_price`` (0.0 is falsy in Python).
+
+This test verifies that ``correct-accounts`` detects and closes the
+phantom position, and that subsequent ``check-accounts`` passes cleanly.
+
+Requires:
+- ~/hyper-ai-5.json (the production state file with the YEELON phantom)
+- TRADING_STRATEGY_API_KEY environment variable
+- JSON_RPC_HYPERLIQUID environment variable
+"""
+
+import os
+import shutil
+import subprocess
+import sys
+from decimal import Decimal
+from pathlib import Path
+
+import pytest
+
+from tradeexecutor.state.state import State
+from tradeexecutor.state.trade import TradeType
+from tradeexecutor.visual.equity_curve import calculate_compounding_unrealised_trading_profitability
+
+WORKTREE_ROOT = Path(__file__).resolve().parents[2]
+
+SAMPLE_STATE_FILE = Path.home() / "hyper-ai-5.json"
+TEST_PRIVATE_KEY = "0x111e53aed5e777996f26b4bdb89300bbc05b84743f32028c41be7193c0fe0b83"
+REQUIRED_ENV_VARS = ("TRADING_STRATEGY_API_KEY", "JSON_RPC_HYPERLIQUID")
+
+YEELON_POSITION_ID = 15
+YEELON_VAULT_ADDRESS = "0xf6f3d773e11023e3e686cbda883ecba631fefc15"
+
+pytestmark = [
+    pytest.mark.timeout(300),
+    pytest.mark.skipif(
+        (not SAMPLE_STATE_FILE.exists()) or (not all(os.environ.get(name) for name in REQUIRED_ENV_VARS)),
+        reason="Set TRADING_STRATEGY_API_KEY, JSON_RPC_HYPERLIQUID, and ~/hyper-ai-5.json to run this test",
+    ),
+]
+
+
+def _run_cli_command(environment: dict[str, str], command: str) -> subprocess.CompletedProcess[str]:
+    """Run a CLI command in a subprocess pinned to the worktree imports."""
+
+    pythonpath_parts = [str(WORKTREE_ROOT)]
+    existing_pythonpath = os.environ.get("PYTHONPATH")
+    if existing_pythonpath:
+        pythonpath_parts.append(existing_pythonpath)
+
+    process_environment = {
+        **environment,
+        "PYTHONPATH": os.pathsep.join(pythonpath_parts),
+    }
+
+    return subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            f"from tradeexecutor.cli.main import app; app(['{command}'], standalone_mode=False)",
+        ],
+        cwd=WORKTREE_ROOT,
+        env=process_environment,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+def _get_process_output(process: subprocess.CompletedProcess[str]) -> str:
+    """Combine subprocess streams for stable CLI assertions."""
+
+    return "\n".join(part for part in (process.stdout, process.stderr) if part)
+
+
+@pytest.fixture()
+def strategy_file() -> Path:
+    """Path to the live-style Hypercore strategy used by the sample state."""
+
+    return Path(__file__).resolve().parents[2] / "strategies" / "test_only" / "hyper-ai-test.py"
+
+
+@pytest.fixture()
+def state_file(tmp_path: Path) -> Path:
+    """Copy the local sample state to a temporary path for mutation-safe tests."""
+
+    target = tmp_path / "hyper-ai-5-copy.json"
+    shutil.copy2(SAMPLE_STATE_FILE, target)
+    return target
+
+
+@pytest.fixture()
+def environment(state_file: Path, strategy_file: Path, tmp_path: Path) -> dict[str, str]:
+    """Build an isolated CLI environment for the copied sample state."""
+
+    state = State.read_json_file(state_file)
+    vault_address = state.sync.deployment.address
+    assert vault_address, "Copied sample state does not contain a Lagoon vault address"
+
+    # Extract the single Lagoon module address from trade blockchain transactions
+    module_addresses = {
+        tx.contract_address
+        for position in state.portfolio.open_positions.values()
+        for trade in position.trades.values()
+        for tx in trade.blockchain_transactions
+        if tx.contract_address
+    }
+    assert len(module_addresses) == 1, \
+        f"Expected one Lagoon module address in the copied state, got {module_addresses}"
+    module_address = next(iter(module_addresses))
+
+    cache_path = tmp_path / "cache"
+    cache_path.mkdir(exist_ok=True)
+
+    return {
+        "EXECUTOR_ID": "test_hypercore_phantom_position",
+        "STRATEGY_FILE": str(strategy_file),
+        "STATE_FILE": str(state_file),
+        "CACHE_PATH": str(cache_path),
+        "ASSET_MANAGEMENT_MODE": "lagoon",
+        "VAULT_ADDRESS": vault_address,
+        "VAULT_ADAPTER_ADDRESS": module_address,
+        "PRIVATE_KEY": TEST_PRIVATE_KEY,
+        "JSON_RPC_HYPERLIQUID": os.environ["JSON_RPC_HYPERLIQUID"],
+        "TRADING_STRATEGY_API_KEY": os.environ["TRADING_STRATEGY_API_KEY"],
+        "UNIT_TESTING": "true",
+        "LOG_LEVEL": "info",
+        "PATH": os.environ.get("PATH", ""),
+        "HOME": os.environ.get("HOME", str(Path.home())),
+    }
+
+
+def test_correct_accounts_closes_yeelon_phantom_position(
+    environment: dict[str, str],
+    state_file: Path,
+) -> None:
+    """Test that correct-accounts closes the YEELON phantom position from hyper-ai-5.json.
+
+    The YEELON vault (position #15) has quantity=304.16 in state but the
+    Hyperliquid API reports zero equity. Two withdrawals ($207.94 and $96.22)
+    completed on Hyperliquid but the executor failed to confirm them.
+    The valuator already set last_token_price=0.0.
+
+    1. Load the copied sample state and confirm YEELON is open with zero price.
+    2. Run correct-accounts through the CLI.
+    3. Reload state and verify YEELON is closed with a repair trade.
+    4. Verify the equity curve does not crash on the corrected state.
+    """
+
+    # 1. Load the copied sample state and confirm YEELON is open with zero price.
+    initial_state = State.read_json_file(state_file)
+    yeelon = initial_state.portfolio.open_positions.get(YEELON_POSITION_ID)
+    assert yeelon is not None, f"YEELON position #{YEELON_POSITION_ID} not found in open positions"
+    assert yeelon.pair.pool_address.lower() == YEELON_VAULT_ADDRESS.lower()
+    assert yeelon.last_token_price == 0.0
+    assert float(yeelon.get_quantity()) == pytest.approx(304.1648, abs=0.01)
+
+    initial_open_count = len(initial_state.portfolio.open_positions)
+
+    # 2. Run correct-accounts through the CLI.
+    process = _run_cli_command(environment, "correct-accounts")
+    output = _get_process_output(process)
+    assert process.returncode == 0, f"correct-accounts failed:\n{output}"
+    assert "phantom" in output.lower() or "zero equity" in output.lower(), \
+        f"Expected phantom position log message in output:\n{output}"
+
+    # 3. Reload state and verify YEELON is closed with a repair trade.
+    final_state = State.read_json_file(state_file)
+
+    assert YEELON_POSITION_ID not in final_state.portfolio.open_positions, \
+        "YEELON should no longer be in open positions after correct-accounts"
+    assert YEELON_POSITION_ID in final_state.portfolio.closed_positions, \
+        "YEELON should be in closed positions after correct-accounts"
+
+    closed_yeelon = final_state.portfolio.closed_positions[YEELON_POSITION_ID]
+    assert closed_yeelon.get_quantity() == Decimal(0)
+
+    last_trade = list(closed_yeelon.trades.values())[-1]
+    assert last_trade.trade_type == TradeType.repair
+    assert last_trade.executed_reserve == Decimal(0)
+    assert last_trade.is_success()
+
+    # Other positions should still be open (minus YEELON)
+    assert len(final_state.portfolio.open_positions) == initial_open_count - 1
+
+    # 4. Verify the equity curve does not crash on the corrected state.
+    result = calculate_compounding_unrealised_trading_profitability(final_state)
+    assert result is not None

--- a/tests/hyperliquid/test_hypercore_phantom_position_sample_state.py
+++ b/tests/hyperliquid/test_hypercore_phantom_position_sample_state.py
@@ -3,11 +3,11 @@
 Reproduces the YEELON incident from hyper-ai-5.json: two Hypercore vault
 withdrawals completed on Hyperliquid but the executor failed to confirm
 them, leaving a phantom position with quantity=304 USDC but zero on-chain
-equity.  The valuator then set last_token_price=0.0 and the ``start``
+equity.  The valuator already set last_token_price=0.0 and the ``start``
 command crashed on ``assert valuation_price`` (0.0 is falsy in Python).
 
 This test verifies that ``correct-accounts`` detects and closes the
-phantom position, and that subsequent ``check-accounts`` passes cleanly.
+phantom position via the Typer CLI entry point.
 
 Requires:
 - ~/hyper-ai-5.json (the production state file with the YEELON phantom)
@@ -17,22 +17,21 @@ Requires:
 
 import os
 import shutil
-import subprocess
-import sys
 from decimal import Decimal
 from pathlib import Path
+from unittest import mock
 
 import pytest
 
+from tradeexecutor.cli.main import app
 from tradeexecutor.state.state import State
 from tradeexecutor.state.trade import TradeType
 from tradeexecutor.visual.equity_curve import calculate_compounding_unrealised_trading_profitability
 
-WORKTREE_ROOT = Path(__file__).resolve().parents[2]
 
 SAMPLE_STATE_FILE = Path.home() / "hyper-ai-5.json"
-TEST_PRIVATE_KEY = "0x111e53aed5e777996f26b4bdb89300bbc05b84743f32028c41be7193c0fe0b83"
 REQUIRED_ENV_VARS = ("TRADING_STRATEGY_API_KEY", "JSON_RPC_HYPERLIQUID")
+TEST_PRIVATE_KEY = "0x111e53aed5e777996f26b4bdb89300bbc05b84743f32028c41be7193c0fe0b83"
 
 YEELON_POSITION_ID = 15
 YEELON_VAULT_ADDRESS = "0xf6f3d773e11023e3e686cbda883ecba631fefc15"
@@ -44,39 +43,6 @@ pytestmark = [
         reason="Set TRADING_STRATEGY_API_KEY, JSON_RPC_HYPERLIQUID, and ~/hyper-ai-5.json to run this test",
     ),
 ]
-
-
-def _run_cli_command(environment: dict[str, str], command: str) -> subprocess.CompletedProcess[str]:
-    """Run a CLI command in a subprocess pinned to the worktree imports."""
-
-    pythonpath_parts = [str(WORKTREE_ROOT)]
-    existing_pythonpath = os.environ.get("PYTHONPATH")
-    if existing_pythonpath:
-        pythonpath_parts.append(existing_pythonpath)
-
-    process_environment = {
-        **environment,
-        "PYTHONPATH": os.pathsep.join(pythonpath_parts),
-    }
-
-    return subprocess.run(
-        [
-            sys.executable,
-            "-c",
-            f"from tradeexecutor.cli.main import app; app(['{command}'], standalone_mode=False)",
-        ],
-        cwd=WORKTREE_ROOT,
-        env=process_environment,
-        capture_output=True,
-        text=True,
-        check=False,
-    )
-
-
-def _get_process_output(process: subprocess.CompletedProcess[str]) -> str:
-    """Combine subprocess streams for stable CLI assertions."""
-
-    return "\n".join(part for part in (process.stdout, process.stderr) if part)
 
 
 @pytest.fixture()
@@ -103,7 +69,6 @@ def environment(state_file: Path, strategy_file: Path, tmp_path: Path) -> dict[s
     vault_address = state.sync.deployment.address
     assert vault_address, "Copied sample state does not contain a Lagoon vault address"
 
-    # Extract the single Lagoon module address from trade blockchain transactions
     module_addresses = {
         tx.contract_address
         for position in state.portfolio.open_positions.values()
@@ -148,7 +113,7 @@ def test_correct_accounts_closes_yeelon_phantom_position(
     The valuator already set last_token_price=0.0.
 
     1. Load the copied sample state and confirm YEELON is open with zero price.
-    2. Run correct-accounts through the CLI.
+    2. Run correct-accounts through the Typer CLI.
     3. Reload state and verify YEELON is closed with a repair trade.
     4. Verify the equity curve does not crash on the corrected state.
     """
@@ -163,12 +128,12 @@ def test_correct_accounts_closes_yeelon_phantom_position(
 
     initial_open_count = len(initial_state.portfolio.open_positions)
 
-    # 2. Run correct-accounts through the CLI.
-    process = _run_cli_command(environment, "correct-accounts")
-    output = _get_process_output(process)
-    assert process.returncode == 0, f"correct-accounts failed:\n{output}"
-    assert "phantom" in output.lower() or "zero equity" in output.lower(), \
-        f"Expected phantom position log message in output:\n{output}"
+    # 2. Run correct-accounts through the Typer CLI.
+    with mock.patch.dict("os.environ", environment, clear=True):
+        # correct-accounts calls sys.exit(0) on success
+        with pytest.raises(SystemExit) as sys_exit:
+            app(["correct-accounts"], standalone_mode=False)
+        assert sys_exit.value.code == 0
 
     # 3. Reload state and verify YEELON is closed with a repair trade.
     final_state = State.read_json_file(state_file)

--- a/tradeexecutor/cli/commands/correct_accounts.py
+++ b/tradeexecutor/cli/commands/correct_accounts.py
@@ -56,11 +56,18 @@ def _sync_hypercore_vault_positions(
     sync_model,
     web3,
     state,
-) -> None:
-    """Auto-create and mark Hypercore vault positions from the Hyperliquid API."""
+) -> bool:
+    """Auto-create and mark Hypercore vault positions from the Hyperliquid API.
+
+    :return:
+        True if any phantom positions were closed (zero-proceeds repair).
+        The caller should ensure the reserve balance correction runs
+        afterwards, because USDC from untracked withdrawals may be
+        sitting in the Safe without being reflected in state reserves.
+    """
 
     if not asset_management_mode.is_vault() or universe is None:
-        return
+        return False
 
     from tradeexecutor.strategy.trading_strategy_universe import translate_trading_pair
 
@@ -69,7 +76,7 @@ def _sync_hypercore_vault_positions(
         for p in universe.data_universe.pairs.iterate_pairs()
     )
     if not has_vault_pairs:
-        return
+        return False
 
     safe_address = sync_model.get_token_storage_address()
     chain_id = web3.eth.chain_id
@@ -109,6 +116,7 @@ def _sync_hypercore_vault_positions(
         p for p in state.portfolio.get_open_positions()
         if p.pair.is_hyperliquid_vault()
     ]
+    closed_phantom = False
     for position in vault_positions:
         try:
             current_equity = vault_value_func(position.pair)
@@ -195,6 +203,7 @@ def _sync_hypercore_vault_positions(
                 position.position_id,
                 correction_trade.trade_id,
             )
+            closed_phantom = True
             continue
 
         if diff == 0:
@@ -242,6 +251,8 @@ def _sync_hypercore_vault_positions(
                 quantity=quantity,
             )
         )
+
+    return closed_phantom
 
 
 def _has_closed_hypercore_positions(state) -> bool:
@@ -684,7 +695,7 @@ def correct_accounts(
             for evt in exchange_events:
                 logger.info("  Position %d: %s (change: %s)", evt.position_id, evt.notes, evt.quantity)
 
-    _sync_hypercore_vault_positions(
+    closed_phantom_positions = _sync_hypercore_vault_positions(
         asset_management_mode=asset_management_mode,
         universe=universe,
         sync_model=sync_model,
@@ -713,16 +724,16 @@ def correct_accounts(
 
     block_timestamp = get_block_timestamp(web3, block_number)
 
-    # Skip on-chain corrections only when there are no on-chain positions
-    # AND no reserve assets to check. Reserve balance checks must always run
-    # because the Safe may hold USDC from untracked vault withdrawals or
-    # other out-of-band transfers that need to be reconciled.
+    # Skip on-chain corrections when all positions are exchange account positions
+    # (their balances are synced via exchange API, not on-chain balance checks).
+    # Exception: if we just closed a phantom Hypercore vault position, the Safe
+    # may hold USDC from an untracked withdrawal that needs reserve reconciliation.
     has_onchain_positions = (
         any(
             not p.pair.is_exchange_account()
             for p in state.portfolio.get_open_and_frozen_positions()
         )
-        or len(universe.reserve_assets) > 0
+        or closed_phantom_positions
     )
 
     if not has_onchain_positions:

--- a/tradeexecutor/cli/commands/correct_accounts.py
+++ b/tradeexecutor/cli/commands/correct_accounts.py
@@ -31,6 +31,7 @@ from ...ethereum.lagoon.vault import LagoonVaultSyncModel
 from ...ethereum.tx import HotWalletTransactionBuilder
 from ...state.repair import close_hypercore_dust_positions
 from ...state.state import UncleanState
+from ...state.trade import TradeType
 from ...strategy.bootstrap import make_factory_from_strategy_mod
 from ...strategy.account_correction import calculate_account_corrections
 from ...strategy.description import StrategyExecutionDescription
@@ -118,6 +119,83 @@ def _sync_hypercore_vault_positions(
         quantity = position.get_quantity()
         old_value = position.get_value()
         diff = float(current_equity) - old_value
+        vault_name = position.pair.get_vault_name() or "unknown"
+        vault_addr = position.pair.pool_address or "?"
+
+        # Detect phantom positions: the Hyperliquid API reports zero equity
+        # but the state still tracks positive deposited USDC.
+        #
+        # This happens when a Hypercore vault withdrawal completed on
+        # Hyperliquid but the executor failed to confirm it (e.g. timeout
+        # or restart during the 3-phase settlement in _settle_withdrawal).
+        # The repair command zeroes out the unconfirmed trade, leaving a
+        # phantom position with quantity > 0 but no on-chain equity.
+        #
+        # It can also happen when a vault's trading losses wipe out the
+        # follower's deposit entirely — the userVaultEquities API omits
+        # zero-equity vaults, so the value function returns Decimal(0).
+        #
+        # We cannot distinguish these two cases here. The safe approach is
+        # to close the position as a zero-proceeds loss. If USDC actually
+        # returned to the Safe (untracked withdrawal), the generic reserve
+        # balance correction later in correct-accounts will detect the
+        # surplus and credit reserves.
+        #
+        # This check must run before the diff==0 early return below,
+        # because a previous valuator tick may have already set
+        # last_token_price=0.0, making old_value=0 and diff=0.
+        if float(current_equity) == 0 and float(quantity) > 0:
+            logger.warning(
+                "Vault position %d (%s %s): Hyperliquid API reports zero equity "
+                "but state has %s USDC deposited. "
+                "Closing as zero-proceeds loss (phantom position). "
+                "If USDC was returned to the Safe, the reserve correction will credit it.",
+                position.position_id,
+                vault_name,
+                vault_addr,
+                quantity,
+            )
+
+            valued_at = native_datetime_utc_now()
+            reserve_asset = state.portfolio.get_default_reserve_position().asset
+            _position_ref, correction_trade, _created = state.portfolio.create_trade(
+                strategy_cycle_at=valued_at,
+                pair=position.pair,
+                quantity=-quantity,
+                reserve=None,
+                assumed_price=1.0,
+                trade_type=TradeType.repair,
+                reserve_currency=reserve_asset,
+                reserve_currency_price=1.0,
+                position=position,
+                notes=(
+                    f"correct-accounts: closing phantom Hypercore vault position. "
+                    f"Hyperliquid API reports zero equity but state has {quantity} USDC deposited. "
+                    f"This is either an untracked withdrawal or a total vault trading loss. "
+                    f"Any returned USDC will be reconciled by the reserve balance correction."
+                ),
+            )
+            # Use trade.mark_success() directly (not state.mark_trade_success())
+            # to bypass return_capital_to_reserves(). We don't know whether USDC
+            # actually returned to the Safe; the generic reserve correction
+            # handles that separately based on actual on-chain balances.
+            correction_trade.mark_success(
+                executed_at=valued_at,
+                executed_price=0.0,
+                executed_quantity=-quantity,
+                executed_reserve=Decimal(0),
+                lp_fees=0,
+                native_token_price=0.0,
+                force=True,
+            )
+            state.portfolio.close_position(position, valued_at)
+
+            logger.info(
+                "Closed phantom vault position %d with repair trade %d",
+                position.position_id,
+                correction_trade.trade_id,
+            )
+            continue
 
         if diff == 0:
             logger.debug(
@@ -138,8 +216,6 @@ def _sync_hypercore_vault_positions(
             )
             continue
 
-        vault_name = position.pair.get_vault_name() or "unknown"
-        vault_addr = position.pair.pool_address or "?"
         logger.info(
             "Vault position %d (%s %s): marking equity %.2f -> %.2f (diff=%.2f)",
             position.position_id,
@@ -637,11 +713,16 @@ def correct_accounts(
 
     block_timestamp = get_block_timestamp(web3, block_number)
 
-    # Skip on-chain corrections when all positions are exchange account positions
-    # (their balances are synced via exchange API, not on-chain balance checks)
-    has_onchain_positions = any(
-        not p.pair.is_exchange_account()
-        for p in state.portfolio.get_open_and_frozen_positions()
+    # Skip on-chain corrections only when there are no on-chain positions
+    # AND no reserve assets to check. Reserve balance checks must always run
+    # because the Safe may hold USDC from untracked vault withdrawals or
+    # other out-of-band transfers that need to be reconciled.
+    has_onchain_positions = (
+        any(
+            not p.pair.is_exchange_account()
+            for p in state.portfolio.get_open_and_frozen_positions()
+        )
+        or len(universe.reserve_assets) > 0
     )
 
     if not has_onchain_positions:

--- a/tradeexecutor/ethereum/vault/hypercore_routing.py
+++ b/tradeexecutor/ethereum/vault/hypercore_routing.py
@@ -2119,6 +2119,28 @@ class HypercoreVaultRouting(RoutingModel):
 
         In simulate mode, the balance verification is skipped because
         the mock CoreWriter does not actually bridge USDC.
+
+        **Known failure mode — untracked withdrawals:**
+
+        If the executor fails to complete this 3-phase settlement (e.g.
+        timeout, restart, or network error between phases), the withdrawal
+        may have already completed on Hyperliquid (the ``vaultTransfer``
+        in phase 1 is irreversible once confirmed on HyperEVM) but this
+        method never reaches the ``mark_trade_success()`` call with the
+        actual amounts.  The trade ends up with ``executed_quantity=0``
+        and no ``blockchain_transactions``.
+
+        The ``repair`` command then creates a counter-trade (also with
+        ``executed_quantity=0``), effectively nullifying the planned trade
+        without realising the withdrawal actually went through on
+        Hyperliquid.  This leaves a "phantom position" in the state:
+        positive quantity in the executor but zero equity on-chain.
+
+        ``correct-accounts`` detects this mismatch (Hyperliquid API
+        reports zero equity for a position with positive state quantity)
+        and creates a zero-proceeds repair sell trade to close the
+        phantom position.  Any USDC that returned to the Safe is
+        reconciled separately by the generic reserve balance correction.
         """
         # Capture baseline USDC balance before processing receipt.
         # The withdrawal multicall has already been mined but spotSend's

--- a/tradeexecutor/ethereum/vault/hypercore_valuation.py
+++ b/tradeexecutor/ethereum/vault/hypercore_valuation.py
@@ -548,6 +548,12 @@ class HypercoreVaultValuator(ValuationModel):
     - **quantity** = cumulative USDC deposited minus withdrawn
     - **price** = equity / quantity (return multiplier per deposited USDC)
 
+    The underlying ``userVaultEquities`` API endpoint only returns vaults
+    where the user has positive equity. When a vault's trading losses wipe
+    out a follower's deposit entirely, the endpoint omits that vault and
+    the value function returns ``Decimal(0)``, producing ``price = 0.0``.
+    This is a legitimate state, not a data error.
+
     :param simulate:
         When ``True``, skip the Hyperliquid API and use 1.0 USDC per unit.
         Used in Anvil fork mode where the API has no data for the forked Safe.
@@ -624,6 +630,26 @@ class HypercoreVaultValuator(ValuationModel):
         # Position quantity tracks cumulative USDC deposited/withdrawn;
         # the price reflects the return on each deposited USDC.
         quantity = position.get_quantity()
+
+        # The userVaultEquities endpoint omits vaults where the follower's
+        # equity has been drawn down to zero.  This can happen from:
+        # 1. Trading losses wiping out the deposit entirely.
+        # 2. An untracked withdrawal: the executor failed to confirm a
+        #    3-phase withdrawal (see _settle_withdrawal known failure mode),
+        #    the repair command zeroed out the trade, but the withdrawal
+        #    actually completed on Hyperliquid.
+        # In both cases equity=0 and price=0 is correct here.
+        # correct-accounts handles closing the phantom position.
+        if float(equity) == 0 and float(quantity) > 0:
+            logger.warning(
+                "Hyperliquid API returned zero equity for position %s "
+                "which has quantity %s deposited. "
+                "The position will be valued at $0. "
+                "This may be an untracked withdrawal or a total vault trading loss. "
+                "Run correct-accounts to close the phantom position.",
+                position, quantity,
+            )
+
         if float(quantity) > 0:
             new_price = float(equity) / float(quantity)
         else:

--- a/tradeexecutor/ethereum/vault/hypercore_vault.py
+++ b/tradeexecutor/ethereum/vault/hypercore_vault.py
@@ -255,11 +255,19 @@ def create_hypercore_vault_value_func(
     def get_hypercore_vault_value(pair: TradingPairIdentifier) -> Decimal:
         """Get Hypercore vault equity for the given pair.
 
+        Uses the Hyperliquid ``userVaultEquities`` info endpoint under the hood.
+        This endpoint only returns vaults where the user has **positive equity**;
+        vaults where the user's equity has been drawn down to zero (e.g. from
+        trading losses distributed to followers) are omitted from the response
+        entirely, causing :py:func:`~eth_defi.hyperliquid.api.fetch_user_vault_equity`
+        to return ``None``.
+
         :param pair:
             Vault trading pair with Hypercore metadata in other_data.
 
         :return:
-            Vault equity in USD, or ``Decimal(0)`` if no deposit found.
+            Vault equity in USD, or ``Decimal(0)`` if the user has no position
+            or zero equity in the vault (the API omits zero-equity entries).
         """
         assert pair.is_hyperliquid_vault(), f"Not a Hypercore vault pair: {pair}"
 
@@ -289,8 +297,17 @@ def create_hypercore_vault_value_func(
                 )
                 return eq.equity
 
+            # userVaultEquities omits vaults where the user's equity is zero,
+            # so None means either:
+            # 1. The deposit was fully lost to vault trading losses.
+            # 2. An untracked withdrawal zeroed the on-chain equity (the
+            #    executor failed to confirm a 3-phase withdrawal, repair
+            #    zeroed the trade, but the withdrawal completed on HL).
+            # 3. The user never deposited into this vault.
+            # Return 0 so the valuator prices the position at $0.
             logger.debug(
-                "No Hypercore vault position found for %s in vault %s",
+                "No Hypercore vault position found for %s in vault %s "
+                "(user equity is zero or no deposit exists)",
                 safe_address, vault_address,
             )
             return Decimal(0)

--- a/tradeexecutor/state/position.py
+++ b/tradeexecutor/state/position.py
@@ -1983,12 +1983,16 @@ class TradingPosition(GenericPosition):
                 quantity_left_sell = self.get_quantity()
                 if quantity_left_sell:
 
-                    if not valuation_price:
+                    if valuation_price is None:
                         valuation_price = self.last_token_price
 
-                    # Marked down positions need to have special handling
+                    # Marked down positions need to have special handling.
+                    # Use `is not None` instead of truthiness: a valuation price
+                    # of 0.0 is valid (position lost all value, e.g. a Hypercore
+                    # vault where the deposit was wiped out by trading losses or
+                    # an untracked withdrawal zeroed the on-chain equity).
                     if not self.is_marked_down():
-                        assert valuation_price, f"Cannot value unrealised PnL without an explicit valuation price for the unsold portion.\n" \
+                        assert valuation_price is not None, f"Cannot value unrealised PnL without an explicit valuation price for the unsold portion.\n" \
                                                 f"Position was: {self}, quantity left: {quantity_left_sell}, valuation price: {valuation_price}"
                     unrealised_equity = valuation_price * float(quantity_left_sell)
 


### PR DESCRIPTION
## Why

The Hyper AI strategy crashed on startup with `AssertionError: Cannot value unrealised PnL without an explicit valuation price` for position #15 (YEELON vault). Root cause: two Hypercore vault withdrawals ($207.94 and $96.22) completed on Hyperliquid but the executor failed to confirm them during the 3-phase settlement. The repair command zeroed out the unconfirmed trades, leaving a phantom position with quantity=304 USDC but zero on-chain equity. The valuator then set `last_token_price=0.0`, and the `assert valuation_price` check crashed because `0.0` is falsy in Python.

## Lessons learnt

- The Hyperliquid `userVaultEquities` API omits vaults where the user's equity is zero — it returns `None`, not an entry with `equity=0`. This means both "total trading loss" and "untracked withdrawal" look identical from the API's perspective.
- Hypercore vault withdrawals are a 3-phase process (`vaultTransfer` → `transferUsdClass` → `sendAsset`). If the executor fails mid-settlement, the withdrawal completes on Hyperliquid but the state records `executed_quantity=0`. The repair command then nullifies the trade without realising money actually moved.
- When closing a phantom position, we cannot distinguish "untracked withdrawal" from "total trading loss", so the safe approach is a zero-proceeds close with USDC reconciliation deferred to the generic reserve balance correction.
- The `correct-accounts` reserve correction must always run when reserve assets exist, even when no open positions remain — closing a phantom position can remove the last open position, skipping the reserve check that would credit the returned USDC.

## Summary

- **`position.py`**: Fix `assert valuation_price` to use `is not None` instead of truthiness — `0.0` is a valid price for worthless positions.
- **`correct_accounts.py`**: Add phantom position detection in `_sync_hypercore_vault_positions()`: when HL API reports zero equity but state has positive quantity, create a zero-proceeds repair sell trade and close the position. Also fix the reserve correction skip condition to always run when reserve assets exist.
- **`hypercore_valuation.py`**: Document `userVaultEquities` API behaviour in class docstring. Add WARNING log when equity=0 with positive quantity, with guidance to run `correct-accounts`.
- **`hypercore_vault.py`**: Document that `userVaultEquities` omits zero-equity entries and what `None` return means (trading loss or untracked withdrawal).
- **`hypercore_routing.py`**: Document the known failure mode in `_settle_withdrawal` — how unconfirmed 3-phase withdrawals create phantom positions.
- **Tests**: 3 new deterministic unit tests + 1 integration test using the production `hyper-ai-5.json` state file.
