### PR TITLE
Fix vault settlement receipt waits

### DIFF
--- a/.claude/docs/vault-deposit-redeem.md
+++ b/.claude/docs/vault-deposit-redeem.md
@@ -212,6 +212,13 @@ asks the vault's deposit manager for the request status, and acts:
 
 The resolver is idempotent: it recognises an already-confirmed claim,
 rebroadcasts a stuck one, and discards a reverted one before retrying.
+Whenever it needs to wait for a claim or reclaim transaction, it uses
+`wait_for_transaction_receipt_robust()` instead of Web3.py's direct receipt
+wait. This matters on live multi-RPC providers: the first backend may see the
+receipt before another backend can serve the block, logs, or state trie needed
+by the immediate follow-up claim analysis. The robust wait gives every read
+provider time to catch up before the resolver reads events and marks the trade
+`success` or `failed`.
 
 The resolver also runs once at executor startup, so settlements left pending
 by a previous run are picked up before the first cycle. Unlike a stuck CCTP
@@ -315,7 +322,7 @@ The execution layer, in trade-executor:
 | Module | Role |
 |---|---|
 | [tradeexecutor/ethereum/vault/vault_routing.py](../../tradeexecutor/ethereum/vault/vault_routing.py) | Chooses instant vs queued flow, builds request transactions, persists the ticket |
-| [tradeexecutor/ethereum/vault/settlement_retry.py](../../tradeexecutor/ethereum/vault/settlement_retry.py) | Live settlement resolver: poll, claim, reclaim |
+| [tradeexecutor/ethereum/vault/settlement_retry.py](../../tradeexecutor/ethereum/vault/settlement_retry.py) | Live settlement resolver: poll, claim/reclaim, robust receipt wait and idempotent retry |
 | [tradeexecutor/strategy/execution_model.py](../../tradeexecutor/strategy/execution_model.py) | The polymorphic settlement hook called by the runner each cycle |
 | [tradeexecutor/backtest/backtest_execution.py](../../tradeexecutor/backtest/backtest_execution.py) | Simulated requests and delayed settlement; delay configuration |
 | [tradeexecutor/state/trade.py](../../tradeexecutor/state/trade.py), [state.py](../../tradeexecutor/state/state.py) | The `vault_settlement_pending` status and its bookkeeping |

