### PR TITLE
Show vault display flags in trade UI lockup column

### DIFF
--- a/tests/cli/test_trade_ui_settlement_eta.py
+++ b/tests/cli/test_trade_ui_settlement_eta.py
@@ -22,6 +22,12 @@ from tradeexecutor.state.state import State
 from tradeexecutor.state.trade import TradeExecution, TradeType
 
 
+VAULT_DISPLAY_FLAGS = [
+    {"severity": "red", "type": "bad_debt_unrealized", "source": "morpho"},
+    {"severity": "yellow", "type": "not_whitelisted", "source": "morpho"},
+]
+
+
 def _make_vault_pair() -> TradingPairIdentifier:
     """Create a minimal ERC-4626 vault trading pair."""
     base = AssetIdentifier(
@@ -90,6 +96,28 @@ def _make_state_with_pending_deposit(
     return state
 
 
+def _make_state_with_open_position(
+    pair: TradingPairIdentifier,
+    lockup_expires_at: str | None = None,
+) -> State:
+    """Build a State with one open vault position."""
+    position = TradingPosition(
+        position_id=1,
+        pair=pair,
+        opened_at=datetime.datetime(2023, 1, 1),
+        last_pricing_at=datetime.datetime(2023, 1, 1),
+        last_token_price=Decimal("1"),
+        last_reserve_price=Decimal("1"),
+        reserve_currency=pair.quote,
+    )
+    if lockup_expires_at is not None:
+        position.other_data["vault_lockup_expires_at"] = lockup_expires_at
+
+    state = State()
+    state.portfolio.open_positions[position.position_id] = position
+    return state
+
+
 def test_tui_lockup_shows_ostium_settlement_eta(monkeypatch) -> None:
     """A pending Ostium deposit shows its ETA and pending reserve amount.
 
@@ -143,3 +171,73 @@ def test_tui_lockup_shows_pending_when_no_eta(monkeypatch) -> None:
     # 3. Renders as "pending".
     assert _format_lockup(state, pair).plain == "pending"
     assert _get_position_info(state, pair) == "5 USDC"
+
+
+def test_tui_lockup_shows_vault_display_flags_when_empty() -> None:
+    """Generic vault warning flags fill an otherwise empty Lockup cell.
+
+    Steps:
+    1. Build a vault pair with generic red and yellow display flags.
+    2. Build a state without any open or pending position for the pair.
+    3. Assert the Lockup cell shows compact flag counts using red priority.
+    """
+
+    # 1. Build a vault pair with generic red and yellow display flags.
+    pair = _make_vault_pair()
+    pair.other_data["vault_display_flags"] = VAULT_DISPLAY_FLAGS
+
+    # 2. Build a state without any open or pending position for the pair.
+    state = State()
+
+    # 3. The empty Lockup cell falls back to generic warning counts.
+    cell = _format_lockup(state, pair)
+    assert cell.plain == "red 1 yellow 1"
+    assert cell.style == "red"
+
+
+def test_tui_lockup_prefers_expiry_over_vault_display_flags(monkeypatch) -> None:
+    """A real lockup expiry takes priority over generic vault warning flags.
+
+    Steps:
+    1. Freeze the clock so the lockup countdown is deterministic.
+    2. Build an open vault position with a future lockup expiry and warning flags.
+    3. Assert the Lockup cell shows the countdown instead of warning counts.
+    """
+
+    # 1. Freeze "now".
+    now = datetime.datetime(2026, 6, 9, 12, 0, 0)
+    monkeypatch.setattr("tradeexecutor.cli.trade_ui_tui.native_datetime_utc_now", lambda: now)
+
+    # 2. Build an open vault position with a future lockup expiry and warning flags.
+    pair = _make_vault_pair()
+    pair.other_data["vault_display_flags"] = VAULT_DISPLAY_FLAGS
+    state = _make_state_with_open_position(pair, (now + datetime.timedelta(hours=6)).isoformat())
+
+    # 3. The real lockup countdown takes priority over warning counts.
+    cell = _format_lockup(state, pair)
+    assert cell.plain == "6.0h"
+    assert cell.style == "yellow"
+
+
+def test_tui_lockup_prefers_pending_settlement_over_vault_display_flags(monkeypatch) -> None:
+    """Pending vault settlement takes priority over generic vault warning flags.
+
+    Steps:
+    1. Freeze the clock so the settlement countdown is deterministic.
+    2. Build a settlement-pending vault deposit with generic warning flags.
+    3. Assert the Lockup cell shows the pending settlement ETA, not warning counts.
+    """
+
+    # 1. Freeze "now".
+    now = datetime.datetime(2026, 6, 9, 12, 0, 0)
+    monkeypatch.setattr("tradeexecutor.cli.trade_ui_tui.native_datetime_utc_now", lambda: now)
+
+    # 2. Build a settlement-pending vault deposit with generic warning flags.
+    pair = _make_vault_pair()
+    pair.other_data["vault_display_flags"] = VAULT_DISPLAY_FLAGS
+    state = _make_state_with_pending_deposit(pair, (now + datetime.timedelta(hours=2)).isoformat())
+
+    # 3. The settlement ETA takes priority over warning counts.
+    cell = _format_lockup(state, pair)
+    assert cell.plain == "eligible 2.0h"
+    assert cell.style == "yellow"

--- a/tests/test_vault_metadata_translation.py
+++ b/tests/test_vault_metadata_translation.py
@@ -1,0 +1,61 @@
+"""Test vault metadata translation into trade-executor pair identifiers."""
+
+import pytest
+from tradingstrategy.chain import ChainId
+from tradingstrategy.exchange import ExchangeType
+from tradingstrategy.pair import DEXPair
+from tradingstrategy.vault import VaultMetadata
+
+from tradeexecutor.strategy.dex_data_translation import translate_trading_pair
+
+
+def _make_vault_dex_pair(metadata: VaultMetadata) -> DEXPair:
+    """Build a vault DEX pair with attached metadata."""
+    return DEXPair(
+        pair_id=1,
+        chain_id=ChainId.ethereum,
+        exchange_id=1,
+        address="0x0000000000000000000000000000000000000001",
+        token0_address="0x0000000000000000000000000000000000000001",
+        token0_symbol="vUSDC",
+        token0_decimals=18,
+        token1_address="0x0000000000000000000000000000000000000002",
+        token1_symbol="USDC",
+        token1_decimals=6,
+        base_token_symbol="vUSDC",
+        quote_token_symbol="USDC",
+        dex_type=ExchangeType.erc_4626_vault,
+        exchange_slug="morpho",
+        exchange_name="morpho",
+        fee=0,
+        other_data={"token_metadata": metadata},
+    )
+
+
+def test_translate_trading_pair_preserves_vault_display_flags(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Vault display flags are reduced from metadata into pair other data.
+
+    1. Build a vault metadata object and simulate a newer metadata attribute.
+    2. Translate a DEX pair carrying the metadata.
+    3. Assert the translated pair exposes the flags to trade-ui.
+    """
+
+    # 1. Build a vault metadata object and simulate a newer metadata attribute.
+    display_flags = [
+        {"severity": "yellow", "type": "not_whitelisted", "source": "morpho"},
+    ]
+    metadata = VaultMetadata(
+        vault_name="Morpho USDC",
+        protocol_name="Morpho",
+        protocol_slug="morpho",
+        features=[],
+    )
+    # Use class-level monkeypatching so this test works both before and after
+    # trading-strategy adds the field to the slotted frozen VaultMetadata class.
+    monkeypatch.setattr(VaultMetadata, "vault_display_flags", display_flags, raising=False)
+
+    # 2. Translate a DEX pair carrying the metadata.
+    pair = translate_trading_pair(_make_vault_dex_pair(metadata))
+
+    # 3. The translated pair exposes the flags to trade-ui.
+    assert pair.other_data["vault_display_flags"] == display_flags

--- a/tradeexecutor/cli/trade_ui_tui.py
+++ b/tradeexecutor/cli/trade_ui_tui.py
@@ -176,6 +176,39 @@ def _format_remaining(remaining: datetime.timedelta, prefix: str = "") -> str:
     return f"{prefix}{hours:.1f}h"
 
 
+def _format_vault_display_flags(pair: TradingPairIdentifier) -> Text | None:
+    """Format generic vault warning flags for the Lockup column fallback."""
+    display_flags = pair.other_data.get("vault_display_flags") if pair.other_data else None
+    if not display_flags:
+        return None
+
+    red_count = sum(
+        1 for flag in display_flags
+        if isinstance(flag, dict) and flag.get("severity") == "red"
+    )
+    yellow_count = sum(
+        1 for flag in display_flags
+        if isinstance(flag, dict) and flag.get("severity") == "yellow"
+    )
+
+    parts = []
+    if red_count:
+        parts.append(f"red {red_count}")
+    if yellow_count:
+        parts.append(f"yellow {yellow_count}")
+
+    if not parts:
+        return None
+
+    style = "red" if red_count else "yellow"
+    return Text(" ".join(parts), style=style, justify="right")
+
+
+def _format_empty_lockup(pair: TradingPairIdentifier) -> Text:
+    """Format an empty Lockup column cell, falling back to vault warnings."""
+    return _format_vault_display_flags(pair) or Text("-", style="dim", justify="right")
+
+
 def _get_pending_settlement_trade(position: TradingPosition):
     """Return the first pending async-deposit trade for a position, or ``None``.
 
@@ -199,6 +232,7 @@ def _format_lockup(state: State, pair: TradingPairIdentifier) -> Text:
        available (operator-driven ERC-7540 vaults like Lagoon).
     2. Otherwise show the lockup time remaining from the stored expiry
        timestamp, or ``Unlocked`` once it has passed.
+    3. If no lockup data exists, show generic vault warning flags when present.
 
     Non-vault pairs or positions without any of this data show a dash.
     """
@@ -209,7 +243,7 @@ def _format_lockup(state: State, pair: TradingPairIdentifier) -> Text:
     # an open position.
     position = state.portfolio.get_position_by_trading_pair(pair, pending=True)
     if position is None:
-        return Text("-", style="dim", justify="right")
+        return _format_empty_lockup(pair)
 
     now = native_datetime_utc_now()
 
@@ -232,12 +266,12 @@ def _format_lockup(state: State, pair: TradingPairIdentifier) -> Text:
     # 2. Fall back to lockup expiry.
     expires_at_str = position.other_data.get("vault_lockup_expires_at")
     if expires_at_str is None:
-        return Text("-", style="dim", justify="right")
+        return _format_empty_lockup(pair)
 
     try:
         expires_at = datetime.datetime.fromisoformat(expires_at_str)
     except (ValueError, TypeError):
-        return Text("-", style="dim", justify="right")
+        return _format_empty_lockup(pair)
 
     remaining = expires_at - now
     if remaining.total_seconds() <= 0:

--- a/tradeexecutor/strategy/dex_data_translation.py
+++ b/tradeexecutor/strategy/dex_data_translation.py
@@ -228,6 +228,7 @@ def translate_trading_pair(dex_pair: DEXPair, cache: dict | None = None) -> Trad
                 # Risk and status
                 pair.other_data["risk_level"] = metadata.risk_level
                 pair.other_data["flags"] = metadata.flags
+                pair.other_data["vault_display_flags"] = getattr(metadata, "vault_display_flags", None)
                 # Informational metadata
                 pair.other_data["tvl"] = metadata.tvl
                 pair.other_data["tvl_peak"] = metadata.tvl_peak


### PR DESCRIPTION
## Why

Vault metadata can now carry generic red/yellow warning flags, and operators need to see them in trade-ui when the Lockup column would otherwise be empty. This keeps Morpho-specific details out of the TUI while preserving existing lockup and pending-settlement priority.

## Lessons learnt

The Lockup column already carries time-sensitive vault state, so warning flags must stay as a fallback only. Pending settlement and real lockup expiry continue to take priority.

## Summary

- Render generic `vault_display_flags` as compact red/yellow counts in empty Lockup cells.
- Pass `VaultMetadata.vault_display_flags` through pair metadata reduction.
- Add tests for fallback display and priority over flags.