### PR TITLE
build: speed up Docker release image builds

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -14,18 +14,27 @@ jobs:
     env:
       REGISTRY: ghcr.io
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
-          submodules: 'recursive'
+          # Only the top-level submodules (trading-strategy, web3-ethereum-defi,
+          # spec) are needed. Avoid 'recursive', which would also clone all 23
+          # of web3-ethereum-defi's contract submodules (uniswap, aave, enzyme,
+          # openzeppelin, ...) — most are excluded from the Docker build context
+          # by .dockerignore anyway, so cloning them wastes ~2 minutes.
+          submodules: true
+      - name: Check out only the Lagoon contracts submodule needed for the image
+        # The image build runs `forge soldeer install` inside contracts/lagoon-v0,
+        # so we need that one nested submodule (it has no further submodules).
+        run: git -C deps/web3-ethereum-defi submodule update --init --depth 1 contracts/lagoon-v0
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v3
       - name: Read metadata
         id: meta
-        uses: docker/metadata-action@v4
+        uses: docker/metadata-action@v5
         with:
           images: ${{ env.REGISTRY }}/${{ github.repository }}
       - name: Log in to Github Container Registry
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -34,7 +43,7 @@ jobs:
       - name: Scrape build info
         run: echo "RELEASE_VERSION=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
       - name: Build and push
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v6
         with:
           context: .
           target: tradeexecutor
@@ -42,9 +51,15 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          # experimental: https://github.com/docker/build-push-action/blob/master/docs/advanced/cache.md#cache-backend-api
-          cache-from: type=gha,scope=tradeexecutor
-          cache-to: type=gha,mode=max,scope=tradeexecutor
+          # Use a registry-backed build cache (a dedicated :buildcache tag in
+          # ghcr) instead of type=gha. The GitHub Actions cache has a ~10 GB
+          # per-repo budget shared with every other workflow (test venvs,
+          # datasets, ...); this image's mode=max cache was being LRU-evicted
+          # between releases, so even the runtime-base layers rebuilt from
+          # scratch every time. A registry cache is not subject to that budget.
+          # https://docs.docker.com/build/cache/backends/registry/
+          cache-from: type=registry,ref=${{ env.REGISTRY }}/${{ github.repository }}:buildcache
+          cache-to: type=registry,ref=${{ env.REGISTRY }}/${{ github.repository }}:buildcache,mode=max
           # https://stackoverflow.com/questions/67051284/how-to-set-a-dockerfile-arg-in-github-actions
           # https://stackoverflow.com/a/63619526/315168
           build-args: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 
 - Breaking API changes
 
+- Speed up Docker release image builds: use a registry-backed BuildKit cache (a dedicated `:buildcache` ghcr tag) instead of the GitHub Actions cache that was being LRU-evicted between releases, add a Poetry cache mount so PyPI wheels survive `eth_defi`/`trading-strategy` dependency bumps, and check out only the `lagoon-v0` contracts submodule instead of all 23 of web3-ethereum-defi's nested submodules (2026-06-10)
+
 - Auto-discover multichain Lagoon satellite vault modules from the `lagoon-deploy-vault` deployment artifact placed next to the state file, removing the manual `SATELLITE_MODULES` env hand-off that stranded bridged USDC on satellite chains. `perform-test-trade` and `start` now fail fast with an actionable error when a cross-chain destination has no satellite module configured, before any irreversible CCTP bridge (2026-06-10)
 
 - Fix CCTP bridge burning 10^12x too much USDC ("ERC20: transfer amount exceeds balance") in vault-only universes: native USDC is pinned to 6 decimals when generating synthetic bridge pairs, and the burn amount is converted from authoritative on-chain token decimals (`TokenDetails.convert_to_raw()`) instead of trusting pair metadata. This supersedes the 2026-06-03 fix, which trusted `PandasPairUniverse.get_token()` decimals that are themselves wrong (18) when the upstream vault dataset omits decimals (2026-06-09)

--- a/Dockerfile
+++ b/Dockerfile
@@ -46,10 +46,15 @@ COPY deps/trading-strategy/tradingstrategy deps/trading-strategy/tradingstrategy
 COPY deps/web3-ethereum-defi/pyproject.toml deps/web3-ethereum-defi/README.md deps/web3-ethereum-defi/
 COPY deps/web3-ethereum-defi/eth_defi deps/web3-ethereum-defi/eth_defi
 
