### PR TITLE
fix: refresh Ostium settlement ETA in trade-ui

### DIFF
--- a/.claude/docs/vault-deposit-redeem.md
+++ b/.claude/docs/vault-deposit-redeem.md
@@ -37,7 +37,7 @@ We support:
 |---|---|---|
 | Synchronous ERC-4626 | IPOR, Morpho, Euler | Immediately, in the deposit/redeem transaction |
 | ERC-7540 | Lagoon | The vault's operator settles the queue manually — there is **no schedule** and the wait is unknowable in advance |
-| Ostium V1.5 | Ostium OLP | A time window (epoch) passes — the claimable timestamp is known when the request is made |
+| Ostium V1.5 | Ostium OLP | A settlement id is assigned when the request is made; `tryNewSettlement()` becomes eligible after the vault's on-chain interval |
 | Hypercore-native | Hyperliquid HLP | Not on-chain ERC-20 flows at all; handled by a separate Hypercore code path and out of scope here |
 
 The protocol differences are hidden behind one interface: every vault exposes a
@@ -141,8 +141,10 @@ friends) control it:
 
 Ostium-style vaults get a schedule instead of a fixed delay: with no
 override, a request settles **the next day at the epoch settlement hour**
-(`OSTIUM_BACKTEST_SETTLEMENT_HOUR`, 18:00 UTC), approximating Ostium's daily
-on-chain epochs.
+(`OSTIUM_BACKTEST_SETTLEMENT_HOUR`, 18:00 UTC). This is a backtest
+approximation kept for reproducibility. Live Ostium V1.5 reads the concrete
+settlement id from the request event and estimates the eligibility timestamp
+from the vault's on-chain `lastSettlementTs` and `maxSettlementInterval`.
 
 **Note a behaviour change for older backtests.** The two-stage simulation
 switches on *automatically* for any vault whose metadata carries async
@@ -253,10 +255,13 @@ How each command or context takes a request from pending to settled:
   On a real chain it leaves the trade pending and prints
   "re-run perform-test-trade after settlement" — the second run (or the
   daemon) claims it.
-- **`trade-ui`** — observability plus the test-trade route: the position
-  table shows the settlement ETA for pending deposits (a real timestamp for
-  Ostium; `pending` for Lagoon, where no ETA exists). Test trades executed
-  from the UI follow the `perform-test-trade` path above.
+- **`trade-ui`** — observability plus the test-trade route: before drawing the
+  table it runs the same pending-settlement resolver as `start`, so claimable
+  vault requests are completed and display-only settlement metadata is
+  refreshed from chain. The position table shows the settlement eligibility
+  ETA for pending deposits (a real timestamp for Ostium; `pending` for Lagoon,
+  where no ETA exists). Test trades executed from the UI follow the
+  `perform-test-trade` path above.
 - **`check-wallet`** — observability only: reports pending and
   settled-but-unclaimed vault amounts (`maxDeposit`/`maxRedeem`/
   `pendingRedeemRequest`) so the operator can see where in the lifecycle the

