### PR TITLE
fix: CCTP bridge burns 10^12x too much USDC in vault-only universes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 
 - Breaking API changes
 
+- Fix CCTP bridge burning 10^12x too much USDC ("ERC20: transfer amount exceeds balance") in vault-only universes: native USDC is pinned to 6 decimals when generating synthetic bridge pairs, and the burn amount is converted from authoritative on-chain token decimals (`TokenDetails.convert_to_raw()`) instead of trusting pair metadata. This supersedes the 2026-06-03 fix, which trusted `PandasPairUniverse.get_token()` decimals that are themselves wrong (18) when the upstream vault dataset omits decimals (2026-06-09)
+
 - Fix Hypercore vault deposit reverts when Safe EVM USDC balance is less than planned deposit due to cumulative withdrawal drift (2026-06-09)
 
 - Add vault share balance and total supply to `check-wallet` command output; fix `lagoon-redeem` to claim unclaimed redemptions before starting and poll `maxRedeem` to avoid stale-read failures (2026-06-09)

--- a/tests/ethereum/test_cctp_bridge_decimals.py
+++ b/tests/ethereum/test_cctp_bridge_decimals.py
@@ -1,0 +1,158 @@
+"""Regression test for CCTP bridge USDC decimal resolution.
+
+In a vault-only trading universe there is no DEX token metadata, so the
+USDC token decimals default to 18 instead of the real 6. Previously the
+synthetic CCTP bridge pair inherited those wrong 18 decimals, and the
+bridge routing converted the burn amount with ``10 ** 18`` instead of
+``10 ** 6`` — feeding a 10**12x-too-large amount into ``depositForBurn``,
+which reverts with ``ERC20: transfer amount exceeds balance``.
+
+Native USDC is always 6 decimals on every CCTP chain, so the generated
+bridge pair must carry 6-decimal USDC regardless of poisoned universe
+metadata.
+"""
+
+import pytest
+from tradingstrategy.chain import ChainId
+from tradingstrategy.exchange import Exchange, ExchangeType, ExchangeUniverse
+
+from eth_defi.token import USDC_NATIVE_TOKEN
+
+from tradeexecutor.ethereum.cctp.bridge_universe import (
+    generate_primary_to_satellite_cctp_bridge_universe,
+)
+from tradeexecutor.state.identifier import (
+    AssetIdentifier,
+    TradingPairIdentifier,
+    TradingPairKind,
+)
+from tradeexecutor.strategy.trading_strategy_universe import create_pair_universe_from_code
+
+
+#: Wrong decimals a vault-only universe assigns to USDC (no DEX metadata).
+POISONED_DECIMALS = 18
+
+
+@pytest.fixture()
+def poisoned_usdc_arbitrum() -> AssetIdentifier:
+    """Arbitrum USDC with the wrong 18 decimals (vault-only universe)."""
+    return AssetIdentifier(
+        chain_id=ChainId.arbitrum.value,
+        address=USDC_NATIVE_TOKEN[ChainId.arbitrum.value],
+        token_symbol="USDC",
+        decimals=POISONED_DECIMALS,
+    )
+
+
+@pytest.fixture()
+def poisoned_usdc_base() -> AssetIdentifier:
+    """Base USDC with the wrong 18 decimals (vault-only universe)."""
+    return AssetIdentifier(
+        chain_id=ChainId.base.value,
+        address=USDC_NATIVE_TOKEN[ChainId.base.value],
+        token_symbol="USDC",
+        decimals=POISONED_DECIMALS,
+    )
+
+
+def _vault_pair(
+    quote: AssetIdentifier,
+    vault_address: str,
+    symbol: str,
+    internal_id: int,
+    internal_exchange_id: int,
+) -> TradingPairIdentifier:
+    """Build a vault pair whose quote is the (poisoned) USDC asset."""
+    share_token = AssetIdentifier(
+        chain_id=quote.chain_id,
+        address=vault_address,
+        token_symbol=symbol,
+        decimals=18,
+    )
+    return TradingPairIdentifier(
+        base=share_token,
+        quote=quote,
+        pool_address=vault_address,
+        exchange_address=vault_address,
+        internal_id=internal_id,
+        internal_exchange_id=internal_exchange_id,
+        fee=0.0,
+        kind=TradingPairKind.vault,
+        exchange_name=symbol,
+        other_data={"vault_protocol": "ipor_fusion"},
+    )
+
+
+def test_generated_bridge_pair_uses_native_usdc_decimals(
+    poisoned_usdc_arbitrum: AssetIdentifier,
+    poisoned_usdc_base: AssetIdentifier,
+):
+    """Generated CCTP bridge pairs must carry 6-decimal native USDC.
+
+    Reproduces the vault-only universe scenario where USDC metadata is
+    poisoned to 18 decimals and verifies the synthetic bridge pair is
+    immune to it.
+
+    1. Build a vault-only pair universe on Arbitrum (primary) and Base
+       (satellite) where both USDC assets report 18 decimals.
+    2. Generate the synthetic forward CCTP bridge universe.
+    3. Assert one bridge pair was generated for Arbitrum -> Base.
+    4. Assert both legs of the bridge pair use 6-decimal USDC, so the
+       burn amount is converted correctly (no 10**12x over-burn).
+    """
+
+    # 1. Build a vault-only pair universe with poisoned 18-decimal USDC
+    arb_vault = _vault_pair(
+        poisoned_usdc_arbitrum, "0x0000000000000000000000000000000000000011", "vaultARB",
+        internal_id=1, internal_exchange_id=101,
+    )
+    base_vault = _vault_pair(
+        poisoned_usdc_base, "0x0000000000000000000000000000000000000022", "vaultBASE",
+        internal_id=2, internal_exchange_id=102,
+    )
+    pair_universe = create_pair_universe_from_code(ChainId.arbitrum, [arb_vault, base_vault])
+
+    exchange_universe = ExchangeUniverse(
+        exchanges={
+            ex.exchange_id: ex
+            for ex in [
+                Exchange(
+                    chain_id=ChainId.arbitrum,
+                    chain_slug="arbitrum",
+                    exchange_id=101,
+                    exchange_slug="vault-arb",
+                    address="0x0000000000000000000000000000000000000011",
+                    exchange_type=ExchangeType.erc_4626_vault,
+                    pair_count=1,
+                ),
+                Exchange(
+                    chain_id=ChainId.base,
+                    chain_slug="base",
+                    exchange_id=102,
+                    exchange_slug="vault-base",
+                    address="0x0000000000000000000000000000000000000022",
+                    exchange_type=ExchangeType.erc_4626_vault,
+                    pair_count=1,
+                ),
+            ]
+        }
+    )
+
+    # 2. Generate the synthetic forward CCTP bridge universe
+    result = generate_primary_to_satellite_cctp_bridge_universe(
+        pairs=pair_universe,
+        exchange_universe=exchange_universe,
+        reserve_asset=poisoned_usdc_arbitrum,
+        primary_chain=ChainId.arbitrum,
+    )
+
+    # 3. Exactly one forward bridge pair: Arbitrum -> Base
+    assert len(result.generated_pairs) == 1
+    bridge_pair = result.generated_pairs[0]
+    assert bridge_pair.is_cctp_bridge()
+    assert bridge_pair.base.chain_id == ChainId.base.value
+    assert bridge_pair.quote.chain_id == ChainId.arbitrum.value
+
+    # 4. Both legs must use 6-decimal native USDC despite the poisoned universe
+    assert bridge_pair.quote.decimals == 6, "Primary (burn) USDC must be 6 decimals"
+    assert bridge_pair.base.decimals == 6, "Satellite (mint) USDC must be 6 decimals"

