### PR TITLE
Fix async vault reserve allocation accounting

### DIFF
--- a/.claude/docs/agent-tricks-and-troubleshooting.md
+++ b/.claude/docs/agent-tricks-and-troubleshooting.md
@@ -1,5 +1,9 @@
 # Agent tricks and troubleshooting
 
+Read this document before invoking Claude CLI or Codex CLI from another agent.
+It contains local invocation details that are easy to get wrong, especially for
+non-interactive Claude review runs.
+
 This note covers practical ways to use Codex CLI and Claude CLI as local engineering agents, especially when one agent is used to review or debug the other agent's work.
 
 ## Codex CLI
@@ -64,6 +68,7 @@ Common commands:
 claude
 claude -p "Review the current worktree diff"
 claude -p "Review the current worktree diff" --output-format stream-json --verbose
+claude auth status
 claude ultrareview master --timeout 15
 claude doctor
 claude agents
@@ -86,9 +91,29 @@ Useful capabilities:
 - Debug logging with `--debug` or `--debug-file`.
 - MCP and plugin management.
 
+Important authentication note:
+
+- Do not use `--bare` to check whether Claude is signed in. Bare mode skips
+  keychain/OAuth credentials by design and only uses `ANTHROPIC_API_KEY` or an
+  `apiKeyHelper` from `--settings`. A signed-in Unix user can therefore see
+  `Not logged in` in `--bare` mode even though normal `claude -p` works.
+- Use normal mode for local signed-in accounts:
+
+```shell
+claude auth status
+claude -p "Say OK"
+```
+
+- Use `--safe-mode` instead of `--bare` when debugging broken customisations
+  but you still want normal auth, model selection and built-in permissions to
+  work.
+
 Recommended local patterns:
 
 ```shell
+# Smoke-test non-interactive auth and startup.
+claude -p "Say OK"
+
 # Plain one-shot review. Good when you can wait for final buffered output.
 claude -p "Review the current git diff for correctness bugs"
 
@@ -103,6 +128,11 @@ claude -p "Review the current worktree diff. Do not edit files." \
   --dangerously-skip-permissions \
   --allowedTools "Bash,Read,Grep,Glob"
 
+# Safer read-only review without broad bypass mode.
+claude -p "Review the current worktree diff. Do not edit files. Findings first." \
+  --permission-mode dontAsk \
+  --allowedTools "Bash(git status:*),Bash(git diff:*),Bash(sed:*),Bash(rg:*)"
+
 # Avoid pasting huge diffs into the prompt. Make Claude inspect files itself.
 claude -p "Review uncommitted changes. First run git diff --name-only, then inspect targeted diffs."
 
@@ -111,6 +141,19 @@ claude ultrareview master --timeout 15
 ```
 
 For long-running `claude -p` jobs, prefer `--output-format stream-json --verbose`. Text mode can look idle because useful output may be buffered until the final answer.
+
+If a broad review stalls, first verify that basic non-interactive mode and
+read-only Bash tools work before assuming auth is broken:
+
+```shell
+claude -p "Say OK"
+claude -p "Run git status --short and summarise it in one sentence." \
+  --allowedTools "Bash(git status:*)"
+```
+
+If these work but the broad review times out, shrink the request: ask Claude to
+inspect `git diff --name-only` first, review one file group at a time, or provide
+a concise summary of the proposed fix instead of embedding a large diff.
 
 ### Reviewing a plan or document with Claude CLI
 
@@ -407,15 +450,22 @@ Symptoms:
 - `doctor` reports missing auth.
 - MCP servers show `needs-auth`.
 - Tools that depend on external services are absent.
+- `claude --bare -p "Say OK"` says `Not logged in`.
 
 Avoid it:
 
 ```shell
 codex doctor
 codex mcp list
+claude auth status
+claude -p "Say OK"
 claude doctor
 claude mcp
 ```
+
+Do not diagnose normal Claude CLI auth with `--bare`; it intentionally skips
+keychain/OAuth credentials. Use `claude auth status` and a normal `claude -p`
+smoke test instead.
 
 Do not assume missing MCP tools are model limitations. Check installation, auth, workspace policy, and whether the session needs restarting after a config change.
 

