### PR TITLE
fix: cross-chain ERC-7540 satellite deposit crashing trade-ui test trade

### DIFF
--- a/.claude/docs/vault-deposit-redeem.md
+++ b/.claude/docs/vault-deposit-redeem.md
@@ -324,7 +324,7 @@ The execution layer, in trade-executor:
 | [tradeexecutor/ethereum/vault/vault_utils.py](../../tradeexecutor/ethereum/vault/vault_utils.py) | Turning a vault into a tradeable pair identifier |
 | [tradeexecutor/cli/loop.py](../../tradeexecutor/cli/loop.py) | Startup-time settlement retry (non-halting, unlike CCTP) |
 | [tradeexecutor/cli/trade_ui_tui.py](../../tradeexecutor/cli/trade_ui_tui.py) | Settlement ETA display for pending deposits |
-| [tradeexecutor/cli/testtrade.py](../../tradeexecutor/cli/testtrade.py) | Forced settlement of test trades on Anvil forks |
+| [tradeexecutor/cli/testtrade.py](../../tradeexecutor/cli/testtrade.py) | Test-trade pending-settlement handling: forced settlement on Anvil forks, and the cross-chain satellite resolver (`_resolve_satellite_async_settlement()`) that keeps a pending satellite deposit/redeem from being misread as a failure |
 
 ## Tests to read
 

--- a/.claude/docs/vault-deposit-redeem.md
+++ b/.claude/docs/vault-deposit-redeem.md
@@ -254,7 +254,17 @@ How each command or context takes a request from pending to settled:
   in the same run, so a test trade completes its whole cycle in one command.
   On a real chain it leaves the trade pending and prints
   "re-run perform-test-trade after settlement" — the second run (or the
-  daemon) claims it.
+  daemon) claims it. **Cross-chain (CCTP-bridged) satellite vaults follow the
+  same rule.** A satellite-chain ERC-7540 / Ostium deposit lands in
+  `vault_settlement_pending` just like a home-chain one, so the cross-chain
+  flow (`_make_cross_chain_test_trade()`) routes every satellite open/close
+  through the shared `_resolve_satellite_async_settlement()` helper *before*
+  asserting success — a bare `is_success()` check there would misread a pending
+  request as a failure (revert reason `None`, because nothing reverted). On
+  Anvil the helper force-settles on the *destination* chain
+  (`web3config.get_connection(dest_chain_id)`) and forwards `web3config` so the
+  claim is broadcast chain-aware; on a real chain it stops cleanly and leaves
+  the daemon or a re-run to claim it once the operator settles.
 - **`trade-ui`** — observability plus the test-trade route: before drawing the
   table it runs the same pending-settlement resolver as `start`, so claimable
   vault requests are completed and display-only settlement metadata is
@@ -334,5 +344,9 @@ Each test doubles as a worked example:
   — the same lifecycle for the time-window (Ostium) flavour.
 - [tests/erc_4626/test_vault_async_cli_commands.py](../../tests/erc_4626/test_vault_async_cli_commands.py)
   — the flow driven through the CLI (`init`/`start`) as a black box.
+- [tests/units_tests/test_cross_chain_satellite_async_settlement.py](../../tests/units_tests/test_cross_chain_satellite_async_settlement.py)
+  — the cross-chain test-trade control-flow decision in isolation: a pending
+  satellite deposit stops `perform-test-trade` gracefully on a real chain and
+  force-settles on the destination chain on Anvil, instead of crashing.
 - [strategies/test_only/async_vault_backtest_example.py](../../strategies/test_only/async_vault_backtest_example.py)
   — a minimal strategy module written against an async vault.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## 0.2
 
 
