### PR TITLE
fix: ERC-7540 vault pricing crashes on previewDeposit() assert

### DIFF
--- a/tests/erc_4626/test_vault_pricing_erc_7540.py
+++ b/tests/erc_4626/test_vault_pricing_erc_7540.py
@@ -1,0 +1,196 @@
+"""Test ERC-7540 (Lagoon) vault price reading and estimation.
+
+ERC-7540 vaults disable ``previewDeposit()``/``previewRedeem()`` on-chain,
+so :py:class:`VaultPricing` must estimate prices through the
+:py:class:`~eth_defi.vault.base.VaultDepositManager` abstraction
+(``convertToShares()``/``convertToAssets()``) instead of the synchronous
+ERC-4626 preview functions.
+"""
+import datetime
+import os
+from decimal import Decimal
+from typing import cast
+
+import pytest
+from web3 import Web3
+
+from eth_defi.compat import native_datetime_utc_now
+from eth_defi.erc_4626.classification import create_vault_instance_autodetect
+from eth_defi.erc_4626.vault_protocol.lagoon.vault import LagoonVault
+from eth_defi.provider.anvil import AnvilLaunch, fork_network_anvil
+from eth_defi.provider.multi_provider import create_multi_provider_web3
+from eth_typing import HexAddress
+
+from tradeexecutor.ethereum.vault.vault_live_pricing import VaultPricing
+from tradeexecutor.ethereum.vault.vault_valuation import VaultValuator
+from tradeexecutor.ethereum.vault.vault_utils import translate_vault_to_trading_pair
+from tradeexecutor.state.identifier import TradingPairIdentifier
+from tradeexecutor.state.position import TradingPosition
+from tradeexecutor.state.trade import TradeExecution, TradeType
+from tradeexecutor.state.valuation import ValuationUpdate
+
+
+JSON_RPC_BASE = os.environ.get("JSON_RPC_BASE")
+
+pytestmark = pytest.mark.skipif(not JSON_RPC_BASE, reason="No JSON_RPC_BASE environment variable")
+
+
+@pytest.fixture()
+def anvil_base_fork() -> AnvilLaunch:
+    """Fork Base at a pinned block so price asserts are deterministic."""
+    launch = fork_network_anvil(
+        JSON_RPC_BASE,
+        fork_block_number=35_094_246,
+    )
+    try:
+        yield launch
+    finally:
+        launch.close()
+
+
+@pytest.fixture()
+def web3(anvil_base_fork: AnvilLaunch) -> Web3:
+    web3 = create_multi_provider_web3(
+        anvil_base_fork.json_rpc_url,
+        retries=1,
+        default_http_timeout=(3, 250.0),
+    )
+    assert web3.eth.chain_id == 8453
+    return web3
+
+
+@pytest.fixture()
+def lagoon_vault(web3: Web3) -> LagoonVault:
+    """722Capital-USDC ERC-7540 vault on Base.
+
+    https://app.lagoon.finance/vault/8453/0xb09f761cb13baca8ec087ac476647361b6314f98
+    """
+    vault = create_vault_instance_autodetect(
+        web3,
+        vault_address="0xb09f761cb13baca8ec087ac476647361b6314f98",
+    )
+    return cast(LagoonVault, vault)
+
+
+@pytest.fixture()
+def lagoon_usdc(lagoon_vault: LagoonVault) -> TradingPairIdentifier:
+    pair = translate_vault_to_trading_pair(lagoon_vault)
+    assert pair.is_vault()
+    return pair
+
+
+@pytest.fixture()
+def owner() -> HexAddress:
+    """Any address works for owner-scoped checks: ERC-7540 estimates ignore the owner."""
+    return "0x3B95C7cD4075B72ecbC4559AF99211C2B6591b2E"
+
+
+@pytest.fixture()
+def vault_pricing(web3: Web3, owner: HexAddress) -> VaultPricing:
+    return VaultPricing(
+        web3,
+        owner_address_resolver=lambda pair: owner,
+    )
+
+
+def test_erc_7540_vault_pricing(
+    vault_pricing: VaultPricing,
+    lagoon_vault: LagoonVault,
+    lagoon_usdc: TradingPairIdentifier,
+):
+    """Price an ERC-7540 vault that has previewDeposit()/previewRedeem() disabled.
+
+    1. Check the vault is detected as ERC-7540 (Lagoon)
+    2. Estimate buy price (deposit) via the deposit manager (convertToShares)
+    3. Estimate sell price (redeem) via the deposit manager (convertToAssets)
+    4. Check the mid price matches buy/sell as there are no fees in conversions
+    5. Check max deposit/redemption is unlimited (async request-based flow)
+       and the pair reports as tradeable
+    6. Check TVL reading works
+    """
+
+    # 1. Check the vault is detected as ERC-7540 (Lagoon)
+    assert lagoon_vault.erc_7540
+    assert not lagoon_vault.get_deposit_manager().has_synchronous_deposit()
+
+    # 2. Estimate buy price (deposit) via the deposit manager (convertToShares)
+    buy_estimate = vault_pricing.get_buy_price(
+        ts=None,
+        pair=lagoon_usdc,
+        reserve=Decimal("100.00"),
+    )
+    assert buy_estimate.block_number > 0
+    assert buy_estimate.mid_price == pytest.approx(1.0409669064246259)  # Forked by block mainnet
+
+    # 3. Estimate sell price (redeem) via the deposit manager (convertToAssets)
+    sell_estimate = vault_pricing.get_sell_price(
+        ts=None,
+        pair=lagoon_usdc,
+        quantity=Decimal("100.00"),
+    )
+    assert sell_estimate.mid_price == pytest.approx(buy_estimate.mid_price, rel=1e-4)
+
+    # 4. Check the mid price matches buy/sell as there are no fees in conversions
+    mid_price = vault_pricing.get_mid_price(ts=None, pair=lagoon_usdc)
+    assert mid_price == pytest.approx(buy_estimate.mid_price, rel=1e-4)
+
+    # 5. Check max deposit/redemption is unlimited (async request-based flow)
+    assert vault_pricing.get_max_deposit(None, lagoon_usdc) is None
+    assert vault_pricing.get_max_redemption(None, lagoon_usdc) is None
+    assert vault_pricing.can_deposit(None, lagoon_usdc) is True
+    assert vault_pricing.can_redeem(None, lagoon_usdc) is True
+    assert vault_pricing.is_tradeable(None, lagoon_usdc) is True
+
+    # 6. Check TVL reading works
+    tvl = vault_pricing.get_usd_tvl(None, lagoon_usdc)
+    assert tvl > 0
+
+
+def test_erc_7540_vault_valuation(
+    vault_pricing: VaultPricing,
+    lagoon_usdc: TradingPairIdentifier,
+):
+    """Value an open ERC-7540 vault position with the live share price.
+
+    1. Create a position holding 100 vault shares
+    2. Revalue the position using VaultValuator
+    3. Check the new value reflects the live ERC-7540 share price
+    """
+
+    # 1. Create a position holding 100 vault shares
+    position = TradingPosition(
+        position_id=1,
+        pair=lagoon_usdc,
+        opened_at=native_datetime_utc_now(),
+        last_pricing_at=native_datetime_utc_now(),
+        last_token_price=1.0,
+        last_reserve_price=1.0,
+        last_trade_at=1.0,
+        reserve_currency=lagoon_usdc.quote,
+        trades={
+            1: TradeExecution(
+                trade_id=1,
+                position_id=1,
+                trade_type=TradeType.rebalance,
+                opened_at=native_datetime_utc_now(),
+                pair=lagoon_usdc,
+                executed_at=native_datetime_utc_now(),
+                executed_quantity=Decimal(100),
+                planned_quantity=Decimal(100),
+                planned_reserve=Decimal(100),
+                planned_price=1.0,
+                reserve_currency=lagoon_usdc.quote,
+            )
+        }
+    )
+
+    # 2. Revalue the position using VaultValuator
+    valuation_model = VaultValuator(vault_pricing)
+    timestamp = datetime.datetime(2029, 1, 1)
+    valuation = valuation_model(ts=timestamp, position=position)
+
+    # 3. Check the new value reflects the live ERC-7540 share price
+    assert isinstance(valuation, ValuationUpdate)
+    assert valuation.new_price == pytest.approx(1.0409669064246259)  # Forked by block mainnet
+    assert valuation.new_value == pytest.approx(104.09669064246259)  # 100 shares * price
+    assert position.get_last_valued_at() == timestamp

