### PR TITLE
fix: ERC-7540 Lagoon deposit settlement crash in trade-ui (DepositRequest event)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## 0.2
 
 
+- Fix `trade-ui` / live trading crashing with `web3.exceptions.ABIEventNotFound` when settling an async ERC-7540 deposit into a non-legacy (Lagoon v0.5+) vault. `parse_deposit_transaction()` referenced a misspelled `DepositRequested` event; the ERC-7540 standard (and the Lagoon v0.5 ABI) names it `DepositRequest`. The bug went unnoticed because every Lagoon ERC-7540 test fixture pointed at the legacy 722 Capital vault, which takes a different (Referral-topic) parsing branch — the non-legacy branch was never exercised. `test_lagoon_erc_7540` now parses a `requestDeposit` receipt on the freshly deployed non-legacy vault as a regression (2026-06-18)
+
 - Breaking API changes
 
 - Fix HyperCore vault withdrawals crashing the live executor on `phase1_perp_wait` when the vault leader performance fee shrinks the redemption. A successful `vaultTransfer(vault→perp)` whose net perp arrival fell short of the gross request by more than the ~1% slippage tolerance (a fee of ~5-6% on a profitable vault like IKAGI) was mistaken for a silent no-op, halting the whole sequential rebalance. Withdrawal phase-1 verification now widens its accepted shortfall to the worst-case leader performance fee, resolved per vault (the fee differs: ~10% for leader vaults, 0% for protocol/HLP vaults) from the trading pair metadata (`other_data["vault_performance_fee"]`, populated from `VaultMetadata`), then a live `leaderCommission` read, and only a 10% default as a last resort; the same tolerance feeds the vault-equity reflection fallback, and the deduction is logged and shown in the failure diagnostics. `create_hypercore_vault_pair()` gained a `performance_fee` argument (2026-06-18)


### PR DESCRIPTION
## Why

`trade-ui` (and live trading generally) crashed with `web3.exceptions.ABIEventNotFound` when settling an async ERC-7540 deposit into a non-legacy (Lagoon v0.5+) vault such as DeTrade Core USDC. A cross-chain test trade bridged USDC Arbitrum→Base via CCTP successfully, then crashed in `vault_routing.settle_trade()` → `parse_deposit_transaction()`:

```
web3.exceptions.ABIEventNotFound: The event 'DepositRequested' was not found in this
contract's abi. Did you mean: 'DepositRequest'?
```

The root cause is a misspelled event name in `web3-ethereum-defi`; the ERC-7540 standard / Lagoon v0.5 ABI names it `DepositRequest`. This PR bumps the submodule to the fix (web3-ethereum-defi #1117).

## Lessons learnt

- The async settlement path was never exercised end-to-end with a real async vault. The cross-chain test-trade test (`test_perform_test_trade_crosschain.py`) uses an IPOR Fusion vault, which is **synchronous** ERC-4626. The buggy code only runs when `vault_async_flow` is set, which `vault_routing.py` sets only when `has_synchronous_deposit()` is False — so the async branch (and the crash) never triggered in tests, while the production DeTrade vault (async) hit it on the first deposit.
- A green cross-chain test is not the same as a green cross-chain test against an async vault. Coverage should include at least one async ERC-7540 target for the settlement path.

## Summary

- Bump `deps/web3-ethereum-defi` to the fix that uses the correct `DepositRequest` event name (web3-ethereum-defi #1117), which also adds a regression test exercising the previously-uncovered non-legacy parsing branch.
- Add CHANGELOG entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
