### PR TITLE
fix: cover ERC-7540 satellite settlement pitfalls

### DIFF
--- a/tests/erc_4626/test_vault_async_lagoon_erc_7540.py
+++ b/tests/erc_4626/test_vault_async_lagoon_erc_7540.py
@@ -32,6 +32,7 @@ Steps:
 import logging
 import os
 from decimal import Decimal
+from pathlib import Path
 
 import flaky
 import pytest
@@ -40,16 +41,19 @@ from web3 import Web3
 from eth_defi.compat import native_datetime_utc_now
 from eth_defi.erc_4626.classification import create_vault_instance
 from eth_defi.erc_4626.core import ERC4626Feature
+from eth_defi.erc_4626.vault_protocol.lagoon.deployment import LagoonConfig, LagoonDeploymentParameters, deploy_automated_lagoon_vault
 from eth_defi.erc_4626.vault_protocol.lagoon.testing import force_lagoon_settle
 from eth_defi.hotwallet import HotWallet
-from eth_defi.provider.anvil import fork_network_anvil, AnvilLaunch
+from eth_defi.provider.anvil import fork_network_anvil, fund_erc20_on_anvil, launch_anvil, AnvilLaunch
 from eth_defi.provider.multi_provider import create_multi_provider_web3
-from eth_defi.token import fetch_erc20_details
+from eth_defi.token import fetch_erc20_details, USDC_NATIVE_TOKEN
 from eth_defi.trace import assert_transaction_success_with_explanation
 
 from tradeexecutor.ethereum.ethereum_protocol_adapters import EthereumPairConfigurator
 from tradeexecutor.ethereum.execution import EthereumExecution
 from tradeexecutor.ethereum.hot_wallet_sync_model import HotWalletSyncModel
+from tradeexecutor.ethereum.lagoon.execution import LagoonExecution
+from tradeexecutor.ethereum.lagoon.tx import LagoonTransactionBuilder
 from tradeexecutor.ethereum.tx import HotWalletTransactionBuilder
 from tradeexecutor.cli.close_position import close_single_or_all_positions
 from tradeexecutor.ethereum.vault.vault_utils import translate_vault_to_trading_pair
@@ -71,12 +75,14 @@ from tradingstrategy.universe import Universe
 
 
 JSON_RPC_BASE = os.environ.get("JSON_RPC_BASE")
+JSON_RPC_ARBITRUM = os.environ.get("JSON_RPC_ARBITRUM")
 pytestmark = pytest.mark.skipif(not JSON_RPC_BASE, reason="Set JSON_RPC_BASE to run this test")
 
 #: Real ERC-7540 Lagoon vault on Base (722 capital), as used by eth_defi's Lagoon 7540 test.
 LAGOON_7540_VAULT = "0xb09f761cb13baca8ec087ac476647361b6314f98"
 #: The vault's real asset manager — impersonated on the fork to settle the queue.
 TARGET_VAULT_ASSET_MANAGER = "0x3B95C7cD4075B72ecbC4559AF99211C2B6591b2E"
+ANVIL_DEPLOYER_PRIVATE_KEY = "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80"
 FORK_BLOCK = 41_950_000
 BASE_USDC_ADDRESS = "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913"
 USDC_WHALE_BASE = "0x40EbC1Ac8d4Fedd2E144b75fe9C0420BE82750c6"
@@ -98,8 +104,36 @@ def anvil_base_fork() -> AnvilLaunch:
 
 
 @pytest.fixture()
+def anvil_arbitrum_fork() -> AnvilLaunch:
+    """Arbitrum fork used as the source Lagoon chain for satellite settlement tests."""
+    assert JSON_RPC_ARBITRUM, "JSON_RPC_ARBITRUM not set"
+    launch = fork_network_anvil(JSON_RPC_ARBITRUM)
+    try:
+        yield launch
+    finally:
+        launch.close(log_level=logging.ERROR)
+
+
+@pytest.fixture()
+def anvil_home_chain() -> AnvilLaunch:
+    """Launch a separate home-chain Anvil used to model multichain settlement signing."""
+    launch = launch_anvil()
+    try:
+        yield launch
+    finally:
+        launch.close(log_level=logging.ERROR)
+
+
+@pytest.fixture()
 def web3(anvil_base_fork) -> Web3:
     return create_multi_provider_web3(anvil_base_fork.json_rpc_url, default_http_timeout=(3, 250.0), retries=1)
