### PR TITLE
Strip ABI blobs from deployment state info

### DIFF
--- a/tests/test_satellite_preflight.py
+++ b/tests/test_satellite_preflight.py
@@ -134,11 +134,13 @@ def test_update_strategy_file_deployment_info_detects_changes(tmp_path: Path):
                     "Safe": "0xSafe",
                     "Vault": "0xVault",
                     "Trading strategy module": "0xModule",
+                    "ABI": [{"type": "function", "name": "deposit"}],
                 },
                 "config": {
                     "uniswap_v3": {
                         "router": "0xRouter",
                         "position_manager": "0xPositionManager",
+                        "abi": [{"type": "function", "name": "exactInput"}],
                     },
                 },
                 "whitelisted_items": [
@@ -146,6 +148,7 @@ def test_update_strategy_file_deployment_info_detects_changes(tmp_path: Path):
                         "kind": "Sender",
                         "name": "trade-executor",
                         "address": "0xAssetManager",
+                        "ABI": [{"type": "function", "name": "execTransactionFromModule"}],
                     },
                 ],
             },
@@ -156,13 +159,44 @@ def test_update_strategy_file_deployment_info_detects_changes(tmp_path: Path):
     assert state.deployment_info is not None
     assert state.deployment_info.source == "strategy_file"
     assert state.deployment_info.deployment_file == str(artifact)
+    expected_deployments = {
+        "arbitrum": {
+            "vault_address": "0xVault",
+            "safe_address": "0xSafe",
+            "module_address": "0xModule",
+            "asset_manager": "0xAssetManager",
+            "valuation_manager": "0xValuationManager",
+            "is_satellite": False,
+            "deployment_data": {
+                "Safe": "0xSafe",
+                "Vault": "0xVault",
+                "Trading strategy module": "0xModule",
+            },
+            "config": {
+                "uniswap_v3": {
+                    "router": "0xRouter",
+                    "position_manager": "0xPositionManager",
+                },
+            },
+            "whitelisted_items": [
+                {
+                    "kind": "Sender",
+                    "name": "trade-executor",
+                    "address": "0xAssetManager",
+                },
+            ],
+        },
+    }
     assert state.deployment_info.data == {
         "multichain": True,
         "deployment_mode": "full deployment",
         "safe_salt_nonce": 42,
-        "deployments": deployment_payload["deployments"],
+        "deployments": expected_deployments,
     }
     assert "guard_report" not in state.deployment_info.data
+    assert "ABI" not in state.deployment_info.data["deployments"]["arbitrum"]["deployment_data"]
+    assert "abi" not in state.deployment_info.data["deployments"]["arbitrum"]["config"]["uniswap_v3"]
+    assert "ABI" not in state.deployment_info.data["deployments"]["arbitrum"]["whitelisted_items"][0]
     assert len(state.deployment_info.modified) == 1
     assert isinstance(state.deployment_info.modified[0].modified_at, datetime.datetime)
     assert state.deployment_info.modified[0].change_summary_message == f"Initialised strategy-file deployment information from {artifact}"

--- a/tradeexecutor/cli/bootstrap.py
+++ b/tradeexecutor/cli/bootstrap.py
@@ -387,6 +387,26 @@ def _log_multichain_deployment_section(chain_slug: str, section: str, values: ob
         logger.info("Multichain deployment %s %s: %s", chain_slug, section, values)
 
 
+def strip_deployment_state_abi(data: object) -> object:
+    """Strip ABI blobs from deployment data before persisting it to state.
+
+    The deployment state only needs the function/name/address tree for diagnostics.
+    Full ABI blobs are large and can be recovered later from deployment artifacts
+    or block explorers.
+    """
+
+    if isinstance(data, dict):
+        return {
+            key: strip_deployment_state_abi(value)
+            for key, value in data.items()
+            if str(key).lower() != "abi"
+        }
+    elif isinstance(data, list):
+        return [strip_deployment_state_abi(item) for item in data]
+    else:
+        return data
+
+
 def update_strategy_file_deployment_info(state: State, deployment_file: "Path | None") -> bool:
     """Persist strategy-file deployment information to the state if it changed.
 
@@ -405,7 +425,7 @@ def update_strategy_file_deployment_info(state: State, deployment_file: "Path | 
         "multichain": True,
         "deployment_mode": data.get("deployment_mode"),
         "safe_salt_nonce": data.get("safe_salt_nonce"),
-        "deployments": data.get("deployments") or {},
+        "deployments": strip_deployment_state_abi(data.get("deployments") or {}),
     }
     if state.deployment_info is None:
         state.deployment_info = DeploymentInfo()


### PR DESCRIPTION
## Why

Deployment artifacts can contain large ABI blobs. The state file only needs the recoverable deployment tree with names, functions and addresses for diagnostics; persisting full ABI data unnecessarily bloats state JSON.

## Lessons learnt

Startup logging already omits ABI fields, but deployment state persistence stored the nested deployment data wholesale. State persistence needs its own recursive sanitisation step.

## Summary

- Strip `ABI` / `abi` keys recursively before persisting strategy-file multichain deployment info to state.
- Preserve the remaining nested deployment tree, including contract names, addresses, config and whitelist entries.
- Extend deployment-info state tests to cover nested ABI removal and preserved address mappings.