-RUN poetry install --all-extras --no-interaction --no-ansi --without=dev --no-root
-
-# Clean Poetry cache to reduce image size.
-RUN poetry cache clear pypi --all --no-interaction
+# Use a BuildKit cache mount for the Poetry download/build cache. The cache
+# lives in a persistent BuildKit volume, not in the image layer, so:
+#  - rebuilds reuse already-downloaded/built wheels even when this layer is
+#    invalidated by a path-dependency (eth_defi / trading-strategy) bump, which
+#    happens on almost every release;
+#  - the image stays small because the cache is never written into the layer,
+#    so no separate "poetry cache clear" step is needed.
+RUN --mount=type=cache,target=/root/.cache/pypoetry \
+    poetry install --all-extras --no-interaction --no-ansi --without=dev --no-root
 
 # Lagoon contract sources are needed for forge dependency installation, but we
 # still keep them separate from the main application copy to preserve cache.


### PR DESCRIPTION
## Why

Docker release image builds were slow (~9–13 min) and the earlier layer-split
work was being undermined by cache eviction.

Investigation of the release runs found three concrete problems:

1. **GitHub Actions cache eviction.** `cache-to: type=gha,mode=max` competes for
   the ~10 GB per-repo Actions cache budget against every other workflow (test
   venvs, datasets, soldeer, …). The repo sat at **13.9 GB across 179 cache
   entries**, so the image's `mode=max` cache was LRU-evicted between releases.
   The latest release build showed **zero `CACHED` layers** — even `runtime-base`
   (apt, Poetry bootstrap, Foundry) rebuilt from scratch every time.

2. **Poetry install re-downloads everything on each dependency bump.** Most
   releases bump `eth_defi` / `trading-strategy`, whose source is copied before
   `poetry install --all-extras`. That invalidates the ~3-minute install layer,
   and without a persistent wheel cache every PyPI wheel is re-downloaded and
   rebuilt, even though `poetry.lock` is unchanged.

3. **Recursive submodule checkout clones 23 unused submodules.** `submodules:
   recursive` clones all of web3-ethereum-defi's contract submodules (uniswap,
   aave, enzyme, openzeppelin, …), but the image only needs `contracts/lagoon-v0`.
   The rest are excluded from the build context by `.dockerignore` anyway, so the
   clone wastes ~2 minutes.

## Lessons learnt

- A `mode=max` GitHub Actions Docker cache silently loses to LRU eviction when a
  repo's total Actions cache exceeds the ~10 GB budget. A registry-backed cache
  (a dedicated `:buildcache` tag in ghcr) is not subject to that budget and
  survives across releases.
- A BuildKit cache mount (`--mount=type=cache,target=/root/.cache/pypoetry`) keeps
  the Poetry download/build cache in a persistent build volume instead of the
  image layer. This speeds up reinstalls after a path-dependency bump **and**
  keeps the image small for free — the previous `poetry cache clear` step was
  unnecessary once the cache no longer lands in a layer.
- `submodules: recursive` is rarely what you want when only one nested submodule
  is needed; `submodules: true` plus an explicit `submodule update --init` of the
  single required path is much cheaper.

## Summary

- **Dockerfile**: wrap `poetry install --all-extras` in a BuildKit cache mount on
  `/root/.cache/pypoetry`; drop the now-redundant `poetry cache clear`.
- **.github/workflows/docker.yml**:
  - Replace `type=gha` build cache with a registry cache
    (`ghcr.io/<repo>:buildcache`, `mode=max`).
  - Replace `submodules: recursive` with `submodules: true` plus an explicit
    shallow init of only `deps/web3-ethereum-defi/contracts/lagoon-v0`.
  - Bump actions: checkout v3→v4, setup-buildx v2→v3, metadata v4→v5,
    login v2→v3, build-push v5→v6.
- **CHANGELOG.md**: add entry.

Verified locally: the image builds cleanly with the new Dockerfile and passes
smoke checks — `trade-executor --help`, `forge --version`, `chromium --version`,
core Python imports (`tradeexecutor`, `eth_defi`, `tradingstrategy`, `web3`,
`pandas`), and the Lagoon soldeer dependencies installed from the narrowed
`lagoon-v0`-only submodule checkout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
