### PR TITLE
fix: Use wait_for_transaction_receipt_robust() in lagoon-redeem and scripts

### DIFF
--- a/scripts/derive-lagoon-test-deposit.py
+++ b/scripts/derive-lagoon-test-deposit.py
@@ -23,6 +23,7 @@ from decimal import Decimal
 
 from eth_defi.compat import native_datetime_utc_now
 from eth_defi.hotwallet import HotWallet
+from eth_defi.provider.receipt import wait_for_transaction_receipt_robust
 from eth_defi.trace import assert_transaction_success_with_explanation
 from tradeexecutor.monkeypatch.web3 import construct_sign_and_send_raw_middleware
 from tradeexecutor.state.identifier import AssetIdentifier
@@ -90,7 +91,10 @@ print(f"Settlement events: {events}")
 
 print(f"\nFinalising deposit for {depositor}...")
 tx_hash = vault.finalise_deposit(depositor).transact({"from": depositor})
-assert_transaction_success_with_explanation(web3, tx_hash)
+# Wait for all read RPCs to sync before reading balanceOf,
+# to avoid stale-provider zero-balance reads on multi-provider setups
+receipt = wait_for_transaction_receipt_robust(web3, tx_hash, confirmation_block_count=2, extra_sleep=2.0)
+assert receipt["status"] == 1, f"Finalise deposit failed: {tx_hash.hex()}"
 print(f"Finalise deposit tx: {tx_hash.hex()}")
 
 # --- Verify ---

