### PR TITLE
feat: Auto-discover Lagoon satellite vaults from deployment artifact and fail fast on missing config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 
 - Breaking API changes
 
+- Auto-discover multichain Lagoon satellite vault modules from the `lagoon-deploy-vault` deployment artifact placed next to the state file, removing the manual `SATELLITE_MODULES` env hand-off that stranded bridged USDC on satellite chains. `perform-test-trade` and `start` now fail fast with an actionable error when a cross-chain destination has no satellite module configured, before any irreversible CCTP bridge (2026-06-10)
+
 - Fix CCTP bridge burning 10^12x too much USDC ("ERC20: transfer amount exceeds balance") in vault-only universes: native USDC is pinned to 6 decimals when generating synthetic bridge pairs, and the burn amount is converted from authoritative on-chain token decimals (`TokenDetails.convert_to_raw()`) instead of trusting pair metadata. This supersedes the 2026-06-03 fix, which trusted `PandasPairUniverse.get_token()` decimals that are themselves wrong (18) when the upstream vault dataset omits decimals (2026-06-09)
 
 - Show estimated settlement time for pending async vault deposits in the trade-ui Lockup column — Ostium V1.5 shows a countdown (`settles 18.0h`), operator-driven ERC-7540 vaults (Lagoon) show `pending` (2026-06-09)

