### PR TITLE
fix: revalue vault positions before trade-ui treasury sync

### DIFF
--- a/tests/cli/test_trade_ui_startup_sync.py
+++ b/tests/cli/test_trade_ui_startup_sync.py
@@ -1,0 +1,111 @@
+"""Trade-ui startup treasury sync ordering tests."""
+
+import datetime
+from types import SimpleNamespace
+
+from tradeexecutor.cli.commands.trade_ui import _sync_trade_ui_startup_treasury
+from tradeexecutor.state.state import State
+
+
+def test_trade_ui_revalues_before_lagoon_post_valuation() -> None:
+    """Trade-ui refreshes async vault settlements and valuations before Lagoon NAV posting.
+
+    1. Build fake execution, runner, sync model and store objects that record call order.
+    2. Run the trade-ui startup treasury helper.
+    3. Verify Lagoon treasury sync happens only after settlement resolution and revaluation.
+    4. Run the helper in simulate mode and verify it does not write the state file.
+    """
+
+    calls: list[str] = []
+    ts = datetime.datetime(2026, 6, 19, 11, 6, 9)
+    state = State()
+    reserve_asset = SimpleNamespace(token_symbol="USDC")
+    universe = SimpleNamespace(reserve_assets=[reserve_asset])
+    pricing_model = object()
+    valuation_method = object()
+
+    class FakeExecutionModel:
+        def initialize(self) -> None:
+            calls.append("initialize")
+
+        def resolve_pending_vault_settlements(self, *, state: State, ts: datetime.datetime, pricing_model):
+            calls.append("resolve_pending_vault_settlements")
+            assert pricing_model is not None
+            return []
+
+    class FakeRunner:
+        def revalue_state(self, revalue_ts: datetime.datetime, revalue_state: State, method) -> None:
+            calls.append("revalue_state")
+            assert revalue_ts == ts
+            assert revalue_state is state
+            assert method is valuation_method
+
+    class FakeSyncModel:
+        def sync_treasury(
+            self,
+            strategy_cycle_ts: datetime.datetime,
+            synced_state: State,
+            supported_reserves: list,
+            post_valuation: bool = False,
+        ):
+            calls.append("sync_treasury")
+            assert strategy_cycle_ts == ts
+            assert synced_state is state
+            assert supported_reserves == [reserve_asset]
+            assert post_valuation is True
+            return []
+
+    class FakeStore:
+        def sync(self, synced_state: State) -> None:
+            calls.append("store_sync")
+            assert synced_state is state
+
+    logger = SimpleNamespace(info=lambda *args, **kwargs: None)
+
+    # 2. Run the trade-ui startup treasury helper.
+    _sync_trade_ui_startup_treasury(
+        ts=ts,
+        state=state,
+        universe=universe,
+        execution_model=FakeExecutionModel(),
+        sync_model=FakeSyncModel(),
+        runner=FakeRunner(),
+        valuation_method=valuation_method,
+        pricing_model=pricing_model,
+        store=FakeStore(),
+        simulate=False,
+        logger=logger,
+    )
+
+    # 3. Verify Lagoon treasury sync happens only after settlement resolution and revaluation.
+    assert calls == [
+        "initialize",
+        "resolve_pending_vault_settlements",
+        "revalue_state",
+        "sync_treasury",
+        "store_sync",
+    ]
+
+    calls.clear()
+
+    # 4. Run in simulate mode and verify the state file is not written.
+    _sync_trade_ui_startup_treasury(
+        ts=ts,
+        state=state,
+        universe=universe,
+        execution_model=FakeExecutionModel(),
+        sync_model=FakeSyncModel(),
+        runner=FakeRunner(),
+        valuation_method=valuation_method,
+        pricing_model=pricing_model,
+        store=FakeStore(),
+        simulate=True,
+        logger=logger,
+    )
+
+    assert calls == [
+        "initialize",
+        "resolve_pending_vault_settlements",
+        "revalue_state",
+        "sync_treasury",
+    ]

--- a/tradeexecutor/cli/commands/trade_ui.py
+++ b/tradeexecutor/cli/commands/trade_ui.py
@@ -60,6 +60,48 @@ from ...utils.timer import timed_task
 from tradeexecutor.cli.commands import shared_options
 
 
+def _sync_trade_ui_startup_treasury(
+    *,
+    ts: datetime.datetime,
+    state,
+    universe,
+    execution_model,
+    sync_model,
+    runner,
+    valuation_method,
+    pricing_model,
+    store,
+    simulate: bool,
+    logger,
+):
+    """Refresh trade-ui balances before opening the interactive view."""
+    execution_model.initialize()
+
+    resolved = execution_model.resolve_pending_vault_settlements(
+        state=state,
+        ts=ts,
+        pricing_model=pricing_model,
+    )
+    if resolved:
+        logger.info("Resolved %d pending vault settlement(s) before opening trade-ui", len(resolved))
+
+    # Lagoon sync_treasury(post_valuation=True) posts NAV on-chain. Make sure
+    # external vault positions, e.g. Ostium, have fresh valuation data first.
+    runner.revalue_state(ts, state, valuation_method)
+
+    balance_updates = sync_model.sync_treasury(
+        ts,
+        state,
+        list(universe.reserve_assets),
+        post_valuation=True,
+    )
+
+    if not simulate:
+        store.sync(state)
+
+    return balance_updates
+
+
 @app.command()
 @shared_options.with_json_rpc_options()
 def trade_ui(
@@ -225,20 +267,19 @@ def trade_ui(
 
     # Sync treasury so balances are up to date for the TUI display
     web3 = web3config.get_default()
-    execution_model.initialize()
-
-    balance_updates = sync_model.sync_treasury(
-        ts,
-        state,
-        list(universe.reserve_assets),
-        post_valuation=True,
+    balance_updates = _sync_trade_ui_startup_treasury(
+        ts=ts,
+        state=state,
+        universe=universe,
+        execution_model=execution_model,
+        sync_model=sync_model,
+        runner=runner,
+        valuation_method=valuation_method,
+        pricing_model=pricing_model,
+        store=store,
+        simulate=simulate,
+        logger=logger,
     )
-
-    resolved = execution_model.resolve_pending_vault_settlements(state=state, ts=ts)
-    if resolved:
-        logger.info("Resolved %d pending vault settlement(s) before opening trade-ui", len(resolved))
-    if not simulate:
-        store.sync(state)
 
     # Gather balance info for the TUI header
     hot_wallet = sync_model.get_hot_wallet()


### PR DESCRIPTION
## Why

`trade-ui` could crash during startup for Lagoon vault strategies holding Ostium vault positions. The command called `sync_treasury(..., post_valuation=True)` before refreshing open-position valuations, so Lagoon's NAV posting freshness check saw stale Ostium valuation timestamps and aborted before the TUI opened.

## Lessons learnt

One-off CLI startup paths need the same valuation freshness discipline as the daemon tick when they post Lagoon NAV. Async vault settlement resolution and position revaluation should happen before treasury sync so the NAV calculation uses current position values.

Resolving claimable async vault settlements before the one-shot `trade-ui` treasury sync is intentional: it lets the displayed balances and the posted NAV reflect positions that became claimable while the daemon was not running.

## Summary

- Adds a `trade-ui` startup treasury-sync helper that initialises execution, resolves claimable async vault settlements, revalues positions, and only then runs Lagoon treasury sync.
- Preserves the simulate-mode behaviour of not writing state back to disk.
- Adds a focused regression test for the startup ordering and simulate-mode persistence branch.
- Reviewed the change with Claude CLI; no correctness issues were found.