--- a/tests/cli/test_trade_ui_settlement_eta.py
+++ b/tests/cli/test_trade_ui_settlement_eta.py
@@ -91,12 +91,12 @@ def _make_state_with_pending_deposit(
 
 
 def test_tui_lockup_shows_ostium_settlement_eta(monkeypatch) -> None:
-    """A pending Ostium deposit with a future estimate shows a settlement countdown.
+    """A pending Ostium deposit with a future estimate shows an eligibility countdown.
 
     Steps:
     1. Freeze the clock so the remaining time is deterministic.
     2. Build a state with a settlement-pending deposit estimated ~18h ahead.
-    3. Assert the Lockup cell shows a ``settles`` countdown, not ``-``.
+    3. Assert the Lockup cell shows an ``eligible`` countdown, not ``-``.
     4. Build a state whose estimate has already passed and assert ``settling``.
     """
 
@@ -110,9 +110,9 @@ def test_tui_lockup_shows_ostium_settlement_eta(monkeypatch) -> None:
     future = (now + datetime.timedelta(hours=18)).isoformat()
     state = _make_state_with_pending_deposit(pair, future)
 
-    # 3. Future estimate renders as a "settles" countdown.
+    # 3. Future estimate renders as an "eligible" countdown.
     cell = _format_lockup(state, pair)
-    assert "settles" in cell.plain
+    assert "eligible" in cell.plain
     assert "18.0h" in cell.plain
 
     # 4. A past estimate (settlement slipped) renders as "settling".

--- a/tests/ethereum/test_vault_settlement_lifecycle.py
+++ b/tests/ethereum/test_vault_settlement_lifecycle.py
@@ -24,6 +24,7 @@ from tradeexecutor.state.identifier import (
 )
 from tradeexecutor.state.state import State
 from tradeexecutor.state.trade import TradeExecution, TradeStatus, TradeType
+from tradeexecutor.ethereum.vault.settlement_estimate import refresh_vault_settlement_estimate
 
 
 USDC_ARBITRUM_ADDRESS = "0xaf88d065e77c8cC2239327C5EDb3A432268e5831"
@@ -161,6 +162,51 @@ def test_vault_settlement_pending_value_in_equity(
     # Vault pending: 500
     total_equity = state.portfolio.calculate_total_equity()
     assert total_equity == pytest.approx(10_000.0)
+
+
+def test_vault_settlement_estimate_refresh_uses_generic_ticket_method(
+    vault_pair: TradingPairIdentifier,
+    usdc_arbitrum: AssetIdentifier,
+) -> None:
+    """Check generic settlement refresh stores display ETA from an adapter ticket method.
+
+    1. Create a settlement-pending vault deposit trade.
+    2. Mock a deposit manager with a ticket-based settlement ETA method.
+    3. Refresh the trade estimate and verify the persisted ISO timestamp.
+    """
+    state = State()
+    ts = datetime.datetime(2025, 1, 1)
+
+    # 1. Create a settlement-pending vault deposit trade.
+    state.portfolio.initialise_reserves(usdc_arbitrum)
+    reserve = state.portfolio.get_default_reserve_position()
+    reserve.quantity = Decimal(10_000)
+    reserve.reserve_token_price = 1.0
+    trade = _create_vault_buy_trade(state, vault_pair, usdc_arbitrum, Decimal(500), ts)
+    state.start_execution(ts, trade)
+    trade.mark_broadcasted(ts)
+    state.mark_vault_settlement_pending(
+        ts,
+        trade,
+        {
+            "vault_address": OLP_ARBITRUM_ADDRESS,
+            "vault_owner": "0xTestOwner",
+            "vault_to": "0xTestOwner",
+            "vault_raw_amount": 500_000_000,
+            "vault_request_tx_hash": "0xrequest123",
+            "vault_settlement_id": 42,
+        },
+    )
+
+    # 2. Mock a deposit manager with a ticket-based settlement ETA method.
+    ticket = object()
+    deposit_manager = MagicMock()
+    deposit_manager.get_deposit_ticket_delay_over.return_value = datetime.datetime(2026, 6, 19, 16, 33, 48)
+
+    # 3. Refresh the trade estimate and verify the persisted ISO timestamp.
+    refresh_vault_settlement_estimate(trade, deposit_manager, ticket, "deposit")
+    assert trade.other_data["vault_settlement_estimated_at"] == "2026-06-19T16:33:48"
+    deposit_manager.get_deposit_ticket_delay_over.assert_called_once_with(ticket)
 
 
 def test_vault_settlement_pending_sell_not_counted(

--- a/tradeexecutor/backtest/backtest_execution.py
+++ b/tradeexecutor/backtest/backtest_execution.py
@@ -79,9 +79,9 @@ DEFAULT_VAULT_SETTLEMENT_DELAY = datetime.timedelta(days=1)
 
 #: Hour of day (UTC, naive) when Ostium-style vaults settle in backtesting.
 #:
-#: Live Ostium settles in roughly daily epochs (``lastSettlementTs +
-#: maxSettlementInterval`` on-chain); the backtest approximates this as
-#: "the request becomes claimable the next day at this hour". Override the
+#: Live Ostium V1.5 exposes settlement eligibility through the request
+#: settlement id and ``lastSettlementTs + maxSettlementInterval``. Backtests
+#: keep the earlier next-day approximation for reproducibility. Override the
 #: schedule per vault with ``vault_settlement_delay_overrides``.
 OSTIUM_BACKTEST_SETTLEMENT_HOUR = 18
 
@@ -368,8 +368,8 @@ class BacktestExecution(ExecutionModel):
         1. Per-vault override (``vault_settlement_delay_overrides``) — a fixed
            delay from the request time.
         2. Ostium-style vaults (``ostium_like`` feature) — the next day at
-           :py:data:`OSTIUM_BACKTEST_SETTLEMENT_HOUR`, approximating Ostium's
-           daily epoch settlement schedule.
+           :py:data:`OSTIUM_BACKTEST_SETTLEMENT_HOUR`, preserving the
+           historical backtest approximation.
         3. The global default delay (``vault_settlement_delay``).
         """
         if pair.pool_address:
@@ -379,8 +379,8 @@ class BacktestExecution(ExecutionModel):
 
         features = pair.get_vault_features() or set()
         if ERC4626Feature.ostium_like in features:
-            # Ostium settles in daily epochs: the request becomes claimable
-            # the following day at the epoch settlement hour.
+            # Preserve the original Ostium backtest approximation instead of
+            # changing historical simulations when live vault intervals move.
             next_day = ts + datetime.timedelta(days=1)
             return next_day.replace(hour=OSTIUM_BACKTEST_SETTLEMENT_HOUR, minute=0, second=0, microsecond=0)
 

--- a/tradeexecutor/cli/commands/trade_ui.py
+++ b/tradeexecutor/cli/commands/trade_ui.py
@@ -234,6 +234,12 @@ def trade_ui(
         post_valuation=True,
     )
 
+    resolved = execution_model.resolve_pending_vault_settlements(state=state, ts=ts)
+    if resolved:
+        logger.info("Resolved %d pending vault settlement(s) before opening trade-ui", len(resolved))
+    if not simulate:
+        store.sync(state)
+
     # Gather balance info for the TUI header
     hot_wallet = sync_model.get_hot_wallet()
     gas_balance = hot_wallet.get_native_currency_balance(web3)

--- a/tradeexecutor/cli/trade_ui_tui.py
+++ b/tradeexecutor/cli/trade_ui_tui.py
@@ -186,7 +186,7 @@ def _format_lockup(state: State, pair: TradingPairIdentifier) -> Text:
     Priority:
 
     1. If an async deposit is pending settlement, show the estimated
-       settlement time (``settles 18.5h``), ``settling`` when the stored
+       settlement eligibility time (``eligible 18.5h``), ``settling`` when the stored
        estimate has already passed, or ``pending`` when no on-chain ETA is
        available (operator-driven ERC-7540 vaults like Lagoon).
     2. Otherwise show the lockup time remaining from the stored expiry
@@ -219,7 +219,7 @@ def _format_lockup(state: State, pair: TradingPairIdentifier) -> Text:
         if remaining.total_seconds() <= 0:
             # Estimate has passed — settlement is due / in progress.
             return Text("settling", style="yellow", justify="right")
-        return Text(_format_remaining(remaining, prefix="settles "), style="yellow", justify="right")
+        return Text(_format_remaining(remaining, prefix="eligible "), style="yellow", justify="right")
 
     # 2. Fall back to lockup expiry.
     expires_at_str = position.other_data.get("vault_lockup_expires_at")

--- a/tradeexecutor/ethereum/vault/settlement_estimate.py
+++ b/tradeexecutor/ethereum/vault/settlement_estimate.py
@@ -1,0 +1,46 @@
+"""Display-only async vault settlement estimate helpers."""
+
+import logging
+
+from tradeexecutor.state.trade import TradeExecution
+
+
+logger = logging.getLogger(__name__)
+
+
+def refresh_vault_settlement_estimate(
+    trade: TradeExecution,
+    deposit_manager,
+    ticket,
+    direction: str,
+) -> None:
+    """Refresh display-only vault settlement ETA from a protocol ticket.
+
+    Some async vault adapters can estimate when a specific request ticket
+    becomes eligible for settlement. Persist that estimate in ``other_data`` so
+    all user interfaces show the same metadata.
+    """
+    method_name = (
+        "get_deposit_ticket_delay_over"
+        if direction == "deposit"
+        else "get_redemption_ticket_delay_over"
+    )
+    method = getattr(deposit_manager, method_name, None)
+    if method is None:
+        return
+
+    try:
+        settles_at = method(ticket)
+    except NotImplementedError:
+        return
+    except Exception as e:
+        logger.warning(
+            "Could not refresh vault settlement estimate for trade #%d: %s",
+            trade.trade_id,
+            e,
+        )
+        return
+
+    trade.other_data["vault_settlement_estimated_at"] = (
+        settles_at.isoformat() if settles_at else None
+    )

--- a/tradeexecutor/ethereum/vault/settlement_retry.py
+++ b/tradeexecutor/ethereum/vault/settlement_retry.py
@@ -26,6 +26,7 @@ from web3 import Web3
 from web3.contract.contract import ContractFunction
 
 from tradeexecutor.ethereum.tx import HotWalletTransactionBuilder, TransactionBuilder
+from tradeexecutor.ethereum.vault.settlement_estimate import refresh_vault_settlement_estimate
 from tradeexecutor.ethereum.vault.vault_routing import get_vault_for_pair
 from tradeexecutor.state.blockhain_transaction import BlockchainTransaction
 from tradeexecutor.state.state import State
@@ -301,6 +302,7 @@ def _resolve_single_vault_trade(
         ticket = deposit_manager.reconstruct_deposit_ticket(trade.other_data)
     else:
         ticket = deposit_manager.reconstruct_redemption_ticket(trade.other_data)
+    refresh_vault_settlement_estimate(trade, deposit_manager, ticket, direction)
 
     # STEP A: Check for existing post-request tx (idempotent handling)
     request_tx_count = trade.other_data.get("vault_request_tx_count", 1)

--- a/tradeexecutor/ethereum/vault/vault_routing.py
+++ b/tradeexecutor/ethereum/vault/vault_routing.py
@@ -19,6 +19,7 @@ from eth_defi.vault.deposit_redeem import VaultDepositManager
 
 from tradeexecutor.ethereum.swap import get_swap_transactions, report_failure
 from tradeexecutor.ethereum.token_cache import get_default_token_cache
+from tradeexecutor.ethereum.vault.settlement_estimate import refresh_vault_settlement_estimate
 from tradeexecutor.state.blockhain_transaction import BlockchainTransaction
 from tradeexecutor.state.portfolio import Portfolio
 from tradeexecutor.state.state import State
@@ -444,6 +445,12 @@ class VaultRouting(RoutingModel):
                 )
                 ticket = deposit_request.parse_deposit_transaction(tx_hashes)
                 ticket_data = deposit_manager.serialize_deposit_ticket(ticket)
+                refresh_vault_settlement_estimate(
+                    trade,
+                    deposit_manager,
+                    ticket,
+                    direction,
+                )
             else:
                 # Reconstruct redemption request using shares (Decimal) —
                 # Lagoon asserts `not raw_shares` so we must pass the decimal form.
@@ -467,6 +474,12 @@ class VaultRouting(RoutingModel):
                     )
                 ticket = redemption_request.parse_redeem_transaction(tx_hashes)
                 ticket_data = deposit_manager.serialize_redemption_ticket(ticket)