+- Fix `trade-ui` / `perform-test-trade` crashing with `AssertionError: Satellite open failed: None` when a cross-chain (CCTP-bridged) test trade opened a position in an asynchronous satellite vault. An ERC-7540 (Lagoon) or Ostium V1.5 deposit on a satellite chain lands in `vault_settlement_pending` after its `requestDeposit` confirms, but `_make_cross_chain_test_trade()` asserted `is_success()` immediately — and because nothing reverted the revert reason was `None`. The single-chain test-trade path already tolerated this; the cross-chain path did not. Both satellite open and close now route through the shared `_resolve_satellite_async_settlement()` helper, which force-settles on the *destination* chain on Anvil (and forwards `web3config` for chain-aware claiming) or stops cleanly on a real chain so the daemon / a re-run claims it. The gap went unnoticed because every cross-chain fork test used a synchronous satellite vault (IPOR Fusion, Mo Earn Max), while the async ERC-7540 tests never drove the cross-chain test-trade flow (2026-06-19)
+
 - Fix `trade-ui` / live trading crashing with `web3.exceptions.ABIEventNotFound` when settling an async ERC-7540 deposit into a non-legacy (Lagoon v0.5+) vault. `parse_deposit_transaction()` referenced a misspelled `DepositRequested` event; the ERC-7540 standard (and the Lagoon v0.5 ABI) names it `DepositRequest`. The bug went unnoticed because every Lagoon ERC-7540 test fixture pointed at the legacy 722 Capital vault, which takes a different (Referral-topic) parsing branch — the non-legacy branch was never exercised. `test_lagoon_erc_7540` now parses a `requestDeposit` receipt on the freshly deployed non-legacy vault as a regression (2026-06-18)
 
 - Breaking API changes