+
+
+@pytest.fixture()
+def arbitrum_web3(anvil_arbitrum_fork) -> Web3:
+    web3 = create_multi_provider_web3(anvil_arbitrum_fork.json_rpc_url, default_http_timeout=(3, 250.0), retries=1)
+    assert web3.eth.chain_id == ChainId.arbitrum.value
+    return web3
 
 
 @pytest.fixture()
@@ -202,6 +236,126 @@ def _execute(execution_model, routing_model, strategy_universe, state, trades):
     """Broadcast a batch of trades through the live execution model."""
     routing_state = routing_model.create_routing_state(strategy_universe, execution_model.get_routing_state_details())
     execution_model.execute_trades(native_datetime_utc_now(), state, trades, routing_model, routing_state, check_balances=True)
+
+
+def _open_position_and_request_redeem(
+    asset_manager_address: str,
+    target_vault,
+    strategy_universe: TradingStrategyUniverse,
+    execution_model: EthereumExecution,
+    sync_model: HotWalletSyncModel,
+    routing_model,
+    pricing_model: GenericPricing,
+    vault_pair: TradingPairIdentifier,
+    base_usdc: AssetIdentifier,
+) -> tuple[State, Decimal, object, object]:
+    """Open a settled ERC-7540 position and leave its redeem request pending."""
+    state = State()
+    sync_model.sync_initial(state, reserve_asset=base_usdc, reserve_token_price=1.0)
+    sync_model.sync_treasury(native_datetime_utc_now(), state, supported_reserves=[base_usdc])
+    starting_equity = state.portfolio.calculate_total_equity()
+
+    pm = PositionManager(native_datetime_utc_now(), strategy_universe, state, pricing_model)
+    buy_trades = pm.open_spot(vault_pair, value=DEPOSIT_VALUE)
+    _execute(execution_model, routing_model, strategy_universe, state, buy_trades)
+    assert buy_trades[0].get_status() == TradeStatus.vault_settlement_pending
+    force_lagoon_settle(target_vault, asset_manager_address)
+    resolved = execution_model.resolve_pending_vault_settlements(state=state, ts=native_datetime_utc_now())
+    assert len(resolved) == 1
+
+    position = state.portfolio.get_position_by_id(buy_trades[0].position_id)
+    assert position.is_open()
+
+    pm = PositionManager(native_datetime_utc_now(), strategy_universe, state, pricing_model)
+    sell_trades = pm.close_all()
+    _execute(execution_model, routing_model, strategy_universe, state, sell_trades)
+    sell_trade = sell_trades[0]
+    assert sell_trade.get_status() == TradeStatus.vault_settlement_pending
+
+    return state, starting_equity, position, sell_trade
+
+
+class _SingleChainWeb3Config:
+    """Minimal Web3Config-like object for settlement retry tests."""
+
+    def __init__(self, chain_id: ChainId, web3: Web3):
+        self.chain_id = chain_id
+        self.web3 = web3
+
+    def get_connection(self, chain_id: ChainId) -> Web3:
+        assert chain_id == self.chain_id
+        return self.web3
+
+
+class _MultiChainWeb3Config:
+    """Minimal Web3Config-like object for multichain settlement retry tests."""
+
+    def __init__(self, connections: dict[ChainId, Web3]):
+        self.connections = connections
+
+    def get_connection(self, chain_id: ChainId) -> Web3:
+        return self.connections[chain_id]
+
+
+def _deploy_source_and_satellite_lagoon(
+    arbitrum_web3: Web3,
+    base_web3: Web3,
+    target_vault,
+) -> tuple[object, object, HotWallet]:
+    """Deploy a source Lagoon vault on Arbitrum and a Base satellite Safe/module."""
+    deployer = HotWallet.from_private_key(ANVIL_DEPLOYER_PRIVATE_KEY)
+    for chain_web3 in (arbitrum_web3, base_web3):
+        chain_web3.provider.make_request("anvil_setBalance", [deployer.address, hex(100 * 10**18)])
+
+    asset_manager = deployer
+    safe_salt_nonce = 7540
+
+    source_parameters = LagoonDeploymentParameters(
+        underlying=USDC_NATIVE_TOKEN[ChainId.arbitrum.value],
+        name="ERC7540SettlementSource",
+        symbol="E7540S",
+    )
+    deployer.sync_nonce(arbitrum_web3)
+    source_deployment = deploy_automated_lagoon_vault(
+        web3=arbitrum_web3,
+        deployer=deployer,
+        config=LagoonConfig(
+            parameters=source_parameters,
+            safe_owners=[deployer.address],
+            safe_threshold=1,
+            asset_manager=asset_manager.address,
+            any_asset=True,
+            from_the_scratch=False,
+            use_forge=False,
+            safe_salt_nonce=safe_salt_nonce,
+        ),
+    )
+
+    satellite_parameters = LagoonDeploymentParameters(
+        underlying=USDC_NATIVE_TOKEN[ChainId.base.value],
+        name="ERC7540SettlementSatellite",
+        symbol="E7540B",
+    )
+    deployer.sync_nonce(base_web3)
+    satellite_deployment = deploy_automated_lagoon_vault(
+        web3=base_web3,
+        deployer=deployer,
+        config=LagoonConfig(
+            parameters=satellite_parameters,
+            safe_owners=[deployer.address],
+            safe_threshold=1,
+            asset_manager=asset_manager.address,
+            any_asset=True,
+            erc_4626_vaults=[target_vault],
+            from_the_scratch=False,
+            use_forge=False,
+            safe_salt_nonce=safe_salt_nonce,
+            satellite_chain=True,
+        ),
+    )
+
+    assert source_deployment.safe_address == satellite_deployment.safe_address
+    return source_deployment, satellite_deployment, asset_manager
 
 
 @flaky.flaky