+                refresh_vault_settlement_estimate(
+                    trade,
+                    deposit_manager,
+                    ticket,
+                    direction,
+                )
 
             state.mark_vault_settlement_pending(ts, trade, ticket_data)
             logger.info(


### PR DESCRIPTION
## Why

`trade-ui` showed pending Ostium deposits as if their settlement timestamp was a guaranteed settlement time. For Ostium V1.5 the timestamp is better treated as the time when `tryNewSettlement()` becomes eligible, and pending requests should be refreshed through the same on-chain resolver used by the daemon.

The UI also needs to use the request's persisted settlement ticket metadata instead of relying on moving vault target settlement ids.

## Lessons learnt

The settlement ETA is display metadata only. The executor must continue polling request status and claim as soon as the vault reports the request as claimable.

For persisted async vault requests, the request ticket's settlement id is the stable key. Live target settlement ids can move after a request is opened.

## Summary

- Runs the generic pending vault settlement resolver before opening `trade-ui`, so claimable requests are completed and display metadata is refreshed from chain.
- Adds a shared settlement estimate helper used by both request parsing and settlement retry.
- Changes the trade-ui lockup wording from `settles ...` to `eligible ...` for pending async vault deposits.
- Updates Ostium async-vault docs and backtest comments to distinguish live on-chain eligibility from the historical backtest approximation.
- Bumps `deps/web3-ethereum-defi` to tradingstrategy-ai/web3-ethereum-defi#1115.
