### PR TITLE
Fix shared CCTP bridge test trades

### DIFF
--- a/.claude/docs/agent-tricks-and-troubleshooting.md
+++ b/.claude/docs/agent-tricks-and-troubleshooting.md
@@ -1,0 +1,385 @@
+# Agent tricks and troubleshooting
+
+This note covers practical ways to use Codex CLI and Claude CLI as local engineering agents, especially when one agent is used to review or debug the other agent's work.
+
+## Codex CLI
+
+Codex is useful for local repository work where the agent should inspect files, edit code, run tests, and keep working until a task is complete.
+
+Common commands:
+
+```shell
+codex
+codex "Explain this codebase"
+codex exec "Review the current diff for correctness bugs"
+codex exec --json "Summarise the failing tests"
+codex review
+codex doctor
+codex resume --last
+codex mcp list
+codex plugin list
+```
+
+Useful capabilities:
+
+- Interactive terminal UI for iterative coding and review.
+- Non-interactive automation with `codex exec`.
+- Local code review with `codex review` or `/review` inside the interactive UI.
+- Git-aware operation over the current worktree.
+- Sandbox and approval controls with `--sandbox` and `--ask-for-approval`.
+- Machine-readable automation output with `codex exec --json`.
+- MCP server management with `codex mcp`.
+- Plugin management with `codex plugin`.
+- Diagnostic checks with `codex doctor`.
+- Session continuation with `codex resume`.
+
+Recommended local patterns:
+
+```shell
+# Ask for a bounded review of local changes.
+codex exec "Review uncommitted changes for correctness bugs only"
+
+# Pass logs as context while keeping the prompt explicit.
+poetry run pytest tests/foo.py -q 2>&1 \
+  | codex exec "Explain the failure and suggest the smallest fix"
+
+# Run with explicit permissions in automation.
+codex exec --sandbox workspace-write --ask-for-approval never "Fix the failing focused test"
+
+# Debug local setup.
+codex doctor
+```
+
+Use `codex exec` for CI-like or scripted work. It streams progress to stderr and final output to stdout, which makes it easier to pipe the result into files or other commands.
+
+Use interactive `codex` when the task needs back-and-forth decisions, screenshots, manual inspection, or careful approval of edits.
+
+## Claude CLI
+
+Claude CLI is useful for independent second opinions, code reviews, background agents, and checking whether another agent's change makes sense.
+
+Common commands:
+
+```shell
+claude
+claude -p "Review the current worktree diff"
+claude -p "Review the current worktree diff" --output-format stream-json --verbose
+claude ultrareview master --timeout 15
+claude doctor
+claude agents
+claude mcp
+claude plugin list
+claude --help
+```
+
+Useful capabilities:
+
+- Interactive Claude Code session by default.
+- Non-interactive print mode with `-p` / `--print`.
+- Streaming automation output with `--output-format stream-json`.
+- Tool restrictions with `--allowedTools` and `--disallowedTools`.
+- Permission mode control with `--permission-mode`.
+- Custom or selected agents with `--agent` and `--agents`.
+- Cloud-hosted multi-agent review with `claude ultrareview`.
+- Safe mode for debugging broken customisations with `--safe-mode`.
+- Bare mode for minimal startup with `--bare`.
+- Debug logging with `--debug` or `--debug-file`.
+- MCP and plugin management.
+
+Recommended local patterns:
+
+```shell
+# Plain one-shot review. Good when you can wait for final buffered output.
+claude -p "Review the current git diff for correctness bugs"
+
+# Better for long reviews: stream progress and tool calls.
+claude -p "Review the current git diff for correctness bugs" \
+  --output-format stream-json \
+  --verbose
+
+# Restrict tools for a read-only review.
+claude -p "Review the current worktree diff. Do not edit files." \
+  --permission-mode bypassPermissions \
+  --dangerously-skip-permissions \
+  --allowedTools "Bash,Read,Grep,Glob"
+
+# Avoid pasting huge diffs into the prompt. Make Claude inspect files itself.
+claude -p "Review uncommitted changes. First run git diff --name-only, then inspect targeted diffs."
+
+# Run cloud review when account credits and PR/base context are available.
+claude ultrareview master --timeout 15
+```
+
+For long-running `claude -p` jobs, prefer `--output-format stream-json --verbose`. Text mode can look idle because useful output may be buffered until the final answer.
+
+## Cross-agent review patterns
+
+Use the other agent as a reviewer when:
+
+1. The change touches state accounting, execution, security, or money movement.
+2. The first agent wrote a large test or complex fixture.
+3. You want a second model to challenge assumptions before opening a pull request.
+4. You suspect the first agent is stuck in a local optimum.
+
+Good review prompt:
+
+```text
+Review the current uncommitted worktree diff for correctness bugs only.
+Do not run the full test suite.
+Do not paste the full git diff into context.
+First inspect git status --short, git diff --name-only, and targeted diffs.
+Focus on behavioural regressions and test fragility.
+Return findings first with file:line references.
+If there are no high-confidence bugs, say so clearly and list residual risks.
+```
+
+Avoid asking for broad "thoughts" on a large diff. Ask for a scoped review:
+
+- correctness bugs
+- behavioural regressions
+- missing tests
+- test fragility
+- security or money-movement risks
+- repository instruction compliance
+
+## Common failure modes
+
+### The command looks hung
+
+Symptoms:
+
+- `claude -p` prints nothing for a long time.
+- The terminal appears idle, but the process is still alive.
+
+Causes:
+
+- Text output is buffered until the final answer.
+- The model is doing a long review or reading a large diff.
+- The prompt caused the agent to paste a huge diff into context.
+- A subprocess is waiting for input or a permission decision.
+
+Avoid it:
+
+```shell
+claude -p "Review the current diff" --output-format stream-json --verbose
+```
+
+For Codex automation, use:
+
+```shell
+codex exec --json "Review the current diff"
+```
+
+Also constrain the prompt:
+
+```text
+Do not paste the full diff into context. Use git diff --name-only first, then inspect targeted hunks.
+```
+
+### The review consumes too much context
+
+Symptoms:
+
+- The model reads `git diff` for a large change and slows down.
+- Output includes truncated tool results.
+- The final answer misses important details.
+
+Avoid it:
+
+- Start with `git diff --stat` and `git diff --name-only`.
+- Inspect changed files with `sed`, `nl`, `rg`, or targeted `git diff -- path`.
+- Ask the reviewer to avoid full diff dumps.
+- Split reviews by topic or file group.
+
+Better prompt:
+
+```text
+Review only tradeexecutor/cli/testtrade.py and tradeexecutor/strategy/pandas_trader/position_manager.py first.
+Then inspect tests only if needed to validate coverage.
+```
+
+### The agent cannot use tools
+
+Symptoms:
+
+- Claude says it cannot inspect files.
+- Codex refuses to edit or run commands.
+- A non-interactive run exits after a permission problem.
+
+Avoid it:
+
+- For Codex, set explicit sandbox and approval flags:
+
+```shell
+codex exec --sandbox workspace-write --ask-for-approval never "Run the focused test and fix failures"
+```
+
+- For Claude, set explicit permission mode and allowed tools:
+
+```shell
+claude -p "Read-only review" \
+  --permission-mode bypassPermissions \
+  --dangerously-skip-permissions \
+  --allowedTools "Bash,Read,Grep,Glob"
+```
+
+Use broad bypass modes only in trusted repositories or externally sandboxed environments.
+
+### The cloud review does not start
+
+Symptoms:
+
+- `claude ultrareview` exits immediately.
+- Error mentions usage credits or account limits.
+
+Example:
+
+```text
+Ultrareview could not launch: Usage credits exhausted.
+```
+
+Avoid it:
+
+- Fall back to local `claude -p`.
+- Use streaming output for visibility.
+- Narrow the review prompt to reduce cost.
+- Run local focused tests yourself and include the results in the final assessment.
+
+### The agent reviews the wrong tree
+
+Symptoms:
+
+- Findings refer to the parent repository instead of the worktree.
+- Tests import parent source instead of worktree source.
+- The branch name or status does not match expectations.
+
+Avoid it:
+
+```shell
+pwd
+git status --short --branch
+git rev-parse --show-toplevel
+```
+
+For this repository's worktrees, run tests through the parent Poetry environment but force worktree imports:
+
+```shell
+source .local-test.env && PYTHONPATH="$(pwd):$PYTHONPATH" poetry run pytest tests/path/to/test.py
+```
+
+### The agent misses repository instructions
+
+Symptoms:
+
+- Test docstrings do not follow repo rules.
+- Commands omit `source .local-test.env`.
+- Python style diverges from `AGENTS.md`.
+
+Avoid it:
+
+- Tell the reviewer to read `AGENTS.md` first.
+- Cite the relevant instruction in the prompt.
+- Ask specifically for "AGENTS.md compliance" as a review axis.
+
+Good prompt:
+
+```text
+Read AGENTS.md first. Review the new pytest tests for repository instruction compliance:
+docstring format, comments matching steps, type hints, and command invocation assumptions.
+```
+
+### The agent runs too much
+
+Symptoms:
+
+- Full test suite starts unexpectedly.
+- Long-running fork tests or Docker pulls start during review.
+- CI-like commands exceed local time budgets.
+
+Avoid it:
+
+- Say "do not run the full test suite".
+- Name the exact tests that may be run.
+- For review-only work, restrict tools to read-only commands.
+
+Example:
+
+```text
+Do not run tests. Inspect the code and tell me what focused tests should be run.
+```
+
+### The agent changes files during a review
+
+Symptoms:
+
+- A review command edits files.
+- Formatting or unrelated cleanup appears in `git diff`.
+
+Avoid it:
+
+- For Claude, omit edit tools from `--allowedTools`.
+- For Codex, ask for review only and use read-only sandbox:
+
+```shell
+codex exec --sandbox read-only "Review uncommitted changes for correctness bugs"
+```
+
+### Output is not machine-readable
+
+Symptoms:
+
+- Scripts cannot reliably parse the answer.
+- Progress messages are mixed with final output.
+
+Avoid it:
+
+- Codex: use `codex exec --json` for JSONL event streams.
+- Claude: use `claude -p --output-format json` for one result or `stream-json` for live events.
+- Ask for a schema when stable fields are needed.
+
+Claude example:
+
+```shell
+claude -p "Return {\"findings\": [...], \"risk\": \"...\"}" \
+  --json-schema '{"type":"object","properties":{"findings":{"type":"array"},"risk":{"type":"string"}},"required":["findings","risk"]}'
+```
+
+### Authentication or MCP setup is broken
+
+Symptoms:
+
+- `doctor` reports missing auth.
+- MCP servers show `needs-auth`.
+- Tools that depend on external services are absent.
+
+Avoid it:
+
+```shell
+codex doctor
+codex mcp list
+claude doctor
+claude mcp
+```
+
+Do not assume missing MCP tools are model limitations. Check installation, auth, workspace policy, and whether the session needs restarting after a config change.
+
+## Practical checklist
+
+Before launching another agent:
+
+1. Confirm the working directory and branch.
+2. Decide whether the task is interactive, non-interactive, or cloud review.
+3. Restrict tools if it is a review.
+4. Prefer streaming JSON for long non-interactive jobs.
+5. Tell the agent not to paste huge diffs.
+6. Name the exact risk areas to review.
+7. Ask for file:line findings and residual risks.
+8. Run focused tests yourself when the reviewer cannot.
+
+After the agent finishes:
+
+1. Separate high-confidence findings from speculation.
+2. Verify any proposed bug against the code.
+3. Apply only fixes that match the original task.
+4. Re-run focused tests if code changed.
+5. Record useful failure modes in this document.