--- a/scripts/lagoon/manual-trade-executor-crosschain-hypercore.py
+++ b/scripts/lagoon/manual-trade-executor-crosschain-hypercore.py
@@ -131,7 +131,7 @@ from eth_defi.provider.anvil import (
 from eth_defi.provider.broken_provider import _latest_delayed_block_number_cache
 from eth_defi.provider.multi_provider import create_multi_provider_web3
 from eth_defi.token import USDC_NATIVE_TOKEN, fetch_erc20_details
-from eth_defi.trace import assert_transaction_success_with_explanation
+from eth_defi.provider.receipt import wait_for_transaction_receipt_robust
 from eth_defi.utils import setup_console_logging
 
 from tradeexecutor.cli.main import app
@@ -224,7 +224,10 @@ def spoof_cctp_attestation(
 
     deployer.current_nonce = dest_web3.eth.get_transaction_count(deployer.address)
     tx_hash = deployer.transact_and_broadcast_with_contract(receive_fn)
-    assert_transaction_success_with_explanation(dest_web3, tx_hash)
+    # Wait for all read RPCs to see the CCTP receive receipt before
+    # reading token balances, to avoid stale-provider reads
+    receipt = wait_for_transaction_receipt_robust(dest_web3, tx_hash, confirmation_block_count=2, extra_sleep=2.0)
+    assert receipt["status"] == 1, f"receiveMessage failed: {tx_hash.hex()}"
 
     logger.info("receiveMessage successful: %s", tx_hash.hex() if hasattr(tx_hash, "hex") else tx_hash)
 
@@ -262,7 +265,10 @@ def complete_cctp_bridge(
 
     deployer.current_nonce = dest_web3.eth.get_transaction_count(deployer.address)
     tx_hash = deployer.transact_and_broadcast_with_contract(receive_fn)
-    assert_transaction_success_with_explanation(dest_web3, tx_hash)
+    # Wait for all read RPCs to see the CCTP receive receipt before
+    # reading token balances, to avoid stale-provider reads
+    receipt = wait_for_transaction_receipt_robust(dest_web3, tx_hash, confirmation_block_count=2, extra_sleep=2.0)
+    assert receipt["status"] == 1, f"receiveMessage failed: {tx_hash.hex()}"
 
     logger.info("receiveMessage successful: %s", tx_hash.hex() if hasattr(tx_hash, "hex") else tx_hash)
 

--- a/scripts/lagoon/manual-trade-executor-gmx.py
+++ b/scripts/lagoon/manual-trade-executor-gmx.py
@@ -119,7 +119,7 @@ from eth_defi.provider.anvil import (AnvilLaunch, fork_network_anvil,
 from eth_defi.provider.broken_provider import _latest_delayed_block_number_cache
 from eth_defi.provider.multi_provider import create_multi_provider_web3
 from eth_defi.token import USDC_NATIVE_TOKEN, TokenDetails, fetch_erc20_details
-from eth_defi.trace import assert_transaction_success_with_explanation
+from eth_defi.provider.receipt import wait_for_transaction_receipt_robust
 from eth_defi.utils import setup_console_logging
 from eth_defi.vault.base import VaultSpec
 
@@ -155,8 +155,11 @@ def _broadcast_and_wait(
 
     signed_tx = lagoon_wallet.sign_transaction_with_new_nonce(tx)
     tx_hash = web3.eth.send_raw_transaction(signed_tx.rawTransaction)
-    assert_transaction_success_with_explanation(web3, tx_hash)
-    return web3.eth.wait_for_transaction_receipt(tx_hash)
+    # Wait for all read RPCs to see the receipt before returning,
+    # to avoid stale-provider reads on multi-provider setups
+    receipt = wait_for_transaction_receipt_robust(web3, tx_hash, confirmation_block_count=2, extra_sleep=2.0)
+    assert receipt["status"] == 1, f"Transaction failed: {tx_hash.hex()}"
+    return receipt
 
 
 def _check_shares(web3: Web3, vault_address: str, deployer_address: str, label: str):

--- a/scripts/lagoon/manual-trade-executor-hyperliquid.py
+++ b/scripts/lagoon/manual-trade-executor-hyperliquid.py
@@ -169,7 +169,8 @@ from eth_defi.hyperliquid.session import (
 from eth_defi.provider.broken_provider import _latest_delayed_block_number_cache
 from eth_defi.provider.multi_provider import create_multi_provider_web3
 from eth_defi.token import USDC_NATIVE_TOKEN, TokenDetails, fetch_erc20_details
-from eth_defi.trace import assert_transaction_success_with_explanation
+from eth_defi.provider.receipt import wait_for_transaction_receipt_robust
+from eth_defi.trace import TransactionAssertionError
 from eth_defi.utils import setup_console_logging
 from eth_defi.vault.base import VaultSpec
 
@@ -357,7 +358,10 @@ def _do_hypercore_deposit(
         evm_usdc_amount=usdc_amount_raw,
     )
     tx_hash = deployer.transact_and_broadcast_with_contract(fn1)
-    receipt = assert_transaction_success_with_explanation(web3, tx_hash)
+    # Wait for all read RPCs to sync before reading on-chain state,
+    # to avoid stale-provider reads on multi-provider setups
+    receipt = wait_for_transaction_receipt_robust(web3, tx_hash, confirmation_block_count=2, extra_sleep=2.0)
+    assert receipt["status"] == 1, f"Transaction failed: {tx_hash.hex()}"
     logger.info("Phase 1 tx: %s (gas: %d)", tx_hash.hex(), receipt["gasUsed"])
 
     # Wait for EVM escrow to clear
@@ -373,7 +377,10 @@ def _do_hypercore_deposit(
         vault_address=vault_address,
     )
     tx_hash = deployer.transact_and_broadcast_with_contract(fn2)
-    receipt = assert_transaction_success_with_explanation(web3, tx_hash)
+    # Wait for all read RPCs to sync before reading on-chain state,
+    # to avoid stale-provider reads on multi-provider setups
+    receipt = wait_for_transaction_receipt_robust(web3, tx_hash, confirmation_block_count=2, extra_sleep=2.0)
+    assert receipt["status"] == 1, f"Transaction failed: {tx_hash.hex()}"
     logger.info("Phase 2 tx: %s (gas: %d)", tx_hash.hex(), receipt["gasUsed"])
 
     # Wait for CoreWriter actions to settle
@@ -444,7 +451,10 @@ def _do_hypercore_withdraw(
                     vault_address=vault_address,
                 )
             )
-            receipt = assert_transaction_success_with_explanation(web3, tx_hash)
+            # Wait for all read RPCs to sync before reading on-chain state,
+            # to avoid stale-provider reads on multi-provider setups
+            receipt = wait_for_transaction_receipt_robust(web3, tx_hash, confirmation_block_count=2, extra_sleep=2.0)
+            assert receipt["status"] == 1, f"Transaction failed: {tx_hash.hex()}"
             print(f"\n  Withdrawal phase 1 tx: {tx_hash.hex()} (gas: {receipt['gasUsed']})")
             _wait_for_perp_withdrawable_balance(session, safe_address, baseline_perp + requested_human)
             current_perp = _get_perp_withdrawable_balance(session, safe_address)
@@ -475,7 +485,10 @@ def _do_hypercore_withdraw(
                     to_perp=False,
                 )
             )
-            receipt = assert_transaction_success_with_explanation(web3, tx_hash)
+            # Wait for all read RPCs to sync before reading on-chain state,
+            # to avoid stale-provider reads on multi-provider setups
+            receipt = wait_for_transaction_receipt_robust(web3, tx_hash, confirmation_block_count=2, extra_sleep=2.0)
+            assert receipt["status"] == 1, f"Transaction failed: {tx_hash.hex()}"
             print(f"\n  Withdrawal phase 2 tx: {tx_hash.hex()} (gas: {receipt['gasUsed']})")
             _wait_for_perp_withdrawable_balance(session, safe_address, baseline_perp)
             _wait_for_spot_free_balance(session, safe_address, baseline_spot + requested_human)
@@ -513,7 +526,10 @@ def _do_hypercore_withdraw(
                 evm_usdc_amount=hypercore_amount_raw,
             )
         )
-        receipt = assert_transaction_success_with_explanation(web3, tx_hash)
+        # Wait for all read RPCs to sync before reading on-chain state,
+        # to avoid stale-provider reads on multi-provider setups
+        receipt = wait_for_transaction_receipt_robust(web3, tx_hash, confirmation_block_count=2, extra_sleep=2.0)
+        assert receipt["status"] == 1, f"Transaction failed: {tx_hash.hex()}"
         print(f"\n  Withdrawal phase 3 tx: {tx_hash.hex()} (gas: {receipt['gasUsed']})")
         _wait_for_evm_usdc_balance(safe_usdc, safe_address, baseline_evm + requested_human)
     except (TransactionAssertionError, Exception) as e:
@@ -753,7 +769,10 @@ def _run_test_lifecycle(
                     usdc_token.transfer(safe_address, transfer_amount),
                     gas_limit=100_000,
                 )
-                assert_transaction_success_with_explanation(web3, tx_hash)
+                # Wait for all read RPCs to see the USDC transfer before
+                # proceeding to HyperCore deposit which reads the Safe balance
+                receipt = wait_for_transaction_receipt_robust(web3, tx_hash, confirmation_block_count=2, extra_sleep=2.0)
+                assert receipt["status"] == 1, f"USDC transfer failed: {tx_hash.hex()}"
 
             deployer.sync_nonce(web3)
             _do_hypercore_deposit(

--- a/scripts/lagoon/manual-trade-executor-multichain.py
+++ b/scripts/lagoon/manual-trade-executor-multichain.py
@@ -161,6 +161,7 @@ from eth_defi.provider.anvil import (AnvilLaunch, fork_network_anvil,
                                      fund_erc20_on_anvil, set_balance)
 from eth_defi.provider.multi_provider import create_multi_provider_web3
 from eth_defi.token import USDC_NATIVE_TOKEN, fetch_erc20_details
+from eth_defi.provider.receipt import wait_for_transaction_receipt_robust
 from eth_defi.trace import assert_transaction_success_with_explanation
 from eth_defi.utils import setup_console_logging
 
@@ -1135,7 +1136,10 @@ def _run_test_lifecycle(
         deployer.sync_nonce(arb_web3)
         finalise_fn = vault.finalise_redeem(deployer.address)
         tx_hash = deployer.transact_and_broadcast_with_contract(finalise_fn)
-        assert_transaction_success_with_explanation(arb_web3, tx_hash)
+        # Wait for all read RPCs to sync before reading the USDC balance,
+        # otherwise fetch_balance_of may return stale data on multi-provider setups
+        receipt = wait_for_transaction_receipt_robust(arb_web3, tx_hash, confirmation_block_count=2, extra_sleep=2.0)
+        assert receipt["status"] == 1, f"finalise_redeem failed: {tx_hash.hex()}"
 
         deployer_usdc_after = arb_usdc.fetch_balance_of(deployer.address)
         redeemed_usdc = deployer_usdc_after - deployer_usdc_before

--- a/tests/cli/test_lagoon_redeem.py
+++ b/tests/cli/test_lagoon_redeem.py
@@ -39,7 +39,7 @@ def test_claim_leftover_redemptions() -> None:
     vault.vault_contract.functions.maxRedeem.return_value.call.return_value = settled_raw
     vault.vault_contract.functions.pendingRedeemRequest.return_value.call.return_value = 0
 
-    with patch("tradeexecutor.cli.commands.lagoon_redeem.assert_transaction_success_with_explanation"):
+    with patch("tradeexecutor.cli.commands.lagoon_redeem._broadcast_and_wait"):
         _claim_leftover_redemptions(vault, hot_wallet, web3, share_token)
 
     vault.finalise_redeem.assert_called_once_with("0xABCD", raw_amount=settled_raw)
@@ -57,7 +57,7 @@ def test_claim_leftover_redemptions() -> None:
     vault.vault_contract.functions.pendingRedeemRequest.return_value.call.return_value = pending_raw
 
     with (
-        patch("tradeexecutor.cli.commands.lagoon_redeem.assert_transaction_success_with_explanation"),
+        patch("tradeexecutor.cli.commands.lagoon_redeem._broadcast_and_wait"),
         patch("tradeexecutor.cli.commands.lagoon_redeem.time.sleep") as mock_sleep,
     ):
         _claim_leftover_redemptions(vault, hot_wallet, web3, share_token)
@@ -82,7 +82,7 @@ def test_claim_leftover_redemptions() -> None:
 def test_claim_leftover_deposits() -> None:
     """Pre-flight claims unclaimed deposits so shares move from vault contract to hot wallet.
 
-    1. Call with maxDeposit() > 0: verify finalise_deposit is called with explicit raw_amount.
+    1. Call with maxDeposit() > 0: verify 3-arg deposit() called via _broadcast_and_wait.
     2. Call with maxDeposit() == 0: verify no transactions broadcast.
     """
     tx_hash = b"\x00" * 32
@@ -105,11 +105,11 @@ def test_claim_leftover_deposits() -> None:
     deposit_raw = 10_000_000
     vault.vault_contract.functions.maxDeposit.return_value.call.return_value = deposit_raw
 
-    with patch("tradeexecutor.cli.commands.lagoon_redeem.assert_transaction_success_with_explanation"):
+    with patch("tradeexecutor.cli.commands.lagoon_redeem._broadcast_and_wait") as mock_bw:
         _claim_leftover_deposits(vault, hot_wallet, web3)
 
     vault.vault_contract.functions.deposit.assert_called_once_with(deposit_raw, "0xABCD", "0xABCD")
-    hot_wallet.transact_and_broadcast_with_contract.assert_called_once()
+    mock_bw.assert_called_once()
 
     # 2. No unclaimed deposits: maxDeposit == 0 — no transactions
     vault, hot_wallet, web3 = make_mocks()

--- a/tradeexecutor/cli/commands/lagoon_redeem.py
+++ b/tradeexecutor/cli/commands/lagoon_redeem.py
@@ -16,7 +16,7 @@ from pathlib import Path
 from typing import Optional
 
 from eth_defi.erc_4626.vault_protocol.lagoon.testing import redeem_vault_shares
-from eth_defi.trace import assert_transaction_success_with_explanation
+from eth_defi.provider.receipt import wait_for_transaction_receipt_robust
 
 from tradeexecutor.cli.bootstrap import prepare_cache_and_token_cache, prepare_executor_id
 from tradeexecutor.cli.commands import shared_options
@@ -30,6 +30,26 @@ from tradeexecutor.cli.log import setup_logging
 from tradeexecutor.strategy.strategy_module import read_strategy_module
 
 logger = logging.getLogger(__name__)
+
+
+def _broadcast_and_wait(web3, hot_wallet, func, gas_limit=1_000_000):
+    """Broadcast a transaction and wait until all read RPC providers see it.
+
+    Production multi-provider setups (e.g. Arbitrum with sequencer + read RPCs)
+    have propagation delays between write and read providers. Without waiting
+    for all providers, state reads immediately after a transaction (like
+    ``balanceOf``) may hit a stale provider and return zero.
+    """
+    tx_hash = hot_wallet.transact_and_broadcast_with_contract(func, gas_limit=gas_limit)
+    receipt = wait_for_transaction_receipt_robust(
+        web3, tx_hash,
+        confirmation_block_count=2,
+        extra_sleep=2.0,
+    )
+    assert receipt["status"] == 1, (
+        f"Transaction {tx_hash.hex()} failed with status 0. "
+        f"Block: {receipt.get('blockNumber')}, gas used: {receipt.get('gasUsed')}"
+    )
 
 
 def _poll_and_finalise_redeem(vault, hot_wallet, web3, share_token, max_attempts=12, poll_delay=5):
@@ -54,11 +74,11 @@ def _poll_and_finalise_redeem(vault, hot_wallet, web3, share_token, max_attempts
     redeemable_human = share_token.convert_to_decimals(max_redeemable_raw)
     logger.info("  Finalising redemption of %s %s", redeemable_human, share_token.symbol)
     hot_wallet.sync_nonce(web3)
-    tx_hash = hot_wallet.transact_and_broadcast_with_contract(
+    # Wait for all read RPCs to see the receipt before reading balances
+    _broadcast_and_wait(
+        web3, hot_wallet,
         vault.finalise_redeem(hot_wallet.address, raw_amount=max_redeemable_raw),
-        gas_limit=1_000_000,
     )
-    assert_transaction_success_with_explanation(web3, tx_hash)
 
 
 def _claim_leftover_deposits(vault, hot_wallet, web3):
@@ -89,11 +109,8 @@ def _claim_leftover_deposits(vault, hot_wallet, web3):
             hot_wallet.address,
             hot_wallet.address,
         )
-        tx_hash = hot_wallet.transact_and_broadcast_with_contract(
-            bound_func,
-            gas_limit=1_000_000,
-        )
-        assert_transaction_success_with_explanation(web3, tx_hash)
+        # Wait for all read RPCs to sync before reading the share balance
+        _broadcast_and_wait(web3, hot_wallet, bound_func)
         share_balance = vault.share_token.fetch_balance_of(hot_wallet.address)
         logger.info("  Claimed deposit — share balance is now %s %s", share_balance, vault.share_token.symbol)
 
@@ -117,11 +134,11 @@ def _claim_leftover_redemptions(vault, hot_wallet, web3, share_token):
             redeemable_human, share_token.symbol,
         )
         hot_wallet.sync_nonce(web3)
-        tx_hash = hot_wallet.transact_and_broadcast_with_contract(
+        # Wait for all read RPCs to sync so subsequent balance reads are fresh
+        _broadcast_and_wait(
+            web3, hot_wallet,
             vault.finalise_redeem(hot_wallet.address, raw_amount=max_redeemable_raw),
-            gas_limit=1_000_000,
         )
-        assert_transaction_success_with_explanation(web3, tx_hash)
         logger.info("  Claimed previous redemption")
 
     # State B: pending unsettled
@@ -136,16 +153,12 @@ def _claim_leftover_redemptions(vault, hot_wallet, web3, share_token):
         )
         nav = vault.fetch_nav()
         hot_wallet.sync_nonce(web3)
-        tx_hash = hot_wallet.transact_and_broadcast_with_contract(
-            vault.post_new_valuation(nav), gas_limit=1_000_000,
-        )
-        assert_transaction_success_with_explanation(web3, tx_hash)
+        # Wait for all read RPCs to see valuation before settling
+        _broadcast_and_wait(web3, hot_wallet, vault.post_new_valuation(nav))
 
         hot_wallet.sync_nonce(web3)
-        tx_hash = hot_wallet.transact_and_broadcast_with_contract(
-            vault.settle_via_trading_strategy_module(nav), gas_limit=1_000_000,
-        )
-        assert_transaction_success_with_explanation(web3, tx_hash)
+        # Wait for all read RPCs to see settlement before polling maxRedeem
+        _broadcast_and_wait(web3, hot_wallet, vault.settle_via_trading_strategy_module(nav))
 
         _poll_and_finalise_redeem(vault, hot_wallet, web3, share_token)
         logger.info("  Settled and claimed previous pending redemption")
@@ -246,16 +259,12 @@ def lagoon_redeem(
     logger.info("  Current NAV: %s %s", nav, denomination_token.symbol)
 
     hot_wallet.sync_nonce(web3)
-    tx_hash = hot_wallet.transact_and_broadcast_with_contract(
-        vault.post_new_valuation(nav), gas_limit=1_000_000,
-    )
-    assert_transaction_success_with_explanation(web3, tx_hash)
+    # Wait for all read RPCs to see valuation before settling
+    _broadcast_and_wait(web3, hot_wallet, vault.post_new_valuation(nav))
 
     hot_wallet.sync_nonce(web3)
-    tx_hash = hot_wallet.transact_and_broadcast_with_contract(
-        vault.settle_via_trading_strategy_module(nav), gas_limit=1_000_000,
-    )
-    assert_transaction_success_with_explanation(web3, tx_hash)
+    # Wait for all read RPCs to see settlement before polling maxRedeem
+    _broadcast_and_wait(web3, hot_wallet, vault.settle_via_trading_strategy_module(nav))
 
     # Phase 3: Claim redeemed denomination tokens
     logger.info("Phase 3: Finalising redemption")

--- a/tradeexecutor/ethereum/lagoon/vault.py
+++ b/tradeexecutor/ethereum/lagoon/vault.py
@@ -584,7 +584,9 @@ class LagoonVaultSyncModel(AddressSyncModel):
             )
             settle_tx_hash = signed_tx_2.hash
 
-        wait_for_transaction_receipt_robust(web3, settle_tx_hash)
+        # Wait for all read RPCs to see the settlement receipt and let state
+        # propagate before reading on-chain analysis data
+        wait_for_transaction_receipt_robust(web3, settle_tx_hash, confirmation_block_count=2, extra_sleep=2.0)
 
         analysis = analyse_vault_flow_in_settlement(
             vault,


### PR DESCRIPTION
## Why

`lagoon-redeem` used `assert_transaction_success_with_explanation()` which calls `web3.eth.wait_for_transaction_receipt()` — a single-provider receipt wait. On production Arbitrum with multi-provider setup (sequencer + separate read RPCs like Goldsky and dRPC), state reads immediately after a confirmed transaction can hit a **different provider that hasn't propagated the state change yet**, returning stale zero balances.

This caused `lagoon-redeem` to successfully broadcast `deposit()` but then read `balanceOf() == 0` from a stale RPC, failing the `assert share_balance > 0` check.

Integration tests didn't catch this because Anvil has a single local node with perfectly consistent state — every write is instantly visible to every read.

## Lessons learnt

- `assert_transaction_success_with_explanation` is designed for Anvil-based tests (says so in its docstring: "Designed to be used on Anvil backend based tests")
- Production multi-provider setups need `wait_for_transaction_receipt_robust()` which polls ALL read providers until they see the receipt, plus an `extra_sleep` for state propagation
- The `testing.py` helper in eth_defi already documented this exact issue in comments and used a polling approach

## Summary

**lagoon_redeem.py**: Added `_broadcast_and_wait()` private helper that wraps `transact_and_broadcast_with_contract` + `wait_for_transaction_receipt_robust(confirmation_block_count=2, extra_sleep=2.0)`. Replaced all 8 `assert_transaction_success_with_explanation` calls.

**Scripts** (5 files): Replaced `assert_transaction_success_with_explanation` with `wait_for_transaction_receipt_robust` in manual Lagoon test scripts that use multi-provider web3:
- `manual-trade-executor-multichain.py` — finalise_redeem before balance read
- `manual-trade-executor-hyperliquid.py` — all HyperCore deposit/withdrawal phases
- `manual-trade-executor-gmx.py` — `_broadcast_and_wait` helper
- `manual-trade-executor-crosschain-hypercore.py` — CCTP receive calls
- `derive-lagoon-test-deposit.py` — finalise_deposit before balanceOf
