### PR TITLE
Add vault name to Lagoon freshness logs

### DIFF
--- a/tests/lagoon/test_lagoon_vault_logging.py
+++ b/tests/lagoon/test_lagoon_vault_logging.py
@@ -1,0 +1,67 @@
+from types import SimpleNamespace
+
+from tradeexecutor.ethereum.lagoon.vault import _get_position_vault_log_suffix
+
+
+def test_position_vault_log_suffix_uses_pair_vault_name() -> None:
+    """Test direct pair vault names are included in Lagoon freshness logs.
+
+    1. Create a position-like object whose pair exposes a vault name.
+    2. Build the vault log suffix.
+    3. Check the suffix carries the vault name.
+    """
+    # 1. Create a position-like object whose pair exposes a vault name.
+    pair = SimpleNamespace(
+        get_vault_name=lambda: "Autopilot USDC Base",
+        get_token_metadata=lambda: None,
+    )
+    position = SimpleNamespace(pair=pair)
+
+    # 2. Build the vault log suffix.
+    suffix = _get_position_vault_log_suffix(position)
+
+    # 3. Check the suffix carries the vault name.
+    assert suffix == ", vault=Autopilot USDC Base"
+
+
+def test_position_vault_log_suffix_uses_metadata_vault_name() -> None:
+    """Test metadata vault names are included in Lagoon freshness logs.
+
+    1. Create a position-like object whose pair has no direct vault name.
+    2. Build the vault log suffix from token metadata.
+    3. Check the suffix carries the metadata vault name.
+    """
+    # 1. Create a position-like object whose pair has no direct vault name.
+    metadata = SimpleNamespace(vault_name="IndeFi USDC")
+    pair = SimpleNamespace(
+        get_vault_name=lambda: None,
+        get_token_metadata=lambda: metadata,
+    )
+    position = SimpleNamespace(pair=pair)
+
+    # 2. Build the vault log suffix from token metadata.
+    suffix = _get_position_vault_log_suffix(position)
+
+    # 3. Check the suffix carries the metadata vault name.
+    assert suffix == ", vault=IndeFi USDC"
+
+
+def test_position_vault_log_suffix_is_empty_without_vault_name() -> None:
+    """Test non-vault positions keep Lagoon freshness logs unchanged.
+
+    1. Create a position-like object without vault name metadata.
+    2. Build the vault log suffix.
+    3. Check no suffix is added.
+    """
+    # 1. Create a position-like object without vault name metadata.
+    pair = SimpleNamespace(
+        get_vault_name=lambda: None,
+        get_token_metadata=lambda: None,
+    )
+    position = SimpleNamespace(pair=pair)
+
+    # 2. Build the vault log suffix.
+    suffix = _get_position_vault_log_suffix(position)
+
+    # 3. Check no suffix is added.
+    assert suffix == ""

--- a/tradeexecutor/ethereum/lagoon/vault.py
+++ b/tradeexecutor/ethereum/lagoon/vault.py
@@ -45,6 +45,22 @@ from tradeexecutor.strategy.trading_strategy_universe import \
 logger = logging.getLogger(__name__)
 
 
+def _get_position_vault_log_suffix(position) -> str:
+    """Get optional vault name suffix for position freshness logs."""
+    vault_name = position.pair.get_vault_name()
+    if not vault_name:
+        metadata = position.pair.get_token_metadata()
+        if isinstance(metadata, dict):
+            vault_name = metadata.get("vault_name")
+        else:
+            vault_name = getattr(metadata, "vault_name", None)
+
+    if vault_name:
+        return f", vault={vault_name}"
+
+    return ""
+
+
 def _transact_anvil_sequentially(
     web3,
     hot_wallet: HotWallet,
@@ -325,7 +341,7 @@ class LagoonVaultSyncModel(AddressSyncModel):
                 last_event = p.valuation_updates[-1] if p.valuation_updates else None
 
                 logger.info(
-                    "Freshness check position #%d %s: valued_at=%s, ago=%s, valuation_updates=%d, last_pricing_at=%s, kind=%s, qty=%s",
+                    "Freshness check position #%d %s: valued_at=%s, ago=%s, valuation_updates=%d, last_pricing_at=%s, kind=%s, qty=%s%s",
                     p.position_id,
                     p.pair.base.token_symbol,
                     valued_at,
@@ -334,15 +350,17 @@ class LagoonVaultSyncModel(AddressSyncModel):
                     p.last_pricing_at,
                     p.pair.kind.value,
                     p.get_quantity(),
+                    _get_position_vault_log_suffix(p),
                 )
 
                 # Try to dump as much as possible information for diagnostics
                 assert updated_ago < self.valuation_data_freshness, f"The last valuation of this position is too old for us to comfortably update the onchain share price. Position {p}. Now: {now}, updated at: {valued_at}, diff: {updated_ago}, threshold: {self.valuation_data_freshness}, last valuation event: {last_event}"
             else:
                 logger.info(
-                    "Freshness check position #%d %s: skipped (quantity=0)",
+                    "Freshness check position #%d %s: skipped (quantity=0)%s",
                     p.position_id,
                     p.pair.base.token_symbol,
+                    _get_position_vault_log_suffix(p),
                 )
 
         if self.calculate_valuation_func is not None:


### PR DESCRIPTION
## Why

Lagoon valuation freshness logs identified positions by token symbol only. This made vault and bridge positions hard to distinguish when several positions shared the same base token.

## Lessons learnt

Vault names can be available either directly on the pair or through token metadata, so diagnostic logging needs to check both locations.

## Summary

- Added a Lagoon freshness-log suffix that includes the vault name when available.
- Kept non-vault freshness log lines unchanged.
- Added focused tests for direct vault names, metadata vault names, and positions without a vault name.