--- a/tests/ethereum/test_cctp_bridge_strategy.py
+++ b/tests/ethereum/test_cctp_bridge_strategy.py
@@ -41,6 +41,23 @@ USDC_BASE_ADDRESS = "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913"
 class DummyCctpPricingModel:
     """Minimal pricing model for exercising bridge close planning."""
 
+    def get_buy_price(
+        self,
+        timestamp: datetime.datetime,
+        pair: TradingPairIdentifier,
+        reserve: Decimal,
+    ) -> TradePricing:
+        """Return 1:1 pricing for a CCTP bridge buy."""
+        assert pair.is_cctp_bridge()
+        assert reserve is not None
+        return TradePricing(
+            price=1.0,
+            mid_price=1.0,
+            lp_fee=[0.0],
+            pair_fee=[0.0],
+            side=True,
+        )
+
     def get_sell_price(
         self,
         timestamp: datetime.datetime,
@@ -64,9 +81,9 @@ class DummyCctpPricingModel:
         direction: str,
         default_slippage_tolerance: float,
     ) -> float:
-        """Return a fixed small slippage tolerance for close planning."""
+        """Return a fixed small slippage tolerance for bridge planning."""
         assert pair.is_cctp_bridge()
-        assert direction == "sell"
+        assert direction in ("buy", "sell")
         return 0.01
 
 