--- a/tradeexecutor/ethereum/vault/vault_live_pricing.py
+++ b/tradeexecutor/ethereum/vault/vault_live_pricing.py
@@ -5,7 +5,6 @@ from decimal import Decimal
 from typing import Callable
 
 from eth_defi.compat import native_datetime_utc_now
-from eth_defi.erc_4626.estimate import estimate_4626_redeem, estimate_4626_deposit
 from eth_defi.erc_4626.vault import ERC4626Vault
 from web3 import Web3
 
@@ -20,6 +19,12 @@ logger = logging.getLogger(__name__)
 
 class VaultPricing(PricingModel):
     """Always pull the latest live share price of a vault.
+
+    Deposit and redeem estimations go through the protocol-specific
+    :py:class:`~eth_defi.vault.base.VaultDepositManager`, so both synchronous
+    ERC-4626 vaults (``previewDeposit()``/``previewRedeem()``) and asynchronous
+    ERC-7540 vaults such as Lagoon (``convertToShares()``/``convertToAssets()``,
+    as previews are disabled on-chain) are supported.
 
     .. note::
 
@@ -77,10 +82,10 @@ class VaultPricing(PricingModel):
         block_number = web3.eth.block_number
         vault = self.get_vault(pair)
 
-        estimated_usd = estimate_4626_redeem(
-            vault=vault,
-            owner=None,
-            share_amount=quantity,
+        deposit_manager = vault.get_deposit_manager()
+        estimated_usd = deposit_manager.estimate_redeem(
+            owner=self.get_owner_address(pair),
+            shares=quantity,
             block_identifier=block_number,
         )
 
@@ -115,9 +120,10 @@ class VaultPricing(PricingModel):
         block_number = web3.eth.block_number
         vault = self.get_vault(pair)
 
-        estimated_shares = estimate_4626_deposit(
-            vault=vault,
-            denomination_token_amount=reserve,
+        deposit_manager = vault.get_deposit_manager()
+        estimated_shares = deposit_manager.estimate_deposit(
+            owner=self.get_owner_address(pair),
+            amount=reserve,
             block_identifier=block_number,
         )
 
@@ -186,6 +192,13 @@ class VaultPricing(PricingModel):
         web3 = self.get_web3_for_pair(pair)
         block_number = web3.eth.block_number
         vault = self.get_vault(pair)
+
+        if not vault.get_deposit_manager().has_synchronous_deposit():
+            # On asynchronous vaults (ERC-7540) maxDeposit() returns the claimable
+            # amount of settled deposit requests, not the deposit capacity.
+            # Request-based deposits have no on-chain capacity limit.
+            return None
+
         raw_amount = vault.vault_contract.functions.maxDeposit(owner).call(block_identifier=block_number)
         return vault.denomination_token.convert_to_decimals(raw_amount)
 
@@ -202,6 +215,13 @@ class VaultPricing(PricingModel):
         web3 = self.get_web3_for_pair(pair)
         block_number = web3.eth.block_number
         vault = self.get_vault(pair)
+
+        if not vault.get_deposit_manager().has_synchronous_redemption():
+            # On asynchronous vaults (ERC-7540) maxRedeem() returns the claimable
+            # amount of settled redemption requests, not how many shares can be
+            # requested for redemption.
+            return None
+
         raw_amount = vault.vault_contract.functions.maxRedeem(owner).call(block_identifier=block_number)
         return vault.share_token.convert_to_decimals(raw_amount)
 


### PR DESCRIPTION
# Why

The `trade-ui` cross-chain test trade crashed in production when buying a Lagoon vault position (Hub Capital USDC vault on Ethereum):

```
AssertionError: previewDeposit() is not supported for ERC-7540 vaults:
<Lagoon vault:0xca790385506B790554571Cbc9DA73f0130CDCFD5 safe:0x774A9D67975C2Bd5aa52Dd89873a2BE0c607f888>
```

`VaultPricing.get_buy_price()` called `estimate_4626_deposit()` directly, which hard-asserts on ERC-7540 vaults because asynchronous vaults disable `previewDeposit()` on-chain (Lagoon reverts with `ERC7540PreviewDepositDisabled()`). Routing and execution already supported ERC-7540 via the `VaultDepositManager` abstraction — pricing was the only layer still hardwired to the synchronous ERC-4626 preview functions.

A second latent bug: `get_max_deposit()`/`get_max_redemption()` read `maxDeposit()`/`maxRedeem()` from the vault. On ERC-7540 these return the *claimable* amount of settled requests — normally 0 — not deposit/redemption capacity, so `can_deposit()`/`can_redeem()` would have reported any ERC-7540 vault as closed and blocked all rebalances into it.

# Lessons learnt

- eth_defi already exposes protocol-agnostic deposit/redeem estimation through `vault.get_deposit_manager()`: `ERC4626DepositManager` uses `previewDeposit()`/`previewRedeem()`, while `ERC7540DepositManager` (Lagoon) uses `convertToShares()`/`convertToAssets()`. New vault-facing code should go through this abstraction rather than calling `estimate_4626_*()` helpers directly.
- ERC-7540 redefines `maxDeposit()`/`maxRedeem()` semantics: they return claimable amounts of settled requests, not capacity. Any capacity check must be gated on `has_synchronous_deposit()`/`has_synchronous_redemption()`.
- `VaultValuator` delegates to `get_sell_price()`, so fixing the pricing model fixes valuation transitively.

# Summary

- `VaultPricing.get_buy_price()`/`get_sell_price()` now estimate through `vault.get_deposit_manager().estimate_deposit()`/`.estimate_redeem()`, supporting both synchronous ERC-4626 and asynchronous ERC-7540 vaults polymorphically. Behaviour for ERC-4626 vaults is unchanged.
- `VaultPricing.get_max_deposit()`/`get_max_redemption()` return `None` (no limit) for asynchronous vaults, as request-based deposits/redemptions have no on-chain capacity limit.
- New test module `tests/erc_4626/test_vault_pricing_erc_7540.py` prices the real 722Capital-USDC Lagoon ERC-7540 vault on a pinned Base fork (same vault and block as eth_defi's own ERC-7540 tests): buy/sell/mid price, unlimited max deposit/redemption, tradeability, TVL and position valuation through `VaultValuator`.

Test results:

- `tests/erc_4626/test_vault_pricing_erc_7540.py` — 2 passed (new)
- `tests/erc_4626/test_vault_pricing.py` — 9 passed
- `tests/erc_4626/test_vault_trading_e2e.py` — 1 passed
- `tests/erc_4626/test_vault_rebalance_status.py` — 4 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