--- a/tests/ethereum/test_vault_settlement_lifecycle.py
+++ b/tests/ethereum/test_vault_settlement_lifecycle.py
@@ -119,7 +119,7 @@ def test_vault_settlement_pending_value_in_equity(
 
     1. Create a state with reserves and a vault deposit (buy) trade
     2. Advance trade to vault_settlement_pending
-    3. Verify get_vault_settlement_pending_value() returns the planned_reserve
+    3. Verify reserve cash was debited and get_vault_settlement_pending_value() returns the planned_reserve
     4. Verify calculate_total_equity() includes the pending value
     """
     state = State()
@@ -154,8 +154,10 @@ def test_vault_settlement_pending_value_in_equity(
     }
     state.mark_vault_settlement_pending(ts, trade, ticket_data)
 
-    # 3. Verify status and pending value
+    # 3. Verify reserve cash was debited and get_vault_settlement_pending_value() returns the planned_reserve.
     assert trade.get_status() == TradeStatus.vault_settlement_pending
+    assert trade.reserve_currency_allocated == pytest.approx(Decimal(500))
+    assert reserve.quantity == pytest.approx(Decimal(9_500))
     pending_value = state.portfolio.get_vault_settlement_pending_value()
     assert pending_value == pytest.approx(500.0)
 
@@ -403,6 +405,250 @@ def test_vault_settlement_retry_claimable(
     assert trade.vault_settlement_pending_at is None
     assert trade.executed_reserve == pytest.approx(Decimal(100))
     assert trade.executed_quantity == pytest.approx(Decimal("96.15"))
+
+
+def test_vault_settlement_retry_repairs_legacy_missing_reserve_debit(
+    vault_pair: TradingPairIdentifier,
+    usdc_arbitrum: AssetIdentifier,
+):
+    """Verify settlement retry repairs older pending deposit state with missing reserve debit.
+
+    1. Create a vault deposit that is pending settlement.
+    2. Simulate a legacy/corrupt state where reserve cash was put back and allocation was lost.
+    3. Mock the deposit manager to return CLAIMABLE status and claim analysis.
+    4. Resolve the settlement retry.
+    5. Verify the reserve debit exists after claim, so cash is not overstated.
+
+    The legacy mutation is mocked because current ``mark_vault_settlement_pending()``
+    rejects this state; the test reproduces a persisted state from before that guard.
+    """
+    state = State()
+    ts = datetime.datetime(2025, 1, 1)
+
+    # 1. Create a vault deposit that is pending settlement.
+    state.portfolio.initialise_reserves(usdc_arbitrum)
+    reserve = state.portfolio.get_default_reserve_position()
+    reserve.quantity = Decimal(10_000)
+    reserve.reserve_token_price = 1.0
+    trade = _create_vault_buy_trade(state, vault_pair, usdc_arbitrum, Decimal(100), ts)
+    state.start_execution(ts, trade)
+    trade.mark_broadcasted(ts)
+
+    approve_tx = BlockchainTransaction()
+    approve_tx.tx_hash = "0xapprove"
+    request_tx = BlockchainTransaction()
+    request_tx.tx_hash = "0xrequest"
+    trade.blockchain_transactions = [approve_tx, request_tx]
+    state.mark_vault_settlement_pending(
+        ts,
+        trade,
+        {
+            "vault_async_flow": True,
+            "vault_chain_id": 42161,
+            "vault_direction": "deposit",
+            "vault_owner_address": "0xTestOwner",
+            "vault_raw_amount": 100_000_000,
+            "vault_address": OLP_ARBITRUM_ADDRESS,
+            "vault_request_tx_hash": "0xrequest",
+            "vault_settlement_id": 42,
+            "vault_request_tx_count": 2,
+        },
+    )
+
+    # 2. Simulate a legacy/corrupt state where reserve cash was put back and allocation was lost.
+    reserve.quantity += Decimal(100)
+    trade.reserve_currency_allocated = None
+    assert reserve.quantity == pytest.approx(Decimal(10_000))
+
+    # 3. Mock the deposit manager to return CLAIMABLE status and claim analysis.
+    mock_deposit_manager = MagicMock()
+    mock_deposit_manager.get_deposit_request_status.return_value = AsyncVaultRequestStatus.claimable
+    mock_deposit_manager.reconstruct_deposit_ticket.return_value = MagicMock()
+    mock_deposit_manager.finish_deposit.return_value = MagicMock()
+    mock_analysis = MagicMock(spec=DepositRedeemEventAnalysis)
+    mock_analysis.denomination_amount = Decimal(100)
+    mock_analysis.share_count = Decimal("96.15")
+    mock_deposit_manager.analyse_deposit.return_value = mock_analysis
+
+    mock_vault = MagicMock()
+    mock_vault.get_deposit_manager.return_value = mock_deposit_manager
+    mock_vault.vault_contract = MagicMock()
+
+    mock_web3 = MagicMock()
+    mock_receipt = {"status": 1, "transactionHash": b"\x00" * 32, "blockNumber": 100}
+    mock_web3.eth.send_raw_transaction.return_value = b"\x00" * 32
+
+    mock_execution_model = MagicMock()
+    mock_execution_model.web3 = mock_web3
+    mock_tx = BlockchainTransaction()
+    mock_tx.tx_hash = "0x" + "ab" * 32
+    mock_tx.signed_bytes = b"\xab" * 32
+    mock_tx.other = {}
+    mock_execution_model.tx_builder.sign_transaction.return_value = mock_tx
+
+    # 4. Resolve the settlement retry.
+    with (
+        patch("tradeexecutor.ethereum.vault.settlement_retry.get_vault_for_pair", return_value=mock_vault),
+        patch("tradeexecutor.ethereum.vault.settlement_retry.wait_for_transaction_receipt_robust", return_value=mock_receipt),
+    ):
+        resolved = check_and_resolve_vault_settlements(
+            state=state,
+            execution_model=mock_execution_model,
+        )
+
+    # 5. Verify the reserve debit exists after claim, so cash is not overstated.
+    assert len(resolved) == 1
+    assert trade.get_status() == TradeStatus.success
+    assert trade.reserve_currency_allocated == pytest.approx(Decimal(0))
+    assert reserve.quantity == pytest.approx(Decimal(9_900))
+    assert trade.executed_reserve == pytest.approx(Decimal(100))
+    assert trade.executed_quantity == pytest.approx(Decimal("96.15"))
+
+
+def test_vault_settlement_retry_repairs_legacy_missing_bridge_allocation(
+    usdc_arbitrum: AssetIdentifier,
+):
+    """Verify settlement retry repairs older satellite vault deposits with missing bridge allocation.
+
+    1. Create a CCTP bridge position from Arbitrum to Base.
+    2. Create a Base vault deposit funded from the bridge position.
+    3. Simulate a legacy/corrupt state where bridge allocation was lost.
+    4. Resolve the settlement retry.
+    5. Verify partial refunds return to bridge capital and home reserves are not credited.
+
+    The legacy mutation is mocked because current ``mark_vault_settlement_pending()``
+    rejects this state; the test reproduces a persisted state from before that guard.
+    """
+    ts = datetime.datetime(2025, 1, 1)
+    state = State()
+    usdc_base = AssetIdentifier(
+        chain_id=8453,
+        address="0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+        token_symbol="USDC",
+        decimals=6,
+    )
+    base_vault_asset = AssetIdentifier(
+        chain_id=8453,
+        address="0x1111111111111111111111111111111111111111",
+        token_symbol="vUSDC",
+        decimals=18,
+    )
+    cctp_pair = TradingPairIdentifier(
+        base=usdc_base,
+        quote=usdc_arbitrum,
+        pool_address="0x28b5a0e9C621a5BadaA536219b3a228C8168cf5d",
+        exchange_address="0x28b5a0e9C621a5BadaA536219b3a228C8168cf5d",
+        fee=0,
+        kind=TradingPairKind.cctp_bridge,
+        other_data={"bridge_protocol": "cctp"},
+    )
+    base_vault_pair = TradingPairIdentifier(
+        base=base_vault_asset,
+        quote=usdc_base,
+        pool_address=base_vault_asset.address,
+        exchange_address=base_vault_asset.address,
+        fee=0,
+        kind=TradingPairKind.vault,
+    )
+
+    # 1. Create a CCTP bridge position from Arbitrum to Base.
+    state.portfolio.initialise_reserves(usdc_arbitrum)
+    reserve = state.portfolio.get_default_reserve_position()
+    reserve.quantity = Decimal(10_000)
+    reserve.reserve_token_price = 1.0
+    _, bridge_trade, _ = state.create_trade(
+        strategy_cycle_at=ts,
+        pair=cctp_pair,
+        quantity=None,
+        reserve=Decimal(100),
+        assumed_price=1.0,
+        trade_type=TradeType.rebalance,
+        reserve_currency=usdc_arbitrum,
+        reserve_currency_price=1.0,
+    )
+    state.start_execution(ts, bridge_trade)
+    bridge_trade.mark_broadcasted(ts)
+    state.mark_trade_success(
+        executed_at=ts,
+        trade=bridge_trade,
+        executed_price=1.0,
+        executed_amount=Decimal(100),
+        executed_reserve=Decimal(100),
+        lp_fees=0,
+        native_token_price=0,
+    )
+    bridge_position = state.portfolio.get_bridge_position_for_chain(8453)
+    assert bridge_position is not None
+    assert reserve.quantity == pytest.approx(Decimal(9_900))
+
+    # 2. Create a Base vault deposit funded from the bridge position.
+    trade = _create_vault_buy_trade(state, base_vault_pair, usdc_arbitrum, Decimal(100), ts)
+    state.start_execution(ts, trade)
+    trade.mark_broadcasted(ts)
+    request_tx = BlockchainTransaction()
+    request_tx.tx_hash = "0xrequest"
+    trade.blockchain_transactions = [request_tx]
+    state.mark_vault_settlement_pending(
+        ts,
+        trade,
+        {
+            "vault_async_flow": True,
+            "vault_chain_id": 8453,
+            "vault_direction": "deposit",
+            "vault_owner_address": "0xTestOwner",
+            "vault_raw_amount": 100_000_000,
+            "vault_address": base_vault_asset.address,
+            "vault_request_tx_hash": "0xrequest",
+            "vault_settlement_id": 42,
+            "vault_request_tx_count": 1,
+        },
+    )
+    assert bridge_position.bridge_capital_allocated == pytest.approx(Decimal(100))
+
+    # 3. Simulate a legacy/corrupt state where bridge allocation was lost.
+    bridge_position.bridge_capital_allocated = Decimal(0)
+    trade.bridge_currency_allocated = None
+
+    mock_deposit_manager = MagicMock()
+    mock_deposit_manager.get_deposit_request_status.return_value = AsyncVaultRequestStatus.claimable
+    mock_deposit_manager.reconstruct_deposit_ticket.return_value = MagicMock()
+    mock_deposit_manager.finish_deposit.return_value = MagicMock()
+    mock_analysis = MagicMock(spec=DepositRedeemEventAnalysis)
+    mock_analysis.denomination_amount = Decimal(80)
+    mock_analysis.share_count = Decimal("76.92")
+    mock_deposit_manager.analyse_deposit.return_value = mock_analysis
+    mock_vault = MagicMock()
+    mock_vault.get_deposit_manager.return_value = mock_deposit_manager
+    mock_vault.vault_contract = MagicMock()
+    mock_web3 = MagicMock()
+    mock_receipt = {"status": 1, "transactionHash": b"\x00" * 32, "blockNumber": 100}
+    mock_web3.eth.send_raw_transaction.return_value = b"\x00" * 32
+    mock_execution_model = MagicMock()
+    mock_execution_model.web3 = mock_web3
+    mock_tx = BlockchainTransaction()
+    mock_tx.tx_hash = "0x" + "ab" * 32
+    mock_tx.signed_bytes = b"\xab" * 32
+    mock_tx.other = {}
+    mock_execution_model.tx_builder.sign_transaction.return_value = mock_tx
+
+    # 4. Resolve the settlement retry.
+    with (
+        patch("tradeexecutor.ethereum.vault.settlement_retry.get_vault_for_pair", return_value=mock_vault),
+        patch("tradeexecutor.ethereum.vault.settlement_retry.wait_for_transaction_receipt_robust", return_value=mock_receipt),
+    ):
+        resolved = check_and_resolve_vault_settlements(
+            state=state,
+            execution_model=mock_execution_model,
+        )
+
+    # 5. Verify partial refunds return to bridge capital and home reserves are not credited.
+    assert len(resolved) == 1
+    assert trade.get_status() == TradeStatus.success
+    assert reserve.quantity == pytest.approx(Decimal(9_900))
+    assert bridge_position.bridge_capital_allocated == pytest.approx(Decimal(80))
+    assert trade.bridge_currency_allocated == pytest.approx(Decimal(80))
+    assert trade.executed_reserve == pytest.approx(Decimal(80))
+    assert trade.executed_quantity == pytest.approx(Decimal("76.92"))
 
 
 def test_vault_settlement_retry_rebroadcast_uses_robust_receipt_wait(

--- a/tests/ethereum/test_vault_settlement_lifecycle.py
+++ b/tests/ethereum/test_vault_settlement_lifecycle.py
@@ -986,6 +986,142 @@ def test_vault_settlement_retry_reclaimable(
     assert cash_after == pytest.approx(cash_before + 100.0)
 
 
+def test_vault_settlement_retry_reclaimable_bridge_returns_allocated_capital(
+    usdc_arbitrum: AssetIdentifier,
+):
+    """Verify reclaimable satellite vault deposits release allocated bridge capital.
+
+    1. Create a CCTP bridge position from Arbitrum to Base.
+    2. Create a Base vault deposit funded from the bridge position.
+    3. Mock the deposit manager to return RECLAIMABLE status.
+    4. Resolve the settlement retry.
+    5. Verify the trade fails and bridge capital becomes available again.
+    """
+    ts = datetime.datetime(2025, 1, 1)
+    state = State()
+    usdc_base = AssetIdentifier(
+        chain_id=8453,
+        address="0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+        token_symbol="USDC",
+        decimals=6,
+    )
+    base_vault_asset = AssetIdentifier(
+        chain_id=8453,
+        address="0x1111111111111111111111111111111111111111",
+        token_symbol="vUSDC",
+        decimals=18,
+    )
+    cctp_pair = TradingPairIdentifier(
+        base=usdc_base,
+        quote=usdc_arbitrum,
+        pool_address="0x28b5a0e9C621a5BadaA536219b3a228C8168cf5d",
+        exchange_address="0x28b5a0e9C621a5BadaA536219b3a228C8168cf5d",
+        fee=0,
+        kind=TradingPairKind.cctp_bridge,
+        other_data={"bridge_protocol": "cctp"},
+    )
+    base_vault_pair = TradingPairIdentifier(
+        base=base_vault_asset,
+        quote=usdc_base,
+        pool_address=base_vault_asset.address,
+        exchange_address=base_vault_asset.address,
+        fee=0,
+        kind=TradingPairKind.vault,
+    )
+
+    # 1. Create a CCTP bridge position from Arbitrum to Base.
+    state.portfolio.initialise_reserves(usdc_arbitrum)
+    reserve = state.portfolio.get_default_reserve_position()
+    reserve.quantity = Decimal(10_000)
+    reserve.reserve_token_price = 1.0
+    _, bridge_trade, _ = state.create_trade(
+        strategy_cycle_at=ts,
+        pair=cctp_pair,
+        quantity=None,
+        reserve=Decimal(100),
+        assumed_price=1.0,
+        trade_type=TradeType.rebalance,
+        reserve_currency=usdc_arbitrum,
+        reserve_currency_price=1.0,
+    )
+    state.start_execution(ts, bridge_trade)
+    bridge_trade.mark_broadcasted(ts)
+    state.mark_trade_success(
+        executed_at=ts,
+        trade=bridge_trade,
+        executed_price=1.0,
+        executed_amount=Decimal(100),
+        executed_reserve=Decimal(100),
+        lp_fees=0,
+        native_token_price=0,
+    )
+    bridge_position = state.portfolio.get_bridge_position_for_chain(8453)
+    assert bridge_position is not None
+    assert reserve.quantity == pytest.approx(Decimal(9_900))
+
+    # 2. Create a Base vault deposit funded from the bridge position.
+    trade = _create_vault_buy_trade(state, base_vault_pair, usdc_arbitrum, Decimal(100), ts)
+    state.start_execution(ts, trade)
+    trade.mark_broadcasted(ts)
+    request_tx = BlockchainTransaction()
+    request_tx.tx_hash = "0xrequest"
+    trade.blockchain_transactions = [request_tx]
+    state.mark_vault_settlement_pending(
+        ts,
+        trade,
+        {
+            "vault_async_flow": True,
+            "vault_chain_id": 8453,
+            "vault_direction": "deposit",
+            "vault_owner_address": "0xTestOwner",
+            "vault_raw_amount": 100_000_000,
+            "vault_address": base_vault_asset.address,
+            "vault_request_tx_hash": "0xrequest",
+            "vault_settlement_id": 42,
+            "vault_request_tx_count": 1,
+        },
+    )
+    assert bridge_position.bridge_capital_allocated == pytest.approx(Decimal(100))
+    assert bridge_position.get_available_bridge_capital() == pytest.approx(Decimal(0))
+
+    # 3. Mock the deposit manager to return RECLAIMABLE status.
+    mock_deposit_manager = MagicMock()
+    mock_deposit_manager.get_deposit_request_status.return_value = AsyncVaultRequestStatus.reclaimable
+    mock_deposit_manager.reconstruct_deposit_ticket.return_value = MagicMock()
+    mock_deposit_manager.reclaim_deposit.return_value = MagicMock()
+    mock_vault = MagicMock()
+    mock_vault.get_deposit_manager.return_value = mock_deposit_manager
+    mock_vault.vault_contract = MagicMock()
+    mock_web3 = MagicMock()
+    mock_receipt = {"status": 1, "transactionHash": b"\x00" * 32, "blockNumber": 100}
+    mock_web3.eth.send_raw_transaction.return_value = b"\x00" * 32
+    mock_execution_model = MagicMock()
+    mock_execution_model.web3 = mock_web3
+    mock_tx = BlockchainTransaction()
+    mock_tx.tx_hash = "0x" + "cd" * 32
+    mock_tx.signed_bytes = b"\xcd" * 32
+    mock_tx.other = {}
+    mock_execution_model.tx_builder.sign_transaction.return_value = mock_tx
+
+    # 4. Resolve the settlement retry.
+    with (
+        patch("tradeexecutor.ethereum.vault.settlement_retry.get_vault_for_pair", return_value=mock_vault),
+        patch("tradeexecutor.ethereum.vault.settlement_retry.wait_for_transaction_receipt_robust", return_value=mock_receipt),
+    ):
+        resolved = check_and_resolve_vault_settlements(
+            state=state,
+            execution_model=mock_execution_model,
+        )
+
+    # 5. Verify the trade fails and bridge capital becomes available again.
+    assert len(resolved) == 1
+    assert trade.get_status() == TradeStatus.failed
+    assert trade.vault_settlement_pending_at is None
+    assert reserve.quantity == pytest.approx(Decimal(9_900))
+    assert bridge_position.bridge_capital_allocated == pytest.approx(Decimal(0))
+    assert bridge_position.get_available_bridge_capital() == pytest.approx(Decimal(100))
+
+
 def test_is_swap_function_includes_async_selectors():
     """Verify that requestDeposit and requestWithdraw are recognised as swap functions.
 

--- a/tradeexecutor/ethereum/vault/settlement_retry.py
+++ b/tradeexecutor/ethereum/vault/settlement_retry.py
@@ -11,6 +11,7 @@ Works with any vault protocol that implements the generic
 """
 
 import logging
+from decimal import Decimal
 from itertools import chain as ichain
 
 from eth_defi.abi import get_topic_signature_from_event
@@ -285,6 +286,99 @@ def check_and_resolve_vault_settlements(
     return resolved
 
 
+def _ensure_legacy_pending_deposit_capital_allocated(state: State, trade: TradeExecution) -> None:
+    """Repair old pending deposit state that missed its funding-source allocation.
+
+    Current code debits reserves in ``state.start_execution()`` before the async
+    request is broadcast, or allocates bridge capital for satellite vault
+    deposits. Older/corrupt state can have the request persisted but the funding
+    source still visible. If we claim such a trade without repairing first, the
+    position receives shares while the same capital remains visible elsewhere.
+    """
+    assert trade.is_buy(), f"Only deposit trades can reserve-debit repair, got {trade}"
+
+    planned_reserve = trade.planned_reserve
+
+    bridge_position = state.portfolio.get_bridge_position_for_chain(trade.pair.chain_id)
+    if bridge_position is not None:
+        allocated = trade.bridge_currency_allocated
+        if allocated == planned_reserve:
+            return
+        if allocated not in (None, Decimal(0)):
+            raise RuntimeError(
+                f"Vault deposit trade #{trade.trade_id} has inconsistent bridge allocation: "
+                f"planned_reserve={planned_reserve}, bridge_currency_allocated={allocated}"
+            )
+
+        logger.warning(
+            "Repairing legacy vault pending deposit bridge accounting before claim: "
+            "trade #%d, bridge allocation %s %s was missing",
+            trade.trade_id,
+            planned_reserve,
+            trade.reserve_currency.token_symbol,
+        )
+        bridge_position.adjust_bridge_capital_allocated(planned_reserve)
+        trade.bridge_currency_allocated = planned_reserve
+        return
+
+    allocated = trade.reserve_currency_allocated
+    if allocated == planned_reserve:
+        return
+    if allocated not in (None, Decimal(0)):
+        raise RuntimeError(
+            f"Vault deposit trade #{trade.trade_id} has inconsistent reserve allocation: "
+            f"planned_reserve={planned_reserve}, reserve_currency_allocated={allocated}"
+        )
+
+    logger.warning(
+        "Repairing legacy vault pending deposit reserve accounting before claim: "
+        "trade #%d, reserve debit %s %s was missing",
+        trade.trade_id,
+        planned_reserve,
+        trade.reserve_currency.token_symbol,
+    )
+    state.portfolio.adjust_reserves(
+        trade.reserve_currency,
+        -planned_reserve,
+        f"Repair missing reserve debit for vault pending deposit trade #{trade.trade_id}",
+    )
+    trade.reserve_currency_allocated = planned_reserve
+
+
+def _refund_partial_deposit_to_funding_source(
+    state: State,
+    trade: TradeExecution,
+    refund_amount: Decimal,
+) -> None:
+    """Return an async deposit partial-fill refund to the original funding source."""
+    assert refund_amount > 0, f"Refund amount must be positive, got {refund_amount}"
+
+    if trade.bridge_currency_allocated is not None:
+        bridge_position = state.portfolio.get_bridge_position_for_chain(trade.pair.chain_id)
+        assert bridge_position is not None, f"No bridge position for bridge-funded vault trade #{trade.trade_id}"
+        bridge_position.adjust_bridge_capital_allocated(-refund_amount)
+        trade.bridge_currency_allocated -= refund_amount
+        logger.info(
+            "Vault partial deposit refund returned to bridge position: trade #%d, amount=%s %s",
+            trade.trade_id,
+            refund_amount,
+            trade.reserve_currency.token_symbol,
+        )
+        return
+
+    state.portfolio.adjust_reserves(
+        trade.reserve_currency,
+        refund_amount,
+        f"Vault partial deposit refund: trade #{trade.trade_id}",
+    )
+    logger.info(
+        "Vault partial deposit refund returned to reserves: trade #%d, amount=%s %s",
+        trade.trade_id,
+        refund_amount,
+        trade.reserve_currency.token_symbol,
+    )
+
+
 def _resolve_single_vault_trade(
     state: State,
     trade: TradeExecution,
@@ -518,6 +612,7 @@ def _resolve_single_vault_trade(
             executed_reserve = analysis.denomination_amount
             executed_amount = analysis.share_count
             price = float(executed_reserve / executed_amount) if executed_amount else 0
+            _ensure_legacy_pending_deposit_capital_allocated(state, trade)
         else:
             executed_amount = -analysis.share_count
             executed_reserve = analysis.denomination_amount
@@ -539,11 +634,7 @@ def _resolve_single_vault_trade(
         # Handle partial deposit refunds
         if direction == "deposit" and executed_reserve < trade.planned_reserve:
             refund_amount = trade.planned_reserve - executed_reserve
-            state.portfolio.adjust_reserves(
-                trade.reserve_currency,
-                refund_amount,
-                f"Vault partial deposit refund: trade #{trade.trade_id}",
-            )
+            _refund_partial_deposit_to_funding_source(state, trade, refund_amount)
 
         logger.info(
             "Vault trade #%d settled successfully (direction=%s, amount=%s, reserve=%s, price=%s)",

--- a/tradeexecutor/state/state.py
+++ b/tradeexecutor/state/state.py
@@ -1131,6 +1131,18 @@ class State:
             deposit_manager.serialize_redemption_ticket().
             Protocol-specific fields (e.g. settlement_id) are included by the adapter.
         """
+        if trade.is_buy():
+            allocated = trade.reserve_currency_allocated
+            if allocated is None:
+                allocated = trade.bridge_currency_allocated
+            assert allocated == trade.planned_reserve, (
+                f"Cannot mark vault buy trade #{trade.trade_id} settlement pending without allocated capital. "
+                f"planned_reserve={trade.planned_reserve}, "
+                f"reserve_currency_allocated={trade.reserve_currency_allocated}, "
+                f"bridge_currency_allocated={trade.bridge_currency_allocated}. "
+                "state.start_execution() must debit the funding source before the async request is persisted."
+            )
+
         trade.vault_settlement_pending_at = ts
         trade.other_data["vault_async_flow"] = True
         trade.other_data["vault_chain_id"] = trade.pair.chain_id

--- a/tradeexecutor/state/state.py
+++ b/tradeexecutor/state/state.py
@@ -1079,15 +1079,18 @@ class State:
     def mark_trade_failed(self, failed_at: datetime.datetime, trade: TradeExecution):
         """Unroll the allocated capital."""
         trade.mark_failed(failed_at)
-        # Return unused reserves back to accounting.
-        # Satellite chain trades (spending from CCTP bridge positions)
-        # have no reserve_currency_allocated, so skip the reserve adjustment.
-        if trade.is_buy() and trade.reserve_currency_allocated is not None:
-            self.portfolio.adjust_reserves(
-                trade.reserve_currency,
-                trade.reserve_currency_allocated,
-                f"Trade failed, allocated reserve was not used:\n{trade}"
-            )
+        if trade.is_buy():
+            # Return unused reserves back to accounting.
+            if trade.reserve_currency_allocated is not None:
+                self.portfolio.adjust_reserves(
+                    trade.reserve_currency,
+                    trade.reserve_currency_allocated,
+                    f"Trade failed, allocated reserve was not used:\n{trade}"
+                )
+            elif trade.bridge_currency_allocated is not None:
+                bridge_position = self.portfolio.get_bridge_position_for_chain(trade.pair.chain_id)
+                assert bridge_position is not None, f"No bridge position for failed bridge-funded trade {trade}"
+                bridge_position.adjust_bridge_capital_allocated(-trade.bridge_currency_allocated)
 
     def mark_bridge_in_transit(self, ts: datetime.datetime, trade: TradeExecution):
         """Mark a CCTP bridge trade as in-transit (burn confirmed, receive pending).


### PR DESCRIPTION
## Why

`trade-ui` startup could still report a reserve balance mismatch after resolving pending async vault deposits. The mismatch was not a NAV display problem: a pending deposit could exist without the matching internal capital allocation, leaving the same USDC visible in reserves or bridge capital while the vault position was later credited with shares.

This must be prevented at the state transition that persists an async vault request, and older already-persisted states need a narrow repair path before their claim is settled.

## Lessons learnt

Async vault deposits must carry their funding-source allocation for the whole request/claim lifecycle. Home-chain vault deposits debit reserves; satellite vault deposits allocate CCTP bridge capital. Any partial deposit refund must return to the same funding source, otherwise reserve cash and bridge available capital diverge.

Also, `claude --bare` is not a valid smoke test for a signed-in local Claude CLI session because bare mode skips keychain/OAuth credentials.

## Summary

- Assert that vault buy trades cannot enter `vault_settlement_pending` unless `start_execution()` has already allocated the planned reserve from reserves or bridge capital.
- Repair legacy pending deposit state before claim settlement when the persisted request is missing its reserve debit or bridge allocation.
- Return partial async deposit refunds to the original funding source, including CCTP bridge capital for satellite vault deposits.
- Release bridge capital when bridge-funded satellite buys fail or async deposit requests are reclaimed.
- Extend lifecycle coverage for reserve debits, legacy reserve repair, legacy bridge repair, bridge partial refunds, and bridge-funded reclaim rollback.
- Document correct Claude CLI non-interactive auth and review invocation patterns.