@@ -541,6 +558,52 @@ def test_close_cctp_bridge_uses_available_bridge_capital(
     assert trade.planned_reserve == Decimal("1020")
     assert TradeFlag.close in trade.flags
     assert TradeFlag.reduce in trade.flags
+    assert len(state.portfolio.open_positions) == 1
+    assert list(state.portfolio.open_positions.values())[0] == bridge_position
+
+
+def test_open_cctp_bridge_reuses_existing_bridge_position(
+    cctp_pair: TradingPairIdentifier,
+    usdc_arbitrum_asset: AssetIdentifier,
+):
+    """Test that repeated bridge-out increases the existing bridge position.
+
+    1. Open an initial CCTP bridge position.
+    2. Plan another bridge-out through PositionManager.
+    3. Verify the new trade is attached to the original bridge position.
+    """
+    # 1. Open an initial CCTP bridge position.
+    state = State()
+    ts = datetime.datetime(2025, 1, 1)
+    state.portfolio.initialise_reserves(usdc_arbitrum_asset)
+    reserve = state.portfolio.get_default_reserve_position()
+    reserve.quantity = Decimal(10000)
+    reserve.reserve_token_price = 1.0
+
+    create_open_bridge_position(
+        state=state,
+        ts=ts,
+        cctp_pair=cctp_pair,
+        reserve_asset=usdc_arbitrum_asset,
+        reserve_amount=Decimal(1000),
+    )
+    bridge_position = state.portfolio.get_bridge_position_for_chain(ChainId.base.value)
+    assert bridge_position is not None
+
+    # 2. Plan another bridge-out through PositionManager.
+    strategy_universe = create_dummy_strategy_universe(usdc_arbitrum_asset)
+    pricing_model = DummyCctpPricingModel()
+    position_manager = PositionManager(ts, strategy_universe, state, pricing_model)
+    trades = position_manager.open_cctp_bridge_position(cctp_pair, Decimal(500))
+
+    # 3. Verify the new trade is attached to the original bridge position.
+    assert len(trades) == 1
+    trade = trades[0]
+    assert trade.is_buy()
+    assert trade.position_id == bridge_position.position_id
+    assert trade.planned_reserve == Decimal(500)
+    assert TradeFlag.open in trade.flags
+    assert TradeFlag.increase in trade.flags
     assert len(state.portfolio.open_positions) == 1
     assert list(state.portfolio.open_positions.values())[0] == bridge_position
 

--- a/tests/mainnet_fork/test_lagoon_vault_from_bridge.py
+++ b/tests/mainnet_fork/test_lagoon_vault_from_bridge.py
@@ -52,6 +52,7 @@ from tradeexecutor.ethereum.web3config import Web3Config
 from tradeexecutor.state.identifier import AssetIdentifier, TradingPairIdentifier, TradingPairKind
 from tradeexecutor.state.state import State
 from tradeexecutor.state.trade import TradeType
+from tradeexecutor.strategy.generic.generic_pricing_model import GenericPricing
 from tradeexecutor.strategy.generic.generic_router import GenericRouting
 from tradeexecutor.strategy.pandas_trader.position_manager import PositionManager
 from tradeexecutor.strategy.trading_strategy_universe import TradingStrategyUniverse, create_pair_universe_from_code
@@ -68,10 +69,13 @@ BASE_CHAIN_ID = 8453
 
 # IPOR Fusion vault on Base — USDC, no lockup beyond ~1 hour
 IPOR_VAULT_ADDRESS = "0x45aa96f0b3188d47a1dafdbefce1db6b37f58216"
+MUSCADINE_VAULT_ADDRESS = "0xf7e26fa48a568b8b0038e104dfd8abdf0f99074f"
+MO_EARN_MAX_VAULT_ADDRESS = "0x3094b241aade60f91f1c82b0628a10d9501462f9"
 
-DEPOSIT_AMOUNT = Decimal("10")  # Total USDC deposited
+DEPOSIT_AMOUNT = Decimal("30")  # Total USDC deposited
 BRIDGE_AMOUNT = Decimal("5")    # USDC bridged to Base
 VAULT_AMOUNT = Decimal("3")     # USDC deposited into vault
+SHARED_BRIDGE_TRADE_AMOUNT = Decimal("4")
 
 #: Pin Base fork to a block where the IPOR Fusion vault has sufficient
 #: deposit headroom.  The vault's ``totalSupplyCap`` has been nearly full
@@ -188,6 +192,28 @@ def ipor_share_token() -> AssetIdentifier:
 
 
 @pytest.fixture()
+def muscadine_share_token() -> AssetIdentifier:
+    """Muscadine USDC Vault share token on Base."""
+    return AssetIdentifier(
+        chain_id=BASE_CHAIN_ID,
+        address=MUSCADINE_VAULT_ADDRESS,
+        token_symbol="mvUSDC",
+        decimals=18,
+    )
+
+
+@pytest.fixture()
+def mo_earn_max_share_token() -> AssetIdentifier:
+    """Mo Earn Max USDC share token on Base."""
+    return AssetIdentifier(
+        chain_id=BASE_CHAIN_ID,
+        address=MO_EARN_MAX_VAULT_ADDRESS,
+        token_symbol="maxUSD",
+        decimals=18,
+    )
+
+
+@pytest.fixture()
 def bridge_pair(usdc_base, usdc_arb) -> TradingPairIdentifier:
     """CCTP bridge pair: Arbitrum USDC → Base USDC."""
     return TradingPairIdentifier(
@@ -207,6 +233,38 @@ def bridge_pair(usdc_base, usdc_arb) -> TradingPairIdentifier:
     )
 
 
+def _make_base_vault_pair(
+    *,
+    share_token: AssetIdentifier,
+    address: str,
+    internal_id: int,
+    exchange_name: str,
+    vault_protocol: str = "erc_4626",
+    vault_features: list[str] | None = None,
+) -> TradingPairIdentifier:
+    """Create a Base USDC vault pair for fork tests."""
+    return TradingPairIdentifier(
+        base=share_token,
+        quote=AssetIdentifier(
+            chain_id=BASE_CHAIN_ID,
+            address=USDC_NATIVE_TOKEN[BASE_CHAIN_ID],
+            token_symbol="USDC",
+            decimals=6,
+        ),
+        pool_address=address,
+        exchange_address=address,
+        internal_id=internal_id,
+        internal_exchange_id=internal_id,
+        fee=0.0,
+        kind=TradingPairKind.vault,
+        exchange_name=exchange_name,
+        other_data={
+            "vault_protocol": vault_protocol,
+            "vault_features": vault_features,
+        },
+    )
+
+
 @pytest.fixture()
 def vault_pair(ipor_share_token, usdc_base) -> TradingPairIdentifier:
     """IPOR Fusion vault pair on Base."""
@@ -222,7 +280,32 @@ def vault_pair(ipor_share_token, usdc_base) -> TradingPairIdentifier:
         exchange_name="IPOR Fusion",
         other_data={
             "vault_protocol": "ipor_fusion",
+            "vault_features": ["ipor_like"],
         },
+    )
+
+
+@pytest.fixture()
+def muscadine_vault_pair(muscadine_share_token) -> TradingPairIdentifier:
+    """Muscadine USDC Vault pair on Base."""
+    return _make_base_vault_pair(
+        share_token=muscadine_share_token,
+        address=MUSCADINE_VAULT_ADDRESS,
+        internal_id=3,
+        exchange_name="Muscadine USDC Vault",
+        vault_features=["morpho_like", "euler_earn_like"],
+    )
+
+
+@pytest.fixture()
+def mo_earn_max_vault_pair(mo_earn_max_share_token) -> TradingPairIdentifier:
+    """Mo Earn Max USDC pair on Base."""
+    return _make_base_vault_pair(
+        share_token=mo_earn_max_share_token,
+        address=MO_EARN_MAX_VAULT_ADDRESS,
+        internal_id=4,
+        exchange_name="Mo Earn Max USDC",
+        vault_features=["morpho_like", "euler_earn_like"],
     )
 
 
