### PR TITLE
fix: repair HyperCore partial sell redemption accounting

### DIFF
--- a/tests/hypercore_writer/test_hyper_ai_live_loop.py
+++ b/tests/hypercore_writer/test_hyper_ai_live_loop.py
@@ -588,6 +588,12 @@ def test_hyper_ai_hypercore_close_cycle(
     )
 
     assert_phased_withdrawal_trade(close_trade)
+    assert close_trade.executed_quantity == close_trade.planned_quantity
+    assert close_trade.executed_reserve != abs(close_trade.executed_quantity)
+    assert close_trade.executed_price == pytest.approx(
+        float(close_trade.executed_reserve / abs(close_trade.executed_quantity))
+    )
+    assert close_trade.executed_price > 1.0
     assert all(t.blockchain_transactions for t in state.portfolio.get_all_trades())
     assert not any(position.is_frozen() for position in state.portfolio.get_all_positions())
 
@@ -718,15 +724,20 @@ def test_hyper_ai_hypercore_increase_then_decrease_position(
         routing_model=hypercore_routing_model,
         routing_state=routing_state,
     )
+    decrease_value = Decimal("40")
+    decrease_quantity = -(decrease_value / Decimal(str(second_valuation.new_price)))
     decrease_trades = decrease_position_manager.adjust_position(
         pair=pair,
-        dollar_delta=Decimal("-40"),
-        quantity_delta=Decimal("-40"),
+        dollar_delta=-decrease_value,
+        quantity_delta=decrease_quantity,
         weight=1.0,
     )
     assert len(decrease_trades) == 1
     decrease_trade = decrease_trades[0]
     assert decrease_trade.is_sell()