--- a/tests/units_tests/test_cross_chain_satellite_async_settlement.py
+++ b/tests/units_tests/test_cross_chain_satellite_async_settlement.py
@@ -188,16 +188,23 @@ def test_cross_chain_buy_does_not_crash_when_satellite_open_is_pending(monkeypat
     satellite deposit landing in ``vault_settlement_pending`` on a real chain —
     the exact production scenario. The collaborators that touch the chain
     (execution, bridging, position sizing) are mocked so only the orchestration
-    control flow is exercised. The old code asserted
-    ``satellite_buy_trade.is_success()`` here and raised
-    "Satellite open failed: None"; the fix must return gracefully instead.
+    control flow is exercised. The pending satellite trade is faithful to
+    production: ``is_success()`` is ``False`` and ``get_revert_reason()`` is
+    ``None`` (nothing reverted).
+
+    The regression is locked by the ``is_success.assert_not_called()`` check: the
+    fix must reach the early ``return`` *before* the ``is_success()`` assertion,
+    whereas the old code called ``satellite_buy_trade.is_success()`` (and, with a
+    real-bool ``False`` return, raised "Satellite open failed: None"). So this
+    test fails on the old code — either on the ``assert_not_called`` check or on
+    the AssertionError it would raise.
 
     1. Mock a real chain (``is_anvil`` False) and a successful CCTP bridge-in trade.
     2. Make the internally-constructed PositionManager return a satellite deposit
-       trade stuck in ``vault_settlement_pending``.
+       trade stuck in ``vault_settlement_pending`` (is_success False, no revert).
     3. Run the cross-chain buy-only test trade.
     4. Verify it returns without raising and the satellite trade was executed but
-       never asserted to be successful.
+       its success was never asserted.
     """
     # 1. Mock a real chain (is_anvil False) and a successful CCTP bridge-in trade.
     monkeypatch.setattr(testtrade, "is_anvil", lambda web3: False)
@@ -213,7 +220,11 @@ def test_cross_chain_buy_does_not_crash_when_satellite_open_is_pending(monkeypat
     bridge_pm.open_spot.return_value = [bridge_trade]
 
     # 2. Make the internally-constructed PositionManager return a pending satellite deposit.
+    #    Faithful to production: requestDeposit confirmed but not settled, so the
+    #    trade is not yet successful and nothing reverted.
     satellite_trade = _make_trade(TradeStatus.vault_settlement_pending)
+    satellite_trade.is_success.return_value = False
+    satellite_trade.get_revert_reason.return_value = None
     satellite_pm = MagicMock()
     satellite_pm.open_spot.return_value = [satellite_trade]
     monkeypatch.setattr(testtrade, "PositionManager", MagicMock(return_value=satellite_pm))

--- a/tests/units_tests/test_cross_chain_satellite_async_settlement.py
+++ b/tests/units_tests/test_cross_chain_satellite_async_settlement.py
@@ -1,0 +1,257 @@
+"""Tests for cross-chain satellite async vault settlement handling in test trades.
+
+Why this exists: a CCTP-bridged ERC-7540 (Lagoon) or Ostium V1.5 satellite
+deposit lands in ``vault_settlement_pending`` after its ``requestDeposit``
+transaction confirms — the request succeeds on-chain but no shares are minted
+until the vault operator settles the queue off-chain. The cross-chain
+test-trade flow (``_make_cross_chain_test_trade``) used to assert
+``satellite_buy_trade.is_success()`` immediately after executing the satellite
+deposit. For an async vault that assertion is always False at request time, and
+because nothing reverted ``get_revert_reason()`` is ``None`` — which is exactly
+how this crashed ``perform-test-trade`` / ``trade-ui`` in production:
+
+    AssertionError: Satellite open failed: None
+
+The fix routes every satellite trade through
+``_resolve_satellite_async_settlement()`` before the ``is_success()`` assertion.
+These tests lock in its three branches so the regression cannot return.
+
+The real-chain async settlement mechanics (force-settle, claim, escrow,
+restart-after-claim) are covered by the fork tests in
+``tests/erc_4626/test_vault_async_lagoon_erc_7540.py``; here we isolate the
+cross-chain test-trade control-flow decision that those tests do not exercise.
+"""
+
+from decimal import Decimal
+from unittest.mock import MagicMock
+
+import pytest
+
+from tradingstrategy.chain import ChainId
+
+from tradeexecutor.cli import testtrade
+from tradeexecutor.cli.testtrade import _resolve_satellite_async_settlement, _make_cross_chain_test_trade
+from tradeexecutor.state.trade import TradeStatus
+from tradeexecutor.strategy.generic.generic_pricing_model import GenericPricing
+
+
+BASE_CHAIN_ID = ChainId.base.value
+
+
+def _make_trade(status: TradeStatus) -> MagicMock:
+    """Build a minimal trade stub exposing the status interface the resolver reads."""
+    trade = MagicMock()
+    trade.trade_id = 14
+    trade.get_status.return_value = status
+    return trade
+
+
+def test_synchronous_satellite_trade_continues(monkeypatch) -> None:
+    """A synchronous satellite deposit lets the test-trade flow continue.
+
+    1. Build a satellite trade that already executed successfully (sync vault).
+    2. Resolve the satellite async settlement on a real chain.
+    3. Verify the resolver tells the caller to continue (return False).
+    4. Verify it never reaches for a chain connection or forces settlement.
+    """
+    # 1. Build a satellite trade that already executed successfully (sync vault).
+    trade = _make_trade(TradeStatus.success)
+
+    # 2. Resolve the satellite async settlement on a real chain.
+    forced = []
+    monkeypatch.setattr(
+        testtrade, "_force_vault_settlement_and_resolve",
+        lambda *a, **k: forced.append(True),
+    )
+    web3config = MagicMock()
+    stop = _resolve_satellite_async_settlement(
+        trade=trade,
+        on_anvil=False,
+        web3config=web3config,
+        dest_chain_id=BASE_CHAIN_ID,
+        chain_name="Base",
+        state=MagicMock(),
+        execution_model=MagicMock(),
+    )
+
+    # 3. Verify the resolver tells the caller to continue (return False).
+    assert stop is False
+
+    # 4. Verify it never reaches for a chain connection or forces settlement.
+    web3config.get_connection.assert_not_called()
+    assert forced == []
+
+
+def test_pending_satellite_trade_on_mainnet_stops_without_crashing(monkeypatch) -> None:
+    """A pending async satellite deposit on a real chain stops gracefully.
+
+    This is the exact production scenario: the satellite ``requestDeposit``
+    succeeded but settlement is off-chain, so the command must report and exit
+    rather than crash with "Satellite open failed: None".
+
+    1. Build a satellite trade left in ``vault_settlement_pending``.
+    2. Resolve it with ``on_anvil=False`` (real chain semantics).
+    3. Verify the resolver tells the caller to stop (return True) and raises nothing.
+    4. Verify it does NOT attempt to force settlement (cannot rush an operator).
+    """
+    # 1. Build a satellite trade left in vault_settlement_pending.
+    trade = _make_trade(TradeStatus.vault_settlement_pending)
+
+    # 2. Resolve it with on_anvil=False (real chain semantics).
+    forced = []
+    monkeypatch.setattr(
+        testtrade, "_force_vault_settlement_and_resolve",
+        lambda *a, **k: forced.append(True),
+    )
+    web3config = MagicMock()
+    stop = _resolve_satellite_async_settlement(
+        trade=trade,
+        on_anvil=False,
+        web3config=web3config,
+        dest_chain_id=BASE_CHAIN_ID,
+        chain_name="Base",
+        state=MagicMock(),
+        execution_model=MagicMock(),
+    )
+
+    # 3. Verify the resolver tells the caller to stop (return True) and raises nothing.
+    assert stop is True
+
+    # 4. Verify it does NOT attempt to force settlement (cannot rush an operator).
+    assert forced == []
+    web3config.get_connection.assert_not_called()
+
+
+def test_pending_satellite_trade_on_anvil_force_settles_on_destination_chain(monkeypatch) -> None:
+    """A pending async satellite deposit on Anvil force-settles on the satellite chain.
+
+    The destination-chain connection — not the home chain — must drive the
+    operator-impersonation settlement, otherwise the settle transaction is sent
+    to the wrong chain / wrong Safe module.
+
+    1. Build a satellite trade left in ``vault_settlement_pending``.
+    2. Resolve it with ``on_anvil=True`` and a web3config mapping Base -> a marker web3.
+    3. Verify the resolver tells the caller to continue (return False) after forcing.
+    4. Verify settlement was forced with the destination-chain connection and the
+       web3config forwarded for chain-aware claiming.
+    """
+    # 1. Build a satellite trade left in vault_settlement_pending.
+    trade = _make_trade(TradeStatus.vault_settlement_pending)
+
+    # 2. Resolve it with on_anvil=True and a web3config mapping Base -> a marker web3.
+    dest_web3 = object()
+    web3config = MagicMock()
+    web3config.get_connection.return_value = dest_web3
+    captured = {}
+
+    def fake_force(web3, state, trade, execution_model, web3config=None):
+        captured["web3"] = web3
+        captured["state"] = state
+        captured["trade"] = trade
+        captured["execution_model"] = execution_model
+        captured["web3config"] = web3config
+        # Simulate a successful operator settlement: the queue resolved, so the
+        # trade is no longer pending (matches force_lagoon_settle + claim on Anvil).
+        trade.get_status.return_value = TradeStatus.success
+
+    monkeypatch.setattr(testtrade, "_force_vault_settlement_and_resolve", fake_force)
+
+    state = MagicMock()
+    execution_model = MagicMock()
+    stop = _resolve_satellite_async_settlement(
+        trade=trade,
+        on_anvil=True,
+        web3config=web3config,
+        dest_chain_id=BASE_CHAIN_ID,
+        chain_name="Base",
+        state=state,
+        execution_model=execution_model,
+    )
+
+    # 3. Verify the resolver tells the caller to continue (return False) after forcing.
+    assert stop is False
+
+    # 4. Verify settlement was forced with the destination-chain connection and the
+    #    web3config forwarded for chain-aware claiming.
+    web3config.get_connection.assert_called_once_with(ChainId(BASE_CHAIN_ID))
+    assert captured["web3"] is dest_web3
+    assert captured["web3config"] is web3config
+    assert captured["trade"] is trade
+    assert captured["state"] is state
+    assert captured["execution_model"] is execution_model
+
+
+def test_cross_chain_buy_does_not_crash_when_satellite_open_is_pending(monkeypatch) -> None:
+    """The cross-chain buy flow tolerates an async satellite open (production crash).
+
+    This drives the real ``_make_cross_chain_test_trade()`` buy flow with the
+    satellite deposit landing in ``vault_settlement_pending`` on a real chain —
+    the exact production scenario. The collaborators that touch the chain
+    (execution, bridging, position sizing) are mocked so only the orchestration
+    control flow is exercised. The old code asserted
+    ``satellite_buy_trade.is_success()`` here and raised
+    "Satellite open failed: None"; the fix must return gracefully instead.
+
+    1. Mock a real chain (``is_anvil`` False) and a successful CCTP bridge-in trade.
+    2. Make the internally-constructed PositionManager return a satellite deposit
+       trade stuck in ``vault_settlement_pending``.
+    3. Run the cross-chain buy-only test trade.
+    4. Verify it returns without raising and the satellite trade was executed but
+       never asserted to be successful.
+    """
+    # 1. Mock a real chain (is_anvil False) and a successful CCTP bridge-in trade.
+    monkeypatch.setattr(testtrade, "is_anvil", lambda web3: False)
+    # Guard: settlement must never be force-resolved on a real chain.
+    monkeypatch.setattr(
+        testtrade, "_force_vault_settlement_and_resolve",
+        lambda *a, **k: pytest.fail("Must not force settlement on a real chain"),
+    )
+
+    bridge_trade = MagicMock()
+    bridge_trade.is_success.return_value = True
+    bridge_pm = MagicMock()
+    bridge_pm.open_spot.return_value = [bridge_trade]
+
+    # 2. Make the internally-constructed PositionManager return a pending satellite deposit.
+    satellite_trade = _make_trade(TradeStatus.vault_settlement_pending)
+    satellite_pm = MagicMock()
+    satellite_pm.open_spot.return_value = [satellite_trade]
+    monkeypatch.setattr(testtrade, "PositionManager", MagicMock(return_value=satellite_pm))
+
+    execution_model = MagicMock()
+    pricing_model = MagicMock(spec=GenericPricing)  # satisfies the isinstance() guard
+    routing_model = MagicMock()  # has a pair_configurator attribute by default
+    pair = MagicMock()
+    pair.chain_id = BASE_CHAIN_ID
+
+    # 3. Run the cross-chain buy-only test trade.
+    result = _make_cross_chain_test_trade(
+        web3=MagicMock(),
+        web3config=MagicMock(),
+        execution_model=execution_model,
+        pricing_model=pricing_model,
+        sync_model=MagicMock(),
+        state=MagicMock(),
+        universe=MagicMock(),
+        routing_model=routing_model,
+        routing_state=MagicMock(),
+        position_manager=bridge_pm,
+        pair=pair,
+        bridge_pair=MagicMock(),
+        amount=Decimal("5"),
+        max_slippage=0.05,
+        buy_only=True,
+        close_only=False,
+        gas_at_start=Decimal("1"),
+        hot_wallet=MagicMock(),
+        reserve_currency="USDC",
+        reserve_currency_at_start=80.0,
+    )
+
+    # 4. Verify it returns without raising and the satellite trade was executed but
+    #    never asserted to be successful.
+    assert result is None
+    bridge_pm.open_spot.assert_called_once()
+    satellite_pm.open_spot.assert_called_once()
+    execution_model.execute_trades.assert_called()
+    satellite_trade.is_success.assert_not_called()

--- a/tradeexecutor/cli/testtrade.py
+++ b/tradeexecutor/cli/testtrade.py
@@ -144,6 +144,17 @@ def _make_cross_chain_test_trade(
     on_anvil = is_anvil(web3)
     dest_chain_id = pair.chain_id
 
+    def _settle_satellite_async_trade(trade) -> bool:
+        return _resolve_satellite_async_settlement(
+            trade=trade,
+            on_anvil=on_anvil,
+            web3config=web3config,
+            dest_chain_id=dest_chain_id,
+            chain_name=chain_name,
+            state=state,
+            execution_model=execution_model,
+        )
+
     if close_only:
         # Close-only: find existing positions and close them
         satellite_position = state.portfolio.get_position_by_trading_pair(pair)
@@ -169,6 +180,8 @@ def _make_cross_chain_test_trade(
             satellite_position, notes=notes, flags={TradeFlag.test_trade},
         )
         execution_model.execute_trades(ts, state, trades, routing_model, routing_state)
+        if _settle_satellite_async_trade(trades[0]):
+            return
         assert trades[0].is_success(), f"Satellite close failed: {trades[0].get_revert_reason()}"
 
         # Step 2: Bridge back — sized by get_available_bridge_capital()
@@ -227,6 +240,10 @@ def _make_cross_chain_test_trade(
         )
         execution_model.execute_trades(ts, state, satellite_trades, routing_model, routing_state)
         satellite_buy_trade = satellite_trades[0]
+        # Async ERC-7540 (Lagoon) / Ostium V1.5 deposits settle off-chain in a
+        # second stage; the request tx succeeds but the trade stays pending.
+        if _settle_satellite_async_trade(satellite_buy_trade):
+            return
         assert satellite_buy_trade.is_success(), \
             f"Satellite open failed: {satellite_buy_trade.get_revert_reason()}"
 
@@ -256,6 +273,8 @@ def _make_cross_chain_test_trade(
                 satellite_position, notes=notes, flags={TradeFlag.test_trade},
             )
             execution_model.execute_trades(ts, state, close_trades, routing_model, routing_state)
+            if _settle_satellite_async_trade(close_trades[0]):
+                return
             assert close_trades[0].is_success(), \
                 f"Satellite close failed: {close_trades[0].get_revert_reason()}"
 
@@ -300,11 +319,24 @@ def _make_cross_chain_test_trade(
     logger.info("  Reserves: %s %s (was %s)", reserve_currency_at_end, reserve_currency, reserve_currency_at_start)
 
 
-def _force_vault_settlement_and_resolve(web3, state, trade, execution_model):
+def _force_vault_settlement_and_resolve(web3, state, trade, execution_model, web3config=None):
     """Force settlement on Anvil for an async vault test trade and resolve it.
 
     Uses protocol-specific settlement forcing (e.g. tryNewSettlement for Ostium V1.5,
     force_lagoon_settle for ERC-7540) then runs the generic settlement retry.
+
+    :param web3:
+        Web3 connection for the chain the vault lives on. For cross-chain
+        satellite vaults this must be the destination (satellite) chain
+        connection, not the home chain — otherwise the operator-impersonation
+        force-settle is sent to the wrong chain.
+
+    :param web3config:
+        Multichain web3 config. When given it is forwarded to the settlement
+        resolver so the claim transaction is signed and broadcast on the
+        vault's own chain (chain-aware claiming for satellite vaults). Without
+        it the resolver falls back to the execution model's default connection,
+        which is only correct for home-chain vaults.
     """
     from eth_defi.erc_4626.vault_protocol.gains.vault import OstiumVault, OstiumVersion
     from eth_defi.erc_4626.vault_protocol.gains.testing import force_ostium_v15_settlement
@@ -333,15 +365,95 @@ def _force_vault_settlement_and_resolve(web3, state, trade, execution_model):
             # Need the vault manager address — for test trades this is typically the owner
             force_lagoon_settle(vault, owner)
 
-    # Now run the generic settlement retry
+    # Now run the generic settlement retry. Pass web3config so the claim is
+    # broadcast on the vault's own chain for cross-chain satellite vaults.
     resolved = check_and_resolve_vault_settlements(
         state=state,
         execution_model=execution_model,
+        web3config=web3config,
     )
     if resolved:
         logger.info("Test trade vault settlement resolved: %d trade(s)", len(resolved))
     else:
         logger.warning("Test trade vault settlement NOT resolved after forcing — may need manual intervention")
+
+
+def _resolve_satellite_async_settlement(
+    *,
+    trade,
+    on_anvil: bool,
+    web3config,
+    dest_chain_id: int,
+    chain_name: str,
+    state: State,
+    execution_model,
+) -> bool:
+    """Resolve an async satellite vault trade left in ``vault_settlement_pending``.
+
+    Satellite-chain vaults can be asynchronous (ERC-7540 Lagoon, Ostium V1.5):
+    the request transaction (``requestDeposit`` / ``requestRedeem``) confirms,
+    but the trade stays in ``vault_settlement_pending`` until the vault operator
+    settles the queue off-chain. The cross-chain test-trade flow must not treat
+    that as a hard failure — doing so is the production crash this guards against
+    (``AssertionError: Satellite open failed: None``, where the revert reason is
+    ``None`` precisely because nothing reverted).
+
+    This mirrors the single-chain handling in :func:`make_test_trade`:
+
+    - **On Anvil** we play the vault operator and force-settle on the
+      *destination* chain (``web3config.get_connection(dest_chain_id)``), then
+      resolve the claim, so the test trade completes its whole cycle in one run.
+      Forcing the settlement on the home-chain connection would send the
+      operator transaction to the wrong chain.
+    - **On a real chain** nobody can make an off-chain operator settle on
+      demand, so we report that settlement is in flight and tell the caller to
+      stop. The ``start`` daemon or a re-run of ``perform-test-trade`` claims it
+      once the operator has settled.
+
+    :param trade:
+        The satellite vault trade just executed (deposit or redeem).
+
+    :param on_anvil:
+        Whether the home chain connection is an Anvil fork (test context).
+
+    :param dest_chain_id:
+        Chain id of the satellite vault — the chain the settlement happens on.
+
+    :return:
+        ``True`` if the caller should stop because settlement is still pending
+        off-chain (real chain). ``False`` to continue: either the trade is
+        synchronous (already ``success``/failed) or it was force-settled and
+        resolved on Anvil.
+    """
+    if trade.get_status() != TradeStatus.vault_settlement_pending:
+        return False
+
+    if on_anvil:
+        logger.info(
+            "Satellite trade #%d is vault_settlement_pending on Anvil, forcing settlement on chain %s...",
+            trade.trade_id, dest_chain_id,
+        )
+        dest_web3 = web3config.get_connection(ChainId(dest_chain_id))
+        _force_vault_settlement_and_resolve(
+            dest_web3, state, trade, execution_model, web3config=web3config,
+        )
+        # Surface a clear error if forcing did not resolve the queue, instead of
+        # falling through to the caller's is_success() assertion (which would
+        # report the misleading "Satellite open failed: None" this fix removes).
+        assert trade.get_status() != TradeStatus.vault_settlement_pending, (
+            f"Forced settlement on Anvil did not resolve satellite trade #{trade.trade_id} "
+            f"on chain {dest_chain_id}; it is still vault_settlement_pending. Check that the "
+            f"test vault operator/asset manager can settle the queue (vault_owner_address)."
+        )
+        return False
+
+    logger.info(
+        "Satellite trade #%d is vault_settlement_pending — async (ERC-7540/Ostium) "
+        "settlement happens off-chain on %s. Re-run perform-test-trade after settlement "
+        "to complete the cycle.",
+        trade.trade_id, chain_name,
+    )
+    return True
 
 
 def make_test_trade(

--- a/tradeexecutor/cli/testtrade.py
+++ b/tradeexecutor/cli/testtrade.py
@@ -141,6 +141,9 @@ def _make_cross_chain_test_trade(
     ts = native_datetime_utc_now()
     chain_name = ChainId(pair.chain_id).get_name()
     notes = "A test trade created with perform-test-trade command line command"
+    # Judged from the home connection. We assume a home-chain Anvil fork implies
+    # the satellite chain is also a fork (the cross-chain test harness forks both;
+    # production forks neither), so this also governs satellite force-settlement.
     on_anvil = is_anvil(web3)
     dest_chain_id = pair.chain_id
 


### PR DESCRIPTION
## Why

A bridged ERC-7540 deposit crashed `trade-ui` / `perform-test-trade` in production:

```
AssertionError: Satellite open failed: None
```

The deposit did **not** actually fail. The CCTP bridge (Arbitrum → Base) and the on-chain `requestDeposit` into DeTrade Core USDC — an asynchronous **Lagoon ERC-7540** vault — both succeeded. The trade correctly resolved to `status=vault_settlement_pending` (`failed=False`, `revert_reason=None`): an ERC-7540 deposit settles off-chain in a second stage, so no shares are minted at request time.

The cross-chain test-trade path (`_make_cross_chain_test_trade`) then asserted `satellite_buy_trade.is_success()` immediately after executing the satellite deposit. For a pending async trade that is `False`, and because nothing reverted `get_revert_reason()` is `None` — producing the misleading crash. The single-chain `make_test_trade` path already tolerated this state (via the earlier ERC-7540 PRs #1508 / #1517 / 634df31c), but the cross-chain satellite path was never given the same handling.

## Lessons learnt

- An async vault trade in `vault_settlement_pending` is **not** a failure. Any code that opens or closes a satellite vault position must check for the pending status before asserting `is_success()`, exactly as the single-chain path does.
- Settlement forcing must be **chain-aware**: a satellite vault settles on the destination chain, so the operator-impersonation force-settle (and the subsequent claim) must use `web3config.get_connection(dest_chain_id)`, not the home-chain connection. `_force_vault_settlement_and_resolve()` now forwards `web3config` into `check_and_resolve_vault_settlements()` so the claim is broadcast on the vault's own chain.
- The coverage gap was structural: every cross-chain fork test used a **synchronous** satellite vault (IPOR Fusion; "Mo Earn Max USDC" `0x3094b241…`), so the satellite open always completed instantly and `is_success()` was `True`. The async ERC-7540 tests, conversely, drove `PositionManager` directly and never went through `_make_cross_chain_test_trade`. The async-satellite-via-test-trade combination — the exact production path — had no test.

## Summary

- Added `_resolve_satellite_async_settlement()` and routed all three satellite trade spots in `_make_cross_chain_test_trade()` (buy-flow open — the crash site, sell-flow close, and close-only close) through it before the `is_success()` assertion. On Anvil it force-settles on the destination chain; on a real chain it stops cleanly so the `start` daemon or a re-run of `perform-test-trade` claims it once the operator settles — mirroring the single-chain behaviour and the production lifecycle.
- Forwarded `web3config` from `_force_vault_settlement_and_resolve()` into the settlement resolver for chain-aware claiming. Single-chain callers still pass `None`, so their behaviour is unchanged.
- Added a clear assertion if Anvil force-settlement does not resolve the queue, instead of falling back through to the old confusing `Satellite open failed: None`.
- New `tests/units_tests/test_cross_chain_satellite_async_settlement.py`: the three helper branches (sync → continue; pending on mainnet → graceful stop, no force; pending on Anvil → force-settle on the destination chain) plus an orchestration test that drives the real `_make_cross_chain_test_trade()` buy flow with a pending satellite open and verifies it returns without crashing (this fails on the old code, which called `is_success()`).
- Updated `.claude/docs/vault-deposit-redeem.md` (async deposit handling) and `CHANGELOG.md`.
- Reviewed with `codex`: no correctness blockers; both initial low-severity findings (helper-only coverage, unconditional continue after force-settle) addressed; final pass reported no findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
