### PR TITLE
Log multichain deployment info on startup

### DIFF
--- a/tradeexecutor/cli/bootstrap.py
+++ b/tradeexecutor/cli/bootstrap.py
@@ -1,5 +1,6 @@
 """Command line application initialisation helpers."""
 import datetime
+import json
 import logging
 import os
 import shutil
@@ -292,8 +293,6 @@ def resolve_satellite_modules(deployment_file: "Path | None") -> dict:
         Mapping of chain slug to satellite trading strategy module address. Empty
         when neither source provides satellites.
     """
-    import json
-
     env_json = os.environ.get("SATELLITE_MODULES")
     if env_json:
         return json.loads(env_json)
@@ -313,6 +312,78 @@ def resolve_satellite_modules(deployment_file: "Path | None") -> dict:
             return modules
 
     return {}
+
+
+def log_multichain_deployment_information(deployment_file: "Path | None") -> None:
+    """Log the multichain deployment artifact summary at startup."""
+
+    if deployment_file is None or not deployment_file.exists():
+        return
+
+    data = json.loads(deployment_file.read_text())
+    if not data.get("multichain"):
+        return
+
+    deployments = data.get("deployments") or {}
+    logger.info(
+        "Using multichain deployment artifact %s, deployment_mode=%s, safe_salt_nonce=%s, chains=%s",
+        deployment_file,
+        data.get("deployment_mode"),
+        data.get("safe_salt_nonce"),
+        ", ".join(deployments.keys()),
+    )
+
+    for slug, dep in deployments.items():
+        role = "satellite" if dep.get("is_satellite") else "master"
+        logger.info(
+            "Multichain deployment %s (%s): vault=%s, safe=%s, module=%s, asset_manager=%s, valuation_manager=%s, deployment_mode=%s",
+            slug,
+            role,
+            dep.get("vault_address"),
+            dep.get("safe_address"),
+            dep.get("module_address"),
+            dep.get("asset_manager"),
+            dep.get("valuation_manager"),
+            dep.get("deployment_mode"),
+        )
+        _log_multichain_deployment_section(slug, "Deployment", dep.get("deployment_data") or {})
+        _log_multichain_deployment_section(slug, "Lagoon config", dep.get("config") or {})
+        _log_multichain_deployment_section(slug, "Guard whitelist", {"entries": dep.get("whitelisted_items") or []})
+        if dep.get("guard_migration"):
+            _log_multichain_deployment_section(slug, "Guard migration", dep.get("guard_migration") or {})
+
+
+def _log_multichain_deployment_section(chain_slug: str, section: str, values: object, prefix: str = "") -> None:
+    """Log deployment artifact data in the same sections as lagoon-deploy-vault."""
+
+    if values is None:
+        return
+
+    if isinstance(values, dict):
+        for key, value in values.items():
+            label = f"{section}.{prefix}{key}"
+            if key == "ABI":
+                logger.info("Multichain deployment %s %s: <omitted>", chain_slug, label)
+                continue
+
+            next_prefix = f"{prefix}{key}."
+            if isinstance(value, (dict, list)):
+                _log_multichain_deployment_section(chain_slug, section, value, next_prefix)
+            else:
+                logger.info("Multichain deployment %s %s: %s", chain_slug, label, value)
+    elif isinstance(values, list):
+        if not values:
+            label = f"{section}.{prefix[:-1]}" if prefix else section
+            logger.info("Multichain deployment %s %s: []", chain_slug, label)
+        for idx, value in enumerate(values, start=1):
+            next_prefix = f"{prefix}{idx}."
+            label = f"{section}.{prefix}{idx}"
+            if isinstance(value, (dict, list)):
+                _log_multichain_deployment_section(chain_slug, section, value, next_prefix)
+            else:
+                logger.info("Multichain deployment %s %s: %s", chain_slug, label, value)
+    else:
+        logger.info("Multichain deployment %s %s: %s", chain_slug, section, values)
 
 
 def resolve_deployment_file(id: str, state_file: "str | Path | None" = None) -> Path:

--- a/tradeexecutor/cli/bootstrap.py
+++ b/tradeexecutor/cli/bootstrap.py
@@ -55,6 +55,7 @@ from tradeexecutor.ethereum.velvet.vault import VelvetVaultSyncModel
 from tradeexecutor.ethereum.web3config import Web3Config, get_rpc_env_var_name
 from tradeexecutor.monkeypatch.dataclasses_json import patch_dataclasses_json
 from tradeexecutor.state.metadata import Metadata, OnChainData
+from tradeexecutor.state.deployment_info import DeploymentInfo
 from tradeexecutor.state.state import State
 from tradeexecutor.state.store import JSONFileStore, SimulateStore
 from tradeexecutor.strategy.default_routing_options import TradeRouting
@@ -384,6 +385,35 @@ def _log_multichain_deployment_section(chain_slug: str, section: str, values: ob
                 logger.info("Multichain deployment %s %s: %s", chain_slug, label, value)
     else:
         logger.info("Multichain deployment %s %s: %s", chain_slug, section, values)
+
+
+def update_strategy_file_deployment_info(state: State, deployment_file: "Path | None") -> bool:
+    """Persist strategy-file deployment information to the state if it changed.
+
+    Only multichain strategy-file deployment artifacts are recorded here. Legacy
+    deployment sync data remains under ``state.sync.deployment``.
+    """
+
+    if deployment_file is None or not deployment_file.exists():
+        return False
+
+    data = json.loads(deployment_file.read_text())
+    if not data.get("multichain"):
+        return False
+
+    deployment_data = {
+        "multichain": True,
+        "deployment_mode": data.get("deployment_mode"),
+        "safe_salt_nonce": data.get("safe_salt_nonce"),
+        "deployments": data.get("deployments") or {},
+    }
+    if state.deployment_info is None:
+        state.deployment_info = DeploymentInfo()
+
+    return state.deployment_info.update_strategy_file_deployment_data(
+        str(deployment_file),
+        deployment_data,
+    )
 
 
 def resolve_deployment_file(id: str, state_file: "str | Path | None" = None) -> Path:

--- a/tradeexecutor/cli/commands/start.py
+++ b/tradeexecutor/cli/commands/start.py
@@ -23,7 +23,7 @@ from tradingstrategy.timebucket import TimeBucket
 from . import shared_options
 from .app import app
 from ..bootstrap import prepare_executor_id, prepare_cache_and_token_cache, create_web3_config, create_state_store, \
-    create_execution_and_sync_model, resolve_deployment_file, log_multichain_deployment_information, create_metadata, create_approval_model, create_client, configure_default_chain
+    create_execution_and_sync_model, resolve_deployment_file, log_multichain_deployment_information, update_strategy_file_deployment_info, create_metadata, create_approval_model, create_client, configure_default_chain
 from ...exchange_account.derive import DeriveNetwork
 from ..log import setup_logging, setup_discord_logging, setup_logstash_logging, setup_file_logging, setup_telegram_logging, setup_sentry_logging
 from ..loop import ExecutionLoop
@@ -650,6 +650,10 @@ def start(
     except Exception as e:
         logger.error("trade-executor crashed on initialisation: %s", e)
         raise e
+
+    if update_strategy_file_deployment_info(state, deployment_file):
+        logger.info("Updated strategy-file deployment information in the state")
+        store.sync(state)
 
     if preload_webhook_data:
         if not http_enabled:

--- a/tradeexecutor/cli/commands/start.py
+++ b/tradeexecutor/cli/commands/start.py
@@ -23,7 +23,7 @@ from tradingstrategy.timebucket import TimeBucket
 from . import shared_options
 from .app import app
 from ..bootstrap import prepare_executor_id, prepare_cache_and_token_cache, create_web3_config, create_state_store, \
-    create_execution_and_sync_model, resolve_deployment_file, create_metadata, create_approval_model, create_client, configure_default_chain
+    create_execution_and_sync_model, resolve_deployment_file, log_multichain_deployment_information, create_metadata, create_approval_model, create_client, configure_default_chain
 from ...exchange_account.derive import DeriveNetwork
 from ..log import setup_logging, setup_discord_logging, setup_logstash_logging, setup_file_logging, setup_telegram_logging, setup_sentry_logging
 from ..loop import ExecutionLoop
@@ -316,6 +316,9 @@ def start(
 
         assert web3config is not None, "Web3 RPC configuration failed?"
 
+        deployment_file = resolve_deployment_file(id, state_file)
+        log_multichain_deployment_information(deployment_file)
+
         execution_model, sync_model, valuation_model_factory, pricing_model_factory = create_execution_and_sync_model(
             asset_management_mode=asset_management_mode,
             private_key=private_key,
@@ -331,8 +334,8 @@ def start(
             unit_testing=unit_testing,
             token_cache=token_cache,
             # Auto-discover satellite modules from the deployment artifact next to
-            # the state file. Honour a custom STATE_FILE location (matches deploy).
-            deployment_file=resolve_deployment_file(id, os.environ.get("STATE_FILE")),
+            # the state file.
+            deployment_file=deployment_file,
         )
 
         # TODO: Unit test hack

--- a/tradeexecutor/state/deployment_info.py
+++ b/tradeexecutor/state/deployment_info.py
@@ -1,0 +1,68 @@
+"""Strategy-file deployment information persisted in the executor state."""
+
+import datetime
+from dataclasses import dataclass, field
+
+from dataclasses_json import dataclass_json
+
+from eth_defi.compat import native_datetime_utc_now
+
+
+@dataclass_json
+@dataclass(slots=True)
+class DeploymentInfoChange:
+    """Audit entry for deployment information changes."""
+
+    #: When deployment information was changed in the state.
+    modified_at: datetime.datetime = field(default_factory=native_datetime_utc_now)
+
+    #: Human-readable change summary.
+    change_summary_message: str = ""
+
+
+@dataclass_json
+@dataclass(slots=True)
+class DeploymentInfo:
+    """Strategy-file based deployment information.
+
+    This is separate from legacy ``sync.deployment`` data, which tracks on-chain
+    vault sync state.
+    """
+
+    #: Deployment source. Currently only strategy-file multichain artifacts use this.
+    source: str | None = None
+
+    #: Deployment artifact path read during startup.
+    deployment_file: str | None = None
+
+    #: Machine-readable deployment data from the deployment artifact.
+    data: dict = field(default_factory=dict)
+
+    #: Deployment information change history.
+    modified: list[DeploymentInfoChange] = field(default_factory=list)
+
+    def update_strategy_file_deployment_data(
+        self,
+        deployment_file: str,
+        data: dict,
+    ) -> bool:
+        """Update strategy-file deployment data if it changed.
+
+        :return:
+            ``True`` if data changed and an audit entry was added.
+        """
+
+        self.source = "strategy_file"
+        self.deployment_file = deployment_file
+
+        if self.data == data:
+            return False
+
+        if self.data:
+            change_summary_message = f"Updated strategy-file deployment information from {deployment_file}"
+        else:
+            change_summary_message = f"Initialised strategy-file deployment information from {deployment_file}"
+
+        self.data = data
+        self.modified.append(DeploymentInfoChange(change_summary_message=change_summary_message))
+        return True

--- a/tradeexecutor/state/state.py
+++ b/tradeexecutor/state/state.py
@@ -22,6 +22,7 @@ from tradeexecutor.strategy.trade_pricing import TradePricing
 from tradeexecutor.utils.summarydataframe import as_duration, format_value
 
 from ..strategy.cycle import CycleDuration
+from .deployment_info import DeploymentInfo
 from .identifier import (AssetFriendlyId, AssetIdentifier,
                          TradingPairIdentifier, TradingPairKind)
 from .other_data import OtherData
@@ -215,6 +216,11 @@ class State:
     uptime: Uptime = field(default_factory=Uptime)
 
     sync: Sync = field(default_factory=Sync)
+
+    #: Strategy-file based deployment information.
+    #:
+    #: Separate from legacy ``sync.deployment`` on-chain sync state.
+    deployment_info: DeploymentInfo | None = None
 
     #: Backtest data related to this backtest result
     #:


### PR DESCRIPTION
## Why

Multichain Lagoon executors can discover satellite deployment details from the deployment artifact at runtime, but the start command did not log or persist the resolved deployment information during startup. This made it harder to confirm which Safe, module, vault, guard whitelist and Lagoon config addresses the executor was using.

## Lessons learnt

The deployment artifact already contains the same structured sections emitted by lagoon-deploy-vault. Startup should reuse that artifact for both diagnostics and state metadata, while keeping it separate from legacy sync deployment data.

## Summary

- Added startup logging for multichain deployment artifacts, including per-chain deployment data, Lagoon config, guard whitelist and guard migration details.
- Omitted the bulky ABI field from startup logs.
- Resolved the deployment artifact once from the effective state file and reused that path for Lagoon satellite discovery.
- Added a `deployment_info` state JSON section for strategy-file multichain deployment data.
- Persist deployment info on `start` when the deployment artifact is first seen or changes, appending `modified` audit entries with `modified_at` and `change_summary_message`.