### PR TITLE
Fix trade-ui pending vault deposit size

### DIFF
--- a/tests/cli/test_trade_ui_settlement_eta.py
+++ b/tests/cli/test_trade_ui_settlement_eta.py
@@ -11,7 +11,7 @@ so the operator knows when the shares will appear, instead of just seeing
 import datetime
 from decimal import Decimal
 
-from tradeexecutor.cli.trade_ui_tui import _format_lockup
+from tradeexecutor.cli.trade_ui_tui import _format_lockup, _get_position_info
 from tradeexecutor.state.identifier import (
     AssetIdentifier,
     TradingPairIdentifier,
@@ -91,7 +91,7 @@ def _make_state_with_pending_deposit(
 
 
 def test_tui_lockup_shows_ostium_settlement_eta(monkeypatch) -> None:
-    """A pending Ostium deposit with a future estimate shows an eligibility countdown.
+    """A pending Ostium deposit shows its ETA and pending reserve amount.
 
     Steps:
     1. Freeze the clock so the remaining time is deterministic.
@@ -114,6 +114,7 @@ def test_tui_lockup_shows_ostium_settlement_eta(monkeypatch) -> None:
     cell = _format_lockup(state, pair)
     assert "eligible" in cell.plain
     assert "18.0h" in cell.plain
+    assert _get_position_info(state, pair) == "5 USDC"
 
     # 4. A past estimate (settlement slipped) renders as "settling".
     past = (now - datetime.timedelta(hours=1)).isoformat()
@@ -122,12 +123,12 @@ def test_tui_lockup_shows_ostium_settlement_eta(monkeypatch) -> None:
 
 
 def test_tui_lockup_shows_pending_when_no_eta(monkeypatch) -> None:
-    """An operator-driven vault (no on-chain ETA) shows ``pending``.
+    """An operator-driven vault (no on-chain ETA) shows ``pending`` and reserve amount.
 
     Steps:
     1. Freeze the clock.
     2. Build a state with a settlement-pending deposit but no stored estimate.
-    3. Assert the Lockup cell shows ``pending``.
+    3. Assert the Lockup cell shows ``pending`` and the Position cell shows the reserve amount.
     """
 
     # 1. Freeze "now".
@@ -141,3 +142,4 @@ def test_tui_lockup_shows_pending_when_no_eta(monkeypatch) -> None:
 
     # 3. Renders as "pending".
     assert _format_lockup(state, pair).plain == "pending"
+    assert _get_position_info(state, pair) == "5 USDC"

--- a/tradeexecutor/cli/trade_ui_tui.py
+++ b/tradeexecutor/cli/trade_ui_tui.py
@@ -150,14 +150,22 @@ def _format_price(price: float | None) -> Text:
     return Text(f"${price:,.4f}", justify="right")
 
 
+def _format_decimal_amount(amount: Decimal) -> str:
+    """Format a Decimal for compact terminal display."""
+    return format(amount.normalize(), "f")
+
+
 def _get_position_info(state: State, pair: TradingPairIdentifier) -> str:
     """Get open position info for a pair, or empty string."""
-    position = state.portfolio.get_position_by_trading_pair(pair)
+    position = state.portfolio.get_position_by_trading_pair(pair, pending=True)
     if position is None:
         return ""
     quantity = position.get_quantity()
+    pending_trade = _get_pending_settlement_trade(position)
+    if quantity == 0 and pending_trade is not None:
+        return f"{_format_decimal_amount(pending_trade.planned_reserve)} {pending_trade.reserve_currency.token_symbol}"
     symbol = pair.base.token_symbol
-    return f"{quantity} {symbol}"
+    return f"{_format_decimal_amount(quantity)} {symbol}"
 
 
 def _format_remaining(remaining: datetime.timedelta, prefix: str = "") -> str:


### PR DESCRIPTION
## Why

When an ERC-7540 / async vault deposit is waiting for settlement, the strategy has committed reserve currency but has not received vault shares yet. The trade-ui Position column previously displayed the settled share quantity only, so a pending first deposit appeared as `0 oLP`, even though the deposit amount was already in flight.

## Lessons learnt

Pending async vault deposits need to be surfaced consistently across trade-ui columns. The Lockup column already checks pending positions and pending settlement trades, and the Position column needs the same pending-position awareness to avoid misleading operators.

## Summary

- Show the pending deposit reserve amount in the trade-ui Position column when a vault deposit is settlement-pending and share quantity is still zero.
- Keep settled positions showing their vault share quantity.
- Expand the existing trade-ui pending settlement tests to cover the Position column for ETA and no-ETA pending deposit cases.
