### PR TITLE
feat: Show estimated settlement time for pending async vault deposits in trade-ui

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 
 - Breaking API changes
 
+- Show estimated settlement time for pending async vault deposits in the trade-ui Lockup column — Ostium V1.5 shows a countdown (`settles 18.0h`), operator-driven ERC-7540 vaults (Lagoon) show `pending` (2026-06-09)
+
 - Fix Hypercore vault deposit reverts when Safe EVM USDC balance is less than planned deposit due to cumulative withdrawal drift (2026-06-09)
 
 - Add vault share balance and total supply to `check-wallet` command output; fix `lagoon-redeem` to claim unclaimed redemptions before starting and poll `maxRedeem` to avoid stale-read failures (2026-06-09)

--- a/tests/cli/test_trade_ui_settlement_eta.py
+++ b/tests/cli/test_trade_ui_settlement_eta.py
@@ -1,0 +1,143 @@
+"""Test trade-ui Lockup column showing async vault deposit settlement ETA.
+
+When an async vault deposit (Ostium V1.5, ERC-7540 Lagoon) has been requested
+on-chain but not yet settled, the trade sits in
+``TradeStatus.vault_settlement_pending`` and the position holds 0 shares.
+The trade-ui reuses the Lockup column to surface the estimated settlement time
+so the operator knows when the shares will appear, instead of just seeing
+``0 oLP`` with no hint.
+"""
+
+import datetime
+from decimal import Decimal
+
+from tradeexecutor.cli.trade_ui_tui import _format_lockup
+from tradeexecutor.state.identifier import (
+    AssetIdentifier,
+    TradingPairIdentifier,
+    TradingPairKind,
+)
+from tradeexecutor.state.position import TradingPosition
+from tradeexecutor.state.state import State
+from tradeexecutor.state.trade import TradeExecution, TradeType
+
+
+def _make_vault_pair() -> TradingPairIdentifier:
+    """Create a minimal ERC-4626 vault trading pair."""
+    base = AssetIdentifier(
+        chain_id=42161,
+        address="0x0000000000000000000000000000000000000001",
+        token_symbol="oLP",
+        decimals=18,
+    )
+    quote = AssetIdentifier(
+        chain_id=42161,
+        address="0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
+        token_symbol="USDC",
+        decimals=6,
+    )
+    return TradingPairIdentifier(
+        base=base,
+        quote=quote,
+        pool_address="0x0000000000000000000000000000000000000001",
+        exchange_address="0x0000000000000000000000000000000000000000",
+        internal_id=1,
+        internal_exchange_id=1,
+        fee=0.0,
+        kind=TradingPairKind.vault,
+        exchange_name="ostium",
+        other_data={"vault_protocol": "erc4626", "vault_name": "Ostium Liquidity Pool Vault"},
+    )
+
+
+def _make_state_with_pending_deposit(
+    pair: TradingPairIdentifier,
+    estimated_at: str | None,
+) -> State:
+    """Build a State with one open vault position whose buy trade is settlement-pending.
+
+    ``estimated_at`` is the stored ISO settlement estimate (or ``None`` for
+    operator-driven vaults that have no on-chain ETA).
+    """
+    position = TradingPosition(
+        position_id=1,
+        pair=pair,
+        opened_at=datetime.datetime(2023, 1, 1),
+        last_pricing_at=datetime.datetime(2023, 1, 1),
+        last_token_price=Decimal("1"),
+        last_reserve_price=Decimal("1"),
+        reserve_currency=pair.quote,
+    )
+    trade = TradeExecution(
+        trade_id=1,
+        position_id=1,
+        trade_type=TradeType.rebalance,
+        pair=pair,
+        opened_at=datetime.datetime(2023, 1, 1),
+        planned_quantity=Decimal("1.0"),  # positive -> buy / deposit
+        planned_price=1.0,
+        planned_reserve=Decimal("5"),
+        reserve_currency=pair.quote,
+    )
+    # vault_settlement_pending_at set (and executed_at/failed_at unset) makes
+    # get_status() return vault_settlement_pending.
+    trade.vault_settlement_pending_at = datetime.datetime(2023, 1, 1)
+    trade.other_data["vault_settlement_estimated_at"] = estimated_at
+    position.trades[trade.trade_id] = trade
+
+    state = State()
+    state.portfolio.open_positions[position.position_id] = position
+    return state
+
+
+def test_tui_lockup_shows_ostium_settlement_eta(monkeypatch) -> None:
+    """A pending Ostium deposit with a future estimate shows a settlement countdown.
+
+    Steps:
+    1. Freeze the clock so the remaining time is deterministic.
+    2. Build a state with a settlement-pending deposit estimated ~18h ahead.
+    3. Assert the Lockup cell shows a ``settles`` countdown, not ``-``.
+    4. Build a state whose estimate has already passed and assert ``settling``.
+    """
+
+    # 1. Freeze "now" so the countdown is deterministic.
+    now = datetime.datetime(2026, 6, 9, 12, 0, 0)
+    monkeypatch.setattr("tradeexecutor.cli.trade_ui_tui.native_datetime_utc_now", lambda: now)
+
+    pair = _make_vault_pair()
+
+    # 2. Estimate 18 hours in the future.
+    future = (now + datetime.timedelta(hours=18)).isoformat()
+    state = _make_state_with_pending_deposit(pair, future)
+
+    # 3. Future estimate renders as a "settles" countdown.
+    cell = _format_lockup(state, pair)
+    assert "settles" in cell.plain
+    assert "18.0h" in cell.plain
+
+    # 4. A past estimate (settlement slipped) renders as "settling".
+    past = (now - datetime.timedelta(hours=1)).isoformat()
+    state_past = _make_state_with_pending_deposit(pair, past)
+    assert _format_lockup(state_past, pair).plain == "settling"
+
+
+def test_tui_lockup_shows_pending_when_no_eta(monkeypatch) -> None:
+    """An operator-driven vault (no on-chain ETA) shows ``pending``.
+
+    Steps:
+    1. Freeze the clock.
+    2. Build a state with a settlement-pending deposit but no stored estimate.
+    3. Assert the Lockup cell shows ``pending``.
+    """
+
+    # 1. Freeze "now".
+    now = datetime.datetime(2026, 6, 9, 12, 0, 0)
+    monkeypatch.setattr("tradeexecutor.cli.trade_ui_tui.native_datetime_utc_now", lambda: now)
+
+    pair = _make_vault_pair()
+
+    # 2. No estimate stored (Lagoon / ERC-7540 operator settlement).
+    state = _make_state_with_pending_deposit(pair, None)
+
+    # 3. Renders as "pending".
+    assert _format_lockup(state, pair).plain == "pending"