--- a/tradeexecutor/ethereum/cctp/bridge_universe.py
+++ b/tradeexecutor/ethereum/cctp/bridge_universe.py
@@ -107,39 +107,26 @@ def generate_primary_to_satellite_cctp_bridge_universe(
         name="CCTP Bridge",
     )
 
-    # Resolve USDC decimals from the pair universe by address lookup.
-    # The reserve_asset.decimals can be wrong (e.g. 18) when the
-    # DEXPair symbol-based decimal resolution is ambiguous (both tokens
-    # share the same symbol in vault pairs).
-    #
-    # Fallback hierarchy:
-    # 1. Pair universe lookup (most accurate — reads from actual DEXPair data)
-    # 2. Hardcoded 6 (native USDC is always 6 decimals on all CCTP chains)
-    # Never fall back to reserve_asset.decimals — it may be wrong.
+    # Native USDC is always 6 decimals on every CCTP-supported chain, so we
+    # hardcode it rather than reading the pair universe or reserve_asset.
+    # Both of those sources can report a wrong 18 decimals on a vault-only
+    # universe (DEXPair token decimals default to 18 when there is no DEX
+    # token metadata), which would feed a 10**12x-too-large burn amount into
+    # CctpBridgeRouting and revert with "transfer amount exceeds balance".
     NATIVE_USDC_DECIMALS = 6
     primary_usdc_address = USDC_NATIVE_TOKEN[primary_chain.value]
