### PR TITLE
build: keep guard ABI bundle in Docker context

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -69,3 +69,7 @@ deps/web3-ethereum-defi/eth_defi/abi/**/Vm*.json
 deps/web3-ethereum-defi/eth_defi/abi/**/Std*.json
 deps/web3-ethereum-defi/eth_defi/abi/**/console*.json
 deps/web3-ethereum-defi/eth_defi/abi/**/safeconsole.json
+
+# Guard ABI bundle is needed at runtime by HyperCore vault execution.
+!deps/web3-ethereum-defi/eth_defi/abi/guard/
+!deps/web3-ethereum-defi/eth_defi/abi/guard/**


### PR DESCRIPTION
## Why

The Docker runtime pruning rules removed `eth_defi/abi/guard/MockCoreDepositWallet.json`, which HyperCore vault withdrawal execution loads at runtime. The guard ABI bundle also contains `MockCoreWriter.json`, used by the same execution path.

## Lessons learnt

The guard ABI directory contains files with mock-style names that are still production runtime ABIs for HyperCore system contract calls. Name-based pruning of ABI artefacts needs an explicit guard bundle exception.

## Summary

- Keep `deps/web3-ethereum-defi/eth_defi/abi/guard/**` in the Docker build context after the generated ABI pruning rules.
- Restore Docker image availability for HyperCore guard ABIs without changing application code.