### PR TITLE
fix: pin Hyper AI remote-data test to the HLP parent vault

### DIFF
--- a/tests/hypercore_writer/test_hyper_ai_remote_data.py
+++ b/tests/hypercore_writer/test_hyper_ai_remote_data.py
@@ -17,11 +17,14 @@ from tradingstrategy.client import Client
 pytestmark = pytest.mark.skipif(os.environ.get("TRADING_STRATEGY_API_KEY") is None, reason="Set TRADING_STRATEGY_API_KEY environment variable to run this test")
 
 
-FIXED_HYPERCORE_VAULTS = [
-    (ChainId.hypercore, "0x010461c14e146ac35fe42271bdc1134ee31c703a"),
-]
-
-#: HLP vault — the main Hyperliquid Liquidity Provider vault.
+#: HLP vault — the main Hyperliquid Liquidity Provider (HLP) parent vault.
+#:
+#: Used as the fixed single-vault universe in these remote-data tests because the
+#: HLP parent is always present in ``top_vaults_by_chain.json`` and always open for
+#: deposits. Do not pin HLP child strategy sub-vaults (e.g. "HLP Strategy A",
+#: ``0x010461c14e146ac35fe42271bdc1134ee31c703a``) here: the vault scanner only
+#: lists the HLP parent, so the universe would filter to empty and fail with
+#: "Vault universe cannot be empty".
 HLP_VAULT = [
     (ChainId.hypercore, "0xdfc24b077bc1425ad1dea75bcb6f8158e10df303"),
 ]
@@ -47,7 +50,7 @@ def test_hyper_ai_strategy_create_trading_universe_uses_remote_vault_data(
     monkeypatch.setattr(
         hyper_ai_strategy_module,
         "build_hyperliquid_vault_universe",
-        lambda min_tvl, min_age: FIXED_HYPERCORE_VAULTS,
+        lambda min_tvl, min_age: HLP_VAULT,
     )
     original_load_vault_universe_with_metadata = hyper_ai_strategy_module.load_vault_universe_with_metadata
     original_load_partial_data = hyper_ai_strategy_module.load_partial_data
@@ -87,7 +90,7 @@ def test_hyper_ai_strategy_create_trading_universe_uses_remote_vault_data(
     strategy_universe = hyper_ai_strategy_module.create_trading_universe(input_data)
 
     # 3. Confirm the resulting universe contains remote vault metadata, candles, liquidity and downloaded files.
-    raw_pair = strategy_universe.data_universe.pairs.get_pair_by_smart_contract(FIXED_HYPERCORE_VAULTS[0][1])
+    raw_pair = strategy_universe.data_universe.pairs.get_pair_by_smart_contract(HLP_VAULT[0][1])
     assert raw_pair is not None
     assert raw_pair.get_vault_metadata() is not None
 


### PR DESCRIPTION
## Problem

`tests/hypercore_writer/test_hyper_ai_remote_data.py::test_hyper_ai_strategy_create_trading_universe_uses_remote_vault_data` fails with `AssertionError: Vault universe cannot be empty`.

Root cause: the test pinned an HLP **child strategy sub-vault** (`0x010461c…703a`, "HLP Strategy A") as its fixed single-vault universe. Following the recent vault-scanner (web3-ethereum-defi) changes now in production, `top_vaults_by_chain.json` lists only the **HLP parent** and no longer includes HLP child sub-vaults. With `check_all_vaults_found=False`, `limit_to_vaults()` silently filters the universe down to an empty set and `VaultUniverse([])` trips the non-empty assertion.

The live universe is otherwise healthy (3,737 vaults, 540 on Hypercore), so this is not an empty-endpoint flake — it is a deterministic consequence of the scanner change and reproduces on every run.

## Fix

Repoint the test to the always-present, always-open HLP **parent** vault (`0xdfc24b…df303`), consolidating onto the existing `HLP_VAULT` constant already used by the sibling `test_hypercore_vault_other_data_populated` test, and add a comment documenting why HLP child sub-vaults must not be pinned here.

Note: this only repoints the test. Whether the scanner dropping all HLP child sub-vaults is intended or a regression in web3-ethereum-defi is a separate question this PR does not address.

🤖 Generated with [Claude Code](https://claude.com/claude-code)