+    assert decrease_trade.planned_price == pytest.approx(second_valuation.new_price)
+    assert decrease_trade.planned_reserve == pytest.approx(decrease_value)
+    assert decrease_trade.planned_quantity == pytest.approx(decrease_quantity)
 
     phased_withdrawal_router = install_hypercore_live_withdrawal_mocks(
         monkeypatch,
@@ -734,6 +745,14 @@ def test_hyper_ai_hypercore_increase_then_decrease_position(
         pair,
     )
     phased_withdrawal_router.simulate = False
+    short_arrival_raw = 10_000_000
+    monkeypatch.setattr(
+        phased_withdrawal_router,
+        "_wait_for_usdc_arrival",
+        lambda baseline_balance_raw, expected_increase_raw, timeout=30.0, poll_interval=2.0: (
+            expected_increase_raw - short_arrival_raw
+        ),
+    )
 
     hypercore_execution_model.execute_trades(
         datetime.datetime(2026, 2, 5),
@@ -745,9 +764,18 @@ def test_hyper_ai_hypercore_increase_then_decrease_position(
     )
 
     decreased_quantity = position.get_quantity()
+    expected_executed_reserve = decrease_trade.executed_reserve
+    expected_executed_amount = -(expected_executed_reserve / Decimal(str(decrease_trade.planned_price)))
     assert decrease_trade.is_success()
+    assert decrease_trade.executed_reserve < decrease_trade.planned_reserve - Decimal("9.99")
+    assert decrease_trade.executed_reserve > decrease_trade.planned_reserve - Decimal("10.02")
+    assert decrease_trade.executed_quantity == pytest.approx(expected_executed_amount)
+    assert abs(decrease_trade.executed_quantity) < abs(decrease_trade.planned_quantity)
+    assert decrease_trade.executed_quantity != -decrease_trade.executed_reserve
+    assert decrease_trade.executed_price == pytest.approx(second_valuation.new_price)
     assert decreased_quantity < increased_quantity
     assert decreased_quantity > 0
+    assert decreased_quantity == pytest.approx(increased_quantity + expected_executed_amount)
     assert_phased_withdrawal_trade(decrease_trade)
 
     final_valuation = hypercore_valuation_model(datetime.datetime(2026, 2, 5), position)
@@ -755,6 +783,143 @@ def test_hyper_ai_hypercore_increase_then_decrease_position(
     assert final_valuation.quantity == pytest.approx(decreased_quantity)
     assert len(state.portfolio.open_positions) == 1
     assert not any(position.is_frozen() for position in state.portfolio.get_all_positions())
+
+
+@pytest.mark.timeout(300)
+def test_hyper_ai_hypercore_close_short_arrival_keeps_residual_position(
+    monkeypatch: pytest.MonkeyPatch,
+    hyper_ai_strategy_module: ModuleType,
+    make_fake_indicators: IndicatorFactory,
+    hypercore_state_with_safe_reserves: tuple[LagoonVault, State],
+    hypercore_execution_model: LagoonExecution,
+    hypercore_pricing_model: GenericPricing,
+    hypercore_routing_model: GenericRouting,
+    hypercore_strategy_universe: TradingStrategyUniverse,
+    hypercore_valuation_model: GenericValuation,
+    hypercore_vault_pair: TradingPairIdentifier,
+) -> None:
+    """Exercise a short-arrival Hypercore full close at a non-1.0 share price.
+
+    1. Open and revalue one Hypercore position above a 1.0 share price.
+    2. Generate a full close sell through the Hyper AI rebalance path.
+    3. Settle less USDC than requested and verify only the received value's vault units are removed.
+    """
+    # 1. Open and revalue one Hypercore position above a 1.0 share price.
+    install_hypercore_wait_failures(monkeypatch)
+    monkeypatch.setattr(hyper_ai_strategy_module, "is_quarantined", lambda pool_address, timestamp: False)
+
+    vault, state = hypercore_state_with_safe_reserves
+    del vault
+    pair = hypercore_strategy_universe.get_pair_by_id(hypercore_vault_pair.internal_id)
+
+    hypercore_execution_model.initialize()
+    routing_state = hypercore_routing_model.create_routing_state(
+        hypercore_strategy_universe,
+        hypercore_execution_model.get_routing_state_details(),
+    )
+    ensure_hypercore_routing_state(
+        hypercore_routing_model,
+        routing_state,
+        pair,
+    )
+
+    open_ts = datetime.datetime(2026, 1, 21)
+    parameters = create_hyper_ai_test_parameters(
+        hyper_ai_strategy_module,
+        initial_cash=100.0,
+        allocation=0.50,
+    )
+    open_input = make_hyper_ai_strategy_input(
+        hyper_ai_strategy_module=hyper_ai_strategy_module,
+        make_fake_indicators=make_fake_indicators,
+        state=state,
+        strategy_universe=hypercore_strategy_universe,
+        pricing_model=hypercore_pricing_model,
+        routing_model=hypercore_routing_model,
+        routing_state=routing_state,
+        pair=pair,
+        timestamp=open_ts,
+        cycle=1,
+        include_pair=True,
+        parameters=parameters,
+    )
+    open_trades = hyper_ai_strategy_module.decide_trades(open_input)
+    hypercore_execution_model.execute_trades(
+        open_ts,
+        state,
+        open_trades,
+        hypercore_routing_model,
+        routing_state,
+        check_balances=False,
+    )
+
+    position = next(iter(state.portfolio.open_positions.values()))
+    open_quantity = position.get_quantity()
+    valuation_ts = datetime.datetime(2026, 2, 3)
+    valuation_update = hypercore_valuation_model(valuation_ts, position)
+    assert valuation_update.new_price > 1.0
+
+    # 2. Generate a full close sell through the Hyper AI rebalance path.
+    phased_withdrawal_router = install_hypercore_live_withdrawal_mocks(
+        monkeypatch,
+        hypercore_routing_model,
+        pair,
+    )
+    phased_withdrawal_router.simulate = False
+    short_arrival_raw = 10_000_000
+    monkeypatch.setattr(
+        phased_withdrawal_router,
+        "_wait_for_usdc_arrival",
+        lambda baseline_balance_raw, expected_increase_raw, timeout=30.0, poll_interval=2.0: (
+            expected_increase_raw - short_arrival_raw
+        ),
+    )
+
+    close_input = make_hyper_ai_strategy_input(
+        hyper_ai_strategy_module=hyper_ai_strategy_module,
+        make_fake_indicators=make_fake_indicators,
+        state=state,
+        strategy_universe=hypercore_strategy_universe,
+        pricing_model=hypercore_pricing_model,
+        routing_model=hypercore_routing_model,
+        routing_state=routing_state,
+        pair=pair,
+        timestamp=valuation_ts,
+        cycle=2,
+        include_pair=False,
+        parameters=parameters,
+    )
+    close_trades = hyper_ai_strategy_module.decide_trades(close_input)
+    assert len(close_trades) == 1
+    close_trade = close_trades[0]
+    assert close_trade.is_sell()
+    assert close_trade.planned_quantity == -open_quantity
+    assert close_trade.planned_price == pytest.approx(valuation_update.new_price)
+
+    # 3. Settle less USDC than requested and verify only the received value's vault units are removed.
+    hypercore_execution_model.execute_trades(
+        valuation_ts,
+        state,
+        close_trades,
+        hypercore_routing_model,
+        routing_state,
+        check_balances=False,
+    )
+
+    expected_executed_quantity = -(close_trade.executed_reserve / Decimal(str(close_trade.planned_price)))
+    residual_quantity = position.get_quantity()
+    assert close_trade.is_success()
+    assert close_trade.executed_reserve < close_trade.planned_reserve - Decimal("9.99")
+    assert close_trade.executed_reserve > close_trade.planned_reserve - Decimal("10.20")
+    assert close_trade.executed_quantity == pytest.approx(expected_executed_quantity)
+    assert abs(close_trade.executed_quantity) < abs(close_trade.planned_quantity)
+    assert close_trade.executed_quantity != close_trade.planned_quantity
+    assert close_trade.executed_price == pytest.approx(valuation_update.new_price)
+    assert residual_quantity == pytest.approx(open_quantity + expected_executed_quantity)
+    assert residual_quantity > 0
+    assert len(state.portfolio.open_positions) == 1
+    assert not state.portfolio.closed_positions
+    assert_phased_withdrawal_trade(close_trade)
 
 
 @pytest.mark.timeout(300)

--- a/tests/hypercore_writer/test_hyper_ai_live_loop.py
+++ b/tests/hypercore_writer/test_hyper_ai_live_loop.py
@@ -12,6 +12,7 @@ from web3 import Web3
 
 from tradeexecutor.ethereum.lagoon.execution import LagoonExecution
 from tradeexecutor.ethereum.lagoon.vault import LagoonVaultSyncModel
+from tradeexecutor.ethereum.vault.hypercore_routing import raw_to_usdc
 from tradeexecutor.exchange_account.allocation import get_redeemable_capital
 from tradeexecutor.state.identifier import TradingPairIdentifier
 from tradeexecutor.state.state import State
@@ -745,12 +746,12 @@ def test_hyper_ai_hypercore_increase_then_decrease_position(
         pair,
     )
     phased_withdrawal_router.simulate = False
-    short_arrival_raw = 10_000_000
+    phase1_fee_shortfall = Decimal("10")
     monkeypatch.setattr(
         phased_withdrawal_router,
-        "_wait_for_usdc_arrival",
-        lambda baseline_balance_raw, expected_increase_raw, timeout=30.0, poll_interval=2.0: (
-            expected_increase_raw - short_arrival_raw
+        "_wait_for_perp_withdrawable_balance",
+        lambda baseline_balance, expected_increase_raw, relative_tolerance=None, timeout=30.0, poll_interval=2.0: (
+            baseline_balance + raw_to_usdc(expected_increase_raw) - phase1_fee_shortfall
         ),
     )
 
@@ -765,17 +766,20 @@ def test_hyper_ai_hypercore_increase_then_decrease_position(
 
     decreased_quantity = position.get_quantity()
     expected_executed_reserve = decrease_trade.executed_reserve
-    expected_executed_amount = -(expected_executed_reserve / Decimal(str(decrease_trade.planned_price)))
+    net_derived_quantity = -(expected_executed_reserve / Decimal(str(decrease_trade.planned_price)))
     assert decrease_trade.is_success()
     assert decrease_trade.executed_reserve < decrease_trade.planned_reserve - Decimal("9.99")
     assert decrease_trade.executed_reserve > decrease_trade.planned_reserve - Decimal("10.02")
-    assert decrease_trade.executed_quantity == pytest.approx(expected_executed_amount)
-    assert abs(decrease_trade.executed_quantity) < abs(decrease_trade.planned_quantity)
+    assert abs(decrease_trade.executed_quantity) > abs(net_derived_quantity)
+    assert abs(decrease_trade.executed_quantity) <= abs(decrease_trade.planned_quantity)
     assert decrease_trade.executed_quantity != -decrease_trade.executed_reserve
-    assert decrease_trade.executed_price == pytest.approx(second_valuation.new_price)
+    assert decrease_trade.executed_price == pytest.approx(
+        float(expected_executed_reserve / abs(decrease_trade.executed_quantity))
+    )
+    assert decrease_trade.executed_price < second_valuation.new_price
     assert decreased_quantity < increased_quantity
     assert decreased_quantity > 0
-    assert decreased_quantity == pytest.approx(increased_quantity + expected_executed_amount)
+    assert decreased_quantity == pytest.approx(increased_quantity + decrease_trade.executed_quantity)
     assert_phased_withdrawal_trade(decrease_trade)
 
     final_valuation = hypercore_valuation_model(datetime.datetime(2026, 2, 5), position)
@@ -786,7 +790,7 @@ def test_hyper_ai_hypercore_increase_then_decrease_position(
 
 
 @pytest.mark.timeout(300)
-def test_hyper_ai_hypercore_close_short_arrival_keeps_residual_position(
+def test_hyper_ai_hypercore_close_phase1_fee_accounts_price_slippage(
     monkeypatch: pytest.MonkeyPatch,
     hyper_ai_strategy_module: ModuleType,
     make_fake_indicators: IndicatorFactory,
@@ -798,11 +802,11 @@ def test_hyper_ai_hypercore_close_short_arrival_keeps_residual_position(
     hypercore_valuation_model: GenericValuation,
     hypercore_vault_pair: TradingPairIdentifier,
 ) -> None:
-    """Exercise a short-arrival Hypercore full close at a non-1.0 share price.
+    """Exercise a phase-1 fee-shaped Hypercore full close at a non-1.0 share price.
 
     1. Open and revalue one Hypercore position above a 1.0 share price.
     2. Generate a full close sell through the Hyper AI rebalance path.
-    3. Settle less USDC than requested and verify only the received value's vault units are removed.
+    3. Settle less USDC into perp than requested and verify the shortfall becomes price slippage.
     """
     # 1. Open and revalue one Hypercore position above a 1.0 share price.
     install_hypercore_wait_failures(monkeypatch)
@@ -866,12 +870,12 @@ def test_hyper_ai_hypercore_close_short_arrival_keeps_residual_position(
         pair,
     )
     phased_withdrawal_router.simulate = False
-    short_arrival_raw = 10_000_000
+    phase1_fee_shortfall = Decimal("10")
     monkeypatch.setattr(
         phased_withdrawal_router,
-        "_wait_for_usdc_arrival",
-        lambda baseline_balance_raw, expected_increase_raw, timeout=30.0, poll_interval=2.0: (
-            expected_increase_raw - short_arrival_raw
+        "_wait_for_perp_withdrawable_balance",
+        lambda baseline_balance, expected_increase_raw, relative_tolerance=None, timeout=30.0, poll_interval=2.0: (
+            baseline_balance + raw_to_usdc(expected_increase_raw) - phase1_fee_shortfall
         ),
     )
 
@@ -896,7 +900,7 @@ def test_hyper_ai_hypercore_close_short_arrival_keeps_residual_position(
     assert close_trade.planned_quantity == -open_quantity
     assert close_trade.planned_price == pytest.approx(valuation_update.new_price)
 
-    # 3. Settle less USDC than requested and verify only the received value's vault units are removed.
+    # 3. Settle less USDC into perp than requested and verify the shortfall becomes price slippage.
     hypercore_execution_model.execute_trades(
         valuation_ts,
         state,
@@ -906,19 +910,21 @@ def test_hyper_ai_hypercore_close_short_arrival_keeps_residual_position(
         check_balances=False,
     )
 
-    expected_executed_quantity = -(close_trade.executed_reserve / Decimal(str(close_trade.planned_price)))
     residual_quantity = position.get_quantity()
+    net_derived_quantity = -(close_trade.executed_reserve / Decimal(str(close_trade.planned_price)))
     assert close_trade.is_success()
     assert close_trade.executed_reserve < close_trade.planned_reserve - Decimal("9.99")
     assert close_trade.executed_reserve > close_trade.planned_reserve - Decimal("10.20")
-    assert close_trade.executed_quantity == pytest.approx(expected_executed_quantity)
-    assert abs(close_trade.executed_quantity) < abs(close_trade.planned_quantity)
-    assert close_trade.executed_quantity != close_trade.planned_quantity
-    assert close_trade.executed_price == pytest.approx(valuation_update.new_price)
-    assert residual_quantity == pytest.approx(open_quantity + expected_executed_quantity)
-    assert residual_quantity > 0
-    assert len(state.portfolio.open_positions) == 1
-    assert not state.portfolio.closed_positions
+    assert abs(close_trade.executed_quantity) > abs(net_derived_quantity)
+    assert abs(close_trade.executed_quantity) <= abs(close_trade.planned_quantity)
+    assert close_trade.executed_price == pytest.approx(
+        float(close_trade.executed_reserve / abs(close_trade.executed_quantity))
+    )
+    assert close_trade.executed_price < valuation_update.new_price
+    assert residual_quantity == pytest.approx(open_quantity + close_trade.executed_quantity)
+    assert residual_quantity < Decimal("0.01")
+    assert not state.portfolio.open_positions
+    assert len(state.portfolio.closed_positions) == 1
     assert_phased_withdrawal_trade(close_trade)
 
 

--- a/tests/hyperliquid/test_hypercore_dual_chain.py
+++ b/tests/hyperliquid/test_hypercore_dual_chain.py
@@ -10,7 +10,10 @@ import logging
 from decimal import Decimal
 from unittest.mock import MagicMock, patch
 
+import pytest
+
 from eth_defi.hyperliquid.api import UserVaultEquity
+from hexbytes import HexBytes
 
 
 VAULT_ADDR = "0xdfc24b077bc1425ad1dea75bcb6f8158e10df303"
@@ -51,6 +54,8 @@ def _make_trade(planned_reserve=Decimal("50.0"), is_buy=False):
     trade.get_planned_reserve.return_value = planned_reserve
     trade.planned_quantity = -planned_reserve if not is_buy else planned_reserve
     trade.planned_price = 1.0
+    trade.slippage_tolerance = 0.20
+    trade.closing = False
     trade.flags = set()
     trade.trade_id = 1
     trade.position_id = 1
@@ -379,6 +384,35 @@ def test_wait_for_perp_withdrawable_balance_rejects_large_shortfall():
     assert "did not reach" in str(exc_info.value)
 
 
+def test_wait_for_perp_withdrawable_balance_accepts_trade_slippage_tolerance():
+    """Accept phase-1 perp balance shortfalls covered by the trade slippage tolerance.
+
+    1. Create a routing object and mock a HyperCore performance-fee shaped perp increase.
+    2. Wait for perp withdrawable balance using a wider trade slippage tolerance.
+    3. Verify the phase-1 wait accepts the net amount instead of timing out.
+    """
+    routing = _make_routing()
+
+    # 1. Create a routing object and mock a HyperCore performance-fee shaped perp increase.
+    routing._fetch_safe_perp_withdrawable_balance = MagicMock(
+        side_effect=[Decimal("123.0")],
+    )
+
+    # 2. Wait for perp withdrawable balance using a wider trade slippage tolerance.
+    with patch("tradeexecutor.ethereum.vault.hypercore_routing.time.sleep"):
+        with patch("tradeexecutor.ethereum.vault.hypercore_routing.time.time", side_effect=_monotonic_time()):
+            result = routing._wait_for_perp_withdrawable_balance(
+                baseline_balance=Decimal("0"),
+                expected_increase_raw=130_000_000,
+                relative_tolerance=Decimal("0.20"),
+                timeout=30.0,
+                poll_interval=2.0,
+            )
+
+    # 3. Verify the phase-1 wait accepts the net amount instead of timing out.
+    assert result == Decimal("123.0")
+
+
 def test_withdrawal_already_reflected_in_vault_equity_is_detected():
     """Detect a phase 1 withdrawal that already reduced vault equity.
 
@@ -579,6 +613,279 @@ def test_withdrawal_phase3_uses_fee_adjusted_amount(
     phase3.assert_called_once_with(expected_phase3_raw)
     assert wait_evm.call_args.kwargs["expected_increase_raw"] == expected_phase3_raw
     assert state.mark_trade_success.call_args.kwargs["executed_reserve"] == raw_to_usdc(expected_phase3_raw)
+
+
+@patch("tradeexecutor.ethereum.vault.hypercore_routing.get_block_timestamp")
+@patch("tradeexecutor.ethereum.vault.hypercore_routing.fetch_user_vault_equity")
+def test_withdrawal_uses_gross_vault_decrease_for_quantity_and_net_usdc_for_reserve(
+    mock_fetch_equity,
+    mock_block_ts,
+):
+    """Account HyperCore withdrawal fees as execution price slippage, not fewer vault units sold.
+
+    1. Simulate a withdrawal where HyperCore removes 130 USDC of vault equity but only 123 USDC reaches perp/EVM.
+    2. Settle the phased withdrawal using the net amount for phases 2 and 3.
+    3. Verify executed quantity follows the gross vault decrease while executed reserve follows net USDC received.
+    """
+    routing = _make_routing()
+    trade = _make_trade(planned_reserve=Decimal("130.0"))
+    trade.planned_price = 2.0
+    trade.planned_quantity = Decimal("-65")
+    state = MagicMock()
+    state.portfolio.get_position_by_id.return_value.get_quantity.return_value = Decimal("200")
+    state.portfolio.find_position_for_trade.return_value.get_quantity.return_value = Decimal("200")
+    mock_block_ts.return_value = datetime.datetime(2025, 1, 1)
+    mock_fetch_equity.side_effect = [
+        _make_equity(Decimal("1000.0")),
+        _make_equity(Decimal("870.0")),
+    ]
+    receipts = {HexBytes("0xabc"): {"status": 1, "blockNumber": 100}}
+
+    phase2_tx = MagicMock(tx_hash="0xdef")
+    phase3_tx = MagicMock(tx_hash="0x123")
+    captured_phase2_raw = []
+    captured_phase3_raw = []
+
+    def capture_phase2(raw_amount: int):
+        captured_phase2_raw.append(raw_amount)
+        return phase2_tx, {"status": 1, "blockNumber": 101}
+
+    def capture_phase3(raw_amount: int):
+        captured_phase3_raw.append(raw_amount)
+        return phase3_tx, {"status": 1, "blockNumber": 102}
+
+    # 1. Simulate a withdrawal where HyperCore removes 130 USDC of vault equity but only 123 USDC reaches perp/EVM.
+    # 2. Settle the phased withdrawal using the net amount for phases 2 and 3.
+    # 3. Verify executed quantity follows the gross vault decrease while executed reserve follows net USDC received.
+    with (
+        patch.object(routing, "_fetch_safe_evm_usdc_balance", return_value=100_000_000),
+        patch.object(routing, "_fetch_safe_perp_withdrawable_balance", return_value=Decimal("0")),
+        patch.object(routing, "_fetch_safe_spot_free_usdc_balance", return_value=Decimal("0")),
+        patch.object(routing, "_wait_for_perp_withdrawable_balance", return_value=Decimal("123.0")),
+        patch.object(routing, "_broadcast_withdrawal_phase2", side_effect=capture_phase2),
+        patch.object(routing, "_wait_for_spot_free_usdc_balance", return_value=Decimal("123.0")),
+        patch.object(routing, "_broadcast_withdrawal_phase3", side_effect=capture_phase3),
+        patch.object(routing, "_wait_for_usdc_arrival", return_value=122_990_000),
+    ):
+        routing._settle_withdrawal(
+            routing.web3,
+            state,
+            trade,
+            receipts,
+            stop_on_execution_failure=False,
+        )
+
+    assert captured_phase2_raw == [123_000_000]
+    assert captured_phase3_raw == [122_990_000]
+    success_kwargs = state.mark_trade_success.call_args.kwargs
+    assert success_kwargs["executed_amount"] == Decimal("-65")
+    assert success_kwargs["executed_reserve"] == Decimal("122.99")
+    assert success_kwargs["executed_price"] == pytest.approx(122.99 / 65)
+
+
+@patch("tradeexecutor.ethereum.vault.hypercore_routing.get_block_timestamp")
+@patch("tradeexecutor.ethereum.vault.hypercore_routing.fetch_user_vault_equity")
+def test_withdrawal_uses_phase1_request_for_quantity_when_post_equity_check_fails(
+    mock_fetch_equity,
+    mock_block_ts,
+):
+    """Use phase-1 gross request for quantity when post-withdrawal equity cannot be read.
+
+    1. Simulate a withdrawal where 130 USDC is requested from the vault and only 123 USDC reaches perp/EVM.
+    2. Make the post-withdrawal vault equity read fail after the baseline snapshot succeeds.
+    3. Verify executed quantity still follows the phase-1 gross request while executed reserve follows net USDC received.
+    """
+    routing = _make_routing()
+    trade = _make_trade(planned_reserve=Decimal("130.0"))
+    trade.planned_price = 2.0
+    trade.planned_quantity = Decimal("-65")
+    state = MagicMock()
+    state.portfolio.get_position_by_id.return_value.get_quantity.return_value = Decimal("200")
+    state.portfolio.find_position_for_trade.return_value.get_quantity.return_value = Decimal("200")
+    mock_block_ts.return_value = datetime.datetime(2025, 1, 1)
+    mock_fetch_equity.side_effect = [
+        _make_equity(Decimal("1000.0")),
+        RuntimeError("HyperCore API down"),
+    ]
+    receipts = {HexBytes("0xabc"): {"status": 1, "blockNumber": 100}}
+
+    phase2_tx = MagicMock(tx_hash="0xdef")
+    phase3_tx = MagicMock(tx_hash="0x123")
+    captured_phase2_raw = []
+    captured_phase3_raw = []
+
+    def capture_phase2(raw_amount: int):
+        captured_phase2_raw.append(raw_amount)
+        return phase2_tx, {"status": 1, "blockNumber": 101}
+
+    def capture_phase3(raw_amount: int):
+        captured_phase3_raw.append(raw_amount)
+        return phase3_tx, {"status": 1, "blockNumber": 102}
+
+    # 1. Simulate a withdrawal where 130 USDC is requested from the vault and only 123 USDC reaches perp/EVM.
+    # 2. Make the post-withdrawal vault equity read fail after the baseline snapshot succeeds.
+    # 3. Verify executed quantity still follows the phase-1 gross request while executed reserve follows net USDC received.
+    with (
+        patch.object(routing, "_fetch_safe_evm_usdc_balance", return_value=100_000_000),
+        patch.object(routing, "_fetch_safe_perp_withdrawable_balance", return_value=Decimal("0")),
+        patch.object(routing, "_fetch_safe_spot_free_usdc_balance", return_value=Decimal("0")),
+        patch.object(routing, "_wait_for_perp_withdrawable_balance", return_value=Decimal("123.0")),
+        patch.object(routing, "_broadcast_withdrawal_phase2", side_effect=capture_phase2),
+        patch.object(routing, "_wait_for_spot_free_usdc_balance", return_value=Decimal("123.0")),
+        patch.object(routing, "_broadcast_withdrawal_phase3", side_effect=capture_phase3),
+        patch.object(routing, "_wait_for_usdc_arrival", return_value=122_990_000),
+    ):
+        routing._settle_withdrawal(
+            routing.web3,
+            state,
+            trade,
+            receipts,
+            stop_on_execution_failure=False,
+        )
+
+    assert captured_phase2_raw == [123_000_000]
+    assert captured_phase3_raw == [122_990_000]
+    success_kwargs = state.mark_trade_success.call_args.kwargs
+    assert success_kwargs["executed_amount"] == Decimal("-65")
+    assert success_kwargs["executed_reserve"] == Decimal("122.99")
+    assert success_kwargs["executed_price"] == pytest.approx(122.99 / 65)
+
+
+@patch("tradeexecutor.ethereum.vault.hypercore_routing.get_block_timestamp")
+@patch("tradeexecutor.ethereum.vault.hypercore_routing.fetch_user_vault_equity")
+def test_withdrawal_caps_gross_quantity_to_planned_sell_value(
+    mock_fetch_equity,
+    mock_block_ts,
+):
+    """Cap equity-derived gross redemption to the planned sell value.
+
+    1. Simulate a withdrawal where vault equity drops by more than the intended 130 USDC sell value.
+    2. Settle the phased withdrawal using the net amount for phases 2 and 3.
+    3. Verify executed quantity does not exceed the planned partial sell quantity.
+    """
+    routing = _make_routing()
+    trade = _make_trade(planned_reserve=Decimal("130.0"))
+    trade.planned_price = 2.0
+    trade.planned_quantity = Decimal("-65")
+    state = MagicMock()
+    state.portfolio.get_position_by_id.return_value.get_quantity.return_value = Decimal("200")
+    state.portfolio.find_position_for_trade.return_value.get_quantity.return_value = Decimal("200")
+    mock_block_ts.return_value = datetime.datetime(2025, 1, 1)
+    mock_fetch_equity.side_effect = [
+        _make_equity(Decimal("1000.0")),
+        _make_equity(Decimal("850.0")),
+    ]
+    receipts = {HexBytes("0xabc"): {"status": 1, "blockNumber": 100}}
+
+    phase2_tx = MagicMock(tx_hash="0xdef")
+    phase3_tx = MagicMock(tx_hash="0x123")
+    captured_phase2_raw = []
+    captured_phase3_raw = []
+
+    def capture_phase2(raw_amount: int):
+        captured_phase2_raw.append(raw_amount)
+        return phase2_tx, {"status": 1, "blockNumber": 101}
+
+    def capture_phase3(raw_amount: int):
+        captured_phase3_raw.append(raw_amount)
+        return phase3_tx, {"status": 1, "blockNumber": 102}
+
+    # 1. Simulate a withdrawal where vault equity drops by more than the intended 130 USDC sell value.
+    # 2. Settle the phased withdrawal using the net amount for phases 2 and 3.
+    # 3. Verify executed quantity does not exceed the planned partial sell quantity.
+    with (
+        patch.object(routing, "_fetch_safe_evm_usdc_balance", return_value=100_000_000),
+        patch.object(routing, "_fetch_safe_perp_withdrawable_balance", return_value=Decimal("0")),
+        patch.object(routing, "_fetch_safe_spot_free_usdc_balance", return_value=Decimal("0")),
+        patch.object(routing, "_wait_for_perp_withdrawable_balance", return_value=Decimal("123.0")),
+        patch.object(routing, "_broadcast_withdrawal_phase2", side_effect=capture_phase2),
+        patch.object(routing, "_wait_for_spot_free_usdc_balance", return_value=Decimal("123.0")),
+        patch.object(routing, "_broadcast_withdrawal_phase3", side_effect=capture_phase3),
+        patch.object(routing, "_wait_for_usdc_arrival", return_value=122_990_000),
+    ):
+        routing._settle_withdrawal(
+            routing.web3,
+            state,
+            trade,
+            receipts,
+            stop_on_execution_failure=False,
+        )
+
+    assert captured_phase2_raw == [123_000_000]
+    assert captured_phase3_raw == [122_990_000]
+    success_kwargs = state.mark_trade_success.call_args.kwargs
+    assert success_kwargs["executed_amount"] == Decimal("-65")
+    assert success_kwargs["executed_reserve"] == Decimal("122.99")
+    assert success_kwargs["executed_price"] == pytest.approx(122.99 / 65)
+
+
+@patch("tradeexecutor.ethereum.vault.hypercore_routing.get_block_timestamp")
+@patch("tradeexecutor.ethereum.vault.hypercore_routing.fetch_user_vault_equity")
+def test_full_close_uses_observed_gross_decrease_when_phase1_under_redeems(
+    mock_fetch_equity,
+    mock_block_ts,
+):
+    """Avoid closing the full planned quantity when observed gross vault debit is short.
+
+    1. Simulate a full-close withdrawal where phase 1 moves net USDC within slippage tolerance.
+    2. Return a post-withdrawal equity snapshot showing only 100 USDC of gross vault debit for a 130 USDC close.
+    3. Verify settlement uses the observed gross debit for quantity instead of marking the full close quantity sold.
+    """
+    routing = _make_routing()
+    trade = _make_trade(planned_reserve=Decimal("130.0"))
+    trade.planned_price = 2.0
+    trade.planned_quantity = Decimal("-65")
+    trade.closing = True
+    state = MagicMock()
+    state.portfolio.get_position_by_id.return_value.get_quantity.return_value = Decimal("65")
+    state.portfolio.find_position_for_trade.return_value.get_quantity.return_value = Decimal("65")
+    mock_block_ts.return_value = datetime.datetime(2025, 1, 1)
+    mock_fetch_equity.side_effect = [
+        _make_equity(Decimal("1000.0")),
+        _make_equity(Decimal("900.0")),
+    ]
+    receipts = {HexBytes("0xabc"): {"status": 1, "blockNumber": 100}}
+
+    phase2_tx = MagicMock(tx_hash="0xdef")
+    phase3_tx = MagicMock(tx_hash="0x123")
+    captured_phase2_raw = []
+    captured_phase3_raw = []
+
+    def capture_phase2(raw_amount: int):
+        captured_phase2_raw.append(raw_amount)
+        return phase2_tx, {"status": 1, "blockNumber": 101}
+
+    def capture_phase3(raw_amount: int):
+        captured_phase3_raw.append(raw_amount)
+        return phase3_tx, {"status": 1, "blockNumber": 102}
+
+    # 1. Simulate a full-close withdrawal where phase 1 moves net USDC within slippage tolerance.
+    # 2. Return a post-withdrawal equity snapshot showing only 100 USDC of gross vault debit for a 130 USDC close.
+    # 3. Verify settlement uses the observed gross debit for quantity instead of marking the full close quantity sold.
+    with (
+        patch.object(routing, "_fetch_safe_evm_usdc_balance", return_value=100_000_000),
+        patch.object(routing, "_fetch_safe_perp_withdrawable_balance", return_value=Decimal("0")),
+        patch.object(routing, "_fetch_safe_spot_free_usdc_balance", return_value=Decimal("0")),
+        patch.object(routing, "_wait_for_perp_withdrawable_balance", return_value=Decimal("110.0")),
+        patch.object(routing, "_broadcast_withdrawal_phase2", side_effect=capture_phase2),
+        patch.object(routing, "_wait_for_spot_free_usdc_balance", return_value=Decimal("110.0")),
+        patch.object(routing, "_broadcast_withdrawal_phase3", side_effect=capture_phase3),
+        patch.object(routing, "_wait_for_usdc_arrival", return_value=109_990_000),
+    ):
+        routing._settle_withdrawal(
+            routing.web3,
+            state,
+            trade,
+            receipts,
+            stop_on_execution_failure=False,
+        )
+
+    assert captured_phase2_raw == [110_000_000]
+    assert captured_phase3_raw == [109_990_000]
+    success_kwargs = state.mark_trade_success.call_args.kwargs
+    assert success_kwargs["executed_amount"] == Decimal("-50")
+    assert success_kwargs["executed_reserve"] == Decimal("109.99")
+    assert success_kwargs["executed_price"] == pytest.approx(109.99 / 50)
 
 
 @patch("tradeexecutor.ethereum.vault.hypercore_routing.report_failure")

--- a/tests/hyperliquid/test_hypercore_dual_chain.py
+++ b/tests/hyperliquid/test_hypercore_dual_chain.py
@@ -49,6 +49,9 @@ def _make_trade(planned_reserve=Decimal("50.0"), is_buy=False):
     trade.is_buy.return_value = is_buy
     trade.is_vault.return_value = True
     trade.get_planned_reserve.return_value = planned_reserve
+    trade.planned_quantity = -planned_reserve if not is_buy else planned_reserve
+    trade.planned_price = 1.0
+    trade.flags = set()
     trade.trade_id = 1
     trade.position_id = 1
     trade.blockchain_transactions = [MagicMock(tx_hash="0xabc")]

--- a/tests/test_rebalance.py
+++ b/tests/test_rebalance.py
@@ -1856,6 +1856,7 @@ def _create_hypercore_position_for_rebalance_test(
     start_ts: datetime.datetime,
     usdc: AssetIdentifier,
     last_token_price: float = 2.0,
+    reserve_amount: Decimal = Decimal(50),
 ) -> TradingPairIdentifier:
     """Create one open Hypercore vault position for alpha-model rebalance tests."""
     pair = create_hypercore_vault_pair(
@@ -1870,7 +1871,7 @@ def _create_hypercore_position_for_rebalance_test(
         strategy_cycle_at=start_ts,
         pair=pair,
         quantity=None,
-        reserve=Decimal(50),
+        reserve=reserve_amount,
         assumed_price=1.0,
         trade_type=TradeType.rebalance,
         reserve_currency=usdc,
@@ -1880,8 +1881,8 @@ def _create_hypercore_position_for_rebalance_test(
     trade.mark_success(
         executed_at=start_ts,
         executed_price=1.0,
-        executed_quantity=Decimal(50),
-        executed_reserve=Decimal(50),
+        executed_quantity=reserve_amount,
+        executed_reserve=reserve_amount,
         lp_fees=0,
         native_token_price=0,
         force=True,
@@ -2134,12 +2135,170 @@ def test_alpha_model_caps_profitable_hypercore_sell_before_trade_generation(
     assert signal is not None
 
     # 3. Verify the signal stores the capped marked-value delta, while the sell trade stores the smaller released cash amount.
-    assert signal.position_adjust_usd == pytest.approx(-20.0)
-    assert signal.position_adjust_quantity == pytest.approx(-10.0)
+    assert signal.position_adjust_usd == pytest.approx(-10.0)
+    assert signal.position_adjust_quantity == pytest.approx(-5.0)
     assert len(trades) == 1
     assert trades[0].is_sell()
-    assert trades[0].planned_quantity == Decimal("-10")
+    assert trades[0].planned_quantity == Decimal("-5")
     assert trades[0].planned_reserve == Decimal("10")
+    assert trades[0].planned_price == pytest.approx(2.0)
+
+
+def test_alpha_model_keeps_hypercore_partial_sell_value_and_quantity_separate(
+    start_ts: datetime.datetime,
+    strategy_universe: TradingStrategyUniverse,
+    pricing_model: BacktestPricing,
+    usdc: AssetIdentifier,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Check IKAGI-shaped Hypercore partial sell keeps vault units separate from USDC value.
+
+    1. Create a profitable Hypercore position whose live valuation implies a share price above 1.
+    2. Generate a rebalance sell matching the IKAGI production value/quantity shape.
+    3. Verify the trade withdraws USDC value, not the vault-unit quantity as USDC.
+    """
+    state = State()
+    tracked_quantity = Decimal("289.642733")
+    live_equity = Decimal("838.06408")
+    target_value = Decimal("707.1863490192")
+    expected_sell_value = live_equity - target_value
+    expected_sell_quantity = Decimal("45.23255988983288489180267788")
+    live_share_price = live_equity / tracked_quantity
+    hypercore_vault_pair = _create_hypercore_position_for_rebalance_test(
+        state,
+        start_ts,
+        usdc,
+        last_token_price=float(live_share_price),
+        reserve_amount=tracked_quantity,
+    )
+
+    # 1. Create a profitable Hypercore position whose live valuation implies a share price above 1.
+    position_manager = PositionManager(
+        start_ts + datetime.timedelta(days=1),
+        strategy_universe.data_universe,
+        state,
+        pricing_model,
+    )
+    _patch_hypercore_pricing(monkeypatch, pricing_model, hypercore_vault_pair)
+    monkeypatch.setattr(
+        pricing_model,
+        "check_redemption",
+        lambda ts, pair, **kwargs: RedemptionCheckResult(
+            timestamp=ts,
+            stage=kwargs["stage"],
+            can_redeem=True,
+            pair_ticker=pair.get_ticker(),
+            vault_address=pair.pool_address,
+            safe_address="0x0000000000000000000000000000000000000abc",
+            max_withdrawable=None,
+            max_redemption=None,
+            message="Hypercore sell is redeemable",
+        ),
+    )
+
+    alpha_model = AlphaModel(timestamp=position_manager.timestamp)
+    alpha_model.set_signal(hypercore_vault_pair, 1.0)
+    alpha_model.select_top_signals(count=5)
+    alpha_model.assign_weights(method=weight_passthrouh)
+    alpha_model.normalise_weights(max_weight=1.0)
+    alpha_model.update_old_weights(state.portfolio, ignore_credit=False)
+    alpha_model.calculate_target_positions(position_manager, investable_equity=float(target_value))
+
+    # 2. Generate a rebalance sell matching the IKAGI production value/quantity shape.
+    trades = alpha_model.generate_rebalance_trades_and_triggers(
+        position_manager,
+        min_trade_threshold=0.01,
+        individual_rebalance_min_threshold=0.01,
+        sell_rebalance_min_threshold=0.01,
+    )
+
+    signal = alpha_model.get_signal_by_pair(hypercore_vault_pair)
+    assert signal is not None
+
+    # 3. Verify the trade withdraws USDC value, not the vault-unit quantity as USDC.
+    assert signal.position_adjust_usd == pytest.approx(-float(expected_sell_value))
+    assert signal.position_adjust_quantity == pytest.approx(-float(expected_sell_quantity))
+    assert len(trades) == 1
+    trade = trades[0]
+    assert trade.is_sell()
+    assert trade.planned_quantity == pytest.approx(-expected_sell_quantity)
+    assert trade.planned_reserve == pytest.approx(expected_sell_value)
+    assert trade.planned_reserve != pytest.approx(abs(trade.planned_quantity))
+    assert trade.planned_price == pytest.approx(float(live_share_price))
+
+
+def test_alpha_model_converts_loss_making_hypercore_usd_cap_to_quantity(
+    start_ts: datetime.datetime,
+    strategy_universe: TradingStrategyUniverse,
+    pricing_model: BacktestPricing,
+    usdc: AssetIdentifier,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Check Hypercore USD redemption cap is converted to vault units when share price is below 1.
+
+    1. Create a loss-making Hypercore position with share price below 1.
+    2. Cap the redemption in USD below the requested sell.
+    3. Verify capped USD is converted to a larger vault-unit quantity.
+    """
+    state = State()
+    hypercore_vault_pair = _create_hypercore_position_for_rebalance_test(
+        state,
+        start_ts,
+        usdc,
+        last_token_price=0.5,
+    )
+
+    # 1. Create a loss-making Hypercore position with share price below 1.
+    position_manager = PositionManager(
+        start_ts + datetime.timedelta(days=1),
+        strategy_universe.data_universe,
+        state,
+        pricing_model,
+    )
+    _patch_hypercore_pricing(monkeypatch, pricing_model, hypercore_vault_pair)
+    monkeypatch.setattr(
+        pricing_model,
+        "check_redemption",
+        lambda ts, pair, **kwargs: RedemptionCheckResult(
+            timestamp=ts,
+            stage=kwargs["stage"],
+            can_redeem=True,
+            pair_ticker=pair.get_ticker(),
+            vault_address=pair.pool_address,
+            safe_address="0x0000000000000000000000000000000000000abc",
+            max_withdrawable=10.0,
+            max_redemption=10.0,
+            message="Hypercore sell is partially redeemable",
+        ),
+    )
+
+    alpha_model = AlphaModel(timestamp=position_manager.timestamp)
+    alpha_model.set_signal(hypercore_vault_pair, 0.0)
+    alpha_model.select_top_signals(count=5)
+    alpha_model.assign_weights(method=weight_passthrouh)
+    alpha_model.normalise_weights(max_weight=1.0)
+    alpha_model.update_old_weights(state.portfolio, ignore_credit=False)
+    alpha_model.calculate_target_positions(position_manager, investable_equity=20.0)
+
+    # 2. Cap the redemption in USD below the requested sell.
+    trades = alpha_model.generate_rebalance_trades_and_triggers(
+        position_manager,
+        min_trade_threshold=0.01,
+        individual_rebalance_min_threshold=0.01,
+        sell_rebalance_min_threshold=0.01,
+    )
+
+    signal = alpha_model.get_signal_by_pair(hypercore_vault_pair)
+    assert signal is not None
+
+    # 3. Verify capped USD is converted to a larger vault-unit quantity.
+    assert signal.position_adjust_usd == pytest.approx(-10.0)
+    assert signal.position_adjust_quantity == pytest.approx(-20.0)
+    assert len(trades) == 1
+    assert trades[0].is_sell()
+    assert trades[0].planned_quantity == Decimal("-20")
+    assert trades[0].planned_reserve == Decimal("10.0")
+    assert trades[0].planned_price == pytest.approx(0.5)
 
 
 def test_alpha_model_skips_hypercore_sell_below_threshold_after_capping(
@@ -2203,8 +2362,8 @@ def test_alpha_model_skips_hypercore_sell_below_threshold_after_capping(
 
     # 3. Verify the alpha model skips the trade instead of emitting a dust Hypercore withdrawal.
     assert trades == []
-    assert signal.position_adjust_usd == pytest.approx(-4.0)
-    assert signal.position_adjust_quantity == pytest.approx(-2.0)
+    assert signal.position_adjust_usd == pytest.approx(-2.0)
+    assert signal.position_adjust_quantity == pytest.approx(-1.0)
     assert TradingPairSignalFlags.individual_trade_size_too_small in signal.flags
 
 

--- a/tradeexecutor/ethereum/vault/hypercore_routing.py
+++ b/tradeexecutor/ethereum/vault/hypercore_routing.py
@@ -104,6 +104,7 @@ from eth_defi.compat import native_datetime_utc_now
 
 from tradeexecutor.ethereum.tx import TransactionBuilder
 from tradeexecutor.state.identifier import TradingPairIdentifier, AssetIdentifier
+from tradeexecutor.strategy.dust import get_close_epsilon_for_pair
 from tradingstrategy.pair import PandasPairUniverse
 
 if TYPE_CHECKING:
@@ -2386,6 +2387,7 @@ class HypercoreVaultRouting(RoutingModel):
             # Simulate mode: mock CoreWriter does not bridge USDC,
             # so skip EVM balance verification and trust planned values.
             executed_reserve = planned_reserve
+            effective_reserve = planned_reserve
         else:
             try:
                 perp_balance = self._wait_for_perp_withdrawable_balance(
@@ -2837,12 +2839,33 @@ class HypercoreVaultRouting(RoutingModel):
                     "Could not verify vault equity after withdrawal: %s", e,
                 )
 
-        executed_amount = -executed_reserve  # Negative for sells
+        position = state.portfolio.find_position_for_trade(trade, pending=True)
+        position_quantity = position.get_quantity() if position else None
+        closes_position_quantity = (
+            isinstance(position_quantity, Decimal)
+            and abs(position_quantity + trade.planned_quantity) <= get_close_epsilon_for_pair(trade.pair)
+        )
+
+        close_shortfall = effective_reserve - executed_reserve
+        close_materially_short = close_shortfall > raw_to_usdc(HYPERCORE_FOLLOW_UP_PHASE_TOLERANCE_RAW)
+        should_close_full_quantity = (
+            (trade.closing or TradeFlag.close in trade.flags or closes_position_quantity)
+            and not close_materially_short
+        )
+
+        if should_close_full_quantity:
+            executed_amount = trade.planned_quantity
+        else:
+            planned_price = Decimal(str(trade.planned_price))
+            assert planned_price > 0, f"Planned Hypercore vault sell price must be positive, got {planned_price}"
+            executed_amount = -(executed_reserve / planned_price)
+
+        executed_price = float(executed_reserve / abs(executed_amount)) if executed_amount else 1.0
 
         state.mark_trade_success(
             ts,
             trade,
-            executed_price=1.0,
+            executed_price=executed_price,
             executed_amount=executed_amount,
             executed_reserve=executed_reserve,
             lp_fees=0,

--- a/tradeexecutor/ethereum/vault/hypercore_routing.py
+++ b/tradeexecutor/ethereum/vault/hypercore_routing.py
@@ -1009,14 +1009,17 @@ class HypercoreVaultRouting(RoutingModel):
         self,
         baseline_balance: Decimal,
         expected_increase_raw: int,
+        relative_tolerance: Decimal | None = None,
         timeout: float = 30.0,
         poll_interval: float = 2.0,
     ) -> Decimal:
         """Poll HyperCore perp withdrawable USDC until the withdrawal reaches perp."""
         expected_increase = raw_to_usdc(expected_increase_raw)
+        if relative_tolerance is None:
+            relative_tolerance = HYPERCORE_RELATIVE_BALANCE_TOLERANCE
         accepted_tolerance = max(
             Decimal("0.10"),
-            expected_increase * HYPERCORE_RELATIVE_BALANCE_TOLERANCE,
+            expected_increase * relative_tolerance,
         )
         expected_balance = baseline_balance + expected_increase - accepted_tolerance
         deadline = time.time() + timeout
@@ -2382,17 +2385,24 @@ class HypercoreVaultRouting(RoutingModel):
         )
 
         planned_reserve = trade.get_planned_reserve()
+        withdrawal_relative_tolerance = max(
+            HYPERCORE_RELATIVE_BALANCE_TOLERANCE,
+            Decimal(str(trade.slippage_tolerance or 0)),
+        )
+        phase1_requested_reserve = raw_to_usdc(expected_raw)
 
         if self.simulate:
             # Simulate mode: mock CoreWriter does not bridge USDC,
             # so skip EVM balance verification and trust planned values.
             executed_reserve = planned_reserve
             effective_reserve = planned_reserve
+            gross_vault_redeemed_reserve = planned_reserve
         else:
             try:
                 perp_balance = self._wait_for_perp_withdrawable_balance(
                     baseline_balance=baseline_perp_withdrawable,
                     expected_increase_raw=expected_raw,
+                    relative_tolerance=withdrawal_relative_tolerance,
                     timeout=30.0,
                     poll_interval=2.0,
                 )
@@ -2503,6 +2513,7 @@ class HypercoreVaultRouting(RoutingModel):
                             return
 
                         expected_raw = retry_raw
+                        phase1_requested_reserve = raw_to_usdc(expected_raw)
                         trade.other_data["hypercore_capped_withdrawal_raw"] = retry_raw
                         vault_equity_before_phase1_snapshot = current_vault_equity
                         has_pre_phase1_vault_equity_snapshot = True
@@ -2511,6 +2522,7 @@ class HypercoreVaultRouting(RoutingModel):
                             perp_balance = self._wait_for_perp_withdrawable_balance(
                                 baseline_balance=baseline_perp_withdrawable,
                                 expected_increase_raw=expected_raw,
+                                relative_tolerance=withdrawal_relative_tolerance,
                                 timeout=30.0,
                                 poll_interval=2.0,
                             )
@@ -2789,6 +2801,7 @@ class HypercoreVaultRouting(RoutingModel):
             # capped, else planned) to avoid spurious "partial" warnings on
             # normal capped-close trades where live equity < planned_reserve.
             effective_reserve = raw_to_usdc(phase3_raw)
+            gross_vault_redeemed_reserve = phase1_requested_reserve
             if executed_reserve < effective_reserve:
                 logger.warning(
                     "Withdrawal partial: received %s USDC but expected %s USDC (trade %s)",
@@ -2811,6 +2824,8 @@ class HypercoreVaultRouting(RoutingModel):
                     equity_decrease = (
                         vault_equity_before_phase1_snapshot - remaining_equity
                     )
+                    if equity_decrease > 0:
+                        gross_vault_redeemed_reserve = equity_decrease
                     expected_decrease = executed_reserve
                     tolerance = expected_decrease * Decimal("0.01")
                     if equity_decrease < expected_decrease - tolerance:
@@ -2846,8 +2861,22 @@ class HypercoreVaultRouting(RoutingModel):
             and abs(position_quantity + trade.planned_quantity) <= get_close_epsilon_for_pair(trade.pair)
         )
 
+        planned_price = Decimal(str(trade.planned_price))
+        assert planned_price > 0, f"Planned Hypercore vault sell price must be positive, got {planned_price}"
+        planned_gross_reserve = abs(trade.planned_quantity) * planned_price
+        expected_gross_redeemed_reserve = min(
+            phase1_requested_reserve,
+            planned_gross_reserve,
+        )
         close_shortfall = effective_reserve - executed_reserve
-        close_materially_short = close_shortfall > raw_to_usdc(HYPERCORE_FOLLOW_UP_PHASE_TOLERANCE_RAW)
+        gross_close_shortfall = expected_gross_redeemed_reserve - min(
+            gross_vault_redeemed_reserve,
+            expected_gross_redeemed_reserve,
+        )
+        close_materially_short = (
+            close_shortfall > raw_to_usdc(HYPERCORE_FOLLOW_UP_PHASE_TOLERANCE_RAW)
+            or gross_close_shortfall > raw_to_usdc(HYPERCORE_FOLLOW_UP_PHASE_TOLERANCE_RAW)
+        )
         should_close_full_quantity = (
             (trade.closing or TradeFlag.close in trade.flags or closes_position_quantity)
             and not close_materially_short
@@ -2856,9 +2885,11 @@ class HypercoreVaultRouting(RoutingModel):
         if should_close_full_quantity:
             executed_amount = trade.planned_quantity
         else:
-            planned_price = Decimal(str(trade.planned_price))
-            assert planned_price > 0, f"Planned Hypercore vault sell price must be positive, got {planned_price}"
-            executed_amount = -(executed_reserve / planned_price)
+            gross_vault_redeemed_reserve = min(
+                gross_vault_redeemed_reserve,
+                planned_gross_reserve,
+            )
+            executed_amount = -(gross_vault_redeemed_reserve / planned_price)
 
         executed_price = float(executed_reserve / abs(executed_amount)) if executed_amount else 1.0
 

--- a/tradeexecutor/strategy/pandas_trader/position_manager.py
+++ b/tradeexecutor/strategy/pandas_trader/position_manager.py
@@ -2,7 +2,7 @@
 
 import datetime
 import warnings
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from decimal import Decimal
 from io import StringIO
 from typing import List, Optional, Union, Set, Literal
@@ -1020,6 +1020,15 @@ class PositionManager:
 
         price = price_structure.price
 
+        if pair.is_hyperliquid_vault() and dollar_delta < 0:
+            assert quantity_delta < 0, f"Hypercore sell quantity must be negative, got {quantity_delta}"
+            price = float(abs(Decimal(str(dollar_delta)) / quantity_delta))
+            price_structure = replace(
+                price_structure,
+                price=price,
+                mid_price=price,
+            )
+
         # use trigger price as planned_price
         if trigger_price and pending:
             price = trigger_price
@@ -1587,7 +1596,7 @@ class PositionManager:
         redemption_cap_bound = False
 
         if max_redemption is not None:
-            max_redeemable_quantity = Decimal(str(max_redemption))
+            max_redeemable_quantity = Decimal(str(max_redemption)) / current_price
             if effective_quantity > max_redeemable_quantity:
                 effective_quantity = max_redeemable_quantity
                 redemption_cap_bound = True

--- a/tradeexecutor/testing/hypercore.py
+++ b/tradeexecutor/testing/hypercore.py
@@ -11,6 +11,7 @@ from typing import Any
 
 import pytest
 from eth_defi.erc_4626.vault_protocol.lagoon.vault import LagoonVault
+from eth_defi.hyperliquid.api import UserVaultEquity
 from eth_defi.provider.anvil import fund_erc20_on_anvil
 from eth_defi.token import TokenDetails
 from eth_defi.trace import assert_transaction_success_with_explanation
@@ -107,8 +108,16 @@ def install_hypercore_live_withdrawal_mocks(
         lambda session, user: "default",
     )
     monkeypatch.setattr(
+        "tradeexecutor.ethereum.vault.hypercore_routing.HyperliquidVault.fetch_info",
+        lambda self, user=None: SimpleNamespace(max_withdrawable=Decimal("1000000")),
+    )
+    monkeypatch.setattr(
         "tradeexecutor.ethereum.vault.hypercore_routing.fetch_user_vault_equity",
-        lambda *args, **kwargs: None,
+        lambda session, user, vault_address, **kwargs: UserVaultEquity(
+            vault_address=vault_address,
+            equity=Decimal("1000000"),
+            locked_until=datetime.datetime(2020, 1, 1),
+        ),
     )
     monkeypatch.setattr(router, "_fetch_safe_evm_usdc_balance", lambda: 0)
     monkeypatch.setattr(router, "_fetch_safe_perp_withdrawable_balance", lambda: Decimal("0"))

--- a/tradeexecutor/testing/hypercore.py
+++ b/tradeexecutor/testing/hypercore.py
@@ -125,7 +125,7 @@ def install_hypercore_live_withdrawal_mocks(
     monkeypatch.setattr(
         router,
         "_wait_for_perp_withdrawable_balance",
-        lambda baseline_balance, expected_increase_raw, timeout=30.0, poll_interval=2.0: (
+        lambda baseline_balance, expected_increase_raw, relative_tolerance=None, timeout=30.0, poll_interval=2.0: (
             baseline_balance + raw_to_usdc(expected_increase_raw)
         ),
     )


### PR DESCRIPTION
## Why

HyperCore partial sell redemptions drifted because planning and settlement mixed vault units, gross vault value, and net USDC received.

The original IKAGI case in `/home/mikko/hyper.log` showed a partial sell planned with a `1.0` vault price even though the live vault unit value was materially higher. The trade therefore requested too little gross vault value and settlement could then treat HyperCore fee-shaped shortfalls as fewer vault units sold. This left phantom residual quantity and made later valuation drift from the actual HyperCore vault equity.

HyperCore settlement also needed to distinguish between:

- gross vault debit, which determines vault quantity sold;
- net USDC received on HyperEVM, which determines cash proceeds and execution price;
- true under-redemption, where the observed vault equity decrease is smaller than the requested gross close.

Without this distinction, partial sells and full closes could either overstate stranded funds, under-remove position quantity, or close a full position despite an observed gross under-redemption.

## Lessons learnt

- HyperCore vault pricing cannot use the deposit/withdrawal shortcut price of `1.0` for partial sell sizing; it must use the live implied share price from current vault value and quantity.
- Phase-1 verification must allow configured trade slippage for performance-fee-shaped gross-to-net arrivals, otherwise successful vault transfers can time out before phases 2 and 3.
- Settlement quantity must follow gross vault redemption or observed vault equity decrease, while cash reserve must follow net EVM USDC received.
- Full-close handling needs both net bridge shortfall and observed gross vault-debit shortfall checks before marking the whole planned quantity sold.
- Integration coverage needs to inject the shortfall at phase-1 perp arrival, not only at final EVM arrival, because that is where HyperCore performance-fee-shaped behaviour appears.

## Summary

- Size HyperCore partial sells using the implied live vault share price.
- Widen phase-1 perp balance verification by the trade slippage tolerance.
- Preserve the phase-1 gross withdrawal request before later phases are capped to observed net balances.
- Account executed vault quantity from gross vault redemption or observed equity decrease, capped by the planned gross sell value.
- Keep executed reserve based on net EVM USDC received so HyperCore fees appear as price slippage.
- Add regression coverage for phase-1 fee-shaped arrivals, gross-vs-net accounting, equity-read fallback, planned-gross caps, and full-close observed gross under-redemption.