-    primary_usdc_token = pairs.get_token(primary_usdc_address.lower(), chain_id=primary_chain)
-    if primary_usdc_token is not None and primary_usdc_token.decimals is not None:
-        usdc_decimals = primary_usdc_token.decimals
-    else:
-        usdc_decimals = NATIVE_USDC_DECIMALS
-        logger.info(
-            "Primary chain USDC not found in pair universe for %s on %s, "
-            "using known native USDC decimals (%d)",
-            primary_usdc_address,
-            primary_chain.get_name(),
-            NATIVE_USDC_DECIMALS,
-        )
+    usdc_decimals = NATIVE_USDC_DECIMALS
 
     if usdc_decimals != reserve_asset.decimals:
         logger.warning(
             "Reserve asset decimals mismatch: reserve_asset.decimals=%d, "
-            "pair universe USDC decimals=%d for %s on chain %s. "
-            "Using pair universe value.",
+            "native USDC decimals=%d for %s on chain %s. "
+            "Using native USDC value (%d).",
             reserve_asset.decimals,
             usdc_decimals,
             primary_usdc_address,
             primary_chain.get_name(),
+            NATIVE_USDC_DECIMALS,
         )
 
     for satellite_chain in satellite_chain_ids:
@@ -147,11 +134,9 @@ def generate_primary_to_satellite_cctp_bridge_universe(
         if route in existing_routes:
             continue
 
-        # Resolve satellite USDC decimals from the pair universe too.
-        # Falls back to NATIVE_USDC_DECIMALS (6) if not in the universe.
+        # Native USDC on the satellite chain is also always 6 decimals.
         sat_usdc_address = USDC_NATIVE_TOKEN[satellite_chain.value]
-        sat_usdc_token = pairs.get_token(sat_usdc_address.lower(), chain_id=satellite_chain)
-        sat_decimals = sat_usdc_token.decimals if (sat_usdc_token and sat_usdc_token.decimals) else NATIVE_USDC_DECIMALS
+        sat_decimals = NATIVE_USDC_DECIMALS
 
         destination_asset = AssetIdentifier(
             chain_id=satellite_chain.value,

--- a/tradeexecutor/ethereum/cctp/routing.py
+++ b/tradeexecutor/ethereum/cctp/routing.py
@@ -102,7 +102,7 @@ class CctpBridgeRouting(RoutingModel):
             prepare_approve_for_burn,
             prepare_deposit_for_burn,
         )
-        from eth_defi.token import USDC_NATIVE_TOKEN
+        from eth_defi.token import USDC_NATIVE_TOKEN, fetch_erc20_details
         from tradingstrategy.chain import ChainId
 
         assert isinstance(routing_state, CctpBridgeRoutingState)
@@ -151,7 +151,14 @@ class CctpBridgeRouting(RoutingModel):
             assert burn_token_address is not None, \
                 f"No USDC address known for source chain {source_chain_id}"
 
-            amount_raw = int(trade.planned_reserve * (10 ** pair.quote.decimals))
+            # Convert the bridged amount to raw units using the burn token's
+            # authoritative on-chain decimals. We must NOT trust
+            # pair.quote.decimals here: synthetic CCTP bridge pairs built on
+            # vault-only universes can carry a wrong 18-decimal USDC metadata
+            # (DEXPair token decimals default to 18), which would burn 10**12x
+            # too much and revert with "ERC20: transfer amount exceeds balance".
+            burn_token = fetch_erc20_details(source_web3, burn_token_address)
+            amount_raw = burn_token.convert_to_raw(trade.planned_reserve)
 
             # Load contract objects needed for signing
             usdc_contract = get_deployed_contract(


### PR DESCRIPTION
## Why

A cross-chain test trade in `trade-ui` (bridge USDC Arbitrum → Base, then deposit into a Base vault) reverted at the bridge-out step with `execution reverted: ERC20: transfer amount exceeds balance`, freezing the bridge position. The `depositForBurn` calldata showed the cause:

```
depositForBurn(amount=5000000000000000000, …)   # 5×10¹⁸
Onchain balance 5.000000                          # vault holds 5 USDC
```

USDC is a 6-decimal token, so 5 USDC must be `5_000_000`. The burn used **18 decimals**, asking to move 5 trillion USDC.

The 18 originates upstream: in a **vault-only universe** the USDC token decimals resolve to 18, because the vault metadata dataset (`top_vaults_by_chain.json`) omits decimals and the loader defaults a missing `denomination_decimals` to 18. The synthetic CCTP bridge pair inherited that 18-decimal USDC metadata, and routing computed `amount_raw = planned_reserve * 10 ** pair.quote.decimals`.

The 2026-06-03 fix (#1472) switched bridge generation to `PandasPairUniverse.get_token(address)` believing it authoritative for decimals. It is not: `get_token()` only de-aliases the token *row* by address and returns the stored `token0_decimals`, which is the poisoned 18. So #1472 could not hold.

(The upstream producer/consumer bugs are being fixed separately in `web3-ethereum-defi` and `trading-strategy`. This PR is the trade-executor defensive layer, which must not depend on dataset decimals for money-moving code.)

## Lessons learnt

- `PandasPairUniverse.get_token(address)` is authoritative for *which token*, not for *its decimals* — it returns whatever decimals the data pipeline stored, which can be wrong (18) for USDC in vault-only universes.
- Money-moving conversions (burn/transfer amounts) must use authoritative on-chain decimals (`TokenDetails.convert_to_raw()`), never pair/universe metadata.
- Native USDC is always 6 decimals on every CCTP-supported chain — a safe invariant to pin rather than re-derive from poisoned data.

## Summary

- **`bridge_universe.py`**: pin native USDC to 6 decimals when generating synthetic forward bridge pairs (primary and satellite legs) instead of the unreliable `pairs.get_token()` lookup added in #1472.
- **`routing.py`**: convert the bridge burn amount from authoritative on-chain token decimals via `fetch_erc20_details(...).convert_to_raw(trade.planned_reserve)` rather than `planned_reserve * 10 ** pair.quote.decimals`.
- **Tests**: `tests/ethereum/test_cctp_bridge_decimals.py` reproduces the vault-only 18-decimal universe and asserts the generated bridge pair carries 6-decimal USDC (fails on old code with `18 == 6`, passes on the fix).
- **CHANGELOG.md**: entry added.
