### PR TITLE
fix: accept terminal whitespace in account correction confirmation

### DIFF
--- a/tests/units_tests/test_account_correction_confirmation.py
+++ b/tests/units_tests/test_account_correction_confirmation.py
@@ -1,0 +1,153 @@
+"""Tests for interactive accounting correction confirmation handling."""
+
+import datetime
+from decimal import Decimal
+from unittest.mock import MagicMock
+
+import pytest
+from tradingstrategy.chain import ChainId
+
+from tradeexecutor.state.balance_update import BalanceUpdateCause, BalanceUpdatePositionType
+from tradeexecutor.state.identifier import AssetIdentifier
+from tradeexecutor.state.state import State
+from tradeexecutor.strategy.account_correction import (
+    AccountingBalanceCheck,
+    AccountingCorrectionAborted,
+    AccountingCorrectionCause,
+    correct_accounts,
+    is_accounting_correction_confirmation_yes,
+)
+
+
+def test_correct_accounts_accepts_confirmation_with_terminal_whitespace(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Correct reserve surplus when terminal input contains whitespace.
+
+    1. Create a state with an empty USDC reserve balance.
+    2. Build an accounting correction matching a production reserve surplus.
+    3. Confirm the interactive prompt with a terminal-style ``y`` response containing whitespace.
+    4. Verify the reserve balance correction is applied instead of aborting.
+    """
+    # 1. Create a state with an empty USDC reserve balance.
+    timestamp = datetime.datetime(2026, 6, 16, 9, 27, 31)
+    usdc = AssetIdentifier(
+        chain_id=ChainId.ethereum.value,
+        address="0x0000000000000000000000000000000000000001",
+        token_symbol="USDC",
+        decimals=6,
+    )
+    state = State()
+    reserve = state.portfolio.initialise_reserves(usdc, reserve_token_price=1.0)
+    reserve.quantity = Decimal("0")
+
+    # 2. Build an accounting correction matching a production reserve surplus.
+    correction = AccountingBalanceCheck(
+        type=AccountingCorrectionCause.unknown_cause,
+        holding_address="0x0000000000000000000000000000000000000002",
+        asset=usdc,
+        positions={reserve},
+        expected_amount=Decimal("0"),
+        actual_amount=Decimal("55.010596"),
+        dust_epsilon=Decimal("0.000001"),
+        relative_epsilon=0.0,
+        block_number=123,
+        timestamp=timestamp,
+        usd_value=55.010596,
+        reserve_asset=True,
+        mismatch=True,
+        price=Decimal("1"),
+        price_at=timestamp,
+    )
+
+    # 3. Confirm the interactive prompt with a terminal-style ``y`` response containing whitespace.
+    monkeypatch.setattr("builtins.input", lambda prompt: " y\r\n")
+
+    balance_updates = correct_accounts(
+        state,
+        [correction],
+        strategy_cycle_included_at=None,
+        tx_builder=MagicMock(),
+        interactive=True,
+    )
+
+    # 4. Verify the reserve balance correction is applied instead of aborting.
+    balance_updates = list(balance_updates)
+    assert len(balance_updates) == 1
+    update = balance_updates[0]
+    assert update.position_type == BalanceUpdatePositionType.reserve
+    assert update.cause == BalanceUpdateCause.correction
+    assert update.quantity == Decimal("55.010596")
+    assert reserve.quantity == Decimal("55.010596")
+    assert state.sync.accounting.last_block_scanned == 123
+
+
+def test_correct_accounts_rejects_negative_confirmation(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Abort correction when the user does not explicitly confirm.
+
+    1. Create a minimal reserve correction.
+    2. Answer the interactive prompt with ``n``.
+    3. Verify the correction is aborted before mutating reserves.
+    """
+    # 1. Create a minimal reserve correction.
+    timestamp = datetime.datetime(2026, 6, 16, 9, 27, 31)
+    usdc = AssetIdentifier(
+        chain_id=ChainId.ethereum.value,
+        address="0x0000000000000000000000000000000000000001",
+        token_symbol="USDC",
+        decimals=6,
+    )
+    state = State()
+    reserve = state.portfolio.initialise_reserves(usdc, reserve_token_price=1.0)
+    correction = AccountingBalanceCheck(
+        type=AccountingCorrectionCause.unknown_cause,
+        holding_address="0x0000000000000000000000000000000000000002",
+        asset=usdc,
+        positions={reserve},
+        expected_amount=Decimal("0"),
+        actual_amount=Decimal("55.010596"),
+        dust_epsilon=Decimal("0.000001"),
+        relative_epsilon=0.0,
+        block_number=123,
+        timestamp=timestamp,
+        usd_value=55.010596,
+        reserve_asset=True,
+        mismatch=True,
+        price=Decimal("1"),
+        price_at=timestamp,
+    )
+
+    # 2. Answer the interactive prompt with ``n``.
+    monkeypatch.setattr("builtins.input", lambda prompt: "n")
+
+    # 3. Verify the correction is aborted before mutating reserves.
+    with pytest.raises(AccountingCorrectionAborted):
+        list(
+            correct_accounts(
+                state,
+                [correction],
+                strategy_cycle_included_at=None,
+                tx_builder=MagicMock(),
+                interactive=True,
+            )
+        )
+    assert reserve.quantity == Decimal("0")
+
+
+def test_accounting_correction_confirmation_accepts_yes_variants() -> None:
+    """Accept common affirmative terminal responses.
+
+    1. Pass short and long affirmative responses with case and whitespace variants.
+    2. Verify all affirmative responses are accepted.
+    3. Verify a negative response is not accepted.
+    """
+    # 1. Pass short and long affirmative responses with case and whitespace variants.
+    responses = ["y", "Y", " y\r\n", "yes", "YES", " yes\n"]
+
+    # 2. Verify all affirmative responses are accepted.
+    assert all(is_accounting_correction_confirmation_yes(response) for response in responses)
+
+    # 3. Verify a negative response is not accepted.
+    assert not is_accounting_correction_confirmation_yes("n")

--- a/tradeexecutor/strategy/account_correction.py
+++ b/tradeexecutor/strategy/account_correction.py
@@ -87,6 +87,11 @@ class AccountingCorrectionAborted(Exception):
     """User presses n"""
 
 
+def is_accounting_correction_confirmation_yes(response: str) -> bool:
+    """Return true if an interactive correction confirmation accepts the action."""
+    return response.strip().casefold() in {"y", "yes"}
+
+
 @dataclass
 class AccountingBalanceCheck:
     """Accounting correction applied to a balance.
@@ -585,8 +590,8 @@ def correct_accounts(
             print("Correction needed:", c)
 
         # print(f"Any tokens that cannot be assigned to an open position will be send to {unknown_token_receiver}")
-        confirmation = input("Attempt to correct balances [y/n]").lower()
-        if confirmation != "y":
+        confirmation = input("Attempt to correct balances [y/n]")
+        if not is_accounting_correction_confirmation_yes(confirmation):
             raise AccountingCorrectionAborted()
 
     for correction in corrections:


### PR DESCRIPTION
## Why

`correct-accounts` can abort after printing a valid reserve correction and receiving an affirmative terminal response.

The production failure showed a USDC reserve surplus correction:

```text
Correction needed: <Accounting correction type unknown_cause for USDC reserve asset USDC, expected 0, actual 55.010596 at 2026-06-16 09:27:31>
Attempt to correct balances [y/n]y
...
tradeexecutor.strategy.account_correction.AccountingCorrectionAborted
```

The interactive confirmation parser only accepted the exact string `y` after lowercasing. Terminal input that carries whitespace, carriage returns, or a pasted `yes` response is treated as a negative answer and raises `AccountingCorrectionAborted`.

## Lessons learnt

- Interactive production commands should normalise confirmation input before making state-changing decisions.
- `correct-accounts` reserve surplus corrections need direct regression coverage because they are often used for operational recovery.
- The correction iterator already handles reserve surplus balance updates correctly; the crash was in confirmation parsing before applying the correction.

## Summary

- Add a small confirmation helper that strips terminal whitespace, case-folds input, and accepts both `y` and `yes`.
- Use the helper in `correct_accounts()`.
- Add unit coverage for the production-shaped USDC reserve surplus correction and confirmation variants.