--- a/tradeexecutor/cli/trade_ui_tui.py
+++ b/tradeexecutor/cli/trade_ui_tui.py
@@ -37,7 +37,9 @@ from tradingstrategy.liquidity import LiquidityDataUnavailable
 from tradingstrategy.chain import ChainId
 
 from tradeexecutor.state.identifier import TradingPairIdentifier
+from tradeexecutor.state.position import TradingPosition
 from tradeexecutor.state.state import State
+from tradeexecutor.state.trade import TradeStatus
 from tradeexecutor.strategy.trading_strategy_universe import TradingStrategyUniverse
 
 logger = logging.getLogger(__name__)
@@ -158,20 +160,68 @@ def _get_position_info(state: State, pair: TradingPairIdentifier) -> str:
     return f"{quantity} {symbol}"
 
 
-def _format_lockup(state: State, pair: TradingPairIdentifier) -> Text:
-    """Format vault lockup time remaining from the stored expiry timestamp.
+def _format_remaining(remaining: datetime.timedelta, prefix: str = "") -> str:
+    """Format a positive timedelta as a compact ``18.5h`` / ``2.1d`` string."""
+    hours = remaining.total_seconds() / 3600
+    if hours >= 24:
+        return f"{prefix}{hours / 24:.1f}d"
+    return f"{prefix}{hours:.1f}h"
 
-    Shows remaining hours until the lockup expires, or ``Unlocked``
-    if the lockup has already passed. Non-vault pairs or positions
-    without lockup data show a dash.
+
+def _get_pending_settlement_trade(position: TradingPosition):
+    """Return the first pending async-deposit trade for a position, or ``None``.
+
+    A deposit that has been requested on-chain but not yet settled sits in
+    :py:attr:`TradeStatus.vault_settlement_pending`.
+    """
+    for trade in position.trades.values():
+        if trade.is_buy() and trade.get_status() == TradeStatus.vault_settlement_pending:
+            return trade
+    return None
+
+
+def _format_lockup(state: State, pair: TradingPairIdentifier) -> Text:
+    """Format the Lockup column for a vault pair.
+
+    Priority:
+
+    1. If an async deposit is pending settlement, show the estimated
+       settlement time (``settles 18.5h``), ``settling`` when the stored
+       estimate has already passed, or ``pending`` when no on-chain ETA is
+       available (operator-driven ERC-7540 vaults like Lagoon).
+    2. Otherwise show the lockup time remaining from the stored expiry
+       timestamp, or ``Unlocked`` once it has passed.
+
+    Non-vault pairs or positions without any of this data show a dash.
     """
     if not pair.is_vault():
         return Text("-", style="dim", justify="right")
 
-    position = state.portfolio.get_position_by_trading_pair(pair)
+    # Include pending positions — an unsettled first deposit may not yet be
+    # an open position.
+    position = state.portfolio.get_position_by_trading_pair(pair, pending=True)
     if position is None:
         return Text("-", style="dim", justify="right")
 
+    now = native_datetime_utc_now()
+
+    # 1. Pending async deposit settlement takes priority over lockup.
+    pending_trade = _get_pending_settlement_trade(position)
+    if pending_trade is not None:
+        settles_at_str = pending_trade.other_data.get("vault_settlement_estimated_at")
+        if settles_at_str is None:
+            return Text("pending", style="yellow", justify="right")
+        try:
+            settles_at = datetime.datetime.fromisoformat(settles_at_str)
+        except (ValueError, TypeError):
+            return Text("pending", style="yellow", justify="right")
+        remaining = settles_at - now
+        if remaining.total_seconds() <= 0:
+            # Estimate has passed — settlement is due / in progress.
+            return Text("settling", style="yellow", justify="right")
+        return Text(_format_remaining(remaining, prefix="settles "), style="yellow", justify="right")
+
+    # 2. Fall back to lockup expiry.
     expires_at_str = position.other_data.get("vault_lockup_expires_at")
     if expires_at_str is None:
         return Text("-", style="dim", justify="right")
@@ -181,16 +231,11 @@ def _format_lockup(state: State, pair: TradingPairIdentifier) -> Text:
     except (ValueError, TypeError):
         return Text("-", style="dim", justify="right")
 
-    now = native_datetime_utc_now()
     remaining = expires_at - now
     if remaining.total_seconds() <= 0:
         return Text("Unlocked", style="green", justify="right")
 
-    hours = remaining.total_seconds() / 3600
-    if hours >= 24:
-        days = hours / 24
-        return Text(f"{days:.1f}d", style="yellow", justify="right")
-    return Text(f"{hours:.1f}h", style="yellow", justify="right")
+    return Text(_format_remaining(remaining), style="yellow", justify="right")
 
 
 def _get_pair_symbol(pair: TradingPairIdentifier) -> str:
@@ -459,7 +504,7 @@ class PairSelectionApp(App):
         table.add_column("TVL", key="tvl", width=14)
         table.add_column("Deposits", key="deposits", width=14)
         table.add_column("Position", key="position", width=20)
-        table.add_column("Lockup", key="lockup", width=10)
+        table.add_column("Lockup", key="lockup", width=14)
 
         for idx, pair in enumerate(self.sorted_pairs, 1):
             symbol = _get_pair_symbol(pair)

--- a/tradeexecutor/ethereum/vault/vault_routing.py
+++ b/tradeexecutor/ethereum/vault/vault_routing.py
@@ -296,6 +296,17 @@ class VaultRouting(RoutingModel):
         trade.other_data["vault_deposit_amount"] = str(swap_amount)
         trade.other_data["vault_owner_address"] = address
 
+        # Estimate when this async deposit will settle, so the trade-ui can show
+        # an ETA while the request is in vault_settlement_pending. Ostium V1.5
+        # returns a real timestamp; operator-driven ERC-7540 vaults (Lagoon)
+        # return None (no deterministic on-chain schedule).
+        try:
+            settles_at = deposit_manager.get_deposit_delay_over(address)
+        except Exception as e:
+            logger.warning("Could not estimate vault deposit settlement time for %s: %s", target_vault.vault_address, e)
+            settles_at = None
+        trade.other_data["vault_settlement_estimated_at"] = settles_at.isoformat() if settles_at else None
+
         # Sign approve tx first
         txs = [tx_builder.sign_transaction(
             contract=target_vault.denomination_token.contract,


### PR DESCRIPTION
## Why

When we make an async vault deposit (Ostium V1.5, ERC-7540 Lagoon), the deposit is *requested* on-chain (`requestDeposit`) but the shares are not minted until the vault *settles* the request (Ostium settles ~daily; Lagoon settles when the operator calls `settleDeposit`). In between, the trade sits in `vault_settlement_pending` and the position holds 0 shares.

In the `trade-ui` table this showed up as `0 oLP` in the Position column with nothing in Lockup — no hint of when the deposit will settle. This adds an estimated settlement time so the operator knows when the shares will appear.

## Summary

- **Store an estimate at request time**: `vault_routing._build_async_deposit_txs()` now records `trade.other_data["vault_settlement_estimated_at"]` (naive-UTC ISO string, or `None`) via the new generic `deposit_manager.get_deposit_delay_over()`. Persisted in state JSON, so it survives restarts.
- **Render it in the Lockup column**: `trade_ui_tui._format_lockup()` shows, for a pending deposit:
  - `settles 18.0h` / `settles 2.1d` — Ostium V1.5 (real on-chain estimate)
  - `settling` — the stored estimate has already passed (settlement slipped)
  - `pending` — operator-driven ERC-7540 vaults (Lagoon) with no deterministic on-chain ETA
  - It now also inspects *pending* positions, and falls through to the existing lockup-expiry display otherwise. Once the deposit settles the trade leaves `vault_settlement_pending`, so the cell reverts automatically. Lockup column widened 10 → 14 to fit.
- **Bump `web3-ethereum-defi`** to include `VaultDepositManager.get_deposit_delay_over()` (tradingstrategy-ai/web3-ethereum-defi#1087).
- New unit test `tests/cli/test_trade_ui_settlement_eta.py` (future ETA → `settles`, past → `settling`, none → `pending`).

## Lessons learnt

- The estimate is intentionally frozen at request time; Ostium settlement can slip, so the UI degrades to `settling` once the stored time passes rather than showing a negative duration.
- The TUI keys off `TradeStatus.vault_settlement_pending`, which is cleared on settlement, so the ETA disappears on its own — no extra cleanup needed.
- Keeping the timing logic behind the generic `VaultDepositManager.get_deposit_delay_over()` in eth_defi keeps trade-executor protocol-agnostic: non-deterministic vaults return `None` and render as `pending` with no special-casing.

## Dependency

Depends on tradingstrategy-ai/web3-ethereum-defi#1087 — the submodule is bumped to that branch commit; re-bump to the merge commit once it lands.
