### PR TITLE
fix: refresh vault metadata before repair startup

### DIFF
--- a/strategies/hyper-ai.py
+++ b/strategies/hyper-ai.py
@@ -276,7 +276,23 @@ def create_trading_universe(
         min_tvl=parameters.min_tvl_usd,
         min_age=0.0,
     )
-    vault_universe = load_vault_universe_with_metadata(client, vaults=source_vaults)
+    vault_universe = load_vault_universe_with_metadata(
+        client,
+        vaults=source_vaults,
+        check_all_vaults_found=False,
+    )
+    metadata_vault_specs = {
+        (ChainId(vault.chain_id), vault.vault_address.lower())
+        for vault in vault_universe.iterate_vaults()
+    }
+    missing_source_vaults = [
+        (chain_id, address)
+        for chain_id, address in source_vaults
+        if (chain_id, address.lower()) not in metadata_vault_specs
+    ]
+    if missing_source_vaults:
+        missing_vault_list = ", ".join(f"{chain_id.value}:{address}" for chain_id, address in missing_source_vaults)
+        debug_printer(f"Skipped {len(missing_source_vaults)} Hypercore vaults missing from remote vault metadata: {missing_vault_list}")
     vault_universe = vault_universe.limit_to_denomination(ALLOWED_VAULT_DENOMINATION_TOKENS, check_all_vaults_found=True)
     debug_printer(f"Loaded {vault_universe.get_vault_count()} vaults from remote vault metadata, source vaults count: {len(source_vaults)}")
 