@@ -454,4 +608,224 @@ def test_lagoon_erc_7540_close_position_rerun(
 
     # 6. Final equity approximately equals starting equity.
     assert state.portfolio.calculate_total_equity() == pytest.approx(starting_equity, rel=0.05)
+    assert state.portfolio.get_vault_settlement_pending_value() == pytest.approx(0.0, abs=1e-6)
+
+
+def test_lagoon_erc_7540_settlement_claim_restart_after_state_loss(
+    asset_manager_address: str,
+    target_vault,
+    strategy_universe: TradingStrategyUniverse,
+    execution_model: EthereumExecution,
+    sync_model: HotWalletSyncModel,
+    routing_model,
+    pricing_model: GenericPricing,
+    vault_pair: TradingPairIdentifier,
+    base_usdc: AssetIdentifier,
+    tmp_path: Path,
+):
+    """A stale state file after a successful claim must not strand ERC-7540 settlement.
+
+    1. Open a Lagoon ERC-7540 position and request a redeem, leaving it pending.
+    2. Save the pending state as the version a restarted CLI process would reload.
+    3. Settle the vault queue and claim once against the in-memory state.
+    4. Reload the stale pending state and run settlement resolution again.
+    5. Verify the stale state is reconciled instead of staying pending forever.
+    """
+
+    # 1. Open a Lagoon ERC-7540 position and request a redeem, leaving it pending.
+    state, starting_equity, _position, sell_trade = _open_position_and_request_redeem(
+        asset_manager_address,
+        target_vault,
+        strategy_universe,
+        execution_model,
+        sync_model,
+        routing_model,
+        pricing_model,
+        vault_pair,
+        base_usdc,
+    )
+
+    # 2. Save the pending state as the version a restarted CLI process would reload.
+    stale_state_file = tmp_path / "stale-pending-redeem.json"
+    state.write_json_file(stale_state_file)
+
+    # 3. Settle the vault queue and claim once against the in-memory state.
+    force_lagoon_settle(target_vault, asset_manager_address)
+    resolved = execution_model.resolve_pending_vault_settlements(state=state, ts=native_datetime_utc_now())
+    assert len(resolved) == 1
+    assert sell_trade.get_status() == TradeStatus.success
+
+    # 4. Reload the stale pending state and run settlement resolution again.
+    stale_state = State.read_json_file(stale_state_file)
+    stale_sell_trade = next(
+        t
+        for p in stale_state.portfolio.open_positions.values()
+        for t in p.trades.values()
+        if t.get_status() == TradeStatus.vault_settlement_pending
+    )
+    resolved = execution_model.resolve_pending_vault_settlements(state=stale_state, ts=native_datetime_utc_now())
+
+    # 5. Verify the stale state is reconciled instead of staying pending forever.
+    assert len(resolved) == 1
+    assert stale_sell_trade.get_status() == TradeStatus.success
+    assert stale_state.portfolio.calculate_total_equity() == pytest.approx(starting_equity, rel=0.05)
+    assert stale_state.portfolio.get_vault_settlement_pending_value() == pytest.approx(0.0, abs=1e-6)
+
+
+def test_lagoon_erc_7540_satellite_settlement_uses_satellite_chain_signer(
+    anvil_home_chain: AnvilLaunch,
+    web3: Web3,
+    asset_manager_address: str,
+    target_vault,
+    strategy_hot_wallet: HotWallet,
+    strategy_universe: TradingStrategyUniverse,
+    execution_model: EthereumExecution,
+    sync_model: HotWalletSyncModel,
+    routing_model,
+    pricing_model: GenericPricing,
+    vault_pair: TradingPairIdentifier,
+    base_usdc: AssetIdentifier,
+):
+    """A satellite-chain ERC-7540 claim must be signed for the satellite chain.
+
+    1. Open a Base Lagoon ERC-7540 position and request a redeem, leaving it pending.
+    2. Replace the default execution tx builder with a separate home-chain Anvil builder.
+    3. Attach a Web3Config-like object that maps the pending vault chain back to Base.
+    4. Settle the Base vault queue and resolve the pending settlement.
+    5. Verify the claim succeeds and the recorded claim transaction targets Base.
+    """
+
+    # 1. Open a Base Lagoon ERC-7540 position and request a redeem, leaving it pending.
+    state, _starting_equity, _position, sell_trade = _open_position_and_request_redeem(
+        asset_manager_address,
+        target_vault,
+        strategy_universe,
+        execution_model,
+        sync_model,
+        routing_model,
+        pricing_model,
+        vault_pair,
+        base_usdc,
+    )
+
+    # 2. Replace the default execution tx builder with a separate home-chain Anvil builder.
+    home_web3 = create_multi_provider_web3(anvil_home_chain.json_rpc_url, default_http_timeout=(3, 250.0), retries=1)
+    home_web3.eth.send_transaction({"from": home_web3.eth.accounts[0], "to": strategy_hot_wallet.address, "value": 5 * 10**18})
+    execution_model.tx_builder = HotWalletTransactionBuilder(home_web3, strategy_hot_wallet)
+    execution_model.tx_builder.init()
+
+    # 3. Attach a Web3Config-like object that maps the pending vault chain back to Base.
+    execution_model.web3config = _SingleChainWeb3Config(ChainId.base, web3)
+
+    # 4. Settle the Base vault queue and resolve the pending settlement.
+    force_lagoon_settle(target_vault, asset_manager_address)
+    resolved = execution_model.resolve_pending_vault_settlements(state=state, ts=native_datetime_utc_now())
+
+    # 5. Verify the claim succeeds and the recorded claim transaction targets Base.
+    assert len(resolved) == 1
+    assert sell_trade.get_status() == TradeStatus.success
+    assert sell_trade.blockchain_transactions[-1].chain_id == ChainId.base.value
+
+
+@pytest.mark.skipif(not JSON_RPC_ARBITRUM, reason="Set JSON_RPC_ARBITRUM to run the Lagoon satellite Safe settlement test")
+@pytest.mark.timeout(900)
+def test_lagoon_erc_7540_satellite_safe_settlement_uses_satellite_module(
+    arbitrum_web3: Web3,
+    web3: Web3,
+    asset_manager_address: str,
+    target_vault,
+    strategy_universe: TradingStrategyUniverse,
+    vault_pair: TradingPairIdentifier,
+    base_usdc: AssetIdentifier,
+):
+    """Satellite ERC-7540 settlement must use deployed Lagoon Safe modules.
+
+    1. Deploy a source Lagoon vault on Arbitrum and a Base satellite Safe/module.
+    2. Fund the Base satellite Safe with USDC and initialise matching state reserves.
+    3. Open the Base ERC-7540 vault position through the Base TradingStrategyModuleV0.
+    4. Settle the Base vault queue and claim the deposit through the satellite module.
+    5. Request redeem through the satellite module and leave it pending.
+    6. Settle the Base vault queue and claim the redeem through the satellite module.
+    7. Verify both claim transactions target Base and the Base satellite module.
+    """
+
+    # 1. Deploy a source Lagoon vault on Arbitrum and a Base satellite Safe/module.
+    source_deployment, satellite_deployment, asset_manager = _deploy_source_and_satellite_lagoon(
+        arbitrum_web3,
+        web3,
+        target_vault,
+    )
+    satellite_vault = satellite_deployment.vault
+    satellite_module = satellite_vault.trading_strategy_module_address
+
+    execution_model = LagoonExecution(
+        vault=source_deployment.vault,
+        tx_builder=LagoonTransactionBuilder(source_deployment.vault, asset_manager),
+        satellite_vaults={ChainId.base.value: satellite_vault},
+        mainnet_fork=True,
+        confirmation_block_count=0,
+    )
+    execution_model.web3config = _MultiChainWeb3Config({
+        ChainId.arbitrum: arbitrum_web3,
+        ChainId.base: web3,
+    })
+    routing_model = execution_model.create_default_routing_model(strategy_universe)
+    pricing_model = GenericPricing(
+        EthereumPairConfigurator(
+            arbitrum_web3,
+            strategy_universe,
+            execution_model=execution_model,
+        )
+    )
+
+    # 2. Fund the Base satellite Safe with USDC and initialise matching state reserves.
+    fund_erc20_on_anvil(
+        web3,
+        BASE_USDC_ADDRESS,
+        satellite_vault.safe_address,
+        int(200 * 10**6),
+    )
+    state = State()
+    state.portfolio.initialise_reserves(base_usdc, reserve_token_price=1.0)
+    state.portfolio.adjust_reserves(base_usdc, Decimal(str(DEPOSIT_VALUE)), "Test Base satellite Safe USDC balance")
+
+    # 3. Open the Base ERC-7540 vault position through the Base TradingStrategyModuleV0.
+    pm = PositionManager(native_datetime_utc_now(), strategy_universe, state, pricing_model)
+    buy_trades = pm.open_spot(vault_pair, value=DEPOSIT_VALUE)
+    _execute(execution_model, routing_model, strategy_universe, state, buy_trades)
+    buy_trade = buy_trades[0]
+    assert buy_trade.get_status() == TradeStatus.vault_settlement_pending
+    assert buy_trade.blockchain_transactions[-1].chain_id == ChainId.base.value
+    assert buy_trade.blockchain_transactions[-1].contract_address.lower() == satellite_module.lower()
+
+    # 4. Settle the Base vault queue and claim the deposit through the satellite module.
+    force_lagoon_settle(target_vault, asset_manager_address)
+    resolved = execution_model.resolve_pending_vault_settlements(state=state, ts=native_datetime_utc_now())
+    assert len(resolved) == 1
+    assert buy_trade.get_status() == TradeStatus.success
+    deposit_claim_tx = buy_trade.blockchain_transactions[-1]
+    assert deposit_claim_tx.chain_id == ChainId.base.value
+    assert deposit_claim_tx.contract_address.lower() == satellite_module.lower()
+    assert deposit_claim_tx.other["vault_settlement_action"] == "claim"
+
+    # 5. Request redeem through the satellite module and leave it pending.
+    pm = PositionManager(native_datetime_utc_now(), strategy_universe, state, pricing_model)
+    sell_trades = pm.close_all()
+    _execute(execution_model, routing_model, strategy_universe, state, sell_trades)
+    sell_trade = sell_trades[0]
+    assert sell_trade.get_status() == TradeStatus.vault_settlement_pending
+    assert sell_trade.blockchain_transactions[-1].chain_id == ChainId.base.value
+    assert sell_trade.blockchain_transactions[-1].contract_address.lower() == satellite_module.lower()
+
+    # 6. Settle the Base vault queue and claim the redeem through the satellite module.
+    force_lagoon_settle(target_vault, asset_manager_address)
+    resolved = execution_model.resolve_pending_vault_settlements(state=state, ts=native_datetime_utc_now())
+    assert len(resolved) == 1
+
+    # 7. Verify both claim transactions target Base and the Base satellite module.
+    assert sell_trade.get_status() == TradeStatus.success
+    redeem_claim_tx = sell_trade.blockchain_transactions[-1]
+    assert redeem_claim_tx.chain_id == ChainId.base.value
+    assert redeem_claim_tx.contract_address.lower() == satellite_module.lower()
+    assert redeem_claim_tx.other["vault_settlement_action"] == "claim"
     assert state.portfolio.get_vault_settlement_pending_value() == pytest.approx(0.0, abs=1e-6)

--- a/tradeexecutor/ethereum/vault/settlement_retry.py
+++ b/tradeexecutor/ethereum/vault/settlement_retry.py
@@ -13,18 +13,180 @@ Works with any vault protocol that implements the generic
 import logging
 from itertools import chain as ichain
 
+from eth_defi.abi import get_topic_signature_from_event
 from eth_defi.compat import native_datetime_utc_now
+from eth_defi.event_reader.conversion import convert_bytes32_to_address, convert_bytes32_to_uint
+from eth_defi.hotwallet import HotWallet
 from eth_defi.vault.deposit_redeem import (
     AsyncVaultRequestStatus,
     DepositRedeemEventAnalysis,
 )
 from hexbytes import HexBytes
+from web3 import Web3
+from web3.contract.contract import ContractFunction
 
+from tradeexecutor.ethereum.tx import HotWalletTransactionBuilder, TransactionBuilder
 from tradeexecutor.ethereum.vault.vault_routing import get_vault_for_pair
+from tradeexecutor.state.blockhain_transaction import BlockchainTransaction
 from tradeexecutor.state.state import State
 from tradeexecutor.state.trade import TradeExecution, TradeStatus
 
 logger = logging.getLogger(__name__)
+
+
+def _get_chain_aware_tx_builder(
+    execution_model,
+    web3: Web3,
+    vault_chain_id: int,
+) -> TransactionBuilder:
+    """Get transaction builder that signs for the vault chain."""
+    tx_builder = execution_model.tx_builder
+    tx_builder_chain_id = getattr(tx_builder, "chain_id", None)
+
+    if not isinstance(tx_builder_chain_id, int) or tx_builder_chain_id == vault_chain_id:
+        return tx_builder
+
+    assert hasattr(tx_builder, "hot_wallet"), f"Cannot create satellite tx builder from {tx_builder}"
+
+    satellite_wallet = HotWallet(tx_builder.hot_wallet.account)
+    satellite_wallet.sync_nonce(web3)
+
+    from tradeexecutor.ethereum.lagoon.tx import LagoonTransactionBuilder
+
+    if isinstance(tx_builder, LagoonTransactionBuilder):
+        satellite_vaults = getattr(execution_model, "satellite_vaults", None) or {}
+        satellite_vault = satellite_vaults.get(vault_chain_id)
+        assert satellite_vault, (
+            f"No satellite vault configured for chain {vault_chain_id}. "
+            f"Available satellite chains: {list(satellite_vaults.keys())}"
+        )
+        return LagoonTransactionBuilder(satellite_vault, satellite_wallet, tx_builder.extra_gnosis_gas)
+
+    return HotWalletTransactionBuilder(web3, satellite_wallet)
+
+
+def _normalise_topic_address(topic) -> str:
+    """Convert an indexed address topic to a comparable lowercase hex address."""
+    return convert_bytes32_to_address(topic).lower()
+
+
+def _normalise_topic_signature(topic) -> str:
+    """Convert a log topic signature to a 0x-prefixed lowercase string."""
+    signature = topic.hex().lower()
+    if not signature.startswith("0x"):
+        signature = "0x" + signature
+    return signature
+
+
+def _get_request_block(web3: Web3, ticket) -> int:
+    """Get the block where the async vault request was opened."""
+    block_number = getattr(ticket, "block_number", 0) or 0
+    if block_number:
+        return block_number
+
+    receipt = web3.eth.get_transaction_receipt(HexBytes(ticket.tx_hash))
+    return receipt["blockNumber"]
+
+
+def _find_already_completed_claim_tx_hash(
+    web3: Web3,
+    vault,
+    ticket,
+    direction: str,
+) -> HexBytes | None:
+    """Find a completed vault claim after local state was lost.
+
+    This handles a crash after the claim transaction was confirmed on-chain but
+    before the JSON state file was written. In that situation the request status
+    can be ``none`` because the claim consumed the request, while local state
+    still shows ``vault_settlement_pending``.
+    """
+    from_block = _get_request_block(web3, ticket)
+    to_block = web3.eth.block_number
+
+    logs = web3.eth.get_logs({
+        "address": vault.vault_contract.address,
+        "fromBlock": from_block,
+        "toBlock": to_block,
+    })
+
+    if direction == "deposit":
+        signatures = {
+            get_topic_signature_from_event(vault.vault_contract.events.Deposit),
+            "0xdcbc1c05240f31ff3ad067ef1ee35ce4997762752e3a095284754544f4c709d7",
+        }
+        expected_to = ticket.to.lower()
+        expected_raw_amount = ticket.raw_amount
+
+        for log in logs:
+            if _normalise_topic_signature(log["topics"][0]) not in signatures:
+                continue
+            if len(log["topics"]) < 3:
+                continue
+            if _normalise_topic_address(log["topics"][2]) != expected_to:
+                continue
+            if convert_bytes32_to_uint(log["data"][0:32]) != expected_raw_amount:
+                continue
+            return HexBytes(log["transactionHash"])
+
+    else:
+        signatures = {
+            get_topic_signature_from_event(vault.vault_contract.events.Withdraw),
+            "0xfbde797d201c681b91056529119e0b02407c7bb96a4a2c75c01fc9667232c8db",
+        }
+        expected_owner = ticket.owner.lower()
+        expected_to = ticket.to.lower()
+        expected_raw_shares = ticket.raw_shares
+
+        for log in logs:
+            if _normalise_topic_signature(log["topics"][0]) not in signatures:
+                continue
+            if len(log["topics"]) < 4:
+                continue
+            if _normalise_topic_address(log["topics"][2]) != expected_to:
+                continue
+            if _normalise_topic_address(log["topics"][3]) != expected_owner:
+                continue
+            if convert_bytes32_to_uint(log["data"][32:64]) != expected_raw_shares:
+                continue
+            return HexBytes(log["transactionHash"])
+
+    return None
+
+
+def _create_recovered_claim_transaction(
+    web3: Web3,
+    vault_chain_id: int,
+    tx_hash: HexBytes,
+    action_label: str,
+    trade: TradeExecution,
+    func: ContractFunction | None,
+) -> BlockchainTransaction:
+    """Create a minimal state transaction for an already-confirmed claim."""
+    tx = web3.eth.get_transaction(tx_hash)
+    receipt = web3.eth.get_transaction_receipt(tx_hash)
+    recovered_tx = BlockchainTransaction(
+        chain_id=vault_chain_id,
+        from_address=tx["from"],
+        contract_address=tx["to"],
+        function_selector=func.fn_name if func is not None else None,
+        transaction_args=func.args if func is not None else None,
+        args=func.args if func is not None else None,
+        tx_hash=tx_hash.hex(),
+        nonce=tx["nonce"],
+        details={"recovered": True},
+        notes=f"Recovered vault {action_label} for trade #{trade.trade_id}",
+    )
+    recovered_tx.other["vault_settlement_action"] = action_label
+    recovered_tx.set_confirmation_information(
+        native_datetime_utc_now(),
+        receipt["blockNumber"],
+        receipt["blockHash"].hex(),
+        receipt.get("effectiveGasPrice", 0),
+        receipt["gasUsed"],
+        receipt["status"] == 1,
+    )
+    return recovered_tx
 
 
 def check_and_resolve_vault_settlements(
@@ -198,14 +360,47 @@ def _resolve_single_vault_trade(
             )
             return
         elif status == AsyncVaultRequestStatus.none:
-            logger.warning(
-                "Unexpected NONE status for vault trade #%d (direction=%s)",
-                trade.trade_id, direction,
+            recovered_tx_hash = _find_already_completed_claim_tx_hash(
+                web3,
+                vault,
+                ticket,
+                direction,
             )
-            return
+            if recovered_tx_hash is None:
+                logger.warning(
+                    "Unexpected NONE status for vault trade #%d (direction=%s)",
+                    trade.trade_id, direction,
+                )
+                return
+
+            action_label = "claim"
+            if direction == "deposit":
+                func = deposit_manager.finish_deposit(ticket)
+            else:
+                func = deposit_manager.finish_redemption(ticket)
+            confirmed_receipt = web3.eth.get_transaction_receipt(recovered_tx_hash)
+            trade.blockchain_transactions.append(
+                _create_recovered_claim_transaction(
+                    web3,
+                    vault_chain_id,
+                    recovered_tx_hash,
+                    action_label,
+                    trade,
+                    func,
+                )
+            )
+            tx_already_confirmed = True
+            is_reclaim_tx = False
+            logger.info(
+                "Recovered already-confirmed vault claim for trade #%d from tx %s",
+                trade.trade_id,
+                recovered_tx_hash.hex(),
+            )
 
         # STEP C: Sign and broadcast claim/reclaim
-        if status == AsyncVaultRequestStatus.claimable:
+        if tx_already_confirmed:
+            pass
+        elif status == AsyncVaultRequestStatus.claimable:
             if direction == "deposit":
                 func = deposit_manager.finish_deposit(ticket)
             else:
@@ -226,43 +421,44 @@ def _resolve_single_vault_trade(
         else:
             return
 
-        # Sync nonce before signing (may be stale from prior txs)
-        tx_builder = execution_model.tx_builder
-        if hasattr(tx_builder, 'hot_wallet'):
-            tx_builder.hot_wallet.sync_nonce(web3)
+        if not tx_already_confirmed:
+            # Sync nonce before signing (may be stale from prior txs)
+            tx_builder = _get_chain_aware_tx_builder(execution_model, web3, vault_chain_id)
+            if hasattr(tx_builder, 'hot_wallet'):
+                tx_builder.hot_wallet.sync_nonce(web3)
 
-        action_label = "reclaim" if is_reclaim_tx else "claim"
-        new_tx = tx_builder.sign_transaction(
-            contract=vault.vault_contract,
-            args_bound_func=func,
-            gas_limit=1_000_000,
-            asset_deltas=[],
-            notes=f"Vault {action_label} for trade #{trade.trade_id} ({direction})",
-        )
-        new_tx.other["vault_settlement_action"] = action_label
-        trade.blockchain_transactions.append(new_tx)
+            action_label = "reclaim" if is_reclaim_tx else "claim"
+            new_tx = tx_builder.sign_transaction(
+                contract=vault.vault_contract,
+                args_bound_func=func,
+                gas_limit=1_000_000,
+                asset_deltas=[],
+                notes=f"Vault {action_label} for trade #{trade.trade_id} ({direction})",
+            )
+            new_tx.other["vault_settlement_action"] = action_label
+            trade.blockchain_transactions.append(new_tx)
 
-        # Broadcast and wait
-        try:
-            web3.eth.send_raw_transaction(HexBytes(new_tx.signed_bytes))
-            new_tx.broadcasted_at = native_datetime_utc_now()
-            confirmed_receipt = web3.eth.wait_for_transaction_receipt(
-                HexBytes(new_tx.tx_hash), timeout=120,
-            )
-        except Exception as e:
-            logger.warning(
-                "Vault %s broadcast failed for trade #%d: %s",
-                action_label, trade.trade_id, e,
-            )
-            return
+            # Broadcast and wait
+            try:
+                web3.eth.send_raw_transaction(HexBytes(new_tx.signed_bytes))
+                new_tx.broadcasted_at = native_datetime_utc_now()
+                confirmed_receipt = web3.eth.wait_for_transaction_receipt(
+                    HexBytes(new_tx.tx_hash), timeout=120,
+                )
+            except Exception as e:
+                logger.warning(
+                    "Vault %s broadcast failed for trade #%d: %s",
+                    action_label, trade.trade_id, e,
+                )
+                return
 
-        if confirmed_receipt["status"] != 1:
-            logger.warning(
-                "Vault %s tx reverted for trade #%d",
-                action_label, trade.trade_id,
-            )
-            trade.blockchain_transactions.pop()
-            return
+            if confirmed_receipt["status"] != 1:
+                logger.warning(
+                    "Vault %s tx reverted for trade #%d",
+                    action_label, trade.trade_id,
+                )
+                trade.blockchain_transactions.pop()
+                return
 
     # STEP D: Analyse confirmed tx and update trade state
     ts = native_datetime_utc_now()


### PR DESCRIPTION
## Why

ERC-7540 Lagoon settlement retry had two production pitfalls not covered by the existing integration tests:

- Satellite-chain claims could be signed with the source-chain transaction builder, sending settlement transactions to the wrong chain or wrong Safe module.
- If executor state was lost after a successful on-chain claim but before state persistence, the retry loop could see no pending ticket and leave the trade permanently pending.

These paths are expensive to catch manually because they require real Anvil forks, Lagoon Safe/module deployment, and ERC-7540 queue settlement.

## Lessons learnt

ERC-7540 settlement retry needs to be chain-aware at the transaction-builder level, not only at the Web3 connection lookup. Lagoon source vaults and satellite vaults must each use their own `TradingStrategyModuleV0` when claiming deposits or redeems.

A missing pending ticket is not always a missing settlement. After a restart, the vault may already have emitted the final ERC-7540 `Deposit` or `Withdraw` event, so retry can safely recover by matching the original request details against vault events.

## Summary

- Add chain-aware settlement transaction-builder selection for hot-wallet and Lagoon satellite settlement retries.
- Recover already-completed ERC-7540 claims from vault `Deposit` / `Withdraw` events after local state loss.
- Add integration coverage for restart-after-claim state loss and satellite-chain settlement signing.
- Add a deployment-backed Anvil fork test that deploys a source Lagoon vault on Arbitrum and a Base satellite Safe/module, then settles a real Base ERC-7540 vault through the satellite `TradingStrategyModuleV0`.
- Bump `deps/web3-ethereum-defi` for the ERC-7540 ticket serialisation support used by these tests.