@@ -256,6 +339,57 @@ def universe(bridge_pair, vault_pair, usdc_arb) -> TradingStrategyUniverse:
         time_bucket=TimeBucket.d1,
         chains={ChainId.arbitrum, ChainId.base},
         exchanges={cctp_exchange, vault_exchange},
+        pairs=pair_universe,
+        candles=None,
+        liquidity=None,
+    )
+
+    return TradingStrategyUniverse(
+        data_universe=data_universe,
+        reserve_assets=[usdc_arb],
+    )
+
+
+@pytest.fixture()
+def shared_bridge_universe(
+    bridge_pair,
+    vault_pair,
+    muscadine_vault_pair,
+    mo_earn_max_vault_pair,
+    usdc_arb,
+) -> TradingStrategyUniverse:
+    """Trading universe with one CCTP bridge and three real Base vaults."""
+
+    vault_pairs = [muscadine_vault_pair, mo_earn_max_vault_pair, vault_pair]
+    pair_universe = create_pair_universe_from_code(ChainId.arbitrum, [bridge_pair] + vault_pairs)
+
+    cctp_exchange = Exchange(
+        chain_id=ChainId.arbitrum,
+        chain_slug="arbitrum",
+        exchange_id=1,
+        exchange_slug="cctp-bridge",
+        address=TOKEN_MESSENGER_V2,
+        exchange_type=ExchangeType.uniswap_v2,
+        pair_count=1,
+    )
+
+    vault_exchanges = [
+        Exchange(
+            chain_id=ChainId.base,
+            chain_slug="base",
+            exchange_id=pair.internal_exchange_id,
+            exchange_slug=pair.exchange_name.lower().replace(" ", "-"),
+            address=pair.exchange_address,
+            exchange_type=ExchangeType.erc_4626_vault,
+            pair_count=1,
+        )
+        for pair in vault_pairs
+    ]
+
+    data_universe = Universe(
+        time_bucket=TimeBucket.d1,
+        chains={ChainId.arbitrum, ChainId.base},
+        exchanges={cctp_exchange, *vault_exchanges},
         pairs=pair_universe,
         candles=None,
         liquidity=None,
@@ -310,6 +444,146 @@ def get_total_equity(state: State) -> float:
     reserve_value = sum(float(r.quantity) for r in state.portfolio.reserves.values())
     position_equity = sum(p.get_equity() for p in state.portfolio.open_positions.values())
     return reserve_value + position_equity
+
+
+def _create_routing_model(arb_web3: Web3, universe: TradingStrategyUniverse, web3config: Web3Config) -> GenericRouting:
+    """Create generic multichain routing for a test universe."""
+    pair_configurator = EthereumPairConfigurator(
+        arb_web3,
+        universe,
+        web3config=web3config,
+    )
+    return GenericRouting(pair_configurator)
+
+
+def _get_bridge_position(state: State, bridge_pair: TradingPairIdentifier):
+    """Return the single shared bridge position for a bridge pair."""
+    bridge_position = state.portfolio.get_position_by_trading_pair(bridge_pair)
+    assert bridge_position is not None and bridge_position.is_open()
+    assert len([p for p in state.portfolio.open_positions.values() if p.pair.is_cctp_bridge()]) == 1
+    return bridge_position
+
+
+def _open_cross_chain_vault_position(
+    *,
+    arb_web3: Web3,
+    execution_model: EthereumExecution,
+    routing_model: GenericRouting,
+    routing_state,
+    sync_model: HotWalletSyncModel,
+    state: State,
+    universe: TradingStrategyUniverse,
+    web3config: Web3Config,
+    pair: TradingPairIdentifier,
+    amount: Decimal,
+) -> None:
+    """Open a Base vault position through the production cross-chain test-trade path."""
+    make_test_trade(
+        web3=arb_web3,
+        execution_model=execution_model,
+        pricing_model=GenericPricing(routing_model.pair_configurator),
+        sync_model=sync_model,
+        state=state,
+        universe=universe,
+        routing_model=routing_model,
+        routing_state=routing_state,
+        max_slippage=0.05,
+        amount=amount,
+        pair=pair,
+        buy_only=True,
+        web3config=web3config,
+    )
+
+
+def _open_shared_bridge_vault_position(
+    *,
+    arb_web3: Web3,
+    execution_model: EthereumExecution,
+    routing_model: GenericRouting,
+    routing_state,
+    sync_model: HotWalletSyncModel,
+    state: State,
+    universe: TradingStrategyUniverse,
+    web3config: Web3Config,
+    pair: TradingPairIdentifier,
+    amount: Decimal,
+    expected_name: str,
+):
+    """Open a Base vault position through the shared CCTP bridge."""
+    _open_cross_chain_vault_position(
+        arb_web3=arb_web3,
+        execution_model=execution_model,
+        routing_model=routing_model,
+        routing_state=routing_state,
+        sync_model=sync_model,
+        state=state,
+        universe=universe,
+        web3config=web3config,
+        pair=pair,
+        amount=amount,
+    )
+    position = state.portfolio.get_position_by_trading_pair(pair)
+    assert position is not None and position.is_open()
+    assert expected_name in position.pair.exchange_name
+    return position
+
+
+def _warm_vault_pricing(
+    *,
+    routing_model: GenericRouting,
+    pairs: list[TradingPairIdentifier],
+) -> None:
+    """Warm vault adapters before the transaction-heavy test sequence starts."""
+    ts = native_datetime_utc_now()
+    pricing_model = GenericPricing(routing_model.pair_configurator)
+    for pair in pairs:
+        pricing_model.get_buy_price(ts, pair, SHARED_BRIDGE_TRADE_AMOUNT)
+
+
+def _execute_vault_sell(
+    *,
+    base_web3: Web3,
+    execution_model: EthereumExecution,
+    routing_model: GenericRouting,
+    routing_state,
+    state: State,
+    universe: TradingStrategyUniverse,
+    position,
+    quantity: Decimal | None = None,
+) -> None:
+    """Sell all or part of a Base vault position, mining past lockups if needed."""
+    pricing_model = routing_model.pair_configurator.get_config(
+        routing_model.pair_configurator.match_router(position.pair)
+    ).pricing_model
+
+    for attempt in range(2):
+        ts = native_datetime_utc_now()
+        position_manager = PositionManager(
+            ts,
+            universe,
+            state,
+            pricing_model,
+            default_slippage_tolerance=0.05,
+        )
+        if quantity is None:
+            trades = position_manager.close_position(position)
+        else:
+            trades = position_manager.close_spot_position(position, quantity=quantity, slippage_tolerance=0.05)
+
+        execution_model.execute_trades(
+            ts,
+            state,
+            trades,
+            routing_model,
+            routing_state,
+        )
+        trade = trades[0]
+        if trade.is_success():
+            return
+        if attempt == 0:
+            mine(base_web3, increase_timestamp=3600)
+
+    raise AssertionError(f"Vault sell failed for {position.pair}: {trade.get_revert_reason()}")
 
 
 # --- Tests ---
@@ -565,3 +839,158 @@ def test_vault_deposit_from_bridge_capital(
     chain_equity = state.portfolio.calculate_total_equity_chain()
     assert chain_equity.get(ChainId.arbitrum, 0) == pytest.approx(float(DEPOSIT_AMOUNT), rel=0.03)
     assert chain_equity.get(ChainId.base, 0) == pytest.approx(0, abs=0.01)
+
+
+@pytest.mark.timeout(900)
+def test_multiple_base_vault_positions_share_one_bridge(
+    arb_web3: Web3,
+    base_web3: Web3,
+    execution_model: EthereumExecution,
+    sync_model: HotWalletSyncModel,
+    state: State,
+    shared_bridge_universe: TradingStrategyUniverse,
+    bridge_pair: TradingPairIdentifier,
+    muscadine_vault_pair: TradingPairIdentifier,
+    mo_earn_max_vault_pair: TradingPairIdentifier,
+    vault_pair: TradingPairIdentifier,
+    web3config: Web3Config,
+):
+    """Three real Base vault positions share and mutate one CCTP bridge.
+
+    1. Bridge from Arbitrum to Base and open Muscadine USDC Vault (X).
+    2. Bridge from Arbitrum to Base and open Mo Earn Max USDC (Y).
+    3. Close Muscadine USDC Vault (X).
+    4. Bridge from Arbitrum to Base and open IPOR Fusion USDC (Z).
+    5. Decrease Mo Earn Max USDC (Y).
+    6. Close IPOR Fusion USDC (Z).
+    7. Close Mo Earn Max USDC (Y).
+    """
+    routing_model = _create_routing_model(arb_web3, shared_bridge_universe, web3config)
+    routing_state = routing_model.create_routing_state(
+        shared_bridge_universe,
+        {"tx_builder": execution_model.tx_builder},
+    )
+    _warm_vault_pricing(
+        routing_model=routing_model,
+        pairs=[muscadine_vault_pair, mo_earn_max_vault_pair, vault_pair],
+    )
+    initial_equity = get_total_equity(state)
+    assert initial_equity == pytest.approx(float(DEPOSIT_AMOUNT), rel=0.01)
+
+    # 1. Bridge from Arbitrum to Base and open Muscadine USDC Vault (X).
+    position_x = _open_shared_bridge_vault_position(
+        arb_web3=arb_web3,
+        execution_model=execution_model,
+        routing_model=routing_model,
+        routing_state=routing_state,
+        sync_model=sync_model,
+        state=state,
+        universe=shared_bridge_universe,
+        web3config=web3config,
+        pair=muscadine_vault_pair,
+        amount=SHARED_BRIDGE_TRADE_AMOUNT,
+        expected_name="Muscadine",
+    )
+    bridge_position = _get_bridge_position(state, bridge_pair)
+    assert float(bridge_position.bridge_capital_allocated) == pytest.approx(float(SHARED_BRIDGE_TRADE_AMOUNT), rel=0.05)
+
+    # 2. Bridge from Arbitrum to Base and open Mo Earn Max USDC (Y).
+    position_y = _open_shared_bridge_vault_position(
+        arb_web3=arb_web3,
+        execution_model=execution_model,
+        routing_model=routing_model,
+        routing_state=routing_state,
+        sync_model=sync_model,
+        state=state,
+        universe=shared_bridge_universe,
+        web3config=web3config,
+        pair=mo_earn_max_vault_pair,
+        amount=SHARED_BRIDGE_TRADE_AMOUNT,
+        expected_name="Mo Earn",
+    )
+    bridge_position = _get_bridge_position(state, bridge_pair)
+    assert float(bridge_position.bridge_capital_allocated) == pytest.approx(float(SHARED_BRIDGE_TRADE_AMOUNT * 2), rel=0.05)
+
+    # 3. Close Muscadine USDC Vault (X).
+    _execute_vault_sell(
+        base_web3=base_web3,
+        execution_model=execution_model,
+        routing_model=routing_model,
+        routing_state=routing_state,
+        state=state,
+        universe=shared_bridge_universe,
+        position=position_x,
+    )
+    assert position_x.is_closed()
+    bridge_position = _get_bridge_position(state, bridge_pair)
+    allocation_after_x_close = bridge_position.bridge_capital_allocated
+    assert float(allocation_after_x_close) == pytest.approx(float(SHARED_BRIDGE_TRADE_AMOUNT), rel=0.10)
+
+    # 4. Bridge from Arbitrum to Base and open IPOR Fusion USDC (Z).
+    position_z = _open_shared_bridge_vault_position(
+        arb_web3=arb_web3,
+        execution_model=execution_model,
+        routing_model=routing_model,
+        routing_state=routing_state,
+        sync_model=sync_model,
+        state=state,
+        universe=shared_bridge_universe,
+        web3config=web3config,
+        pair=vault_pair,
+        amount=SHARED_BRIDGE_TRADE_AMOUNT,
+        expected_name="IPOR",
+    )
+    bridge_position = _get_bridge_position(state, bridge_pair)
+    assert float(bridge_position.bridge_capital_allocated) == pytest.approx(float(SHARED_BRIDGE_TRADE_AMOUNT * 2), rel=0.10)
+
+    # 5. Decrease Mo Earn Max USDC (Y).
+    y_quantity_before_decrease = position_y.get_quantity()
+    y_decrease_quantity = y_quantity_before_decrease / Decimal(2)
+    allocation_before_y_decrease = bridge_position.bridge_capital_allocated
+    _execute_vault_sell(
+        base_web3=base_web3,
+        execution_model=execution_model,
+        routing_model=routing_model,
+        routing_state=routing_state,
+        state=state,
+        universe=shared_bridge_universe,
+        position=position_y,
+        quantity=y_decrease_quantity,
+    )
+    assert position_y.is_open()
+    assert position_y.get_quantity() < y_quantity_before_decrease
+    bridge_position = _get_bridge_position(state, bridge_pair)
+    assert bridge_position.bridge_capital_allocated < allocation_before_y_decrease
+    assert bridge_position.bridge_capital_allocated > 0
+
+    # 6. Close IPOR Fusion USDC (Z).
+    allocation_before_z_close = bridge_position.bridge_capital_allocated
+    _execute_vault_sell(
+        base_web3=base_web3,
+        execution_model=execution_model,
+        routing_model=routing_model,
+        routing_state=routing_state,
+        state=state,
+        universe=shared_bridge_universe,
+        position=position_z,
+    )
+    assert position_z.is_closed()
+    bridge_position = _get_bridge_position(state, bridge_pair)
+    assert bridge_position.bridge_capital_allocated < allocation_before_z_close
+    assert bridge_position.bridge_capital_allocated > 0
+
+    # 7. Close Mo Earn Max USDC (Y).
+    _execute_vault_sell(
+        base_web3=base_web3,
+        execution_model=execution_model,
+        routing_model=routing_model,
+        routing_state=routing_state,
+        state=state,
+        universe=shared_bridge_universe,
+        position=position_y,
+    )
+    assert position_y.is_closed()
+    bridge_position = _get_bridge_position(state, bridge_pair)
+    assert float(bridge_position.bridge_capital_allocated) == pytest.approx(0, abs=0.05)
+    assert len([p for p in state.portfolio.open_positions.values() if p.pair.kind == TradingPairKind.vault]) == 0
+    assert get_total_equity(state) == pytest.approx(initial_equity, rel=0.05)

--- a/tests/mainnet_fork/test_lagoon_vault_from_bridge.py
+++ b/tests/mainnet_fork/test_lagoon_vault_from_bridge.py
@@ -43,7 +43,7 @@ from tradingstrategy.exchange import Exchange, ExchangeType
 from tradingstrategy.timebucket import TimeBucket
 from tradingstrategy.universe import Universe
 
-from tradeexecutor.cli.testtrade import make_test_trade
+from tradeexecutor.cli.testtrade import make_test_trade, _materialise_bridge_on_anvil
 from tradeexecutor.ethereum.ethereum_protocol_adapters import EthereumPairConfigurator
 from tradeexecutor.ethereum.execution import EthereumExecution
 from tradeexecutor.ethereum.hot_wallet_sync_model import HotWalletSyncModel
@@ -590,6 +590,61 @@ def _execute_vault_sell(
     raise AssertionError(f"Vault sell failed for {position.pair}: {trade.get_revert_reason()}")
 
 
+def _close_shared_bridge_position(
+    *,
+    base_web3: Web3,
+    execution_model: EthereumExecution,
+    routing_model: GenericRouting,
+    routing_state,
+    sync_model: HotWalletSyncModel,
+    state: State,
+    universe: TradingStrategyUniverse,
+    web3config: Web3Config,
+    bridge_pair: TradingPairIdentifier,
+    bridge_position,
+) -> None:
+    """Close the remaining shared Base bridge position back to Arbitrum."""
+    base_usdc = fetch_erc20_details(base_web3, USDC_NATIVE_TOKEN[BASE_CHAIN_ID])
+    hot_wallet = execution_model.tx_builder.hot_wallet
+    bridge_sell_quantity = base_usdc.fetch_balance_of(hot_wallet.address)
+    assert bridge_sell_quantity > 0
+
+    ts = native_datetime_utc_now()
+    reserve_asset = universe.get_reserve_asset()
+    _, bridge_back_trade, _ = state.create_trade(
+        strategy_cycle_at=ts,
+        pair=bridge_pair,
+        quantity=-bridge_sell_quantity,
+        reserve=None,
+        assumed_price=1.0,
+        trade_type=TradeType.rebalance,
+        reserve_currency=reserve_asset,
+        reserve_currency_price=1.0,
+        position=bridge_position,
+        closing=True,
+        slippage_tolerance=0.05,
+    )
+
+    execution_model.execute_trades(
+        ts,
+        state,
+        [bridge_back_trade],
+        routing_model,
+        routing_state,
+    )
+    assert bridge_back_trade.is_success(), f"Bridge back failed: {bridge_back_trade.get_revert_reason()}"
+
+    _materialise_bridge_on_anvil(
+        web3config,
+        routing_model,
+        bridge_pair,
+        ARBITRUM_CHAIN_ID,
+        hot_wallet.address,
+        bridge_back_trade,
+    )
+    sync_model.sync_treasury(native_datetime_utc_now(), state, list(universe.reserve_assets))
+
+
 # --- Tests ---
 
 
@@ -868,6 +923,7 @@ def test_multiple_base_vault_positions_share_one_bridge(
     5. Decrease Mo Earn Max USDC (Y).
     6. Close IPOR Fusion USDC (Z).
     7. Close Mo Earn Max USDC (Y).
+    8. Bridge the shared CCTP position back to Arbitrum.
     """
     routing_model = _create_routing_model(arb_web3, shared_bridge_universe, web3config)
     routing_state = routing_model.create_routing_state(
@@ -998,3 +1054,22 @@ def test_multiple_base_vault_positions_share_one_bridge(
     assert float(bridge_position.bridge_capital_allocated) == pytest.approx(0, abs=0.05)
     assert len([p for p in state.portfolio.open_positions.values() if p.pair.kind == TradingPairKind.vault]) == 0
     assert get_total_equity(state) == pytest.approx(initial_equity, rel=0.05)
+
+    # 8. Bridge the shared CCTP position back to Arbitrum.
+    _close_shared_bridge_position(
+        base_web3=base_web3,
+        execution_model=execution_model,
+        routing_model=routing_model,
+        routing_state=routing_state,
+        sync_model=sync_model,
+        state=state,
+        universe=shared_bridge_universe,
+        web3config=web3config,
+        bridge_pair=bridge_pair,
+        bridge_position=bridge_position,
+    )
+    assert len(state.portfolio.open_positions) == 0
+    assert get_total_equity(state) == pytest.approx(initial_equity, rel=0.05)
+    chain_equity = state.portfolio.calculate_total_equity_chain()
+    assert chain_equity.get(ChainId.arbitrum, 0) == pytest.approx(float(DEPOSIT_AMOUNT), rel=0.05)
+    assert chain_equity.get(ChainId.base, 0) == pytest.approx(0, abs=0.05)

--- a/tests/mainnet_fork/test_lagoon_vault_from_bridge.py
+++ b/tests/mainnet_fork/test_lagoon_vault_from_bridge.py
@@ -95,6 +95,10 @@ pytestmark = pytest.mark.skipif(
 
 @pytest.fixture()
 def arb_anvil() -> AnvilLaunch:
+    # Arbitrum is intentionally not pinned: these tests only use it as the
+    # source chain for fork-funded USDC and CCTP burn transactions, while the
+    # stateful vault deposit/redeem behaviour that affects reproducibility is
+    # on Base and is pinned with BASE_FORK_BLOCK.
     launch = fork_network_anvil(JSON_RPC_ARBITRUM)
     try:
         yield launch

--- a/tests/units_tests/test_cross_chain_satellite_async_settlement.py
+++ b/tests/units_tests/test_cross_chain_satellite_async_settlement.py
@@ -217,7 +217,7 @@ def test_cross_chain_buy_does_not_crash_when_satellite_open_is_pending(monkeypat
     bridge_trade = MagicMock()
     bridge_trade.is_success.return_value = True
     bridge_pm = MagicMock()
-    bridge_pm.open_spot.return_value = [bridge_trade]
+    bridge_pm.open_cctp_bridge_position.return_value = [bridge_trade]
 
     # 2. Make the internally-constructed PositionManager return a pending satellite deposit.
     #    Faithful to production: requestDeposit confirmed but not settled, so the
@@ -262,7 +262,7 @@ def test_cross_chain_buy_does_not_crash_when_satellite_open_is_pending(monkeypat
     # 4. Verify it returns without raising and the satellite trade was executed but
     #    never asserted to be successful.
     assert result is None
-    bridge_pm.open_spot.assert_called_once()
+    bridge_pm.open_cctp_bridge_position.assert_called_once()
     satellite_pm.open_spot.assert_called_once()
     execution_model.execute_trades.assert_called()
     satellite_trade.is_success.assert_not_called()

--- a/tradeexecutor/cli/testtrade.py
+++ b/tradeexecutor/cli/testtrade.py
@@ -216,7 +216,7 @@ def _make_cross_chain_test_trade(
 
         # Step 1: Bridge USDC to satellite chain
         logger.info("Cross-chain step 1: bridge %s USDC to %s via CCTP", amount, chain_name)
-        bridge_trades = position_manager.open_spot(
+        bridge_trades = position_manager.open_cctp_bridge_position(
             bridge_pair, float(amount), notes=notes, flags={TradeFlag.test_trade},
         )
         execution_model.execute_trades(ts, state, bridge_trades, routing_model, routing_state)

--- a/tradeexecutor/strategy/pandas_trader/position_manager.py
+++ b/tradeexecutor/strategy/pandas_trader/position_manager.py
@@ -1343,6 +1343,65 @@ class PositionManager:
         assert trade.closing
         return [trade]
 
+    def open_cctp_bridge_position(
+        self,
+        pair: TradingPairIdentifier,
+        value: USDollarAmount | Decimal,
+        trade_type: TradeType = TradeType.rebalance,
+        notes: str | None = None,
+        slippage_tolerance: float | None = None,
+        flags: Set[TradeFlag] | None = None,
+    ) -> List[TradeExecution]:
+        """Open or increase a CCTP bridge position by bridging reserve out."""
+
+        assert pair.is_cctp_bridge()
+        assert value > 0, f"For opening CCTP bridge, the value must be positive. Got: {value} on {pair}"
+
+        if type(value) == float:
+            value = Decimal(value)
+
+        price_structure = self.pricing_model.get_buy_price(self.timestamp, pair, value)
+
+        reserve_asset, reserve_price = self.state.portfolio.get_default_reserve_asset()
+
+        if slippage_tolerance is None:
+            slippage_tolerance = self.pricing_model.calculate_trade_adjusted_slippage_tolerance(
+                pair=pair,
+                direction="buy",
+                default_slippage_tolerance=self.default_slippage_tolerance,
+            )
+
+        flags = {TradeFlag.open, TradeFlag.increase} | (flags or set())
+
+        position, trade, created = self.state.create_trade(
+            self.timestamp,
+            pair=pair,
+            quantity=None,
+            reserve=Decimal(value),
+            assumed_price=price_structure.price,
+            trade_type=trade_type,
+            reserve_currency=reserve_asset,
+            reserve_currency_price=reserve_price,
+            notes=notes,
+            pair_fee=price_structure.get_fee_percentage(),
+            lp_fees_estimated=price_structure.get_total_lp_fees(),
+            planned_mid_price=price_structure.mid_price,
+            price_structure=price_structure,
+            slippage_tolerance=slippage_tolerance,
+            flags=flags,
+        )
+
+        logger.info(
+            "Generated trade %s\nTo %s CCTP bridge position %s\nNotes: %s",
+            trade.get_human_description(),
+            "open" if created else "increase",
+            position.get_human_readable_name(),
+            notes,
+        )
+
+        assert trade.is_buy()
+        return [trade]
+
     def close_credit_supply_position(
         self,
         position: TradingPosition,


### PR DESCRIPTION
## Why

`trade-ui` failed when opening a cross-chain vault position if an existing CCTP bridge position already existed for the destination chain. The bridge leg used `open_spot()`, which requires a newly-created position and asserts when `create_trade()` correctly reuses the existing bridge position.

## Lessons learnt

The integration coverage did not exercise multiple vault positions sharing the same CCTP bridge while opening, closing, decreasing, and opening again. Cross-chain vault tests need to cover bridge-position reuse, not just fresh bridge creation.

## Summary

- Added `PositionManager.open_cctp_bridge_position()` for opening or increasing a CCTP bridge position.
- Switched cross-chain `trade-ui` test trades to use the bridge-specific helper.
- Added unit coverage for reusing an existing bridge position.
- Added an Anvil fork test covering three real Base vault positions sharing one CCTP bridge through open, close, decrease, and close flows.
- Added `.claude/docs/agent-tricks-and-troubleshooting.md` with Codex/Claude CLI review and troubleshooting notes.