--- a/strategies/test_only/hyper-ai-test.py
+++ b/strategies/test_only/hyper-ai-test.py
@@ -251,7 +251,23 @@ def create_trading_universe(
 
     vaults = get_vaults()
 
-    vault_universe = load_vault_universe_with_metadata(client, vaults=vaults)
+    vault_universe = load_vault_universe_with_metadata(
+        client,
+        vaults=vaults,
+        check_all_vaults_found=False,
+    )
+    metadata_vault_specs = {
+        (ChainId(vault.chain_id), vault.vault_address.lower())
+        for vault in vault_universe.iterate_vaults()
+    }
+    missing_source_vaults = [
+        (chain_id, address)
+        for chain_id, address in vaults
+        if (chain_id, address.lower()) not in metadata_vault_specs
+    ]
+    if missing_source_vaults:
+        missing_vault_list = ", ".join(f"{chain_id.value}:{address}" for chain_id, address in missing_source_vaults)
+        debug_printer(f"Skipped {len(missing_source_vaults)} Hypercore vaults missing from remote vault metadata: {missing_vault_list}")
     vault_universe = vault_universe.limit_to_denomination(ALLOWED_VAULT_DENOMINATION_TOKENS, check_all_vaults_found=True)
     debug_printer(f"Loaded {vault_universe.get_vault_count()} vaults from remote vault metadata, source vaults count: {len(vaults)}")
 

--- a/tests/test_vault_download_root.py
+++ b/tests/test_vault_download_root.py
@@ -3,7 +3,10 @@
 from pathlib import Path
 from types import SimpleNamespace
 
-from tradeexecutor.strategy.trading_strategy_universe import _resolve_vault_download_root
+from tradeexecutor.strategy.trading_strategy_universe import (
+    _resolve_vault_download_root,
+    refresh_vault_universe_metadata_cache,
+)
 
 
 def test_vault_download_root_uses_client_cache_path(tmp_path: Path) -> None:
@@ -74,3 +77,66 @@ def test_vault_download_root_falls_back_for_mock_clients() -> None:
     # 3. Check that both return ``None`` for the lower-level default fallback.
     assert missing_transport_root is None
     assert missing_cache_path_root is None
+
+
+def test_refresh_vault_universe_metadata_cache_replaces_only_metadata_json(tmp_path: Path) -> None:
+    """Verify repair startup can force a fresh vault metadata download.
+
+    1. Create a client-like object with cached vault metadata and another unrelated file.
+    2. Refresh the vault universe metadata cache.
+    3. Check the vault metadata file was replaced while unrelated cache data remains.
+    """
+    cache_path = tmp_path / "client-cache"
+    vault_download_root = cache_path / "vaults" / "downloads"
+    vault_download_root.mkdir(parents=True)
+    vault_universe_file = vault_download_root / "vault-universe.json"
+    unrelated_file = vault_download_root / "vault-price-history.parquet"
+    vault_universe_file.write_text("old")
+    unrelated_file.write_text("keep")
+
+    def _fetch_vault_universe(download_root: Path) -> None:
+        (Path(download_root) / "vault-universe.json").write_text("fresh")
+
+    client = SimpleNamespace(
+        transport=SimpleNamespace(cache_path=cache_path),
+        fetch_vault_universe=_fetch_vault_universe,
+    )
+
+    # 1. Create a client-like object with cached vault metadata and another unrelated file.
+    # 2. Refresh the vault universe metadata cache.
+    refreshed_path = refresh_vault_universe_metadata_cache(client)
+
+    # 3. Check the vault metadata file was replaced while unrelated cache data remains.
+    assert refreshed_path == vault_universe_file
+    assert vault_universe_file.read_text() == "fresh"
+    assert unrelated_file.exists()
+
+
+def test_refresh_vault_universe_metadata_cache_restores_stale_file_on_failure(tmp_path: Path) -> None:
+    """Verify repair startup keeps stale vault metadata if refresh fails.
+
+    1. Create a client-like object with cached vault metadata.
+    2. Refresh the vault universe metadata cache with a failing downloader.
+    3. Check the stale vault metadata file was restored for fallback startup.
+    """
+    cache_path = tmp_path / "client-cache"
+    vault_download_root = cache_path / "vaults" / "downloads"
+    vault_download_root.mkdir(parents=True)
+    vault_universe_file = vault_download_root / "vault-universe.json"
+    vault_universe_file.write_text("old")
+
+    def _fetch_vault_universe(download_root: Path) -> None:
+        raise RuntimeError("Download failed")
+
+    client = SimpleNamespace(
+        transport=SimpleNamespace(cache_path=cache_path),
+        fetch_vault_universe=_fetch_vault_universe,
+    )
+
+    # 1. Create a client-like object with cached vault metadata.
+    # 2. Refresh the vault universe metadata cache with a failing downloader.
+    restored_path = refresh_vault_universe_metadata_cache(client)
+
+    # 3. Check the stale vault metadata file was restored for fallback startup.
+    assert restored_path == vault_universe_file
+    assert vault_universe_file.read_text() == "old"

--- a/tests/test_vault_metadata_loader.py
+++ b/tests/test_vault_metadata_loader.py
@@ -1,0 +1,52 @@
+"""Tests for vault metadata loader options."""
+
+from types import SimpleNamespace
+
+from tradingstrategy.chain import ChainId
+
+from tradeexecutor.strategy.trading_strategy_universe import load_vault_universe_with_metadata
+
+
+def _make_client(calls: list[bool]) -> SimpleNamespace:
+    """Create a fake client whose vault universe records strictness flags."""
+    vault_universe = SimpleNamespace()
+
+    def _limit_to_vaults(
+        vaults: list[tuple[ChainId, str]],
+        check_all_vaults_found: bool = True,
+    ) -> SimpleNamespace:
+        calls.append(check_all_vaults_found)
+        return vault_universe
+
+    vault_universe.limit_to_vaults = _limit_to_vaults
+    return SimpleNamespace(
+        transport=SimpleNamespace(cache_path=None),
+        fetch_vault_universe=lambda url=None, download_root=None: vault_universe,
+    )
+
+
+def test_load_vault_universe_with_metadata_forwards_missing_vault_strictness() -> None:
+    """Verify vault metadata loading can tolerate fresher source vault lists.
+
+    1. Create a fake vault universe that records the strictness flag it receives.
+    2. Load metadata with the default arguments.
+    3. Load metadata with missing vault checks disabled.
+    4. Confirm both strictness values were forwarded to the vault universe.
+    """
+    vaults = [(ChainId.hypercore, "0xc8913adaf1174034c1dc5881a2526ee18e03ccf5")]
+    calls: list[bool] = []
+    client = _make_client(calls)
+
+    # 1. Create a fake vault universe that records the strictness flag it receives.
+    # 2. Load metadata with the default arguments.
+    load_vault_universe_with_metadata(client, vaults=vaults)
+
+    # 3. Load metadata with missing vault checks disabled.
+    load_vault_universe_with_metadata(
+        client,
+        vaults=vaults,
+        check_all_vaults_found=False,
+    )
+
+    # 4. Confirm both strictness values were forwarded to the vault universe.
+    assert calls == [True, False]

--- a/tradeexecutor/cli/commands/repair.py
+++ b/tradeexecutor/cli/commands/repair.py
@@ -27,7 +27,7 @@ from ...strategy.execution_model import AssetManagementMode
 from ...strategy.generic.generic_pricing_model import GenericPricing
 from ...strategy.run_state import RunState
 from ...strategy.strategy_module import read_strategy_module
-from ...strategy.trading_strategy_universe import TradingStrategyUniverseModel
+from ...strategy.trading_strategy_universe import TradingStrategyUniverseModel, refresh_vault_universe_metadata_cache
 from ...strategy.universe_model import UniverseOptions
 from ...utils.timer import timed_task
 from eth_defi.compat import native_datetime_utc_now
@@ -135,6 +135,7 @@ def repair(
         asset_management_mode=asset_management_mode,  # Needed for Velvet
     )
     assert client is not None, "You need to give details for TradingStrategy.ai client"
+    refresh_vault_universe_metadata_cache(client)
 
     if not state_file:
         state_file = f"state/{id}.json"

--- a/tradeexecutor/strategy/trading_strategy_universe.py
+++ b/tradeexecutor/strategy/trading_strategy_universe.py
@@ -2297,6 +2297,7 @@ def load_vault_universe_with_metadata(
     vaults: list[tuple[ChainId, JSONHexAddress]] | None = None,
     url: str | None = None,
     download_root: str | Path | None = None,
+    check_all_vaults_found: bool = True,
 ) -> VaultUniverse:
     """Load vault universe with full metadata from JSON blob.
 
@@ -2345,6 +2346,12 @@ def load_vault_universe_with_metadata(
         Override the root directory used for downloaded vault metadata.
         Useful in tests to redirect downloads under ``tmp_path``.
 
+    :param check_all_vaults_found:
+        Raise an assertion if any explicitly requested vault is missing from
+        the downloaded metadata universe. Disable this when the requested
+        vault list comes from a fresher upstream source than the metadata
+        export and missing vaults should be skipped.
+
     :return:
         VaultUniverse containing Vault instances with full VaultMetadata.
     """
@@ -2352,7 +2359,7 @@ def load_vault_universe_with_metadata(
     vault_universe = client.fetch_vault_universe(url=url, download_root=download_root)
 
     if vaults is not None:
-        vault_universe = vault_universe.limit_to_vaults(vaults, check_all_vaults_found=True)
+        vault_universe = vault_universe.limit_to_vaults(vaults, check_all_vaults_found=check_all_vaults_found)
 
     return vault_universe
 
@@ -2406,6 +2413,60 @@ def _resolve_vault_download_root(
         return None
 
     return Path(cache_path) / "vaults" / "downloads"
+
+
+def _get_vault_universe_metadata_cache_path(
+    client: BaseClient,
+) -> Path | None:
+    """Resolve the cached vault metadata JSON path for a client."""
+    download_root = _resolve_vault_download_root(client, None)
+    if download_root is None:
+        return None
+
+    return Path(download_root) / "vault-universe.json"
+
+
+def refresh_vault_universe_metadata_cache(
+    client: BaseClient,
+) -> Path | None:
+    """Refresh cached vault metadata JSON for a client.
+
+    Repair-style commands need the latest vault metadata before constructing a
+    strategy universe, because stale metadata can fail startup before any state
+    repair logic runs. Keep the old cache as a fallback if the fresh download
+    fails, so repair is not made worse during a Trading Strategy data outage.
+
+    :return:
+        Refreshed cache file path, or ``None`` if no cache path is available.
+    """
+    cache_path = _get_vault_universe_metadata_cache_path(client)
+    if cache_path is None:
+        logger.info("Vault metadata cache path unavailable for client %s", client)
+        return None
+
+    backup_path = cache_path.with_suffix(f"{cache_path.suffix}.repair-backup")
+    if not cache_path.exists():
+        backup_path = None
+    else:
+        if backup_path.exists():
+            backup_path.unlink()
+        cache_path.replace(backup_path)
+
+    try:
+        client.fetch_vault_universe(download_root=cache_path.parent)
+    except Exception:
+        if backup_path is not None and backup_path.exists():
+            if cache_path.exists():
+                cache_path.unlink()
+            backup_path.replace(cache_path)
+            logger.warning("Could not refresh vault metadata cache, restored stale file: %s", cache_path, exc_info=True)
+            return cache_path
+        raise
+
+    if backup_path is not None and backup_path.exists():
+        backup_path.unlink()
+    logger.info("Refreshed vault metadata cache file: %s", cache_path)
+    return cache_path
 
 
 def load_partial_data(


### PR DESCRIPTION
## Why

`repair` constructs the strategy universe before it can repair state. Hyper AI can select vaults from fresh HyperCore metadata while `Client.fetch_vault_universe()` still uses a 24-hour cached `vault-universe.json`, causing startup to abort before any repair logic runs.

The command should refresh the vault metadata cache at startup so repair can use the latest vault export without clearing all dataset caches. If the fresh download fails, repair should keep the stale cache as a fallback instead of making an incident response path less available.

## Lessons learnt

Vault metadata freshness matters for startup-only commands as well as live trading loops. A stale vault metadata JSON can block repair before the state file is even reconciled, so repair needs a narrower cache refresh than the global dataset cache purge.

The HyperCore source-vault list and the vault metadata export can also disagree briefly. That mismatch should be visible in logs without assuming opaque vault spec helper equality semantics.

## Summary

- Refresh cached `vault-universe.json` before `repair` constructs the universe, while restoring the stale file if the refresh fails.
- Let vault metadata loading optionally tolerate missing requested vaults, and use that for Hyper AI source vault lists.
- Log any HyperCore source vaults skipped because they are absent from the metadata export using explicit `(chain_id, lower_address)` comparison.
- Add focused tests for vault metadata cache refresh, stale-cache fallback, and missing-vault strictness forwarding.
