### PR TITLE
fix: Use 3-arg ERC-7540 deposit() to claim Lagoon vault deposits

### DIFF
--- a/tests/cli/test_lagoon_redeem.py
+++ b/tests/cli/test_lagoon_redeem.py
@@ -100,7 +100,7 @@ def test_claim_leftover_deposits() -> None:
         web3 = MagicMock()
         return vault, hot_wallet, web3
 
-    # 1. Unclaimed deposit: maxDeposit > 0 — finalise_deposit called
+    # 1. Unclaimed deposit: maxDeposit > 0 — 3-arg deposit() called
     vault, hot_wallet, web3 = make_mocks()
     deposit_raw = 10_000_000
     vault.vault_contract.functions.maxDeposit.return_value.call.return_value = deposit_raw
@@ -108,7 +108,7 @@ def test_claim_leftover_deposits() -> None:
     with patch("tradeexecutor.cli.commands.lagoon_redeem.assert_transaction_success_with_explanation"):
         _claim_leftover_deposits(vault, hot_wallet, web3)
 
-    vault.finalise_deposit.assert_called_once_with("0xABCD", raw_amount=deposit_raw)
+    vault.vault_contract.functions.deposit.assert_called_once_with(deposit_raw, "0xABCD", "0xABCD")
     hot_wallet.transact_and_broadcast_with_contract.assert_called_once()
 
     # 2. No unclaimed deposits: maxDeposit == 0 — no transactions
@@ -117,5 +117,4 @@ def test_claim_leftover_deposits() -> None:
 
     _claim_leftover_deposits(vault, hot_wallet, web3)
 
-    vault.finalise_deposit.assert_not_called()
     hot_wallet.transact_and_broadcast_with_contract.assert_not_called()

--- a/tradeexecutor/cli/commands/lagoon_redeem.py
+++ b/tradeexecutor/cli/commands/lagoon_redeem.py
@@ -64,9 +64,14 @@ def _poll_and_finalise_redeem(vault, hot_wallet, web3, share_token, max_attempts
 def _claim_leftover_deposits(vault, hot_wallet, web3):
     """Claim any leftover deposits from a previous interrupted run.
 
-    When a deposit was settled but ``finalise_deposit()`` was never called,
+    When a deposit was settled but the deposit was never finalised,
     ``maxDeposit(owner)`` returns the claimable amount and shares sit in the
     vault contract waiting to be moved to the hot wallet.
+
+    Uses the 3-argument ERC-7540 ``deposit(assets, receiver, controller)``
+    instead of the 2-argument ERC-4626 ``deposit(assets, receiver)``, because
+    Lagoon vaults require the controller parameter to identify the original
+    deposit request.
     """
     denomination_token = vault.denomination_token
     max_deposit_raw = vault.vault_contract.functions.maxDeposit(hot_wallet.address).call()
@@ -77,8 +82,15 @@ def _claim_leftover_deposits(vault, hot_wallet, web3):
             deposit_human, denomination_token.symbol,
         )
         hot_wallet.sync_nonce(web3)
+        # ERC-7540 requires deposit(assets, receiver, controller) to claim
+        # async deposits. The 2-arg ERC-4626 deposit() does not work here.
+        bound_func = vault.vault_contract.functions.deposit(
+            max_deposit_raw,
+            hot_wallet.address,
+            hot_wallet.address,
+        )
         tx_hash = hot_wallet.transact_and_broadcast_with_contract(
-            vault.finalise_deposit(hot_wallet.address, raw_amount=max_deposit_raw),
+            bound_func,
             gas_limit=1_000_000,
         )
         assert_transaction_success_with_explanation(web3, tx_hash)


### PR DESCRIPTION
## Why

`lagoon-redeem` was calling `finalise_deposit()` which internally uses the 2-argument ERC-4626 `deposit(assets, receiver)`. Lagoon vaults implement ERC-7540 async deposits which require the 3-argument `deposit(assets, receiver, controller)` to identify the original deposit request. Without the controller parameter, the contract cannot match the claim to the pending deposit, so shares remain in the vault contract instead of being transferred to the hot wallet.

This caused `lagoon-redeem` to successfully broadcast the `deposit()` transaction but the share balance stayed at 0, failing the subsequent `assert share_balance > 0` check.

## Lessons learnt

- ERC-7540 vaults have two `deposit()` overloads: the 2-arg ERC-4626 version (for immediate deposits) and the 3-arg ERC-7540 version (for claiming async deposits). The 2-arg version silently does nothing when there are only async deposits to claim.
- The deposit manager's `finish_deposit()` already used the correct 3-arg version — the bug was only in `finalise_deposit()`.

## Summary

- Fixed `_claim_leftover_deposits()` in `lagoon_redeem.py` to call `vault.vault_contract.functions.deposit(amount, address, address)` directly with the 3-arg signature
- Fixed `finalise_deposit()` in both `ERC7540Vault` and `LagoonVault` classes in the `eth_defi` submodule to use the 3-arg `deposit(assets, depositor, depositor)` call
- Updated test assertions to match the new 3-arg call pattern
