### PR TITLE
Fix Ostium vault feature metadata normalisation

### DIFF
--- a/tests/cli/test_trade_ui_deposit_status.py
+++ b/tests/cli/test_trade_ui_deposit_status.py
@@ -8,6 +8,8 @@ consulted the live pricing model.
 
 import datetime
 
+from eth_defi.erc_4626.core import ERC4626Feature
+
 from tradeexecutor.cli.trade_ui_tui import (
     _format_deposits_open,
     _get_deposit_status,
@@ -26,6 +28,8 @@ def _make_erc4626_vault_pair(
     vault_name: str = "Test USDC Vault",
     protocol_slug: str = "lagoon-finance",
     deposit_closed_reason: str | None = None,
+    vault_features: list[str] | None = None,
+    token_metadata: dict | None = None,
     internal_id: int = 1,
 ) -> TradingPairIdentifier:
     """Create a vault pair resembling xchain-master-vault ERC-4626 vaults."""
@@ -55,6 +59,8 @@ def _make_erc4626_vault_pair(
             "vault_protocol": "erc4626",
             "vault_name": vault_name,
             "deposit_closed_reason": deposit_closed_reason,
+            "vault_features": vault_features,
+            "token_metadata": token_metadata,
         },
     )
 
@@ -90,3 +96,38 @@ def test_tui_erc4626_deposit_status_respects_closed_reason() -> None:
     assert closed_status is False
     assert _format_deposits_open(open_vault, open_status).plain == "Yes"
     assert _format_deposits_open(closed_vault, closed_status).plain == "No"
+
+
+def test_tui_erc4626_vault_features_are_normalised_from_remote_metadata() -> None:
+    """ERC-4626 vault feature strings resolve to enum values needed by routing.
+
+    This covers the production metadata shape from the xchain-master-vault
+    trade-ui failure. The older Ostium async integration tests used a live
+    autodetected vault instance, so they carried ``ERC4626Feature`` enum
+    objects directly and did not exercise JSON-style remote metadata.
+
+    1. Create an Ostium vault pair whose top-level vault_features are strings.
+    2. Create another Ostium vault pair whose features only exist in token_metadata.
+    3. Verify both pairs expose enum features for vault routing.
+    """
+    # 1. Create an Ostium vault pair whose top-level vault_features are strings.
+    top_level_features = _make_erc4626_vault_pair(
+        chain_id=42161,
+        vault_address="0x20d419a8e12c45f88fda7c5760bb6923cee27f98",
+        vault_name="Ostium Liquidity Pool Vault",
+        protocol_slug="ostium",
+        vault_features=["ostium_like"],
+    )
+
+    # 2. Create another Ostium vault pair whose features only exist in token_metadata.
+    nested_features = _make_erc4626_vault_pair(
+        chain_id=42161,
+        vault_address="0x20d419a8e12c45f88fda7c5760bb6923cee27f98",
+        vault_name="Ostium Liquidity Pool Vault",
+        protocol_slug="ostium",
+        token_metadata={"features": ["ostium_like"]},
+    )
+
+    # 3. Verify both pairs expose enum features for vault routing.
+    assert top_level_features.get_vault_features() == {ERC4626Feature.ostium_like}
+    assert nested_features.get_vault_features() == {ERC4626Feature.ostium_like}

--- a/tradeexecutor/state/identifier.py
+++ b/tradeexecutor/state/identifier.py
@@ -52,6 +52,19 @@ class AssetType(enum.Enum):
     borrowed = "borrowed"
 
 
+def _normalise_erc_4626_features(features) -> set[ERC4626Feature] | None:
+    """Normalise persisted vault feature metadata to enum values."""
+    if not features:
+        return None
+
+    if isinstance(features, (str, ERC4626Feature)):
+        features = [features]
+
+    return {
+        feature if isinstance(feature, ERC4626Feature) else ERC4626Feature(feature)
+        for feature in features
+    }
+
 
 @dataclass_json
 @dataclass
@@ -879,9 +892,14 @@ class TradingPairIdentifier:
         Needed for ERC-4626 compatibility.
         """
         feats = self.other_data.get("vault_features")
-        if feats:
-            return set(feats)
-        return None
+        if not feats:
+            metadata = self.other_data.get("token_metadata")
+            if isinstance(metadata, dict):
+                feats = metadata.get("features")
+            else:
+                feats = getattr(metadata, "features", None)
+
+        return _normalise_erc_4626_features(feats)
 
     def get_vault_protocol(self) -> str | None:
         """Get the vault protocol name.
@@ -1470,4 +1488,3 @@ class AssetWithTrackedValue:
         self.quantity = quantity
         self.interest_rate_at_open = None
         self.last_interest_rate = None
-


### PR DESCRIPTION
## Why

trade-ui could route the xchain-master-vault Ostium deposit through the generic ERC-4626 `deposit()` path when vault feature metadata arrived from the remote universe as JSON-style strings or nested metadata.

Ostium V1.5 disables synchronous ERC-4626 deposits, so this caused the live `deposit()` transaction to revert with `FunctionDisabled()` instead of using the async `requestDeposit()` flow.

## Lessons learnt

The existing Ostium async tests used live autodetected vault instances, which already carry `ERC4626Feature` enum values. They did not cover the remote metadata shape used by trade-ui and xchain-master-vault, where feature values may be persisted as strings or nested under `token_metadata.features`.

## Summary

Normalise persisted ERC-4626 vault feature metadata back to `ERC4626Feature` enum values before routing uses it.

Expand the existing trade-ui deposit status tests to cover Ostium metadata from both top-level `vault_features` strings and nested `token_metadata.features`.
