### PR TITLE
fix: Docker image crashes at runtime due to missing chains submodule

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -16,16 +16,27 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          # Only the top-level submodules (trading-strategy, web3-ethereum-defi,
-          # spec) are needed. Avoid 'recursive', which would also clone all 23
-          # of web3-ethereum-defi's contract submodules (uniswap, aave, enzyme,
-          # openzeppelin, ...) — most are excluded from the Docker build context
-          # by .dockerignore anyway, so cloning them wastes ~2 minutes.
+          # Fetch the top-level submodules (trading-strategy, web3-ethereum-defi,
+          # spec). The two nested submodules the image actually needs are checked
+          # out explicitly in the next step. Avoid 'recursive', which would also
+          # clone all 23 of web3-ethereum-defi's contract submodules (uniswap,
+          # aave, enzyme, openzeppelin, ...) and the chains 'website' submodule —
+          # most are excluded from the Docker build context by .dockerignore
+          # anyway, so cloning them wastes ~2 minutes.
           submodules: true
-      - name: Check out only the Lagoon contracts submodule needed for the image
-        # The image build runs `forge soldeer install` inside contracts/lagoon-v0,
-        # so we need that one nested submodule (it has no further submodules).
-        run: git -C deps/web3-ethereum-defi submodule update --init --depth 1 contracts/lagoon-v0
+      - name: Check out the nested submodules the image needs
+        # 'submodules: true' is not recursive, so it does not fetch nested
+        # submodules. Two of them are COPY'd into the image and must be present:
+        #  - web3-ethereum-defi/contracts/lagoon-v0: `forge soldeer install` runs
+        #    here during the build (no further nested submodules).
+        #  - trading-strategy/tradingstrategy/chains: chain metadata read at
+        #    runtime — Chain.get_slug() loads chains/_data/chains/*.json. Without
+        #    it the image builds but crashes on first chain lookup. A non-recursive
+        #    init fetches the _data we need while skipping the chains 'website'
+        #    submodule, which the image never uses.
+        run: |
+          git -C deps/web3-ethereum-defi submodule update --init --depth 1 contracts/lagoon-v0
+          git -C deps/trading-strategy submodule update --init --depth 1 tradingstrategy/chains
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
       - name: Read metadata

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 
 - Breaking API changes
 
+- Fix Docker release image (v1392) crashing at runtime with "Chain data folder ... not found": the build-time submodule optimisation switched to a non-recursive checkout but missed the nested `trading-strategy/tradingstrategy/chains` submodule (ethereum-lists/chains), whose `_data/chains/*.json` is read by `Chain.get_slug()`. The release workflow now explicitly checks out the chains submodule alongside `lagoon-v0` (still skipping the unused chains `website` submodule and eth_defi's other contract submodules) (2026-06-11)
+
 - Add `lagoon-reclaim-satellites` CLI command that consolidates capital scattered across multichain Lagoon satellite Safes back into the master vault: it displays a table of all on-chain Safe USDC balances, auto-detects unreceived CCTP burns by scanning `DepositForBurn` events from our Safes and checking Circle's Iris API plus the destination chain's `usedNonces()`, lists the planned reclaim actions and asks for y/n confirmation, completes any in-transit CCTP transfers (including burns missing from the state file, auto-detected or given via `--complete-burn-tx <chain>:<tx_hash>`), bridges each satellite Safe's USDC back to the master Safe via CCTP, and verifies every destination-chain mint confirmed. Supports `--dry-run` to stop after the action list without moving funds (2026-06-10)
 
 - Fix CCTP `receiveMessage` reverting out-of-gas on the destination chain: the mint was signed with a hardcoded 200,000 gas limit (less than the 300,000 used for the lighter `depositForBurn`), so the attestation-verify-plus-mint ran out of gas and stranded the burn `cctp_in_transit`. Gas is now estimated live with a 2x buffer and a generous fixed fallback, in both the live settlement and startup-retry paths (2026-06-10)


### PR DESCRIPTION
## Why

The Docker release image v1392 built successfully but **crashed at runtime** on the
first chain lookup:

```
RuntimeError: Chain data folder /usr/src/trade-executor/deps/trading-strategy/tradingstrategy/chains/_data/chains not found.
Make sure you have initialised git submodules or Python packaging is correct.
```

The submodule build optimisation in #1501 switched the release workflow from
`submodules: recursive` to `submodules: true` plus an explicit init of only
eth_defi's `contracts/lagoon-v0`. That missed a second nested submodule that the
image needs: **`trading-strategy/tradingstrategy/chains`** (ethereum-lists/chains),
whose `_data/chains/*.json` is loaded at runtime by `Chain.get_slug()`. The
Dockerfile copies that path into the image, but with the submodule uninitialised
the directory was empty, so every chain-id lookup raised at startup.

## Lessons learnt

- A non-recursive submodule checkout must enumerate **every** nested submodule that
  ends up inside the build context, not just the obvious one. The two nested
  submodules COPY'd into this image are eth_defi's `lagoon-v0` and
  trading-strategy's `chains`; both must be inited explicitly.
- Verifying a Docker build locally is not enough when the local working tree was
  populated with `git submodule update --recursive` — the missing-submodule case
  only appears in the CI checkout. Verification must reproduce the CI checkout
  state (deinit the submodule, re-init via the exact workflow command) and exercise
  the runtime path, not just confirm the image builds.
- A non-recursive init of `chains` is actually better than `recursive` here: it
  fetches the `_data` the image needs while skipping the chains `website`
  submodule (a separate chainlist site) that the image never uses.

## Summary

- `.github/workflows/docker.yml`: the "check out nested submodules" step now inits
  **both** `web3-ethereum-defi/contracts/lagoon-v0` and
  `trading-strategy/tradingstrategy/chains`, still avoiding `recursive` (so
  eth_defi's other 22 contract submodules and the chains `website` submodule are
  not cloned).
- `CHANGELOG.md`: add fix entry.

Verified by rebuilding the image from a CI-faithful submodule checkout and running,
inside the container: `lagoon-reclaim-satellites --help` (the command that crashed),
`ChainId.ethereum.get_slug()` → `ethereum` (the exact failing code path), and
confirming `chains/_data/chains` contains the 2509 chain files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
