### PR TITLE
feat: Add vault share balance to check-wallet and fix lagoon-redeem unclaimed shares

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 
 - Breaking API changes
 
+- Add vault share balance and total supply to `check-wallet` command output; fix `lagoon-redeem` to claim unclaimed redemptions before starting and poll `maxRedeem` to avoid stale-read failures (2026-06-09)
+
 - Fix phantom Hypercore vault positions from untracked withdrawals: detect and close positions where the Hyperliquid API reports zero equity but state has positive deposited USDC (2026-06-08)
 
 - Fix CCTP bridge USDC decimals: resolve token decimals from pair universe instead of trusting `reserve_asset.decimals` which could be wrong (18 instead of 6) in ERC-4626 vault pair universes (2026-06-03)

--- a/tests/cli/test_check_wallet_hyper_ai.py
+++ b/tests/cli/test_check_wallet_hyper_ai.py
@@ -61,14 +61,39 @@ def test_cli_check_wallet_logs_hot_wallet_and_vault_reserve_balances(
     1. Patch the CLI dependencies so `check-wallet` runs against `hyper-ai-test.py` with a fake Lagoon sync model.
     2. Run the CLI command and capture its log output.
     3. Confirm the reserve token balance is logged separately for the hot wallet and the vault.
+    4. Confirm share token balance and total supply are logged for the default chain.
     """
     from tradeexecutor.cli.commands import check_wallet as check_wallet_module
+
+    SHARE_TOKEN_ADDRESS = "0x3333333333333333333333333333333333333333"
+    SHARE_TOKEN_SYMBOL = "lagVault"
+    SHARE_BALANCE = 42
+    SHARE_TOTAL_SUPPLY = 1000
+
+    class FakeShareToken:
+        def __init__(self):
+            self.address = SHARE_TOKEN_ADDRESS
+            self.symbol = SHARE_TOKEN_SYMBOL
+            self.contract = SimpleNamespace(
+                functions=SimpleNamespace(
+                    totalSupply=lambda: SimpleNamespace(call=lambda: SHARE_TOTAL_SUPPLY),
+                ),
+            )
+
+        def fetch_balance_of(self, address: str) -> int:
+            if address == HOT_WALLET_ADDRESS:
+                return SHARE_BALANCE
+            return 0
+
+        def convert_to_decimals(self, balance: int) -> int:
+            return balance
 
     class FakeLagoonVaultSyncModel:
         def __init__(self, hot_wallet_address: str, safe_address: str, vault_address: str):
             self._hot_wallet_address = hot_wallet_address
             self._safe_address = safe_address
             self.vault_address = vault_address
+            self.vault = SimpleNamespace(share_token=FakeShareToken())
 
         def get_hot_wallet(self):
             return SimpleNamespace(address=self._hot_wallet_address)
@@ -259,3 +284,8 @@ def test_cli_check_wallet_logs_hot_wallet_and_vault_reserve_balances(
     assert any("Vault reserve balance of USD Coin" in message for message in messages)
     assert any(f"Vault reserve balance of USD Coin ({USDC_ADDRESS})" in message for message in messages)
     assert any(f"Safe reserve balance of USD Coin ({BASE_USDC_ADDRESS.lower()})" in message for message in messages)
+
+    # 4. Confirm share token balance and total supply are logged for the default chain.
+    assert any(f"Share token: {SHARE_TOKEN_SYMBOL} ({SHARE_TOKEN_ADDRESS})" in message for message in messages)
+    assert any(f"Asset manager share balance: {SHARE_BALANCE} {SHARE_TOKEN_SYMBOL}" in message for message in messages)
+    assert any(f"Total share supply: {SHARE_TOTAL_SUPPLY} {SHARE_TOKEN_SYMBOL}" in message for message in messages)

--- a/tests/cli/test_lagoon_redeem.py
+++ b/tests/cli/test_lagoon_redeem.py
@@ -1,175 +1,78 @@
-"""CLI coverage for lagoon-redeem pre-flight and Phase 3 polling."""
+"""CLI coverage for lagoon-redeem pre-flight redemption claiming."""
 
 from decimal import Decimal
 from unittest.mock import MagicMock, patch
 
 import pytest
 
-from tradeexecutor.cli.commands.lagoon_redeem import (
-    _claim_leftover_redemptions,
-    _poll_and_finalise_redeem,
-)
+from tradeexecutor.cli.commands.lagoon_redeem import _claim_leftover_redemptions
 
 
 @pytest.mark.timeout(30)
-def test_preflight_claims_settled_unclaimed_redemption() -> None:
-    """Pre-flight state A: settled but unclaimed redemption is claimed via finalise_redeem.
+def test_claim_leftover_redemptions() -> None:
+    """Pre-flight handles both settled-unclaimed and pending-unsettled leftover redemptions.
 
-    1. Set up maxRedeem() > 0 and pendingRedeemRequest() == 0.
-    2. Call _claim_leftover_redemptions.
-    3. Verify finalise_redeem was called with the observed raw_amount.
-    4. Verify no settlement transactions were broadcast (state A skips settle).
+    1. Call with maxRedeem() > 0 (state A): verify finalise_redeem with explicit raw_amount, no settlement.
+    2. Call with maxRedeem() == 0 and pendingRedeemRequest() > 0 (state B): verify settle + poll + finalise.
+    3. Call with both == 0: verify no transactions broadcast.
     """
-    raw_amount = 500_000_000
+    tx_hash = b"\x00" * 32
 
-    vault = MagicMock()
-    vault.vault_contract.functions.maxRedeem.return_value.call.return_value = raw_amount
+    def make_mocks():
+        vault = MagicMock()
+        vault.finalise_redeem.return_value = "mock_finalise"
+        vault.post_new_valuation.return_value = "mock_post_val"
+        vault.settle_via_trading_strategy_module.return_value = "mock_settle"
+        vault.fetch_nav.return_value = Decimal("10000")
+        hot_wallet = MagicMock()
+        hot_wallet.address = "0xABCD"
+        hot_wallet.transact_and_broadcast_with_contract.return_value = tx_hash
+        web3 = MagicMock()
+        share_token = MagicMock()
+        share_token.symbol = "lagVault"
+        share_token.convert_to_decimals.return_value = Decimal("500")
+        return vault, hot_wallet, web3, share_token
+
+    # 1. State A: settled but unclaimed — finalise immediately, no settlement
+    vault, hot_wallet, web3, share_token = make_mocks()
+    settled_raw = 500_000_000
+    vault.vault_contract.functions.maxRedeem.return_value.call.return_value = settled_raw
     vault.vault_contract.functions.pendingRedeemRequest.return_value.call.return_value = 0
-    vault.finalise_redeem.return_value = "mock_finalise"
 
-    hot_wallet = MagicMock()
-    hot_wallet.address = "0xABCD"
-    hot_wallet.transact_and_broadcast_with_contract.return_value = b"\x00" * 32
-
-    web3 = MagicMock()
-
-    share_token = MagicMock()
-    share_token.symbol = "lagVault"
-    share_token.convert_to_decimals.return_value = Decimal("500")
-
-    # 2. Call _claim_leftover_redemptions
-    with patch(
-        "tradeexecutor.cli.commands.lagoon_redeem.assert_transaction_success_with_explanation"
-    ):
+    with patch("tradeexecutor.cli.commands.lagoon_redeem.assert_transaction_success_with_explanation"):
         _claim_leftover_redemptions(vault, hot_wallet, web3, share_token)
 
-    # 3. Verify finalise_redeem was called with the observed raw_amount
-    vault.finalise_redeem.assert_called_once_with("0xABCD", raw_amount=raw_amount)
-
-    # 4. No settlement transactions (post_new_valuation, settle_via_trading_strategy_module)
+    vault.finalise_redeem.assert_called_once_with("0xABCD", raw_amount=settled_raw)
     vault.post_new_valuation.assert_not_called()
     vault.settle_via_trading_strategy_module.assert_not_called()
 
-
-@pytest.mark.timeout(30)
-def test_preflight_settles_and_claims_pending_unsettled_redemption() -> None:
-    """Pre-flight state B: pending unsettled redemption is settled, polled, and claimed.
-
-    1. Set up maxRedeem() == 0 initially (nothing settled yet) and pendingRedeemRequest() > 0.
-    2. After settlement, maxRedeem() returns > 0 on second poll.
-    3. Call _claim_leftover_redemptions.
-    4. Verify post_new_valuation and settle_via_trading_strategy_module were called.
-    5. Verify finalise_redeem was called with the polled raw_amount.
-    """
+    # 2. State B: pending unsettled — settle, poll maxRedeem (0 then >0), finalise
+    vault, hot_wallet, web3, share_token = make_mocks()
     pending_raw = 750_000_000
-    settled_raw = 750_000_000
-
-    vault = MagicMock()
-    # State A check: nothing settled yet
-    # State B check: pending redemption exists
-    # Then _poll_and_finalise_redeem polls maxRedeem: 0 first, then settled_raw
     vault.vault_contract.functions.maxRedeem.return_value.call.side_effect = [
-        0,  # state A check
-        0,  # first poll attempt inside _poll_and_finalise_redeem
-        settled_raw,  # second poll attempt
+        0,            # state A check — nothing settled
+        0,            # first poll attempt (stale RPC)
+        pending_raw,  # second poll attempt
     ]
     vault.vault_contract.functions.pendingRedeemRequest.return_value.call.return_value = pending_raw
-    vault.finalise_redeem.return_value = "mock_finalise"
-    vault.post_new_valuation.return_value = "mock_post_val"
-    vault.settle_via_trading_strategy_module.return_value = "mock_settle"
-    vault.fetch_nav.return_value = Decimal("10000")
 
-    hot_wallet = MagicMock()
-    hot_wallet.address = "0xABCD"
-    hot_wallet.transact_and_broadcast_with_contract.return_value = b"\x00" * 32
-
-    web3 = MagicMock()
-
-    share_token = MagicMock()
-    share_token.symbol = "lagVault"
-    share_token.convert_to_decimals.return_value = Decimal("750")
-
-    # 3. Call _claim_leftover_redemptions
     with (
         patch("tradeexecutor.cli.commands.lagoon_redeem.assert_transaction_success_with_explanation"),
-        patch("tradeexecutor.cli.commands.lagoon_redeem.time.sleep"),
+        patch("tradeexecutor.cli.commands.lagoon_redeem.time.sleep") as mock_sleep,
     ):
         _claim_leftover_redemptions(vault, hot_wallet, web3, share_token)
+        mock_sleep.assert_called_once_with(5)
 
-    # 4. Verify settlement was performed
     vault.post_new_valuation.assert_called_once()
     vault.settle_via_trading_strategy_module.assert_called_once()
+    vault.finalise_redeem.assert_called_once_with("0xABCD", raw_amount=pending_raw)
 
-    # 5. Verify finalise_redeem was called with the polled raw_amount
-    vault.finalise_redeem.assert_called_once_with("0xABCD", raw_amount=settled_raw)
-
-
-@pytest.mark.timeout(30)
-def test_preflight_skips_when_no_leftover_redemptions() -> None:
-    """Pre-flight does nothing when maxRedeem and pendingRedeemRequest are both 0.
-
-    1. Set up maxRedeem() == 0 and pendingRedeemRequest() == 0.
-    2. Call _claim_leftover_redemptions.
-    3. Verify no transactions were broadcast.
-    """
-    vault = MagicMock()
+    # 3. No-op: both 0 — no transactions
+    vault, hot_wallet, web3, share_token = make_mocks()
     vault.vault_contract.functions.maxRedeem.return_value.call.return_value = 0
     vault.vault_contract.functions.pendingRedeemRequest.return_value.call.return_value = 0
 
-    hot_wallet = MagicMock()
-    hot_wallet.address = "0xABCD"
-
-    web3 = MagicMock()
-    share_token = MagicMock()
-
-    # 2. Call _claim_leftover_redemptions
     _claim_leftover_redemptions(vault, hot_wallet, web3, share_token)
 
-    # 3. No transactions broadcast
     vault.finalise_redeem.assert_not_called()
-    vault.post_new_valuation.assert_not_called()
-    vault.settle_via_trading_strategy_module.assert_not_called()
     hot_wallet.transact_and_broadcast_with_contract.assert_not_called()
-
-
-@pytest.mark.timeout(30)
-def test_poll_and_finalise_redeem_retries_on_stale_rpc() -> None:
-    """_poll_and_finalise_redeem polls maxRedeem when the first call returns 0 (stale RPC).
-
-    1. Set up maxRedeem() to return 0 on the first call, then > 0 on the second.
-    2. Patch time.sleep to a no-op.
-    3. Call _poll_and_finalise_redeem.
-    4. Verify maxRedeem was called twice and finalise_redeem used the polled raw_amount.
-    """
-    raw_amount = 1_000_000_000
-
-    vault = MagicMock()
-    vault.vault_contract.functions.maxRedeem.return_value.call.side_effect = [0, raw_amount]
-    vault.finalise_redeem.return_value = "mock_bound_func"
-
-    hot_wallet = MagicMock()
-    hot_wallet.address = "0xABCD"
-    hot_wallet.transact_and_broadcast_with_contract.return_value = b"\x00" * 32
-
-    web3 = MagicMock()
-
-    share_token = MagicMock()
-    share_token.symbol = "lagVault"
-    share_token.convert_to_decimals.return_value = Decimal("1000")
-
-    # 2. Patch time.sleep to a no-op
-    # 3. Call _poll_and_finalise_redeem
-    with (
-        patch("tradeexecutor.cli.commands.lagoon_redeem.time.sleep") as mock_sleep,
-        patch("tradeexecutor.cli.commands.lagoon_redeem.assert_transaction_success_with_explanation"),
-    ):
-        _poll_and_finalise_redeem(vault, hot_wallet, web3, share_token)
-        mock_sleep.assert_called_once_with(5)
-
-    # 4. Verify maxRedeem was called twice (first returned 0, second returned raw_amount)
-    assert vault.vault_contract.functions.maxRedeem.return_value.call.call_count == 2
-
-    # Verify finalise_redeem used the polled raw_amount
-    vault.finalise_redeem.assert_called_once_with(
-        "0xABCD", raw_amount=raw_amount
-    )

--- a/tests/cli/test_lagoon_redeem.py
+++ b/tests/cli/test_lagoon_redeem.py
@@ -1,0 +1,92 @@
+"""CLI coverage for lagoon-redeem pre-flight and Phase 3 polling."""
+
+from decimal import Decimal
+from types import SimpleNamespace
+from unittest.mock import MagicMock, call, patch
+
+import pytest
+
+from tradeexecutor.cli.commands.lagoon_redeem import _poll_and_finalise_redeem
+
+
+@pytest.mark.timeout(30)
+def test_preflight_claims_settled_unclaimed_redemption_then_errors_on_zero_shares() -> None:
+    """Pre-flight detects a settled but unclaimed redemption, claims it, then errors because no shares remain.
+
+    1. Set up a mock vault where maxRedeem() returns > 0 (settled but unclaimed).
+    2. Set up share_token.fetch_balance_of() to return 0 after claiming.
+    3. Call _poll_and_finalise_redeem to claim.
+    4. Verify finalise_redeem was called with the observed raw_amount.
+    """
+    raw_amount = 500_000_000
+
+    vault = MagicMock()
+    vault.vault_contract.functions.maxRedeem.return_value.call.return_value = raw_amount
+    vault.finalise_redeem.return_value = "mock_bound_func"
+
+    hot_wallet = MagicMock()
+    hot_wallet.address = "0xABCD"
+    hot_wallet.transact_and_broadcast_with_contract.return_value = b"\x00" * 32
+
+    web3 = MagicMock()
+
+    share_token = MagicMock()
+    share_token.symbol = "lagVault"
+    share_token.convert_to_decimals.return_value = Decimal("500")
+
+    # 3. Call _poll_and_finalise_redeem — maxRedeem immediately returns > 0
+    with patch(
+        "tradeexecutor.cli.commands.lagoon_redeem.assert_transaction_success_with_explanation"
+    ):
+        _poll_and_finalise_redeem(vault, hot_wallet, web3, share_token)
+
+    # 4. Verify finalise_redeem was called with the observed raw_amount
+    vault.finalise_redeem.assert_called_once_with(
+        "0xABCD", raw_amount=raw_amount
+    )
+    hot_wallet.transact_and_broadcast_with_contract.assert_called_once_with(
+        "mock_bound_func", gas_limit=1_000_000
+    )
+
+
+@pytest.mark.timeout(30)
+def test_phase3_polls_max_redeem_before_finalising() -> None:
+    """Normal Phase 3 polls maxRedeem when the first call returns 0 (stale RPC).
+
+    1. Set up maxRedeem() to return 0 on the first call, then > 0 on the second.
+    2. Patch time.sleep to a no-op.
+    3. Call _poll_and_finalise_redeem.
+    4. Verify maxRedeem was called twice and finalise_redeem used the polled raw_amount.
+    """
+    raw_amount = 1_000_000_000
+
+    vault = MagicMock()
+    vault.vault_contract.functions.maxRedeem.return_value.call.side_effect = [0, raw_amount]
+    vault.finalise_redeem.return_value = "mock_bound_func"
+
+    hot_wallet = MagicMock()
+    hot_wallet.address = "0xABCD"
+    hot_wallet.transact_and_broadcast_with_contract.return_value = b"\x00" * 32
+
+    web3 = MagicMock()
+
+    share_token = MagicMock()
+    share_token.symbol = "lagVault"
+    share_token.convert_to_decimals.return_value = Decimal("1000")
+
+    # 2. Patch time.sleep to a no-op
+    # 3. Call _poll_and_finalise_redeem
+    with (
+        patch("tradeexecutor.cli.commands.lagoon_redeem.time.sleep") as mock_sleep,
+        patch("tradeexecutor.cli.commands.lagoon_redeem.assert_transaction_success_with_explanation"),
+    ):
+        _poll_and_finalise_redeem(vault, hot_wallet, web3, share_token)
+        mock_sleep.assert_called_once_with(5)
+
+    # 4. Verify maxRedeem was called twice (first returned 0, second returned raw_amount)
+    assert vault.vault_contract.functions.maxRedeem.return_value.call.call_count == 2
+
+    # Verify finalise_redeem used the polled raw_amount
+    vault.finalise_redeem.assert_called_once_with(
+        "0xABCD", raw_amount=raw_amount
+    )

--- a/tests/cli/test_lagoon_redeem.py
+++ b/tests/cli/test_lagoon_redeem.py
@@ -1,28 +1,31 @@
 """CLI coverage for lagoon-redeem pre-flight and Phase 3 polling."""
 
 from decimal import Decimal
-from types import SimpleNamespace
-from unittest.mock import MagicMock, call, patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 
-from tradeexecutor.cli.commands.lagoon_redeem import _poll_and_finalise_redeem
+from tradeexecutor.cli.commands.lagoon_redeem import (
+    _claim_leftover_redemptions,
+    _poll_and_finalise_redeem,
+)
 
 
 @pytest.mark.timeout(30)
-def test_preflight_claims_settled_unclaimed_redemption_then_errors_on_zero_shares() -> None:
-    """Pre-flight detects a settled but unclaimed redemption, claims it, then errors because no shares remain.
+def test_preflight_claims_settled_unclaimed_redemption() -> None:
+    """Pre-flight state A: settled but unclaimed redemption is claimed via finalise_redeem.
 
-    1. Set up a mock vault where maxRedeem() returns > 0 (settled but unclaimed).
-    2. Set up share_token.fetch_balance_of() to return 0 after claiming.
-    3. Call _poll_and_finalise_redeem to claim.
-    4. Verify finalise_redeem was called with the observed raw_amount.
+    1. Set up maxRedeem() > 0 and pendingRedeemRequest() == 0.
+    2. Call _claim_leftover_redemptions.
+    3. Verify finalise_redeem was called with the observed raw_amount.
+    4. Verify no settlement transactions were broadcast (state A skips settle).
     """
     raw_amount = 500_000_000
 
     vault = MagicMock()
     vault.vault_contract.functions.maxRedeem.return_value.call.return_value = raw_amount
-    vault.finalise_redeem.return_value = "mock_bound_func"
+    vault.vault_contract.functions.pendingRedeemRequest.return_value.call.return_value = 0
+    vault.finalise_redeem.return_value = "mock_finalise"
 
     hot_wallet = MagicMock()
     hot_wallet.address = "0xABCD"
@@ -34,24 +37,104 @@ def test_preflight_claims_settled_unclaimed_redemption_then_errors_on_zero_share
     share_token.symbol = "lagVault"
     share_token.convert_to_decimals.return_value = Decimal("500")
 
-    # 3. Call _poll_and_finalise_redeem — maxRedeem immediately returns > 0
+    # 2. Call _claim_leftover_redemptions
     with patch(
         "tradeexecutor.cli.commands.lagoon_redeem.assert_transaction_success_with_explanation"
     ):
-        _poll_and_finalise_redeem(vault, hot_wallet, web3, share_token)
+        _claim_leftover_redemptions(vault, hot_wallet, web3, share_token)
 
-    # 4. Verify finalise_redeem was called with the observed raw_amount
-    vault.finalise_redeem.assert_called_once_with(
-        "0xABCD", raw_amount=raw_amount
-    )
-    hot_wallet.transact_and_broadcast_with_contract.assert_called_once_with(
-        "mock_bound_func", gas_limit=1_000_000
-    )
+    # 3. Verify finalise_redeem was called with the observed raw_amount
+    vault.finalise_redeem.assert_called_once_with("0xABCD", raw_amount=raw_amount)
+
+    # 4. No settlement transactions (post_new_valuation, settle_via_trading_strategy_module)
+    vault.post_new_valuation.assert_not_called()
+    vault.settle_via_trading_strategy_module.assert_not_called()
 
 
 @pytest.mark.timeout(30)
-def test_phase3_polls_max_redeem_before_finalising() -> None:
-    """Normal Phase 3 polls maxRedeem when the first call returns 0 (stale RPC).
+def test_preflight_settles_and_claims_pending_unsettled_redemption() -> None:
+    """Pre-flight state B: pending unsettled redemption is settled, polled, and claimed.
+
+    1. Set up maxRedeem() == 0 initially (nothing settled yet) and pendingRedeemRequest() > 0.
+    2. After settlement, maxRedeem() returns > 0 on second poll.
+    3. Call _claim_leftover_redemptions.
+    4. Verify post_new_valuation and settle_via_trading_strategy_module were called.
+    5. Verify finalise_redeem was called with the polled raw_amount.
+    """
+    pending_raw = 750_000_000
+    settled_raw = 750_000_000
+
+    vault = MagicMock()
+    # State A check: nothing settled yet
+    # State B check: pending redemption exists
+    # Then _poll_and_finalise_redeem polls maxRedeem: 0 first, then settled_raw
+    vault.vault_contract.functions.maxRedeem.return_value.call.side_effect = [
+        0,  # state A check
+        0,  # first poll attempt inside _poll_and_finalise_redeem
+        settled_raw,  # second poll attempt
+    ]
+    vault.vault_contract.functions.pendingRedeemRequest.return_value.call.return_value = pending_raw
+    vault.finalise_redeem.return_value = "mock_finalise"
+    vault.post_new_valuation.return_value = "mock_post_val"
+    vault.settle_via_trading_strategy_module.return_value = "mock_settle"
+    vault.fetch_nav.return_value = Decimal("10000")
+
+    hot_wallet = MagicMock()
+    hot_wallet.address = "0xABCD"
+    hot_wallet.transact_and_broadcast_with_contract.return_value = b"\x00" * 32
+
+    web3 = MagicMock()
+
+    share_token = MagicMock()
+    share_token.symbol = "lagVault"
+    share_token.convert_to_decimals.return_value = Decimal("750")
+
+    # 3. Call _claim_leftover_redemptions
+    with (
+        patch("tradeexecutor.cli.commands.lagoon_redeem.assert_transaction_success_with_explanation"),
+        patch("tradeexecutor.cli.commands.lagoon_redeem.time.sleep"),
+    ):
+        _claim_leftover_redemptions(vault, hot_wallet, web3, share_token)
+
+    # 4. Verify settlement was performed
+    vault.post_new_valuation.assert_called_once()
+    vault.settle_via_trading_strategy_module.assert_called_once()
+
+    # 5. Verify finalise_redeem was called with the polled raw_amount
+    vault.finalise_redeem.assert_called_once_with("0xABCD", raw_amount=settled_raw)
+
+
+@pytest.mark.timeout(30)
+def test_preflight_skips_when_no_leftover_redemptions() -> None:
+    """Pre-flight does nothing when maxRedeem and pendingRedeemRequest are both 0.
+
+    1. Set up maxRedeem() == 0 and pendingRedeemRequest() == 0.
+    2. Call _claim_leftover_redemptions.
+    3. Verify no transactions were broadcast.
+    """
+    vault = MagicMock()
+    vault.vault_contract.functions.maxRedeem.return_value.call.return_value = 0
+    vault.vault_contract.functions.pendingRedeemRequest.return_value.call.return_value = 0
+
+    hot_wallet = MagicMock()
+    hot_wallet.address = "0xABCD"
+
+    web3 = MagicMock()
+    share_token = MagicMock()
+
+    # 2. Call _claim_leftover_redemptions
+    _claim_leftover_redemptions(vault, hot_wallet, web3, share_token)
+
+    # 3. No transactions broadcast
+    vault.finalise_redeem.assert_not_called()
+    vault.post_new_valuation.assert_not_called()
+    vault.settle_via_trading_strategy_module.assert_not_called()
+    hot_wallet.transact_and_broadcast_with_contract.assert_not_called()
+
+
+@pytest.mark.timeout(30)
+def test_poll_and_finalise_redeem_retries_on_stale_rpc() -> None:
+    """_poll_and_finalise_redeem polls maxRedeem when the first call returns 0 (stale RPC).
 
     1. Set up maxRedeem() to return 0 on the first call, then > 0 on the second.
     2. Patch time.sleep to a no-op.

--- a/tradeexecutor/cli/commands/check_wallet.py
+++ b/tradeexecutor/cli/commands/check_wallet.py
@@ -140,6 +140,39 @@ def _get_chain_reserve_address(sync_model, execution_model, chain_id: ChainId) -
     return sync_model.get_token_storage_address() or sync_model.get_hot_wallet().address
 
 
+def _log_vault_share_details(sync_model, hot_wallet_address: str) -> None:
+    """Log vault share token balance and total supply for the asset manager."""
+    vault = getattr(sync_model, "vault", None)
+    if vault is None:
+        return
+
+    # Enzyme uses shares_token (plural), Lagoon/Velvet use share_token (singular).
+    # Velvet exposes fetch_share_token() but not a cached share_token property,
+    # so fall back to calling it directly.
+    share_token = getattr(vault, "share_token", None) or getattr(vault, "shares_token", None)
+    if share_token is None:
+        fetch_fn = getattr(vault, "fetch_share_token", None)
+        if callable(fetch_fn):
+            share_token = fetch_fn()
+    if share_token is None:
+        return
+
+    share_balance = share_token.fetch_balance_of(hot_wallet_address)
+
+    # Total supply: Enzyme exposes get_total_supply() returning raw int,
+    # Lagoon/Velvet share_token is a standard ERC-20 so use contract.functions.totalSupply()
+    raw_total_supply_fn = getattr(vault, "get_total_supply", None)
+    if callable(raw_total_supply_fn):
+        total_supply = share_token.convert_to_decimals(raw_total_supply_fn())
+    else:
+        raw = share_token.contract.functions.totalSupply().call()
+        total_supply = share_token.convert_to_decimals(raw)
+
+    logger.info("  Share token: %s (%s)", share_token.symbol, share_token.address)
+    logger.info("  Asset manager share balance: %s %s", share_balance, share_token.symbol)
+    logger.info("  Total share supply: %s %s", total_supply, share_token.symbol)
+
+
 def _log_chain_custody_details(sync_model, execution_model, chain_id: ChainId) -> None:
     """Log vault and custody addresses for a chain."""
     satellite_vault = _get_lagoon_satellite_vault(execution_model, chain_id)
@@ -285,6 +318,8 @@ def check_wallet(
         wallet_check_chains = _collect_wallet_check_chains(universe, default_chain_id, wallet_check_pairs)
         assets_by_chain = _collect_wallet_check_assets_by_chain(universe, wallet_check_pairs)
 
+    default_wallet_check_chain_id = _normalise_wallet_check_chain_id(default_chain_id)
+
     for chain_id in wallet_check_chains:
         web3 = _get_chain_web3(web3config, chain_id)
         reserve_assets = assets_by_chain.get(chain_id, [])
@@ -309,6 +344,8 @@ def check_wallet(
         logger.info("  Hot wallet is %s", sync_model.get_hot_wallet().address)
         gas_balance = web3.eth.get_balance(hot_wallet.address) / 10**18
         _log_chain_custody_details(sync_model, execution_model, chain_id)
+        if chain_id == default_wallet_check_chain_id:
+            _log_vault_share_details(sync_model, hot_wallet.address)
 
         logger.info("  Hot wallet %s has %f native gas tokens", hot_wallet.address, gas_balance)
         logger.info("  The gas error limit is %f tokens", min_gas_balance)

--- a/tradeexecutor/cli/commands/lagoon_redeem.py
+++ b/tradeexecutor/cli/commands/lagoon_redeem.py
@@ -61,6 +61,59 @@ def _poll_and_finalise_redeem(vault, hot_wallet, web3, share_token, max_attempts
     assert_transaction_success_with_explanation(web3, tx_hash)
 
 
+def _claim_leftover_redemptions(vault, hot_wallet, web3, share_token):
+    """Claim any leftover redemptions from a previous interrupted run.
+
+    Handles two states:
+
+    - **State A** (settled but unclaimed): ``maxRedeem() > 0`` — finalise
+      immediately to claim denomination tokens.
+    - **State B** (pending unsettled): ``pendingRedeemRequest() > 0`` — post
+      valuation, settle, poll ``maxRedeem``, then finalise.
+    """
+    # State A: settled but unclaimed
+    max_redeemable_raw = vault.vault_contract.functions.maxRedeem(hot_wallet.address).call()
+    if max_redeemable_raw > 0:
+        redeemable_human = share_token.convert_to_decimals(max_redeemable_raw)
+        logger.info(
+            "Found %s %s settled but unclaimed shares from a previous redemption — claiming now",
+            redeemable_human, share_token.symbol,
+        )
+        hot_wallet.sync_nonce(web3)
+        tx_hash = hot_wallet.transact_and_broadcast_with_contract(
+            vault.finalise_redeem(hot_wallet.address, raw_amount=max_redeemable_raw),
+            gas_limit=1_000_000,
+        )
+        assert_transaction_success_with_explanation(web3, tx_hash)
+        logger.info("  Claimed previous redemption")
+
+    # State B: pending unsettled
+    pending_redeem_raw = vault.vault_contract.functions.pendingRedeemRequest(
+        0, hot_wallet.address
+    ).call()
+    if pending_redeem_raw > 0:
+        pending_human = share_token.convert_to_decimals(pending_redeem_raw)
+        logger.info(
+            "Found %s %s pending unsettled redemption — settling and claiming now",
+            pending_human, share_token.symbol,
+        )
+        nav = vault.fetch_nav()
+        hot_wallet.sync_nonce(web3)
+        tx_hash = hot_wallet.transact_and_broadcast_with_contract(
+            vault.post_new_valuation(nav), gas_limit=1_000_000,
+        )
+        assert_transaction_success_with_explanation(web3, tx_hash)
+
+        hot_wallet.sync_nonce(web3)
+        tx_hash = hot_wallet.transact_and_broadcast_with_contract(
+            vault.settle_via_trading_strategy_module(nav), gas_limit=1_000_000,
+        )
+        assert_transaction_success_with_explanation(web3, tx_hash)
+
+        _poll_and_finalise_redeem(vault, hot_wallet, web3, share_token)
+        logger.info("  Settled and claimed previous pending redemption")
+
+
 @app.command()
 @shared_options.with_json_rpc_options()
 def lagoon_redeem(
@@ -130,48 +183,7 @@ def lagoon_redeem(
     logger.info("  ETH balance: %.6f", eth_human)
     assert eth_human >= 0.001, f"Asset manager has {eth_human:.6f} ETH, need at least 0.001 for gas"
 
-    # Pre-flight: handle any leftover redemption from a previous run.
-    # State A: settled but unclaimed (maxRedeem > 0) — just finalise to claim USDC
-    max_redeemable_raw = vault.vault_contract.functions.maxRedeem(hot_wallet.address).call()
-    if max_redeemable_raw > 0:
-        redeemable_human = share_token.convert_to_decimals(max_redeemable_raw)
-        logger.info(
-            "Found %s %s settled but unclaimed shares from a previous redemption — claiming now",
-            redeemable_human, share_token.symbol,
-        )
-        hot_wallet.sync_nonce(web3)
-        tx_hash = hot_wallet.transact_and_broadcast_with_contract(
-            vault.finalise_redeem(hot_wallet.address, raw_amount=max_redeemable_raw),
-            gas_limit=1_000_000,
-        )
-        assert_transaction_success_with_explanation(web3, tx_hash)
-        logger.info("  Claimed previous redemption")
-
-    # State B: pending unsettled (pendingRedeemRequest > 0) — settle, poll, claim
-    pending_redeem_raw = vault.vault_contract.functions.pendingRedeemRequest(
-        0, hot_wallet.address
-    ).call()
-    if pending_redeem_raw > 0:
-        pending_human = share_token.convert_to_decimals(pending_redeem_raw)
-        logger.info(
-            "Found %s %s pending unsettled redemption — settling and claiming now",
-            pending_human, share_token.symbol,
-        )
-        nav = vault.fetch_nav()
-        hot_wallet.sync_nonce(web3)
-        tx_hash = hot_wallet.transact_and_broadcast_with_contract(
-            vault.post_new_valuation(nav), gas_limit=1_000_000,
-        )
-        assert_transaction_success_with_explanation(web3, tx_hash)
-
-        hot_wallet.sync_nonce(web3)
-        tx_hash = hot_wallet.transact_and_broadcast_with_contract(
-            vault.settle_via_trading_strategy_module(nav), gas_limit=1_000_000,
-        )
-        assert_transaction_success_with_explanation(web3, tx_hash)
-
-        _poll_and_finalise_redeem(vault, hot_wallet, web3, share_token)
-        logger.info("  Settled and claimed previous pending redemption")
+    _claim_leftover_redemptions(vault, hot_wallet, web3, share_token)
 
     share_balance = share_token.fetch_balance_of(hot_wallet.address)
     logger.info("  Share balance: %s %s", share_balance, share_token.symbol)

--- a/tradeexecutor/cli/commands/lagoon_redeem.py
+++ b/tradeexecutor/cli/commands/lagoon_redeem.py
@@ -11,6 +11,7 @@ Redeems all vault shares held by the asset manager from a Lagoon vault:
 """
 
 import logging
+import time
 from pathlib import Path
 from typing import Optional
 
@@ -29,6 +30,35 @@ from tradeexecutor.cli.log import setup_logging
 from tradeexecutor.strategy.strategy_module import read_strategy_module
 
 logger = logging.getLogger(__name__)
+
+
+def _poll_and_finalise_redeem(vault, hot_wallet, web3, share_token, max_attempts=12, poll_delay=5):
+    """Poll maxRedeem after settlement and finalise once claimable.
+
+    Avoids the stale-read problem where ``finalise_redeem()`` does a hidden
+    ``maxRedeem()`` call immediately after settlement, which can return 0 due
+    to RPC lag on live chains.
+    """
+    max_redeemable_raw = 0
+    for attempt in range(1, max_attempts + 1):
+        max_redeemable_raw = vault.vault_contract.functions.maxRedeem(hot_wallet.address).call()
+        if max_redeemable_raw > 0:
+            break
+        logger.info("  Waiting for settlement to propagate (attempt %d/%d)...", attempt, max_attempts)
+        time.sleep(poll_delay)
+
+    assert max_redeemable_raw > 0, (
+        f"Settlement completed but maxRedeem is still 0 for {hot_wallet.address} after polling"
+    )
+
+    redeemable_human = share_token.convert_to_decimals(max_redeemable_raw)
+    logger.info("  Finalising redemption of %s %s", redeemable_human, share_token.symbol)
+    hot_wallet.sync_nonce(web3)
+    tx_hash = hot_wallet.transact_and_broadcast_with_contract(
+        vault.finalise_redeem(hot_wallet.address, raw_amount=max_redeemable_raw),
+        gas_limit=1_000_000,
+    )
+    assert_transaction_success_with_explanation(web3, tx_hash)
 
 
 @app.command()
@@ -100,6 +130,49 @@ def lagoon_redeem(
     logger.info("  ETH balance: %.6f", eth_human)
     assert eth_human >= 0.001, f"Asset manager has {eth_human:.6f} ETH, need at least 0.001 for gas"
 
+    # Pre-flight: handle any leftover redemption from a previous run.
+    # State A: settled but unclaimed (maxRedeem > 0) — just finalise to claim USDC
+    max_redeemable_raw = vault.vault_contract.functions.maxRedeem(hot_wallet.address).call()
+    if max_redeemable_raw > 0:
+        redeemable_human = share_token.convert_to_decimals(max_redeemable_raw)
+        logger.info(
+            "Found %s %s settled but unclaimed shares from a previous redemption — claiming now",
+            redeemable_human, share_token.symbol,
+        )
+        hot_wallet.sync_nonce(web3)
+        tx_hash = hot_wallet.transact_and_broadcast_with_contract(
+            vault.finalise_redeem(hot_wallet.address, raw_amount=max_redeemable_raw),
+            gas_limit=1_000_000,
+        )
+        assert_transaction_success_with_explanation(web3, tx_hash)
+        logger.info("  Claimed previous redemption")
+
+    # State B: pending unsettled (pendingRedeemRequest > 0) — settle, poll, claim
+    pending_redeem_raw = vault.vault_contract.functions.pendingRedeemRequest(
+        0, hot_wallet.address
+    ).call()
+    if pending_redeem_raw > 0:
+        pending_human = share_token.convert_to_decimals(pending_redeem_raw)
+        logger.info(
+            "Found %s %s pending unsettled redemption — settling and claiming now",
+            pending_human, share_token.symbol,
+        )
+        nav = vault.fetch_nav()
+        hot_wallet.sync_nonce(web3)
+        tx_hash = hot_wallet.transact_and_broadcast_with_contract(
+            vault.post_new_valuation(nav), gas_limit=1_000_000,
+        )
+        assert_transaction_success_with_explanation(web3, tx_hash)
+
+        hot_wallet.sync_nonce(web3)
+        tx_hash = hot_wallet.transact_and_broadcast_with_contract(
+            vault.settle_via_trading_strategy_module(nav), gas_limit=1_000_000,
+        )
+        assert_transaction_success_with_explanation(web3, tx_hash)
+
+        _poll_and_finalise_redeem(vault, hot_wallet, web3, share_token)
+        logger.info("  Settled and claimed previous pending redemption")
+
     share_balance = share_token.fetch_balance_of(hot_wallet.address)
     logger.info("  Share balance: %s %s", share_balance, share_token.symbol)
     assert share_balance > 0, f"Asset manager has no vault shares to redeem"
@@ -136,11 +209,7 @@ def lagoon_redeem(
 
     # Phase 3: Claim redeemed denomination tokens
     logger.info("Phase 3: Finalising redemption")
-    hot_wallet.sync_nonce(web3)
-    tx_hash = hot_wallet.transact_and_broadcast_with_contract(
-        vault.finalise_redeem(hot_wallet.address), gas_limit=1_000_000,
-    )
-    assert_transaction_success_with_explanation(web3, tx_hash)
+    _poll_and_finalise_redeem(vault, hot_wallet, web3, share_token)
 
     # Report on-chain balances after redemption
     safe_balance = denomination_token.fetch_balance_of(vault.safe_address)


### PR DESCRIPTION
## Why

The `check-wallet` command showed gas and reserve token balances but not vault share balances — operators had no visibility into how many shares the asset manager held. The `lagoon-redeem` command had two bugs: it didn't handle leftover redemptions from previous interrupted runs (causing assertion failures), and its Phase 3 finalisation suffered from a stale-read problem where `finalise_redeem()` called `maxRedeem()` immediately after settlement, returning 0 due to RPC lag.

## Lessons learnt

- Lagoon's `finalise_redeem()` does a hidden `maxRedeem()` read when `raw_amount` is omitted — always pass the observed value explicitly to avoid stale RPC reads
- ERC-7540 async vaults have two leftover states to handle: settled-but-unclaimed (`maxRedeem > 0`) and pending-unsettled (`pendingRedeemRequest > 0`)
- Enzyme uses `shares_token` (plural) while Lagoon/Velvet use `share_token` (singular), and Velvet may only expose `fetch_share_token()` — need duck-typing fallbacks
- Synthetic chain IDs (e.g. `ChainId.hypercore`) must be normalised before comparing with loop chain IDs in `check-wallet`

## Summary

### check-wallet: vault share balance
- New `_log_vault_share_details()` helper logs the share token address, asset manager's share balance, and total share supply
- Works across Enzyme, Lagoon, and Velvet vault types via duck-typing
- Only logged on the default (normalised) chain where the vault lives

### lagoon-redeem: claim unclaimed shares before starting
- Pre-flight block runs after ETH balance check but before the share balance assert
- **State A** (settled but unclaimed): calls `finalise_redeem()` with explicit `raw_amount`
- **State B** (pending unsettled): posts valuation, settles, polls `maxRedeem`, then claims
- If all shares were already consumed, the existing `share_balance > 0` assert fires

### lagoon-redeem: fix Phase 3 stale-read bug
- Extracted `_poll_and_finalise_redeem()` helper that polls `maxRedeem()` (12 attempts, 5s delay) before finalising
- Replaces direct `finalise_redeem()` call in Phase 3, matching the polling pattern from `fund_lagoon_vault()` in eth_defi
