### PR TITLE
Fix console indicator fallback

### DIFF
--- a/tests/cli/test_console_indicators.py
+++ b/tests/cli/test_console_indicators.py
@@ -1,0 +1,72 @@
+"""Tests for console indicator fallback behaviour."""
+
+import datetime
+import logging
+from types import SimpleNamespace
+
+import pytest
+
+from tradeexecutor.cli.commands import console as console_module
+
+
+class _FakeIndicatorSet:
+    """Minimal indicator set stub for console indicator fallback tests."""
+
+    def generate_combinations(self, universe) -> list[str]:
+        return ["failing_indicator"]
+
+
+class _FakeUniverse:
+    """Minimal universe stub exposing the cache key used by the console helper."""
+
+    def get_cache_key(self) -> str:
+        return "test-universe"
+
+
+def test_calculate_console_indicators_warns_and_disables_indicators(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Check console starts without indicators when indicator calculation fails.
+
+    The mocked ``calculate_indicators`` fails after storage and indicator set
+    setup to verify partially initialised indicator objects are not exposed in
+    console bindings.
+
+    1. Mock console indicator preparation to create a fake indicator set.
+    2. Mock indicator calculation to fail like a live data lookup issue.
+    3. Verify all indicator bindings are disabled and a warning is logged.
+    """
+
+    mod = SimpleNamespace(
+        create_indicators=lambda *args, **kwargs: None,
+        parameters=SimpleNamespace(),
+    )
+    logger = logging.getLogger("test-console-indicators")
+
+    # 1. Mock console indicator preparation to create a fake indicator set.
+    monkeypatch.setattr(console_module, "prepare_indicators", lambda *args, **kwargs: _FakeIndicatorSet())
+    monkeypatch.setattr("builtins.print", lambda *args, **kwargs: None)
+
+    # 2. Mock indicator calculation to fail like a live data lookup issue.
+    def fail_calculate_indicators(*args, **kwargs):
+        raise RuntimeError("missing supporting pair")
+
+    monkeypatch.setattr(console_module, "calculate_indicators", fail_calculate_indicators)
+
+    with caplog.at_level(logging.WARNING, logger="test-console-indicators"):
+        indicator_storage, indicator_set, indicator_result_map, indicators = console_module.calculate_console_indicators(
+            mod=mod,
+            universe=_FakeUniverse(),
+            execution_context=None,
+            cycle_timestamp=datetime.datetime(2026, 6, 19),
+            max_workers=1,
+            logger=logger,
+        )
+
+    # 3. Verify all indicator bindings are disabled and a warning is logged.
+    assert indicator_storage is None
+    assert indicator_set is None
+    assert indicator_result_map is None
+    assert indicators is None
+    assert "Could not calculate real-time indicators for console; continuing without indicators" in caplog.text

--- a/tradeexecutor/cli/commands/console.py
+++ b/tradeexecutor/cli/commands/console.py
@@ -82,6 +82,64 @@ def launch_console(bindings: dict):
     embed(user_ns=bindings, colors="Linux")
 
 
+def calculate_console_indicators(
+    mod,
+    universe,
+    execution_context,
+    cycle_timestamp,
+    max_workers: int | None,
+    logger,
+):
+    """Calculate strategy indicators for console bindings.
+
+    Console is a diagnostic tool and must still open if real-time indicator
+    calculation fails.
+    """
+    indicator_storage = indicator_set = indicator_result_map = indicators = None
+    if mod.create_indicators:
+        try:
+            if max_workers is None:
+                max_workers = get_safe_max_workers_count()
+
+            print(f"Creating real-time indicators for the strategy module for timestamp {cycle_timestamp}")
+            print(f"No indicator cache used")
+
+            # TODO: MemoryIndicatorStorage does not support yet parallel indicator calculations
+            max_workers = 1
+
+            assert mod.parameters, "You need to have Parameters class if create_indicators is specified"
+            indicator_storage = MemoryIndicatorStorage(universe_key=universe.get_cache_key())
+            indicator_set = prepare_indicators(
+                mod.create_indicators,
+                mod.parameters,
+                universe,
+                execution_context,
+                timestamp=cycle_timestamp,
+            )
+            indicators_needed = set(indicator_set.generate_combinations(universe))
+            indicator_result_map = calculate_indicators(
+                universe,
+                indicator_storage,
+                indicator_set,
+                execution_context=execution_context,
+                remaining=indicators_needed,
+                all_combinations=indicators_needed,
+                max_workers=max_workers,
+                strategy_cycle_timestamp=cycle_timestamp,
+            )
+            indicators = StrategyInputIndicators(
+                strategy_universe=universe,
+                available_indicators=indicator_set,
+                indicator_results=indicator_result_map,
+                timestamp=pd.Timestamp(cycle_timestamp),
+            )
+        except Exception as e:
+            indicator_storage = indicator_set = indicator_result_map = indicators = None
+            logger.warning("Could not calculate real-time indicators for console; continuing without indicators: %s", e)
+
+    return indicator_storage, indicator_set, indicator_result_map, indicators
+
+
 @app.command()
 @shared_options.with_json_rpc_options()
 def console(
@@ -322,47 +380,14 @@ def console(
     except Exception as e:
         logger.warning("Could not refresh run state statistics: %s", e)
 
-    if mod.create_indicators:
-        # If the strategy uses indicators calculate and expose them to the console
-        #
-
-        if max_workers is None:
-            max_workers = get_safe_max_workers_count()
-
-        print(f"Creating real-time indicators for the strategy module for timestamp {cycle_timestamp}")
-        print(f"No indicator cache used")
-
-        # TODO: MemoryIndicatorStorage does not support yet parallel indicator calculations
-        max_workers = 1
-
-        assert mod.parameters, "You need to have Parameters class if create_indicators is specified"
-        indicator_storage = MemoryIndicatorStorage(universe_key=universe.get_cache_key())
-        indicator_set = prepare_indicators(
-            mod.create_indicators,
-            mod.parameters,
-            universe,
-            execution_context,
-            timestamp=cycle_timestamp,
-        )
-        indicators_needed = set(indicator_set.generate_combinations(universe))
-        indicator_result_map = calculate_indicators(
-            universe,
-            indicator_storage,
-            indicator_set,
-            execution_context=execution_context,
-            remaining=indicators_needed,
-            all_combinations=indicators_needed,
-            max_workers=max_workers,
-            strategy_cycle_timestamp=cycle_timestamp,
-        )
-        indicators = StrategyInputIndicators(
-            strategy_universe=universe,
-            available_indicators=indicator_set,
-            indicator_results=indicator_result_map,
-            timestamp=pd.Timestamp(cycle_timestamp),
-        )
-    else:
-        indicator_storage = indicator_set = indicator_result_map = indicators = None
+    indicator_storage, indicator_set, indicator_result_map, indicators = calculate_console_indicators(
+        mod,
+        universe,
+        execution_context,
+        cycle_timestamp,
+        max_workers,
+        logger,
+    )
 
     # Expose Vault smart contract proxy class
     vault = getattr(sync_model, "vault", None)


### PR DESCRIPTION
## Why

Opening the Python console should be possible even when real-time indicator calculation fails because the console is often needed for live diagnostics and recovery work.

## Lessons learnt

Some strategies can construct a valid universe for console use while still failing indicator calculation because supporting benchmark pairs are not available in the loaded dataset. Treating indicators as mandatory blocks operational recovery.

## Summary

- Moved console indicator calculation into a best-effort helper.
- When indicator setup or calculation fails, console bindings expose indicator objects as `None` and startup continues with a warning.
- Added a focused regression test for the fallback path.