--- a/tests/ethereum/test_vault_settlement_lifecycle.py
+++ b/tests/ethereum/test_vault_settlement_lifecycle.py
@@ -16,6 +16,9 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+from eth_defi.vault.deposit_redeem import AsyncVaultRequestStatus, DepositRedeemEventAnalysis
+from hexbytes import HexBytes
+from tradeexecutor.ethereum.vault.settlement_retry import check_and_resolve_vault_settlements
 from tradeexecutor.state.blockhain_transaction import BlockchainTransaction
 from tradeexecutor.state.identifier import (
     AssetIdentifier,
@@ -318,8 +321,6 @@ def test_vault_settlement_retry_claimable(
     """
     from unittest.mock import MagicMock, patch
     from eth_defi.vault.deposit_redeem import AsyncVaultRequestStatus, DepositRedeemEventAnalysis
-    from tradeexecutor.ethereum.vault.settlement_retry import check_and_resolve_vault_settlements
-
     state = State()
     ts = datetime.datetime(2025, 1, 1)
 
@@ -375,7 +376,6 @@ def test_vault_settlement_retry_claimable(
     mock_web3 = MagicMock()
     mock_receipt = {"status": 1, "transactionHash": b"\x00" * 32, "blockNumber": 100}
     mock_web3.eth.send_raw_transaction.return_value = b"\x00" * 32
-    mock_web3.eth.wait_for_transaction_receipt.return_value = mock_receipt
 
     mock_execution_model = MagicMock()
     mock_execution_model.web3 = mock_web3
@@ -388,7 +388,10 @@ def test_vault_settlement_retry_claimable(
     mock_execution_model.tx_builder.sign_transaction.return_value = mock_tx
 
     # 4. Patch get_vault_for_pair
-    with patch("tradeexecutor.ethereum.vault.settlement_retry.get_vault_for_pair", return_value=mock_vault):
+    with (
+        patch("tradeexecutor.ethereum.vault.settlement_retry.get_vault_for_pair", return_value=mock_vault),
+        patch("tradeexecutor.ethereum.vault.settlement_retry.wait_for_transaction_receipt_robust", return_value=mock_receipt),
+    ):
         resolved = check_and_resolve_vault_settlements(
             state=state,
             execution_model=mock_execution_model,
@@ -400,6 +403,177 @@ def test_vault_settlement_retry_claimable(
     assert trade.vault_settlement_pending_at is None
     assert trade.executed_reserve == pytest.approx(Decimal(100))
     assert trade.executed_quantity == pytest.approx(Decimal("96.15"))
+
+
+def test_vault_settlement_retry_rebroadcast_uses_robust_receipt_wait(
+    vault_pair: TradingPairIdentifier,
+    usdc_arbitrum: AssetIdentifier,
+):
+    """Verify a stored vault claim transaction is rebroadcast using the robust receipt wait.
+
+    1. Create a vault buy trade with an existing post-request claim transaction
+    2. Mock the first receipt lookup to miss the transaction
+    3. Mock the robust receipt wait and claim analysis
+    4. Call check_and_resolve_vault_settlements
+    5. Verify the stored transaction is rebroadcast and the trade succeeds
+    """
+    state = State()
+    ts = datetime.datetime(2025, 1, 1)
+
+    state.portfolio.initialise_reserves(usdc_arbitrum)
+    reserve = state.portfolio.get_default_reserve_position()
+    reserve.quantity = Decimal(10_000)
+    reserve.reserve_token_price = 1.0
+
+    # 1. Create a vault buy trade with an existing post-request claim transaction
+    trade = _create_vault_buy_trade(state, vault_pair, usdc_arbitrum, Decimal(100), ts)
+    state.start_execution(ts, trade)
+    trade.mark_broadcasted(ts)
+
+    approve_tx = BlockchainTransaction()
+    approve_tx.tx_hash = "0xapprove"
+    request_tx = BlockchainTransaction()
+    request_tx.tx_hash = "0xrequest"
+    claim_tx = BlockchainTransaction()
+    claim_tx.tx_hash = "0x" + "ef" * 32
+    claim_tx.signed_bytes = b"\xef" * 32
+    claim_tx.other["vault_settlement_action"] = "claim"
+    trade.blockchain_transactions = [approve_tx, request_tx, claim_tx]
+
+    trade.other_data["vault_async_flow"] = True
+    trade.other_data["vault_chain_id"] = 42161
+    trade.other_data["vault_direction"] = "deposit"
+    trade.other_data["vault_owner_address"] = "0xTestOwner"
+    trade.other_data["vault_raw_amount"] = 100_000_000
+    trade.other_data["vault_address"] = OLP_ARBITRUM_ADDRESS
+    trade.other_data["vault_request_tx_hash"] = "0xrequest"
+    trade.other_data["vault_settlement_id"] = 42
+    trade.other_data["vault_request_tx_count"] = 2
+    trade.vault_settlement_pending_at = ts
+
+    mock_deposit_manager = MagicMock()
+    mock_deposit_manager.reconstruct_deposit_ticket.return_value = MagicMock()
+
+    mock_analysis = MagicMock(spec=DepositRedeemEventAnalysis)
+    mock_analysis.denomination_amount = Decimal(100)
+    mock_analysis.share_count = Decimal("96.15")
+    mock_deposit_manager.analyse_deposit.return_value = mock_analysis
+
+    mock_vault = MagicMock()
+    mock_vault.get_deposit_manager.return_value = mock_deposit_manager
+
+    mock_web3 = MagicMock()
+    mock_web3.eth.get_transaction_receipt.side_effect = RuntimeError("missing receipt")
+    mock_receipt = {"status": 1, "transactionHash": b"\x00" * 32, "blockNumber": 100}
+
+    mock_execution_model = MagicMock()
+    mock_execution_model.web3 = mock_web3
+
+    # 2. Mock the first receipt lookup to miss the transaction
+    # 3. Mock the robust receipt wait and claim analysis
+    with (
+        patch("tradeexecutor.ethereum.vault.settlement_retry.get_vault_for_pair", return_value=mock_vault),
+        patch("tradeexecutor.ethereum.vault.settlement_retry.wait_for_transaction_receipt_robust", return_value=mock_receipt) as wait_receipt,
+    ):
+        # 4. Call check_and_resolve_vault_settlements
+        resolved = check_and_resolve_vault_settlements(
+            state=state,
+            execution_model=mock_execution_model,
+        )
+
+    # 5. Verify the stored transaction is rebroadcast and the trade succeeds
+    assert len(resolved) == 1
+    assert trade.get_status() == TradeStatus.success
+    mock_web3.eth.send_raw_transaction.assert_called_once_with(HexBytes(claim_tx.signed_bytes))
+    wait_receipt.assert_called_once()
+
+
+def test_vault_settlement_retry_recovers_claim_using_robust_receipt_wait(
+    vault_pair: TradingPairIdentifier,
+    usdc_arbitrum: AssetIdentifier,
+):
+    """Verify an already-completed vault claim is recovered using the robust receipt wait.
+
+    1. Create a vault buy trade whose request status is already consumed
+    2. Mock completed claim discovery for the consumed request
+    3. Mock the robust receipt wait and recovered transaction creation
+    4. Call check_and_resolve_vault_settlements
+    5. Verify the recovered transaction is stored and the trade succeeds
+    """
+    from tradeexecutor.ethereum.vault.settlement_retry import check_and_resolve_vault_settlements
+
+    state = State()
+    ts = datetime.datetime(2025, 1, 1)
+
+    state.portfolio.initialise_reserves(usdc_arbitrum)
+    reserve = state.portfolio.get_default_reserve_position()
+    reserve.quantity = Decimal(10_000)
+    reserve.reserve_token_price = 1.0
+
+    # 1. Create a vault buy trade whose request status is already consumed
+    trade = _create_vault_buy_trade(state, vault_pair, usdc_arbitrum, Decimal(100), ts)
+    state.start_execution(ts, trade)
+    trade.mark_broadcasted(ts)
+
+    approve_tx = BlockchainTransaction()
+    approve_tx.tx_hash = "0xapprove"
+    request_tx = BlockchainTransaction()
+    request_tx.tx_hash = "0xrequest"
+    trade.blockchain_transactions = [approve_tx, request_tx]
+
+    trade.other_data["vault_async_flow"] = True
+    trade.other_data["vault_chain_id"] = 42161
+    trade.other_data["vault_direction"] = "deposit"
+    trade.other_data["vault_owner_address"] = "0xTestOwner"
+    trade.other_data["vault_raw_amount"] = 100_000_000
+    trade.other_data["vault_address"] = OLP_ARBITRUM_ADDRESS
+    trade.other_data["vault_request_tx_hash"] = "0xrequest"
+    trade.other_data["vault_settlement_id"] = 42
+    trade.other_data["vault_request_tx_count"] = 2
+    trade.vault_settlement_pending_at = ts
+
+    mock_deposit_manager = MagicMock()
+    mock_deposit_manager.get_deposit_request_status.return_value = AsyncVaultRequestStatus.none
+    mock_deposit_manager.reconstruct_deposit_ticket.return_value = MagicMock()
+    mock_deposit_manager.finish_deposit.return_value = MagicMock()
+
+    mock_analysis = MagicMock(spec=DepositRedeemEventAnalysis)
+    mock_analysis.denomination_amount = Decimal(100)
+    mock_analysis.share_count = Decimal("96.15")
+    mock_deposit_manager.analyse_deposit.return_value = mock_analysis
+
+    mock_vault = MagicMock()
+    mock_vault.get_deposit_manager.return_value = mock_deposit_manager
+
+    mock_web3 = MagicMock()
+    mock_execution_model = MagicMock()
+    mock_execution_model.web3 = mock_web3
+
+    recovered_tx_hash = HexBytes("0x" + "12" * 32)
+    recovered_tx = BlockchainTransaction()
+    recovered_tx.tx_hash = recovered_tx_hash.hex()
+    recovered_tx.other["vault_settlement_action"] = "claim"
+    mock_receipt = {"status": 1, "transactionHash": recovered_tx_hash, "blockNumber": 100}
+
+    # 2. Mock completed claim discovery for the consumed request
+    # 3. Mock the robust receipt wait and recovered transaction creation
+    with (
+        patch("tradeexecutor.ethereum.vault.settlement_retry.get_vault_for_pair", return_value=mock_vault),
+        patch("tradeexecutor.ethereum.vault.settlement_retry._find_already_completed_claim_tx_hash", return_value=recovered_tx_hash),
+        patch("tradeexecutor.ethereum.vault.settlement_retry._create_recovered_claim_transaction", return_value=recovered_tx),
+        patch("tradeexecutor.ethereum.vault.settlement_retry.wait_for_transaction_receipt_robust", return_value=mock_receipt) as wait_receipt,
+    ):
+        # 4. Call check_and_resolve_vault_settlements
+        resolved = check_and_resolve_vault_settlements(
+            state=state,
+            execution_model=mock_execution_model,
+        )
+
+    # 5. Verify the recovered transaction is stored and the trade succeeds
+    assert len(resolved) == 1
+    assert trade.get_status() == TradeStatus.success
+    assert trade.blockchain_transactions[-1] is recovered_tx
+    wait_receipt.assert_called_once()
 
 
 def test_vault_settlement_retry_pending_skipped(
@@ -536,7 +710,6 @@ def test_vault_settlement_retry_reclaimable(
     mock_web3 = MagicMock()
     mock_receipt = {"status": 1, "transactionHash": b"\x00" * 32, "blockNumber": 100}
     mock_web3.eth.send_raw_transaction.return_value = b"\x00" * 32
-    mock_web3.eth.wait_for_transaction_receipt.return_value = mock_receipt
 
     mock_execution_model = MagicMock()
     mock_execution_model.web3 = mock_web3
@@ -548,7 +721,10 @@ def test_vault_settlement_retry_reclaimable(
     mock_execution_model.tx_builder.sign_transaction.return_value = mock_tx
 
     # 4. Call retry
-    with patch("tradeexecutor.ethereum.vault.settlement_retry.get_vault_for_pair", return_value=mock_vault):
+    with (
+        patch("tradeexecutor.ethereum.vault.settlement_retry.get_vault_for_pair", return_value=mock_vault),
+        patch("tradeexecutor.ethereum.vault.settlement_retry.wait_for_transaction_receipt_robust", return_value=mock_receipt),
+    ):
         resolved = check_and_resolve_vault_settlements(
             state=state,
             execution_model=mock_execution_model,

--- a/tradeexecutor/ethereum/vault/settlement_retry.py
+++ b/tradeexecutor/ethereum/vault/settlement_retry.py
@@ -17,6 +17,7 @@ from eth_defi.abi import get_topic_signature_from_event
 from eth_defi.compat import native_datetime_utc_now
 from eth_defi.event_reader.conversion import convert_bytes32_to_address, convert_bytes32_to_uint
 from eth_defi.hotwallet import HotWallet
+from eth_defi.provider.receipt import wait_for_transaction_receipt_robust
 from eth_defi.vault.deposit_redeem import (
     AsyncVaultRequestStatus,
     DepositRedeemEventAnalysis,
@@ -33,6 +34,8 @@ from tradeexecutor.state.state import State
 from tradeexecutor.state.trade import TradeExecution, TradeStatus
 
 logger = logging.getLogger(__name__)
+
+VAULT_SETTLEMENT_RECEIPT_TIMEOUT = 120
 
 
 def _get_chain_aware_tx_builder(
@@ -64,6 +67,30 @@ def _get_chain_aware_tx_builder(
         return LagoonTransactionBuilder(satellite_vault, satellite_wallet, tx_builder.extra_gnosis_gas)
 
     return HotWalletTransactionBuilder(web3, satellite_wallet)
+
+
+def _broadcast_and_wait_for_settlement_tx(
+    web3: Web3,
+    tx: BlockchainTransaction,
+    mark_broadcasted: bool = False,
+):
+    """Broadcast a vault settlement transaction and wait for all RPCs to see it."""
+    web3.eth.send_raw_transaction(HexBytes(tx.signed_bytes))
+    if mark_broadcasted:
+        tx.broadcasted_at = native_datetime_utc_now()
+    return _wait_for_settlement_tx_receipt(web3, tx.tx_hash)
+
+
+def _wait_for_settlement_tx_receipt(
+    web3: Web3,
+    tx_hash: HexBytes | str,
+):
+    """Wait until a vault settlement transaction receipt is visible."""
+    return wait_for_transaction_receipt_robust(
+        web3,
+        HexBytes(tx_hash),
+        timeout=VAULT_SETTLEMENT_RECEIPT_TIMEOUT,
+    )
 
 
 def _normalise_topic_address(topic) -> str:
@@ -332,10 +359,7 @@ def _resolve_single_vault_trade(
         if has_existing_post_tx and not tx_already_confirmed:
             # Rebroadcast
             try:
-                web3.eth.send_raw_transaction(HexBytes(existing_tx.signed_bytes))
-                confirmed_receipt = web3.eth.wait_for_transaction_receipt(
-                    HexBytes(existing_tx.tx_hash), timeout=120,
-                )
+                confirmed_receipt = _broadcast_and_wait_for_settlement_tx(web3, existing_tx)
                 if confirmed_receipt["status"] == 1:
                     tx_already_confirmed = True
                 else:
@@ -380,7 +404,9 @@ def _resolve_single_vault_trade(
                 func = deposit_manager.finish_deposit(ticket)
             else:
                 func = deposit_manager.finish_redemption(ticket)
-            confirmed_receipt = web3.eth.get_transaction_receipt(recovered_tx_hash)
+            # Even recovered claims need the same read-after-write guard before
+            # immediate event analysis on multi-RPC providers.
+            confirmed_receipt = _wait_for_settlement_tx_receipt(web3, recovered_tx_hash)
             trade.blockchain_transactions.append(
                 _create_recovered_claim_transaction(
                     web3,
@@ -442,10 +468,10 @@ def _resolve_single_vault_trade(
 
             # Broadcast and wait
             try:
-                web3.eth.send_raw_transaction(HexBytes(new_tx.signed_bytes))
-                new_tx.broadcasted_at = native_datetime_utc_now()
-                confirmed_receipt = web3.eth.wait_for_transaction_receipt(
-                    HexBytes(new_tx.tx_hash), timeout=120,
+                confirmed_receipt = _broadcast_and_wait_for_settlement_tx(
+                    web3,
+                    new_tx,
+                    mark_broadcasted=True,
                 )
             except Exception as e:
                 logger.warning(


### PR DESCRIPTION
## Why

Vault settlement retry runs during daemon startup and on each strategy cycle. When a Lagoon or other async vault claim becomes claimable, the resolver broadcasts the claim and immediately analyses the resulting events.

On live multi-RPC providers, a plain Web3 receipt wait can return while another read backend still cannot serve the claimed block or fresh state. This can surface as startup-time RPC errors like missing block data during vault settlement recovery.

## Lessons learnt

Receipt visibility is not enough for this flow: the resolver needs the claim transaction receipt, logs, and follow-up reads to be visible consistently across read providers before it updates trade state.

The recovery branch for already-completed claims has the same consistency requirement as freshly broadcast and rebroadcast settlement transactions.

## Summary

- Use `wait_for_transaction_receipt_robust()` for vault settlement claim/reclaim receipt waits.
- Add small settlement receipt helper functions to keep broadcast/retry paths consistent.
- Update vault settlement lifecycle tests to mock the robust receipt helper.
- Document the multi-RPC consistency reason in the vault deposit/redeem deep-dive.
