### PR TITLE
Increase Base fork timeouts in CI tests

### DIFF
--- a/tests/erc_4626/conftest.py
+++ b/tests/erc_4626/conftest.py
@@ -81,6 +81,8 @@ def anvil_base_fork(request, usdc_holder, test_block_number) -> AnvilLaunch:
         JSON_RPC_BASE,
         unlocked_addresses=[usdc_holder],
         fork_block_number=test_block_number,
+        launch_wait_seconds=60.0,
+        test_request_timeout=30.0,
     )
     try:
         yield launch

--- a/tests/mainnet_fork/test_perform_test_trade_crosschain.py
+++ b/tests/mainnet_fork/test_perform_test_trade_crosschain.py
@@ -83,7 +83,12 @@ def arb_anvil() -> AnvilLaunch:
 
 @pytest.fixture()
 def base_anvil() -> AnvilLaunch:
-    launch = fork_network_anvil(JSON_RPC_BASE, fork_block_number=BASE_FORK_BLOCK)
+    launch = fork_network_anvil(
+        JSON_RPC_BASE,
+        fork_block_number=BASE_FORK_BLOCK,
+        launch_wait_seconds=60.0,
+        test_request_timeout=30.0,
+    )
     try:
         yield launch
     finally:


### PR DESCRIPTION
## Why

Master CI is failing on Base mainnet fork tests because Anvil startup and archive verification use the default 3 second request timeout. The failing logs show Base RPC/archive calls timing out and Anvil failing to become readable before the fixture setup completes.

## Lessons learnt

- Base archive RPC calls can exceed the generic Anvil smoke-test timeout under CI load.
- Tests that depend on pinned Base forks need a timeout budget aligned with the upstream RPC and Anvil startup work they require.

## Summary

- Increased Base ERC-4626 fork launch wait and request timeout.
- Increased the Base cross-chain test-trade fork launch wait and request timeout.