--- a/strategies/test_only/xchain-master-vault-test.py
+++ b/strategies/test_only/xchain-master-vault-test.py
@@ -22,9 +22,9 @@ def _load_base_strategy():
 _base = _load_base_strategy()
 
 TEST_SOURCE_VAULTS = [
-    (ChainId.arbitrum, "0x0df2e3a0b5997adc69f8768e495fd98a4d00f134"),  # ycUSDC
+    (ChainId.arbitrum, "0xbe6a65325a073490d0a2999529633f1ae88bb091"),  # Harvest USDC (instant withdrawal, analyses cleanly)
     (ChainId.base, "0x3094b241aade60f91f1c82b0628a10d9501462f9"),  # maxUSD
-    (ChainId.hyperliquid, "0x8a862fd6c12f9ad34c9c2ff45ab2b6712e8cea27"),  # feUSDC
+    (ChainId.hyperliquid, "0xf9bb65e113418292d1a3555515fbd64637a0be18"),  # Clearstar Yield (Euler, instant withdrawal, deposit liquidity)
 ]
 
 TEST_SUPPORTING_PAIRS = [

--- a/tests/mainnet_fork/test_perform_test_trade_crosschain.py
+++ b/tests/mainnet_fork/test_perform_test_trade_crosschain.py
@@ -24,7 +24,7 @@ from eth_defi.compat import native_datetime_utc_now
 from eth_defi.hotwallet import HotWallet
 from eth_defi.provider.anvil import fork_network_anvil, AnvilLaunch, set_balance, fund_erc20_on_anvil
 from eth_defi.provider.multi_provider import create_multi_provider_web3
-from eth_defi.token import USDC_NATIVE_TOKEN
+from eth_defi.token import USDC_NATIVE_TOKEN, fetch_erc20_details
 from eth_defi.cctp.constants import TOKEN_MESSENGER_V2
 
 from tradingstrategy.chain import ChainId
@@ -582,6 +582,98 @@ def test_make_test_trade_crosschain_close_only(
     final_equity = _get_total_equity(state)
     assert final_equity == pytest.approx(initial_equity, rel=0.05), \
         f"Equity dropped from {initial_equity} to {final_equity}"
+
+
+@pytest.mark.timeout(600)
+def test_crosschain_bridge_resolution_and_deposit_simulation(
+    arb_web3,
+    base_web3,
+    execution_model: EthereumExecution,
+    sync_model: HotWalletSyncModel,
+    routing_model: GenericRouting,
+    state: State,
+    universe: TradingStrategyUniverse,
+    bridge_pair: TradingPairIdentifier,
+    vault_pair: TradingPairIdentifier,
+    ipor_share_token: AssetIdentifier,
+    funded_wallet: HotWallet,
+    web3config: Web3Config,
+):
+    """Resolve CCTP bridge routing and simulate a cross-chain vault deposit in-process.
+
+    Same in-process API as the other perform-test-trade tests (``make_test_trade()``),
+    but it asserts the routing resolution explicitly and verifies the deposit
+    physically settled on the Base fork, not just in portfolio state. This is the
+    path the ``perform-test-trade`` CLI exercises when given a satellite-chain
+    vault pair: the bridge is resolved to a CctpBridgeRouting and the bridged USDC
+    is deposited into the Base vault.
+
+    1. Resolve the CCTP bridge pair -> "cctp-bridge" router (CctpBridgeRouting)
+    2. Resolve the Base vault pair -> "vault" router
+    3. Confirm the bridge pair targets the Base destination domain
+    4. Run a buy-only cross-chain make_test_trade() (bridge in + open vault)
+    5. Assert a CCTP bridge position and a Base vault position were opened, bridge OK
+    6. Assert the deposit physically settled on Base: the hot wallet holds IPOR
+       vault shares on the Base fork
+    """
+    from tradeexecutor.ethereum.cctp.routing import CctpBridgeRouting
+
+    pair_configurator = routing_model.pair_configurator
+
+    # 1. CCTP bridge pair resolves to the CCTP bridge router
+    bridge_routing_id = pair_configurator.match_router(bridge_pair)
+    assert bridge_routing_id.router_name == "cctp-bridge"
+    assert isinstance(pair_configurator.get_routing(bridge_pair), CctpBridgeRouting)
+
+    # 2. Satellite vault pair resolves to the vault router
+    assert pair_configurator.match_router(vault_pair).router_name == "vault"
+
+    # 3. Bridge pair targets the Base destination domain (forward Arbitrum -> Base)
+    assert bridge_pair.other_data["destination_chain_id"] == BASE_CHAIN_ID
+
+    # 4. Buy-only cross-chain test trade: bridge in + open vault on Base
+    routing_state = routing_model.create_routing_state(
+        universe, {"tx_builder": execution_model.tx_builder},
+    )
+    pricing_model = GenericPricing(routing_model.pair_configurator)
+
+    make_test_trade(
+        web3=arb_web3,
+        execution_model=execution_model,
+        pricing_model=pricing_model,
+        sync_model=sync_model,
+        state=state,
+        universe=universe,
+        routing_model=routing_model,
+        routing_state=routing_state,
+        max_slippage=0.05,
+        amount=TEST_TRADE_AMOUNT,
+        pair=vault_pair,
+        buy_only=True,
+        web3config=web3config,
+    )
+
+    # 5. Bridge + vault positions opened, bridge trade succeeded
+    bridge_positions = [
+        p for p in state.portfolio.open_positions.values()
+        if p.pair.is_cctp_bridge()
+    ]
+    vault_positions = [
+        p for p in state.portfolio.open_positions.values()
+        if p.pair.kind == TradingPairKind.vault
+    ]
+    assert len(bridge_positions) == 1
+    assert len(vault_positions) == 1
+    bridge_trade = list(bridge_positions[0].trades.values())[0]
+    assert bridge_trade.is_success(), \
+        f"Bridge trade failed: {bridge_trade.get_revert_reason()}"
+
+    # 6. Cross-chain deposit physically settled on Base: hot wallet holds vault shares
+    base_vault_shares = fetch_erc20_details(
+        base_web3, ipor_share_token.address, chain_id=BASE_CHAIN_ID,
+    ).fetch_balance_of(funded_wallet.address)
+    assert base_vault_shares > 0, \
+        "Expected IPOR vault shares on the Base fork after the cross-chain deposit"
 
 
 @pytest.mark.timeout(600)

--- a/tests/mainnet_fork/test_xchain_master_vault_multichain.py
+++ b/tests/mainnet_fork/test_xchain_master_vault_multichain.py
@@ -15,6 +15,7 @@ import logging
 import os
 from decimal import Decimal
 from pathlib import Path
+from unittest import mock
 
 import pytest
 from eth_account import Account
@@ -38,6 +39,7 @@ from web3 import Web3
 from tradingstrategy.chain import ChainId
 from tradingstrategy.client import Client
 
+from tradeexecutor.cli.bootstrap import resolve_satellite_modules
 from tradeexecutor.cli.main import app
 from tradeexecutor.cli.testtrade import make_test_trade
 from tradeexecutor.ethereum.ethereum_protocol_adapters import EthereumPairConfigurator
@@ -75,9 +77,9 @@ DEPLOYER_PRIVATE_KEY = "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d
 HOT_WALLET_PRIVATE_KEY = "0x7b5b648bde0b4ef1ceb56d2c3e1fb938a6b8fb3d399fa6320ef1639705c2df08"
 
 TEST_VAULTS = {
-    ARBITRUM_CHAIN_ID: "0x0df2e3a0b5997adc69f8768e495fd98a4d00f134",
+    ARBITRUM_CHAIN_ID: "0xbe6a65325a073490d0a2999529633f1ae88bb091",
     BASE_CHAIN_ID: "0x3094b241aade60f91f1c82b0628a10d9501462f9",
-    HYPEREVM_CHAIN_ID: "0x8a862fd6c12f9ad34c9c2ff45ab2b6712e8cea27",
+    HYPEREVM_CHAIN_ID: "0xf9bb65e113418292d1a3555515fbd64637a0be18",
 }
 
 DEPOSIT_AMOUNT = Decimal("20")
@@ -428,10 +430,16 @@ def test_xchain_master_vault_multichain_round_trip(
 ):
     """Exercise the full forward-bridge vault lifecycle across three chains.
 
-    1. Create the auto-bridge universe and deploy the Lagoon multichain vault.
-    2. Open bridge positions and vault positions with ``make_test_trade()``.
-    3. Close vaults, sell bridge positions, receive CCTP transfers back on
-       Arbitrum, and verify the portfolio is flat.
+    1. Create the auto-bridge universe and deploy the Lagoon multichain vault,
+       generating the deployment report and asserting the runtime auto-discovers
+       the Base + HyperEVM satellite modules from the deployment artifact (no
+       SATELLITE_MODULES env var).
+    2. Buy: open bridge positions and satellite vault positions with
+       ``make_test_trade()`` (bridge USDC out, deposit into destination vaults).
+    3. Sell + bridge back: close the vault positions, sell the forward bridge
+       positions to return capital from the satellite chains to the master vault
+       on Arbitrum, receive the CCTP transfers, and verify the portfolio is flat
+       with all equity back on the primary chain.
     """
 
     # 1. Create the auto-bridge universe and deploy the Lagoon multichain vault.
@@ -459,6 +467,7 @@ def test_xchain_master_vault_multichain_round_trip(
         "UNIT_TESTING": "true",
         "LOG_LEVEL": "warning",
         "PRIVATE_KEY": DEPLOYER_PRIVATE_KEY,
+        "STATE_FILE": str(tmp_path / "state.json"),
         "VAULT_RECORD_FILE": str(vault_record_file),
         "FUND_NAME": "Xchain master vault test",
         "FUND_SYMBOL": "XMVT",
@@ -473,6 +482,36 @@ def test_xchain_master_vault_multichain_round_trip(
     deploy_record = json.load(vault_record_file.with_suffix(".json").open("rt"))
     assert deploy_record["multichain"] is True
     assert set(deploy_record["deployments"].keys()) == {"arbitrum", "base", "hyperliquid"}
+
+    # 1b. The deployment report carries satellite info: the primary chain
+    #     (Arbitrum) is not a satellite; Base and HyperEVM are, each with a
+    #     trading strategy module address. The Safe address is shared across all
+    #     chains (CREATE2), so bridging to a satellite IS bridging to the master
+    #     vault's Safe on that chain.
+    deployments = deploy_record["deployments"]
+    master_safe = deployments["arbitrum"]["safe_address"]
+    assert deployments["arbitrum"]["is_satellite"] is False
+    assert deployments["base"]["is_satellite"] is True
+    assert deployments["hyperliquid"]["is_satellite"] is True
+    assert deployments["base"]["module_address"]
+    assert deployments["hyperliquid"]["module_address"]
+    assert deployments["base"]["safe_address"].lower() == master_safe.lower()
+    assert deployments["hyperliquid"]["safe_address"].lower() == master_safe.lower()
+
+    # 1c. Automatic discovery: the deploy also drops the artifact next to the
+    #     state file, and the runtime discovers satellites from it WITHOUT a
+    #     SATELLITE_MODULES env var (the bug that stranded funds in production).
+    assert "SATELLITE_MODULES" not in environment, \
+        "Discovery must come from the deployment artifact, not a manual env var"
+    state_dir = Path(environment["STATE_FILE"]).parent
+    sibling_artifacts = list(state_dir.glob("*.deployment.json"))
+    assert len(sibling_artifacts) == 1, \
+        f"Expected one deployment artifact next to the state file, got {sibling_artifacts}"
+    discovered_satellites = resolve_satellite_modules(sibling_artifacts[0])
+    assert set(discovered_satellites.keys()) == {"base", "hyperliquid"}, \
+        f"Expected Base + HyperEVM satellites auto-discovered, got {discovered_satellites}"
+    assert discovered_satellites["base"] == deployments["base"]["module_address"]
+    assert discovered_satellites["hyperliquid"] == deployments["hyperliquid"]["module_address"]
 
     routing_state = routing_model.create_routing_state(
         strategy_universe,
@@ -662,3 +701,155 @@ def test_xchain_master_vault_multichain_round_trip(
     assert chain_equity.get(ChainId.base, 0) == pytest.approx(0, abs=0.05)
     assert chain_equity.get(ChainId.hyperliquid, 0) == pytest.approx(0, abs=0.05)
     assert chain_equity.get(ChainId.arbitrum, 0) == pytest.approx(float(DEPOSIT_AMOUNT), rel=0.05)
+
+
+@pytest.mark.timeout(900)
+def test_xchain_master_vault_lagoon_cli_bridged_deposit(
+    anvil_arbitrum: AnvilLaunch,
+    anvil_base: AnvilLaunch,
+    anvil_hyperevm: AnvilLaunch,
+    arb_web3: Web3,
+    base_web3: Web3,
+    hyper_web3: Web3,
+    strategy_file: Path,
+    tmp_path: Path,
+):
+    """CLI integration: bridged ERC-4626 deposit through the Lagoon guard.
+
+    Pure Typer-CLI in-process integration — the test drives everything through
+    ``app([...])`` and only reads on-chain state / artifacts to assert. It does
+    NOT call ``make_test_trade`` or any execution-model helper, so it exercises
+    the same production path that stranded funds in production:
+
+    1. Deploy a multichain Lagoon vault via ``lagoon-deploy-vault`` (master Safe on
+       Arbitrum, satellite modules on Base + HyperEVM). The deploy writes the
+       discovery artifact next to the state file.
+    2. Negative startup guard (Q1.4): with the deployment artifact removed and no
+       SATELLITE_MODULES env var, ``perform-test-trade`` for a Base satellite vault
+       must fail fast with the "no satellite module configured" error before any
+       irreversible bridge.
+    3. Restore the artifact, fund the master Safe with USDC (fork setup).
+    4. Positive run: ``perform-test-trade --buy-only`` for the Base vault in lagoon
+       mode. This runs the startup guard (Q1.4), auto-discovers the Base satellite
+       from the artifact, bridges USDC Arbitrum -> Base through the
+       TradingStrategyModuleV0 guard with the CCTP mint recipient resolved to the
+       master Safe (Q1.1, Q1.3), and deposits into the Base vault via the satellite
+       guard.
+    5. Separate verification step on the real receiving contract (Q2.2): the master
+       Safe is a deployed contract on Base and now custodies the Base vault
+       position — the bridged USDC was received by the Safe, not an EOA.
+    """
+
+    # 1. Deploy the multichain Lagoon vault via the CLI.
+    deployer = Account.from_key(DEPLOYER_PRIVATE_KEY)
+    for w3 in (arb_web3, base_web3, hyper_web3):
+        w3.provider.make_request("anvil_setBalance", [deployer.address, hex(100 * 10**18)])
+
+    state_file = tmp_path / "lagoon_cli_state.json"
+    vault_record_file = tmp_path / "lagoon-cli-vault-record.txt"
+    base_vault_address = TEST_VAULTS[BASE_CHAIN_ID]
+
+    base_env = {
+        "PATH": os.environ["PATH"],
+        "EXECUTOR_ID": "test_xchain_lagoon_cli",
+        "NAME": "test_xchain_lagoon_cli",
+        "STRATEGY_FILE": strategy_file.as_posix(),
+        "JSON_RPC_ARBITRUM": anvil_arbitrum.json_rpc_url,
+        "JSON_RPC_BASE": anvil_base.json_rpc_url,
+        "JSON_RPC_HYPERLIQUID": anvil_hyperevm.json_rpc_url,
+        "ASSET_MANAGEMENT_MODE": "lagoon",
+        "UNIT_TESTING": "true",
+        "LOG_LEVEL": "warning",
+        "PRIVATE_KEY": DEPLOYER_PRIVATE_KEY,
+        "STATE_FILE": state_file.as_posix(),
+        "TRADING_STRATEGY_API_KEY": TRADING_STRATEGY_API_KEY,
+        "CACHE_PATH": str(tmp_path / "cache"),
+    }
+
+    cli = get_command(app)
+
+    deploy_env = {
+        **base_env,
+        "VAULT_RECORD_FILE": str(vault_record_file),
+        "FUND_NAME": "Xchain lagoon CLI test",
+        "FUND_SYMBOL": "XLCT",
+        "ANY_ASSET": "true",
+        "SAFE_SALT_NONCE": "77",
+    }
+    with mock.patch.dict("os.environ", deploy_env, clear=True):
+        cli.main(args=["lagoon-deploy-vault"], standalone_mode=False)
+
+    deploy_record = json.load(vault_record_file.with_suffix(".json").open("rt"))
+    deployments = deploy_record["deployments"]
+    master_vault_address = deployments["arbitrum"]["vault_address"]
+    master_safe = deployments["arbitrum"]["safe_address"]
+
+    # The deploy drops the discovery artifact next to the state file.
+    deployment_artifact = state_file.with_name("test_xchain_lagoon_cli.deployment.json")
+    assert deployment_artifact.exists(), f"Deployment artifact missing: {deployment_artifact}"
+
+    trade_env = {
+        **base_env,
+        "VAULT_ADDRESS": master_vault_address,
+        "VAULT_ADAPTER_ADDRESS": deployments["arbitrum"]["module_address"],
+    }
+
+    # 2. Negative startup guard (Q1.4): a run whose deployment artifact is absent
+    #    (a different EXECUTOR_ID, so no sibling artifact and no SATELLITE_MODULES)
+    #    leaves the Base satellite unconfigured. perform-test-trade must fail fast
+    #    with the "no satellite module configured" guard before any irreversible bridge.
+    neg_env = {
+        **trade_env,
+        "EXECUTOR_ID": "test_xchain_lagoon_cli_neg",
+        "NAME": "test_xchain_lagoon_cli_neg",
+        "STATE_FILE": (tmp_path / "lagoon_cli_neg_state.json").as_posix(),
+    }
+    with mock.patch.dict("os.environ", neg_env, clear=True):
+        with pytest.raises(RuntimeError, match="satellite"):
+            cli.main(
+                args=["perform-test-trade", "--pair", f"(base, {base_vault_address})", "--buy-only", "--amount", "4"],
+                standalone_mode=False,
+            )
+
+    # 3. Seed the master vault through the real Lagoon deposit flow: fund the
+    #    depositor with USDC, then `lagoon-first-deposit` (approve + deposit + settle)
+    #    so the vault has consistent assets/shares and a valid valuation. Then
+    #    initialise the state so the treasury sync is set up.
+    fund_erc20_on_anvil(
+        arb_web3,
+        USDC_NATIVE_TOKEN[ARBITRUM_CHAIN_ID],
+        deployer.address,
+        int(DEPOSIT_AMOUNT * 10**6),
+    )
+    with mock.patch.dict("os.environ", trade_env, clear=True):
+        cli.main(args=["init"], standalone_mode=False)
+
+    deposit_env = {**trade_env, "DEPOSIT_AMOUNT": str(int(DEPOSIT_AMOUNT))}
+    with mock.patch.dict("os.environ", deposit_env, clear=True):
+        cli.main(args=["lagoon-first-deposit"], standalone_mode=False)
+
+    # 4. Positive run: bridge + deposit through the Lagoon guard.
+    with mock.patch.dict("os.environ", trade_env, clear=True):
+        cli.main(
+            args=["perform-test-trade", "--pair", f"(base, {base_vault_address})", "--buy-only", "--amount", "4"],
+            standalone_mode=False,
+        )
+
+    state = State.from_json(open(state_file, "rt").read())
+    bridge_positions = [p for p in state.portfolio.open_positions.values() if p.pair.is_cctp_bridge()]
+    vault_positions = [p for p in state.portfolio.open_positions.values() if p.pair.kind == TradingPairKind.vault]
+    assert len(bridge_positions) == 1, f"Expected 1 bridge position, got {len(bridge_positions)}"
+    assert len(vault_positions) == 1, f"Expected 1 Base vault position, got {len(vault_positions)}"
+    bridge_trade = list(bridge_positions[0].trades.values())[0]
+    assert bridge_trade.is_success(), f"Bridge trade failed: {bridge_trade.get_revert_reason()}"
+
+    # 5. Separate step — verify the real receiving contract (master Safe on Base).
+    base_safe_code = base_web3.eth.get_code(base_web3.to_checksum_address(master_safe))
+    assert len(base_safe_code) > 0, "Master Safe is not a deployed contract on Base"
+    base_vault_shares = fetch_erc20_details(
+        base_web3, base_vault_address, chain_id=BASE_CHAIN_ID,
+    ).fetch_balance_of(master_safe)
+    assert base_vault_shares > 0, (
+        "Bridged USDC was not deposited into the Base vault under the master Safe — "
+        "the CCTP mint recipient / custody resolution did not target the real Safe contract."
+    )

--- a/tests/test_satellite_preflight.py
+++ b/tests/test_satellite_preflight.py
@@ -64,16 +64,20 @@ def test_resolve_satellite_modules_precedence(tmp_path: Path, monkeypatch: pytes
 class _FakePair:
     """Minimal trading pair stub for the preflight check."""
 
-    def __init__(self, chain_id: int, *, vault: bool = False, bridge: bool = False):
+    def __init__(self, chain_id: int, *, vault: bool = False, bridge: bool = False, hypercore: bool = False):
         self.chain_id = chain_id
-        self._vault = vault
+        self._vault = vault or hypercore
         self._bridge = bridge
+        self._hypercore = hypercore
 
     def is_cctp_bridge(self) -> bool:
         return self._bridge
 
     def is_vault(self) -> bool:
         return self._vault
+
+    def is_hyperliquid_vault(self) -> bool:
+        return self._hypercore
 
 
 class _FakeUniverse:
@@ -141,3 +145,34 @@ def test_check_universe_contracts_resolve_custody_gating():
     )
     with pytest.raises(RuntimeError, match="satellite"):
         check_universe_contracts_resolve(web3config, universe, lagoon_model)
+
+
+def test_check_universe_contracts_resolve_skips_hypercore_vaults():
+    """HyperCore vault pairs are skipped — no satellite or EVM code requirement.
+
+    HyperCore (Hyperliquid) vault pairs are kind=vault but use the synthetic chain
+    id 9999 and are not EVM contracts. The preflight must not require a satellite
+    for chain 9999 nor try to read on-chain code for them, so a Lagoon strategy
+    that trades a HyperCore vault must not be blocked.
+
+    1. Build a Lagoon-custody universe with the primary chain plus a HyperCore
+       vault pair (synthetic chain 9999, no EVM code)
+    2. Assert the preflight does not raise even though no satellite is configured
+    """
+
+    # 1. Lagoon custody, HyperCore vault pair on synthetic chain 9999, no satellites
+    web3config = _FakeWeb3Config()
+    universe = _FakeUniverse(
+        pairs=[
+            _FakePair(ChainId.arbitrum.value),
+            _FakePair(ChainId.hypercore.value, hypercore=True),
+        ],
+        primary_chain=ChainId.arbitrum,
+    )
+    lagoon_model = _FakeExecutionModel(
+        tx_builder=_FakeTxBuilder(ChainId.arbitrum.value, vault=object()),
+        satellite_vaults={},
+    )
+
+    # 2. HyperCore vault is skipped -> no satellite required, no get_code() -> no raise
+    check_universe_contracts_resolve(web3config, universe, lagoon_model)

--- a/tests/test_satellite_preflight.py
+++ b/tests/test_satellite_preflight.py
@@ -1,0 +1,143 @@
+"""Fast unit tests for satellite-module discovery and the cross-chain preflight.
+
+These cover the deploy->runtime hand-off that stranded bridged USDC in
+production, without needing forks or RPC:
+
+- ``resolve_satellite_modules()`` resolves satellites from the env var or the
+  deployment artifact, with the env var taking precedence.
+- ``check_universe_contracts_resolve()`` only requires satellite modules for
+  vault/Safe custody (Lagoon); hot-wallet custody (same EOA on every chain) must
+  not be flagged for cross-chain trades.
+"""
+
+import json
+from pathlib import Path
+
+import pytest
+from tradingstrategy.chain import ChainId
+
+from tradeexecutor.cli.bootstrap import (
+    resolve_satellite_modules,
+    check_universe_contracts_resolve,
+)
+
+
+def test_resolve_satellite_modules_precedence(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    """Satellites resolve from the env var or the deployment artifact, env first.
+
+    1. No source -> empty mapping
+    2. Deployment artifact -> only the is_satellite entries, keyed by chain slug
+    3. Missing artifact file -> empty mapping
+    4. Single-chain artifact (no multichain flag) -> empty mapping
+    5. SATELLITE_MODULES env var overrides the artifact
+    """
+
+    # 1. No source -> empty mapping
+    monkeypatch.delenv("SATELLITE_MODULES", raising=False)
+    assert resolve_satellite_modules(None) == {}
+
+    # 2. Deployment artifact -> only the is_satellite entries
+    artifact = tmp_path / "strategy.deployment.json"
+    artifact.write_text(json.dumps({
+        "multichain": True,
+        "deployments": {
+            "arbitrum": {"is_satellite": False, "module_address": "0xAAA"},  # primary, not a satellite
+            "base": {"is_satellite": True, "module_address": "0xBBB"},
+            "hyperliquid": {"is_satellite": True, "module_address": "0xCCC"},
+        },
+    }))
+    assert resolve_satellite_modules(artifact) == {"base": "0xBBB", "hyperliquid": "0xCCC"}
+
+    # 3. Missing artifact file -> empty mapping
+    assert resolve_satellite_modules(tmp_path / "does-not-exist.json") == {}
+
+    # 4. Single-chain artifact (no multichain flag) -> empty mapping
+    single_chain = tmp_path / "single.json"
+    single_chain.write_text(json.dumps({"vault_address": "0x1"}))
+    assert resolve_satellite_modules(single_chain) == {}
+
+    # 5. SATELLITE_MODULES env var overrides the artifact
+    monkeypatch.setenv("SATELLITE_MODULES", json.dumps({"base": "0xENV"}))
+    assert resolve_satellite_modules(artifact) == {"base": "0xENV"}
+
+
+class _FakePair:
+    """Minimal trading pair stub for the preflight check."""
+
+    def __init__(self, chain_id: int, *, vault: bool = False, bridge: bool = False):
+        self.chain_id = chain_id
+        self._vault = vault
+        self._bridge = bridge
+
+    def is_cctp_bridge(self) -> bool:
+        return self._bridge
+
+    def is_vault(self) -> bool:
+        return self._vault
+
+
+class _FakeUniverse:
+    """Minimal universe stub exposing only what the preflight check reads."""
+
+    def __init__(self, pairs: list, primary_chain: ChainId):
+        self._pairs = pairs
+        self._primary_chain = primary_chain
+
+    def iterate_pairs(self):
+        return self._pairs
+
+    def get_primary_chain(self) -> ChainId:
+        return self._primary_chain
+
+
+class _FakeTxBuilder:
+    def __init__(self, chain_id: int, vault=None):
+        self.chain_id = chain_id
+        if vault is not None:
+            self.vault = vault
+
+
+class _FakeExecutionModel:
+    def __init__(self, tx_builder: _FakeTxBuilder, satellite_vaults: dict):
+        self.tx_builder = tx_builder
+        self.satellite_vaults = satellite_vaults
+
+
+class _FakeWeb3Config:
+    def __init__(self):
+        # Real (non-test) chains so the check does not early-return for Anvil.
+        self.connections = {ChainId.arbitrum: object(), ChainId.base: object()}
+
+
+def test_check_universe_contracts_resolve_custody_gating():
+    """The satellite requirement applies to vault custody only, not hot wallets.
+
+    Replicates a cross-chain universe (Arbitrum primary + Base satellite, both
+    non-vault pairs so no on-chain code lookups happen) and asserts:
+
+    1. Hot-wallet custody (tx_builder without a vault) does NOT raise — the same
+       EOA works on every chain, so no satellite module is required.
+    2. Vault/Safe custody (tx_builder with a vault) with no satellite configured
+       for the Base chain MUST raise the fail-fast guard.
+    """
+
+    web3config = _FakeWeb3Config()
+    universe = _FakeUniverse(
+        pairs=[_FakePair(ChainId.arbitrum.value), _FakePair(ChainId.base.value)],
+        primary_chain=ChainId.arbitrum,
+    )
+
+    # 1. Hot-wallet custody -> no satellite required -> must not raise
+    hot_wallet_model = _FakeExecutionModel(
+        tx_builder=_FakeTxBuilder(ChainId.arbitrum.value),  # no vault attribute
+        satellite_vaults={},
+    )
+    check_universe_contracts_resolve(web3config, universe, hot_wallet_model)
+
+    # 2. Vault/Safe custody with no satellite for Base -> must raise
+    lagoon_model = _FakeExecutionModel(
+        tx_builder=_FakeTxBuilder(ChainId.arbitrum.value, vault=object()),
+        satellite_vaults={},
+    )
+    with pytest.raises(RuntimeError, match="satellite"):
+        check_universe_contracts_resolve(web3config, universe, lagoon_model)

--- a/tradeexecutor/cli/bootstrap.py
+++ b/tradeexecutor/cli/bootstrap.py
@@ -269,6 +269,52 @@ def create_execution_model(
     return execution_model, valuation_model_factory, pricing_model_factory
 
 
+def resolve_satellite_modules(deployment_file: "Path | None") -> dict:
+    """Resolve ``{chain_slug: module_address}`` for multichain Lagoon satellites.
+
+    Source priority:
+
+    1. ``SATELLITE_MODULES`` env var (explicit JSON override), e.g.
+       ``{"base": "0x<module address>"}``.
+    2. The deployment artifact (``state/{id}.deployment.json``) emitted by
+       ``lagoon-deploy-vault``, auto-discovered next to the state file. Satellite
+       chains are the ``deployments`` entries flagged ``is_satellite``.
+
+    Deploying a guard with ``lagoon-deploy-vault`` does not wire satellites into
+    the running executor by itself; this discovery removes that manual hand-off so
+    every CLI command picks up satellites from the deployment artifact.
+
+    :param deployment_file:
+        Path to the deployment JSON next to the state file, or ``None`` to rely on
+        the env var only.
+
+    :return:
+        Mapping of chain slug to satellite trading strategy module address. Empty
+        when neither source provides satellites.
+    """
+    import json
+
+    env_json = os.environ.get("SATELLITE_MODULES")
+    if env_json:
+        return json.loads(env_json)
+
+    if deployment_file is not None and deployment_file.exists():
+        data = json.loads(deployment_file.read_text())
+        if data.get("multichain"):
+            modules = {}
+            for slug, dep in (data.get("deployments") or {}).items():
+                if dep.get("is_satellite") and dep.get("module_address"):
+                    modules[slug] = dep["module_address"]
+            if modules:
+                logger.info(
+                    "Discovered %d satellite module(s) from deployment artifact %s",
+                    len(modules), deployment_file,
+                )
+            return modules
+
+    return {}
+
+
 def create_execution_and_sync_model(
     asset_management_mode: AssetManagementMode,
     private_key: str,
@@ -283,6 +329,7 @@ def create_execution_and_sync_model(
     routing_hint: Optional[TradeRouting] = None,
     unit_testing: bool = False,
     token_cache: "TokenDiskCache | None" = None,
+    deployment_file: "Path | None" = None,
 ) -> Tuple[ExecutionModel, SyncModel, ValuationModelFactory, PricingModelFactory]:
     """Set up the wallet sync and execution mode for the command line client."""
 
@@ -338,13 +385,14 @@ def create_execution_and_sync_model(
         execution_model.web3config = web3config
         execution_model.token_cache = token_cache
 
-        # Populate satellite vaults for multichain Lagoon deployments
+        # Populate satellite vaults for multichain Lagoon deployments.
+        # Satellites come from the SATELLITE_MODULES env var (explicit override) or
+        # the deployment artifact written next to the state file by
+        # lagoon-deploy-vault. See resolve_satellite_modules().
         if isinstance(execution_model, LagoonExecution):
-            satellite_modules_json = os.environ.get("SATELLITE_MODULES")
-            if satellite_modules_json:
-                import json as _json
+            satellite_modules = resolve_satellite_modules(deployment_file)
+            if satellite_modules:
                 from eth_defi.erc_4626.vault_protocol.lagoon.vault import LagoonSatelliteVault
-                satellite_modules = _json.loads(satellite_modules_json)
                 # The Safe address is shared across all chains (CREATE2)
                 safe_address = sync_model.vault.safe_address
                 satellite_vaults = {}
@@ -937,4 +985,128 @@ def check_universe_chains_have_gas(
             f"Minimum required: {min_gas_balance} native tokens per chain.\n"
             f"Low balance chains:\n{details}\n"
             f"Top up the wallet or adjust MIN_GAS_BALANCE environment variable."
+        )
+
+
+def check_universe_contracts_resolve(
+    web3config: "Web3Config",
+    universe: "TradingStrategyUniverse",
+    execution_model,
+):
+    """Validate that every on-chain contract the universe will trade resolves before trading.
+
+    Cross-chain (CCTP) trades bridge USDC to a destination chain and then deposit
+    into a destination-chain vault. The bridge burn is irreversible, so we must
+    fail fast here rather than stranding funds on a chain whose satellite Lagoon
+    module is missing or whose contracts do not exist.
+
+    For a multichain Lagoon deployment this checks:
+
+    1. Every non-primary chain that carries a tradeable pair has a satellite Lagoon
+       vault configured. Satellites come from the ``SATELLITE_MODULES`` env var
+       (see :py:func:`create_execution_and_sync_model`); deploying the guard with
+       ``lagoon-deploy-vault`` does NOT wire this up automatically.
+    2. Each configured satellite Safe and its trading strategy module have on-chain
+       code on their chain (catches CREATE2 mismatches and wrong module addresses).
+    3. Each tradeable vault contract has on-chain code on its chain.
+
+    :param web3config:
+        Web3 configuration with RPC connections.
+
+    :param universe:
+        Trading universe constructed for the run.
+
+    :param execution_model:
+        Execution model; satellite vaults and the primary chain are read from it.
+
+    :raises RuntimeError:
+        With actionable guidance when a chain is unconfigured or a contract does
+        not resolve on-chain.
+    """
+    if web3config is None or universe is None:
+        return
+
+    from tradeexecutor.ethereum.web3config import TEST_CHAIN_IDS
+
+    configured_chains = set(web3config.connections.keys())
+
+    # Skip on Anvil forks: forked addresses differ from the chain they simulate.
+    if configured_chains & set(TEST_CHAIN_IDS):
+        return
+
+    satellite_vaults = getattr(execution_model, "satellite_vaults", {}) or {}
+
+    # Primary chain = the master vault chain. Fall back to the first universe chain.
+    primary_chain_id = None
+    tx_builder = getattr(execution_model, "tx_builder", None)
+    if tx_builder is not None:
+        primary_chain_id = getattr(tx_builder, "chain_id", None)
+    if primary_chain_id is None:
+        primary_chain_id = universe.get_primary_chain().value
+
+    errors: list[str] = []
+
+    def _has_code(chain_id_value: int, address: str) -> bool | None:
+        # Returns True/False, or None when the chain has no RPC
+        # (already reported by check_universe_chains_have_rpc()).
+        try:
+            web3 = web3config.get_connection(ChainId(chain_id_value))
+        except KeyError:
+            return None
+        if web3 is None:
+            return None
+        code = web3.eth.get_code(web3.to_checksum_address(address))
+        return code is not None and len(code) > 0
+
+    # Collect chains that carry tradeable (non-bridge) pairs, and check vault contracts.
+    tradeable_chains: set[int] = set()
+    for pair in universe.iterate_pairs():
+        if pair.is_cctp_bridge():
+            continue
+        tradeable_chains.add(pair.chain_id)
+
+        # (3) The vault contract must resolve on its own chain.
+        if pair.is_vault():
+            resolved = _has_code(pair.chain_id, pair.base.address)
+            if resolved is False:
+                errors.append(
+                    f"Vault contract {pair.base.address} ({pair.get_vault_name()}) "
+                    f"has no code on {ChainId(pair.chain_id).get_name()}."
+                )
+
+    # (1) Every non-primary tradeable chain needs a satellite Lagoon module.
+    for chain_id_value in sorted(c for c in tradeable_chains if c != primary_chain_id):
+        if chain_id_value not in satellite_vaults:
+            configured = [ChainId(c).get_slug() for c in satellite_vaults] or ["none"]
+            errors.append(
+                f"Universe trades on {ChainId(chain_id_value).get_name()} "
+                f"(chain {chain_id_value}) but no Lagoon satellite module is configured for it. "
+                f"Cross-chain trades bridge USDC there irreversibly and then cannot deposit. "
+                f"Add this chain to the SATELLITE_MODULES env var "
+                f'(JSON like {{"{ChainId(chain_id_value).get_slug()}": "0x<module address>"}}); '
+                f"the module address is in your lagoon-deploy-vault report. "
+                f"Configured satellite chains: {configured}."
+            )
+
+    # (2) Configured satellite Safe + trading strategy module must resolve on-chain.
+    for chain_id_value, satellite_vault in satellite_vaults.items():
+        safe_address = getattr(satellite_vault, "safe_address", None)
+        module_address = getattr(satellite_vault, "trading_strategy_module_address", None)
+        if safe_address and _has_code(chain_id_value, safe_address) is False:
+            errors.append(
+                f"Satellite Safe {safe_address} has no code on "
+                f"{ChainId(chain_id_value).get_name()} - the master Safe may not be "
+                f"deployed there (CREATE2 mismatch)."
+            )
+        if module_address and _has_code(chain_id_value, module_address) is False:
+            errors.append(
+                f"Satellite trading strategy module {module_address} has no code on "
+                f"{ChainId(chain_id_value).get_name()}."
+            )
+
+    if errors:
+        bullet = "\n".join(f"  - {e}" for e in errors)
+        raise RuntimeError(
+            "perform-test-trade cannot resolve all required contracts before trading:\n"
+            f"{bullet}"
         )

--- a/tradeexecutor/cli/bootstrap.py
+++ b/tradeexecutor/cli/bootstrap.py
@@ -1044,6 +1044,14 @@ def check_universe_contracts_resolve(
     if primary_chain_id is None:
         primary_chain_id = universe.get_primary_chain().value
 
+    # Satellite modules are only required for vault/Safe custody (e.g. Lagoon),
+    # where each chain needs its own Safe + guard module. Hot-wallet custody uses
+    # the same EOA on every chain, so cross-chain bridging needs no satellites and
+    # must not be flagged. This mirrors the custody resolver: a tx_builder with a
+    # ``vault`` resolves the mint recipient to the per-chain Safe, whereas a plain
+    # hot-wallet tx_builder uses its own address everywhere.
+    requires_satellites = tx_builder is not None and getattr(tx_builder, "vault", None) is not None
+
     errors: list[str] = []
 
     def _has_code(chain_id_value: int, address: str) -> bool | None:
@@ -1074,9 +1082,11 @@ def check_universe_contracts_resolve(
                     f"has no code on {ChainId(pair.chain_id).get_name()}."
                 )
 
-    # (1) Every non-primary tradeable chain needs a satellite Lagoon module.
+    # (1) For vault/Safe custody, every non-primary tradeable chain needs a
+    #     satellite Lagoon module. Skipped for hot-wallet custody (same EOA on all
+    #     chains, so no satellite is required for cross-chain bridging).
     for chain_id_value in sorted(c for c in tradeable_chains if c != primary_chain_id):
-        if chain_id_value not in satellite_vaults:
+        if requires_satellites and chain_id_value not in satellite_vaults:
             configured = [ChainId(c).get_slug() for c in satellite_vaults] or ["none"]
             errors.append(
                 f"Universe trades on {ChainId(chain_id_value).get_name()} "
@@ -1107,6 +1117,6 @@ def check_universe_contracts_resolve(
     if errors:
         bullet = "\n".join(f"  - {e}" for e in errors)
         raise RuntimeError(
-            "perform-test-trade cannot resolve all required contracts before trading:\n"
+            "Cannot resolve all required contracts before trading:\n"
             f"{bullet}"
         )

--- a/tradeexecutor/cli/bootstrap.py
+++ b/tradeexecutor/cli/bootstrap.py
@@ -1071,6 +1071,12 @@ def check_universe_contracts_resolve(
     for pair in universe.iterate_pairs():
         if pair.is_cctp_bridge():
             continue
+        # HyperCore (Hyperliquid) vault pairs use a synthetic chain id (9999) and
+        # are not EVM contracts — they have their own multi-phase settlement and
+        # need no CCTP satellite. The CCTP planner skips them for the same reason,
+        # so they must neither require a satellite module nor be get_code()-checked.
+        if pair.is_hyperliquid_vault():
+            continue
         tradeable_chains.add(pair.chain_id)
 
         # (3) The vault contract must resolve on its own chain.

--- a/tradeexecutor/cli/commands/lagoon_deploy_vault.py
+++ b/tradeexecutor/cli/commands/lagoon_deploy_vault.py
@@ -258,6 +258,42 @@ def _write_markdown_report(vault_record_file: Path | None, markdown_report: str,
     logger.info("Wrote deployment report to %s", os.path.abspath(md_path))
 
 
+def _write_state_sibling_deployment_artifact(
+    strategy_file: Path | None,
+    json_payload: Any,
+    *,
+    simulate: bool,
+    logger,
+) -> None:
+    """Copy the machine-readable deployment JSON next to the strategy state file.
+
+    The runtime reads ``state/{id}.deployment.json`` to auto-discover satellite
+    Lagoon modules (see :py:func:`tradeexecutor.cli.bootstrap.resolve_satellite_modules`),
+    so every CLI command picks them up without a manual ``SATELLITE_MODULES`` env var.
+
+    The executor id is derived from the strategy module, matching the
+    ``state/{id}.json`` convention used by all commands.
+    """
+    if simulate or not strategy_file:
+        return
+
+    from tradeexecutor.cli.bootstrap import prepare_executor_id
+
+    # Resolve the executor id the same way the runtime commands do (EXECUTOR_ID
+    # env, falling back to the strategy filename) so the artifact filename matches
+    # what start / perform-test-trade look for.
+    executor_id = prepare_executor_id(os.environ.get("EXECUTOR_ID"), strategy_file)
+    # Honour an explicit STATE_FILE location so the artifact lands next to the
+    # state file (and tests don't pollute the repo's state/ dir). Default to the
+    # state/ convention used by all CLI commands.
+    state_file_env = os.environ.get("STATE_FILE")
+    state_dir = Path(state_file_env).parent if state_file_env else Path("state")
+    state_dir.mkdir(parents=True, exist_ok=True)
+    path = state_dir / f"{executor_id}.deployment.json"
+    _write_json_file(path, json_payload, indent=2)
+    logger.info("Wrote deployment artifact for runtime satellite discovery to %s", os.path.abspath(path))
+
+
 def _get_deployment_mode_label(*, guard_only: bool) -> str:
     """Human-readable label for persisted deployment records."""
     return "guard redeploy" if guard_only else "fresh deployment"
@@ -1147,6 +1183,10 @@ def _deploy_multichain(
         simulate=simulate,
         logger=logger,
     )
+
+    # Also place the artifact next to the strategy state file so the runtime
+    # auto-discovers satellite modules without a manual SATELLITE_MODULES env var.
+    _write_state_sibling_deployment_artifact(strategy_file, json_payload, simulate=simulate, logger=logger)
 
     _write_markdown_report(vault_record_file, markdown_report, logger)
 

--- a/tradeexecutor/cli/commands/perform_test_trade.py
+++ b/tradeexecutor/cli/commands/perform_test_trade.py
@@ -24,7 +24,8 @@ from .app import app
 from .pair_mapping import parse_pair_data
 from ..bootstrap import prepare_executor_id, prepare_cache_and_token_cache, create_web3_config, create_state_store, \
     create_execution_and_sync_model, create_client, configure_default_chain, \
-    check_universe_chains_have_rpc, check_universe_chains_have_gas
+    check_universe_chains_have_rpc, check_universe_chains_have_gas, \
+    check_universe_contracts_resolve
 from ..log import setup_logging
 from ..slippage import configure_max_slippage_tolerance
 from ..testtrade import make_test_trade
@@ -175,6 +176,10 @@ def perform_test_trade(
         vault_payment_forwarder_address=vault_payment_forwarder_address,
         routing_hint=mod.trade_routing,
         token_cache=token_cache,
+        # Auto-discover satellite modules from the deployment artifact written
+        # next to the state file by lagoon-deploy-vault. Derive from state_file so
+        # a custom STATE_FILE location is honoured (matches the deploy side).
+        deployment_file=(Path(state_file) if state_file else Path(f"state/{id}.json")).with_name(f"{id}.deployment.json"),
     )
 
     client, routing_model = create_client(
@@ -236,6 +241,11 @@ def perform_test_trade(
     wallet_address = execution_model.tx_builder.get_gas_wallet_address()
     min_gas = getattr(execution_model, 'min_balance_threshold', 0)
     check_universe_chains_have_gas(web3config, universe, wallet_address, min_gas)
+
+    # Resolve every vault, satellite Safe and trading strategy module on-chain
+    # before trading, so a missing SATELLITE_MODULES entry fails fast here rather
+    # than after an irreversible cross-chain CCTP bridge.
+    check_universe_contracts_resolve(web3config, universe, execution_model)
 
     if single_pair:
         pair = universe.get_single_pair()

--- a/tradeexecutor/cli/commands/start.py
+++ b/tradeexecutor/cli/commands/start.py
@@ -330,6 +330,9 @@ def start(
             routing_hint=mod.trade_routing,
             unit_testing=unit_testing,
             token_cache=token_cache,
+            # Auto-discover satellite modules from the deployment artifact next to
+            # the state file. Honour a custom STATE_FILE location (matches deploy).
+            deployment_file=(Path(os.environ["STATE_FILE"]) if os.environ.get("STATE_FILE") else Path(f"state/{id}.json")).with_name(f"{id}.deployment.json"),
         )
 
         # TODO: Unit test hack

--- a/tradeexecutor/cli/loop.py
+++ b/tradeexecutor/cli/loop.py
@@ -532,14 +532,22 @@ class ExecutionLoop:
                     strategy_parameters=self.parameters,
                 )
 
-                # Validate all universe chains have RPC connections and gas
+                # Validate all universe chains have RPC connections and gas, and that
+                # every cross-chain custody/vault/satellite contract resolves before we
+                # trade — so a missing satellite module fails fast here rather than after
+                # an irreversible CCTP bridge.
                 web3config = getattr(self.execution_model, 'web3config', None)
                 if live and web3config is not None:
-                    from tradeexecutor.cli.bootstrap import check_universe_chains_have_rpc, check_universe_chains_have_gas
+                    from tradeexecutor.cli.bootstrap import (
+                        check_universe_chains_have_rpc,
+                        check_universe_chains_have_gas,
+                        check_universe_contracts_resolve,
+                    )
                     check_universe_chains_have_rpc(web3config, universe)
                     wallet_address = self.execution_model.tx_builder.get_gas_wallet_address()
                     min_gas_balance = getattr(self.execution_model, 'min_balance_threshold', 0)
                     check_universe_chains_have_gas(web3config, universe, wallet_address, min_gas_balance)
+                    check_universe_contracts_resolve(web3config, universe, self.execution_model)
 
                 # Check if our data is stagnated and we cannot execute the strategy
                 if self.max_data_delay is not None:

--- a/tradeexecutor/cli/loop.py
+++ b/tradeexecutor/cli/loop.py
@@ -430,6 +430,32 @@ class ExecutionLoop:
         # Mark last refreshed
         run_state.bumb_refreshed()
 
+    def _run_live_preflight(self, universe, live: bool):
+        """Validate chains, gas and cross-chain contracts before a live cycle trades.
+
+        Runs on every live tick — not only when a fresh universe is constructed —
+        because ``run_live()`` warms the universe up front and reuses it across
+        cycles. A missing Lagoon satellite module must fail fast here rather than
+        after an irreversible CCTP bridge.
+        """
+        if not live:
+            return
+
+        web3config = getattr(self.execution_model, 'web3config', None)
+        if web3config is None:
+            return
+
+        from tradeexecutor.cli.bootstrap import (
+            check_universe_chains_have_rpc,
+            check_universe_chains_have_gas,
+            check_universe_contracts_resolve,
+        )
+        check_universe_chains_have_rpc(web3config, universe)
+        wallet_address = self.execution_model.tx_builder.get_gas_wallet_address()
+        min_gas_balance = getattr(self.execution_model, 'min_balance_threshold', 0)
+        check_universe_chains_have_gas(web3config, universe, wallet_address, min_gas_balance)
+        check_universe_contracts_resolve(web3config, universe, self.execution_model)
+
     def tick(
             self,
             unrounded_timestamp: datetime.datetime,
@@ -532,23 +558,6 @@ class ExecutionLoop:
                     strategy_parameters=self.parameters,
                 )
 
-                # Validate all universe chains have RPC connections and gas, and that
-                # every cross-chain custody/vault/satellite contract resolves before we
-                # trade — so a missing satellite module fails fast here rather than after
-                # an irreversible CCTP bridge.
-                web3config = getattr(self.execution_model, 'web3config', None)
-                if live and web3config is not None:
-                    from tradeexecutor.cli.bootstrap import (
-                        check_universe_chains_have_rpc,
-                        check_universe_chains_have_gas,
-                        check_universe_contracts_resolve,
-                    )
-                    check_universe_chains_have_rpc(web3config, universe)
-                    wallet_address = self.execution_model.tx_builder.get_gas_wallet_address()
-                    min_gas_balance = getattr(self.execution_model, 'min_balance_threshold', 0)
-                    check_universe_chains_have_gas(web3config, universe, wallet_address, min_gas_balance)
-                    check_universe_contracts_resolve(web3config, universe, self.execution_model)
-
                 # Check if our data is stagnated and we cannot execute the strategy
                 if self.max_data_delay is not None:
                     self.universe_model.check_data_age(ts, universe, self.max_data_delay)
@@ -560,6 +569,12 @@ class ExecutionLoop:
             # Recycle the universe instance
             logger.info("Reusing previously loaded universe: %s", existing_universe)
             universe = existing_universe
+
+        # Validate chains, gas and cross-chain custody/vault/satellite contracts
+        # before trading. Runs on every live tick, including the warmed-up universe
+        # reused by run_live(), so a missing satellite module fails fast here rather
+        # than after an irreversible CCTP bridge.
+        self._run_live_preflight(universe, live)
 
         # Run cycle checks
         if live:


### PR DESCRIPTION
## Why

A production `xchain-master-vault` deployment bridged USDC from the Arbitrum master vault to Base via CCTP, but the bridged funds could not be deposited into the destination vault — the executor had no satellite Lagoon module configured for Base, so the cross-chain deposit leg failed *after* the irreversible bridge had already happened.

The root cause was a deploy→runtime hand-off gap: `lagoon-deploy-vault` deploys the satellite guard modules and records them in its deployment report, but the running executor only learned about satellites from a hand-set `SATELLITE_MODULES` environment variable. If an operator forgot to wire that env var (or set a custom `STATE_FILE`/`EXECUTOR_ID`), the executor silently bridged to an address it could not trade from.

## Lessons learnt

- Irreversible cross-chain actions must be gated by an *up-front* precondition check. The only guard that enforced "this chain needs a satellite" previously ran on the deposit leg, i.e. after the burn — too late. It now runs before any bridge.
- Deploy-time and runtime config must agree on conventions. Two latent bugs only surfaced once the deployment artifact was actually consumed by the runtime:
  - the deploy wrote the artifact keyed by the strategy *filename stem* while the runtime resolves the id from `EXECUTOR_ID`;
  - the runtime looked for the artifact in a hardcoded `state/` directory instead of honouring a custom `STATE_FILE` location.
- Fork-based CCTP tests that mint to a hand-picked recipient and trade via a hot wallet cannot catch custody/recipient bugs — exactly the class that broke here. A black-box CLI test driving the real Lagoon-guard path (deploy → first deposit → `perform-test-trade`) with the CCTP recipient resolved to the master Safe is needed to cover it.
- Seeding a freshly deployed Lagoon vault by funding the Safe directly leaves assets without shares and reverts settlement (`Panic 0x11`); the vault must be seeded through the real `lagoon-first-deposit` flow.

## Summary

Satellite auto-discovery and fail-fast guard:

- `resolve_satellite_modules()` in `bootstrap.py` resolves satellite modules from `SATELLITE_MODULES` (explicit override) or, failing that, the `lagoon-deploy-vault` deployment artifact (`state/{id}.deployment.json`) auto-discovered next to the state file. Wired into `create_execution_and_sync_model` via a new `deployment_file` parameter; `perform-test-trade` and `start` pass it.
- `lagoon-deploy-vault` now also writes the deployment JSON next to the state file, resolving the executor id and honouring `STATE_FILE` the same way the runtime commands do, so the artifact is discoverable with zero extra config.
- `check_universe_contracts_resolve()` runs at `perform-test-trade` startup: every non-primary chain carrying a tradeable pair must have a satellite module, and each satellite Safe / module / vault contract must resolve on-chain. Raises an actionable error before any bridge.

Tests:

- `tests/mainnet_fork/test_xchain_master_vault_multichain.py`:
  - extended the existing hot-wallet round-trip test to assert deployment-report generation and satellite auto-discovery from the artifact;
  - added `test_xchain_master_vault_lagoon_cli_bridged_deposit`, a pure Typer-CLI in-process integration test that deploys a multichain Lagoon vault, asserts the startup guard fails fast when unconfigured, seeds the vault via `init` + `lagoon-first-deposit`, bridges Arbitrum→Base through the `TradingStrategyModuleV0` guard with custody resolved to the master Safe, and verifies the master Safe (the real receiving contract) custodies the resulting Base vault position.
- `tests/mainnet_fork/test_perform_test_trade_crosschain.py`: added an in-process test asserting CCTP bridge routing resolution and on-chain cross-chain deposit settlement.
- Swapped the test source vaults for high-TVL instant-withdrawal vaults (Arbitrum Harvest `fUSDC`, HyperEVM Euler `eUSDC-4`) whose deposits analyse cleanly on forks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
