### PR TITLE
fix: Detect and claim unclaimed Lagoon vault deposits in check-wallet and lagoon-redeem

### DIFF
--- a/tests/cli/test_check_wallet_hyper_ai.py
+++ b/tests/cli/test_check_wallet_hyper_ai.py
@@ -289,3 +289,230 @@ def test_cli_check_wallet_logs_hot_wallet_and_vault_reserve_balances(
     assert any(f"Share token: {SHARE_TOKEN_SYMBOL} ({SHARE_TOKEN_ADDRESS})" in message for message in messages)
     assert any(f"Asset manager share balance: {SHARE_BALANCE} {SHARE_TOKEN_SYMBOL}" in message for message in messages)
     assert any(f"Total share supply: {SHARE_TOTAL_SUPPLY} {SHARE_TOKEN_SYMBOL}" in message for message in messages)
+
+
+def test_cli_check_wallet_logs_unclaimed_lagoon_deposits_and_redemptions(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+    tmp_path: Path,
+) -> None:
+    """Test `check-wallet` warns about unclaimed Lagoon vault deposits and redemptions.
+
+    1. Patch the CLI so the Lagoon vault has a vault_contract with maxDeposit > 0, maxRedeem > 0, and pendingRedeemRequest > 0.
+    2. Run check-wallet and capture log output.
+    3. Confirm UNCLAIMED DEPOSIT, UNCLAIMED REDEMPTION, and PENDING REDEMPTION warnings appear.
+    """
+    from tradeexecutor.cli.commands import check_wallet as check_wallet_module
+
+    SHARE_TOKEN_ADDRESS = "0x3333333333333333333333333333333333333333"
+    SHARE_TOKEN_SYMBOL = "lagVault"
+    SHARE_BALANCE = 42
+    SHARE_TOTAL_SUPPLY = 1000
+    UNCLAIMED_DEPOSIT_RAW = 10_000_000
+    UNCLAIMED_SHARES_RAW = 500
+    PENDING_SHARES_RAW = 200
+
+    class FakeDenominationToken:
+        def __init__(self):
+            self.symbol = "USDC"
+
+        def convert_to_decimals(self, balance: int) -> int:
+            return balance
+
+    class FakeShareToken:
+        def __init__(self):
+            self.address = SHARE_TOKEN_ADDRESS
+            self.symbol = SHARE_TOKEN_SYMBOL
+            self.contract = SimpleNamespace(
+                functions=SimpleNamespace(
+                    totalSupply=lambda: SimpleNamespace(call=lambda: SHARE_TOTAL_SUPPLY),
+                ),
+            )
+
+        def fetch_balance_of(self, address: str) -> int:
+            if address == HOT_WALLET_ADDRESS:
+                return SHARE_BALANCE
+            return 0
+
+        def convert_to_decimals(self, balance: int) -> int:
+            return balance
+
+    fake_share_token = FakeShareToken()
+    fake_denomination_token = FakeDenominationToken()
+    fake_vault_contract = SimpleNamespace(
+        functions=SimpleNamespace(
+            maxDeposit=lambda address: SimpleNamespace(call=lambda: UNCLAIMED_DEPOSIT_RAW),
+            maxRedeem=lambda address: SimpleNamespace(call=lambda: UNCLAIMED_SHARES_RAW),
+            pendingRedeemRequest=lambda request_id, address: SimpleNamespace(call=lambda: PENDING_SHARES_RAW),
+        ),
+    )
+
+    class FakeLagoonVaultSyncModel:
+        def __init__(self, hot_wallet_address: str, safe_address: str, vault_address: str):
+            self._hot_wallet_address = hot_wallet_address
+            self._safe_address = safe_address
+            self.vault_address = vault_address
+            self.vault = SimpleNamespace(
+                share_token=fake_share_token,
+                denomination_token=fake_denomination_token,
+                vault_contract=fake_vault_contract,
+            )
+
+        def get_hot_wallet(self):
+            return SimpleNamespace(address=self._hot_wallet_address)
+
+        def get_token_storage_address(self) -> str:
+            return self._safe_address
+
+    class FakeExecutionModel:
+        satellite_vaults = {}
+
+        def preflight_check(self) -> None:
+            return None
+
+    class FakeRoutingModel:
+        def perform_preflight_checks_and_logging(self, pairs) -> None:
+            return None
+
+    class FakeRunner:
+        def __init__(self):
+            self.routing_model = FakeRoutingModel()
+
+        def setup_routing(self, universe):
+            return None, SimpleNamespace(), SimpleNamespace()
+
+    class FakeWeb3Config:
+        def __init__(self):
+            self.default_chain_id = None
+            self.connections = {
+                ChainId.hyperliquid: SimpleNamespace(
+                    eth=SimpleNamespace(
+                        chain_id=ChainId.hyperliquid.value,
+                        block_number=30_000_000,
+                        get_balance=lambda address: 0,
+                    )
+                ),
+            }
+
+        def has_chain_configured(self) -> bool:
+            return True
+
+        def set_default_chain(self, chain_id: ChainId) -> None:
+            self.default_chain_id = chain_id
+
+        def check_default_chain_id(self) -> None:
+            return None
+
+        def get_connection(self, chain_id: ChainId):
+            return self.connections[chain_id]
+
+        def get_default(self):
+            return self.connections[self.default_chain_id]
+
+        def close(self) -> None:
+            return None
+
+    class FakeTokenDetails:
+        def __init__(self, address: str):
+            self.name = "USD Coin"
+            self.address = address
+            self.symbol = "USDC"
+
+        def fetch_balance_of(self, address: str) -> int:
+            return 0
+
+        def convert_to_decimals(self, balance: int) -> int:
+            return balance
+
+    HOT_WALLET_ADDRESS = "0xFA093b13C04c5E16e7a2A75d1279C58Df1Fbac62"
+    SAFE_ADDRESS = "0x49Be988d2090aa221586e9A51cacBA3D3A1eA087"
+    VAULT_ADDRESS = "0x1111111111111111111111111111111111111111"
+    USDC_ADDRESS = "0xb88339cb7199b77e23db6e890353e22632ba630f"
+
+    reserve_asset = AssetIdentifier(
+        chain_id=ChainId.hyperliquid.value,
+        address=USDC_ADDRESS,
+        token_symbol="USDC",
+        decimals=6,
+    )
+    fake_universe = SimpleNamespace(
+        reserve_assets=[reserve_asset],
+        cross_chain=False,
+        data_universe=SimpleNamespace(
+            pairs=[],
+            chains={ChainId.hyperliquid},
+        ),
+        iterate_pairs=iter([]),
+    )
+    fake_execution_model = FakeExecutionModel()
+    fake_sync_model = FakeLagoonVaultSyncModel(
+        hot_wallet_address=HOT_WALLET_ADDRESS,
+        safe_address=SAFE_ADDRESS,
+        vault_address=VAULT_ADDRESS,
+    )
+
+    strategy_file = Path(__file__).resolve().parents[2] / "strategies" / "test_only" / "hyper-ai-test.py"
+    environment = {
+        "TRADING_STRATEGY_API_KEY": "test-key",
+        "STRATEGY_FILE": str(strategy_file),
+        "CACHE_PATH": str(tmp_path),
+        "JSON_RPC_HYPERLIQUID": "https://example-hyperliquid-rpc.invalid",
+        "PRIVATE_KEY": "0x111e53aed5e777996f26b4bdb89300bbc05b84743f32028c41be7193c0fe0b83",
+        "MIN_GAS_BALANCE": "0",
+        "UNIT_TESTING": "true",
+        "LOG_LEVEL": "disabled",
+        "ASSET_MANAGEMENT_MODE": "lagoon",
+    }
+
+    # 1. Patch the CLI so the Lagoon vault has a vault_contract with maxRedeem > 0 and pendingRedeemRequest > 0.
+    monkeypatch.setattr(check_wallet_module, "LagoonVaultSyncModel", FakeLagoonVaultSyncModel)
+    monkeypatch.setattr(check_wallet_module, "prepare_executor_id", lambda id, strategy_file: "test-executor")
+    monkeypatch.setattr(
+        check_wallet_module,
+        "prepare_cache_and_token_cache",
+        lambda id, cache_path, unit_testing=False: (tmp_path, object()),
+    )
+    monkeypatch.setattr(check_wallet_module, "create_web3_config", lambda **kwargs: FakeWeb3Config())
+    monkeypatch.setattr(check_wallet_module.Client, "create_live_client", lambda *args, **kwargs: object())
+    monkeypatch.setattr(check_wallet_module, "call_create_trading_universe", lambda *args, **kwargs: fake_universe)
+    monkeypatch.setattr(
+        check_wallet_module,
+        "create_execution_and_sync_model",
+        lambda **kwargs: (fake_execution_model, fake_sync_model, None, None),
+    )
+    monkeypatch.setattr(
+        check_wallet_module,
+        "make_factory_from_strategy_mod",
+        lambda mod: lambda **kwargs: SimpleNamespace(runner=FakeRunner()),
+    )
+    monkeypatch.setattr(check_wallet_module, "fetch_erc20_details", lambda web3, address, cache=None: FakeTokenDetails(address))
+    monkeypatch.setattr(
+        check_wallet_module,
+        "fetch_erc20_balances_by_token_list",
+        lambda web3, address, tokens: {token: 0 for token in tokens},
+    )
+
+    runner = CliRunner()
+    caplog.set_level("WARNING")
+
+    # 2. Run check-wallet and capture log output.
+    result = runner.invoke(app, ["check-wallet"], env=environment)
+
+    if result.exception:
+        raise result.exception
+    assert result.exit_code == 0, result.stdout
+
+    # 3. Confirm UNCLAIMED DEPOSIT, UNCLAIMED REDEMPTION, and PENDING REDEMPTION warnings appear.
+    messages = [record.getMessage() for record in caplog.records]
+    assert any(
+        f"UNCLAIMED DEPOSIT: {UNCLAIMED_DEPOSIT_RAW} USDC" in message
+        for message in messages
+    ), f"Expected unclaimed deposit warning not found in: {messages}"
+    assert any(
+        f"UNCLAIMED REDEMPTION: {UNCLAIMED_SHARES_RAW} {SHARE_TOKEN_SYMBOL}" in message
+        for message in messages
+    ), f"Expected unclaimed redemption warning not found in: {messages}"
+    assert any(
+        f"PENDING REDEMPTION: {PENDING_SHARES_RAW} {SHARE_TOKEN_SYMBOL}" in message
+        for message in messages
+    ), f"Expected pending redemption warning not found in: {messages}"

--- a/tests/cli/test_lagoon_redeem.py
+++ b/tests/cli/test_lagoon_redeem.py
@@ -1,11 +1,11 @@
-"""CLI coverage for lagoon-redeem pre-flight redemption claiming."""
+"""CLI coverage for lagoon-redeem pre-flight deposit and redemption claiming."""
 
 from decimal import Decimal
 from unittest.mock import MagicMock, patch
 
 import pytest
 
-from tradeexecutor.cli.commands.lagoon_redeem import _claim_leftover_redemptions
+from tradeexecutor.cli.commands.lagoon_redeem import _claim_leftover_deposits, _claim_leftover_redemptions
 
 
 @pytest.mark.timeout(30)
@@ -75,4 +75,47 @@ def test_claim_leftover_redemptions() -> None:
     _claim_leftover_redemptions(vault, hot_wallet, web3, share_token)
 
     vault.finalise_redeem.assert_not_called()
+    hot_wallet.transact_and_broadcast_with_contract.assert_not_called()
+
+
+@pytest.mark.timeout(30)
+def test_claim_leftover_deposits() -> None:
+    """Pre-flight claims unclaimed deposits so shares move from vault contract to hot wallet.
+
+    1. Call with maxDeposit() > 0: verify finalise_deposit is called with explicit raw_amount.
+    2. Call with maxDeposit() == 0: verify no transactions broadcast.
+    """
+    tx_hash = b"\x00" * 32
+
+    def make_mocks():
+        vault = MagicMock()
+        vault.finalise_deposit.return_value = "mock_finalise_deposit"
+        vault.denomination_token.symbol = "USDC"
+        vault.denomination_token.convert_to_decimals.return_value = Decimal("10")
+        vault.share_token.symbol = "MASTER"
+        vault.share_token.fetch_balance_of.return_value = Decimal("10")
+        hot_wallet = MagicMock()
+        hot_wallet.address = "0xABCD"
+        hot_wallet.transact_and_broadcast_with_contract.return_value = tx_hash
+        web3 = MagicMock()
+        return vault, hot_wallet, web3
+
+    # 1. Unclaimed deposit: maxDeposit > 0 — finalise_deposit called
+    vault, hot_wallet, web3 = make_mocks()
+    deposit_raw = 10_000_000
+    vault.vault_contract.functions.maxDeposit.return_value.call.return_value = deposit_raw
+
+    with patch("tradeexecutor.cli.commands.lagoon_redeem.assert_transaction_success_with_explanation"):
+        _claim_leftover_deposits(vault, hot_wallet, web3)
+
+    vault.finalise_deposit.assert_called_once_with("0xABCD", raw_amount=deposit_raw)
+    hot_wallet.transact_and_broadcast_with_contract.assert_called_once()
+
+    # 2. No unclaimed deposits: maxDeposit == 0 — no transactions
+    vault, hot_wallet, web3 = make_mocks()
+    vault.vault_contract.functions.maxDeposit.return_value.call.return_value = 0
+
+    _claim_leftover_deposits(vault, hot_wallet, web3)
+
+    vault.finalise_deposit.assert_not_called()
     hot_wallet.transact_and_broadcast_with_contract.assert_not_called()

--- a/tradeexecutor/cli/commands/check_wallet.py
+++ b/tradeexecutor/cli/commands/check_wallet.py
@@ -172,6 +172,73 @@ def _log_vault_share_details(sync_model, hot_wallet_address: str) -> None:
     logger.info("  Asset manager share balance: %s %s", share_balance, share_token.symbol)
     logger.info("  Total share supply: %s %s", total_supply, share_token.symbol)
 
+    _log_lagoon_unclaimed_shares(vault, share_token, hot_wallet_address)
+
+
+def _log_lagoon_unclaimed_shares(vault, share_token, hot_wallet_address: str) -> None:
+    """Check and log unclaimed Lagoon vault deposits and redemptions for the asset manager.
+
+    Lagoon vaults use ERC-7540 async deposit/redeem with intermediate states:
+
+    Deposits:
+    - Settled but unclaimed (maxDeposit > 0): shares ready to claim via finalise_deposit
+
+    Redemptions:
+    - Settled but unclaimed (maxRedeem > 0): denomination tokens ready to claim via finalise_redeem
+    - Pending unsettled (pendingRedeemRequest > 0): redemption requested but not yet settled
+    """
+    vault_contract = getattr(vault, "vault_contract", None)
+    if vault_contract is None:
+        return
+
+    denomination_token = getattr(vault, "denomination_token", None)
+
+    # Check unclaimed deposits (settled deposit, shares not yet claimed)
+    try:
+        max_deposit_raw = vault_contract.functions.maxDeposit(hot_wallet_address).call()
+    except Exception:
+        max_deposit_raw = 0
+
+    if max_deposit_raw > 0:
+        if denomination_token is not None:
+            deposit_human = denomination_token.convert_to_decimals(max_deposit_raw)
+            deposit_symbol = denomination_token.symbol
+        else:
+            deposit_human = max_deposit_raw
+            deposit_symbol = "raw"
+        logger.warning(
+            "  UNCLAIMED DEPOSIT: %s %s settled but unclaimed (run lagoon-redeem to claim shares)",
+            deposit_human, deposit_symbol,
+        )
+
+    # Check settled but unclaimed redemptions
+    try:
+        max_redeemable_raw = vault_contract.functions.maxRedeem(hot_wallet_address).call()
+    except Exception:
+        max_redeemable_raw = 0
+
+    if max_redeemable_raw > 0:
+        redeemable_human = share_token.convert_to_decimals(max_redeemable_raw)
+        logger.warning(
+            "  UNCLAIMED REDEMPTION: %s %s settled but unclaimed shares (run lagoon-redeem to claim)",
+            redeemable_human, share_token.symbol,
+        )
+
+    # Check pending unsettled redemptions
+    try:
+        pending_redeem_raw = vault_contract.functions.pendingRedeemRequest(
+            0, hot_wallet_address
+        ).call()
+    except Exception:
+        pending_redeem_raw = 0
+
+    if pending_redeem_raw > 0:
+        pending_human = share_token.convert_to_decimals(pending_redeem_raw)
+        logger.warning(
+            "  PENDING REDEMPTION: %s %s pending unsettled shares (run lagoon-redeem to settle and claim)",
+            pending_human, share_token.symbol,
+        )
+
 
 def _log_chain_custody_details(sync_model, execution_model, chain_id: ChainId) -> None:
     """Log vault and custody addresses for a chain."""

--- a/tradeexecutor/cli/commands/lagoon_redeem.py
+++ b/tradeexecutor/cli/commands/lagoon_redeem.py
@@ -61,6 +61,31 @@ def _poll_and_finalise_redeem(vault, hot_wallet, web3, share_token, max_attempts
     assert_transaction_success_with_explanation(web3, tx_hash)
 
 
+def _claim_leftover_deposits(vault, hot_wallet, web3):
+    """Claim any leftover deposits from a previous interrupted run.
+
+    When a deposit was settled but ``finalise_deposit()`` was never called,
+    ``maxDeposit(owner)`` returns the claimable amount and shares sit in the
+    vault contract waiting to be moved to the hot wallet.
+    """
+    denomination_token = vault.denomination_token
+    max_deposit_raw = vault.vault_contract.functions.maxDeposit(hot_wallet.address).call()
+    if max_deposit_raw > 0:
+        deposit_human = denomination_token.convert_to_decimals(max_deposit_raw)
+        logger.info(
+            "Found %s %s settled but unclaimed deposit — claiming shares now",
+            deposit_human, denomination_token.symbol,
+        )
+        hot_wallet.sync_nonce(web3)
+        tx_hash = hot_wallet.transact_and_broadcast_with_contract(
+            vault.finalise_deposit(hot_wallet.address, raw_amount=max_deposit_raw),
+            gas_limit=1_000_000,
+        )
+        assert_transaction_success_with_explanation(web3, tx_hash)
+        share_balance = vault.share_token.fetch_balance_of(hot_wallet.address)
+        logger.info("  Claimed deposit — share balance is now %s %s", share_balance, vault.share_token.symbol)
+
+
 def _claim_leftover_redemptions(vault, hot_wallet, web3, share_token):
     """Claim any leftover redemptions from a previous interrupted run.
 
@@ -183,6 +208,7 @@ def lagoon_redeem(
     logger.info("  ETH balance: %.6f", eth_human)
     assert eth_human >= 0.001, f"Asset manager has {eth_human:.6f} ETH, need at least 0.001 for gas"
 
+    _claim_leftover_deposits(vault, hot_wallet, web3)
     _claim_leftover_redemptions(vault, hot_wallet, web3, share_token)
 
     share_balance = share_token.fetch_balance_of(hot_wallet.address)


### PR DESCRIPTION
## Why

Lagoon vaults use ERC-7540 async deposits where settlement and claiming are separate steps. When a deposit is settled but `finalise_deposit()` is never called, shares sit in the vault contract and `maxDeposit(owner)` returns the claimable amount. Neither `check-wallet` nor `lagoon-redeem` detected this state, causing:

- `check-wallet` to report everything as fine when shares were stuck
- `lagoon-redeem` to fail with `assert share_balance > 0` because shares hadn't been claimed into the hot wallet yet

## Lessons learnt

- Lagoon's `maxDeposit(owner)` returns the claimable deposit amount (settled but unclaimed), not future deposit capacity — this is why `can_check_deposit()` returns `False`
- ERC-7540 has three unclaimed states to check: `maxDeposit` (unclaimed deposits), `maxRedeem` (unclaimed redemptions), and `pendingRedeemRequest` (pending unsettled redemptions)

## Summary

**check-wallet**: Added `_log_lagoon_unclaimed_shares()` that checks all three ERC-7540 states on the vault contract and logs warnings:
- `UNCLAIMED DEPOSIT: X USDC settled but unclaimed` — via `maxDeposit()`
- `UNCLAIMED REDEMPTION: X shares settled but unclaimed` — via `maxRedeem()`
- `PENDING REDEMPTION: X shares pending unsettled` — via `pendingRedeemRequest()`

**lagoon-redeem**: Added `_claim_leftover_deposits()` called before `_claim_leftover_redemptions()`:
- Checks `maxDeposit(hot_wallet)` on the vault contract
- If > 0, calls `vault.finalise_deposit()` to move shares from the vault contract to the hot wallet
- Ensures the subsequent share balance check passes

**Tests**: Extended check-wallet and lagoon-redeem test suites to cover unclaimed deposit detection and claiming.
