### PR TITLE
fix: account for cross-chain async vault settlements

### DIFF
--- a/.claude/docs/cctp-async-vault-accounting-plan.md
+++ b/.claude/docs/cctp-async-vault-accounting-plan.md
@@ -1,0 +1,358 @@
+# CCTP async vault accounting plan
+
+## Problem
+
+PR #1543 fixed several symptoms in cross-chain CCTP + async vault backtests, but the remaining failure showed that the backtest wallet, portfolio ledger, and bridge planner still disagree during a satellite-chain async vault deposit.
+
+The failing shape is:
+
+1. Capital is bridged from the primary chain to a satellite chain with CCTP.
+2. A satellite vault deposit is requested and the trade enters `vault_settlement_pending`.
+3. Portfolio accounting treats the satellite USDC as committed to the vault request.
+4. The simulated wallet still holds the satellite USDC until settlement.
+5. The post-trade wallet reconciliation compares the wallet against open-position held assets and reports a mismatch.
+
+The fix must not introduce a separate "deployable per-chain liquidity" model. Strategy target equity remains portfolio-wide: capital is moved between chains and positions by generated trades and their execution sort order.
+
+## Facts to preserve
+
+1. There should be no strategy-facing "deployable per-chain liquidity" concept. Target equity is global, and the trade sort mechanism handles the sequence of sells, bridge-backs, bridge-outs, and buys.
+2. The CCTP planner should bridge only the missing amount needed to execute the generated satellite-chain buys after accounting for existing idle satellite bridge capital.
+3. Async vault backtesting should make wallet reconciliation match the simulated vault lifecycle by debiting the simulated wallet at the vault request step, while settlement still follows the standard vault settlement delays and supported vault schedules added in earlier PRs.
+
+## Design direction
+
+Use request-time wallet movement for async vault deposits and redeems in backtests.
+
+For a deposit request:
+
+1. `state.start_execution()` allocates capital from reserves or the CCTP bridge position.
+2. `simulate_async_vault_request()` marks the trade `vault_settlement_pending`.
+3. The simulated wallet immediately debits the vault denomination token,
+   `pair.quote`; this mirrors live behaviour where the reserve/quote balance
+   leaves the owner wallet and enters the vault's deposit queue.
+4. The debited reserve/quote is no longer spendable, bridgeable, or expected in
+   owner-wallet reconciliation while the deposit is pending.
+5. No vault shares are minted yet.
+6. Portfolio equity remains continuous because the pending deposit value is carried by the `vault_settlement_pending` buy trade until shares settle.
+7. Wallet reconciliation expects neither the debited `pair.quote` nor the not-yet-minted `pair.base` shares in the owner wallet during the pending window.
+8. The delayed resolver later mints vault shares at the settlement-cycle price and marks the trade successful.
+
+If the vault price moves before settlement, the pending deposit keeps carrying
+the committed `pair.quote` value until claim. At settlement, the share quantity
+is recalculated from the settlement-cycle price, so the settled share value
+equals the committed quote amount and there is no artificial equity jump at
+claim time.
+
+For a redeem request:
+
+1. The simulated wallet immediately debits the vault share token, `pair.base`, mirroring escrowed shares.
+2. The position still tracks the shares until settlement, so portfolio equity remains continuous.
+3. Existing expected-balance logic for pending redeems must keep subtracting escrowed shares where account checks need owner-wallet balances.
+4. The delayed resolver later credits the denomination token, `pair.quote`, at the settlement-cycle price and marks the trade successful.
+
+If the vault price moves before redeem settlement, the pending redemption
+remains share exposure and should be valued using the same current-price
+valuation path as a held vault position. At claim, the credited `pair.quote`
+must match the settlement-cycle share value, so claim itself does not create an
+extra accounting discontinuity beyond normal NAV movement.
+
+This is closer to live ERC-7540 semantics than leaving request capital in the simulated wallet until claim.
+
+The implementation must keep the portfolio ledger and simulated wallet ledger separate:
+
+- `state.start_execution()` moves capital inside the portfolio accounting ledger only.
+- `simulate_async_vault_request()` moves tokens in the simulated wallet ledger only.
+- `simulate_async_vault_request()` also persists the exact queued amount on the
+  trade: the debited `pair.quote` amount for deposits and the escrowed
+  `pair.base` amount for redeems.
+- Deposit settlement must not debit `pair.quote` again.
+- Redeem settlement must not debit `pair.base` again.
+- Settlement must only credit the token received at claim time and then record the trade success amounts needed by portfolio accounting.
+
+## Coverage goals
+
+Cover bridge and async-vault interactions by lifecycle stage, not just the original failing deposit case.
+
+The detailed deposit/redeem case catalogue lives in
+`.claude/docs/deposit-cases.md`. Keep that file aligned with this plan and use
+it as the checklist when adding regression tests.
+
+The key invariant across all cases is that physical wallet balances, portfolio accounting, and bridge bookkeeping describe the same state:
+
+- pending deposits have spent `pair.quote`, have not minted `pair.base`, and keep equity continuous through pending value,
+- pending redeems have escrowed `pair.base`, have not received `pair.quote`, and keep equity continuous through the existing position value,
+- CCTP bridge positions expose only available satellite USDC as bridgeable capital, excluding capital already committed to async vault requests,
+- the planner only bridges missing amounts and never invents a deployable-per-chain target model.
+
+The target matrix should include:
+
+| Case | Expected behaviour |
+|------|--------------------|
+| Bridge-out then async satellite deposit with no idle satellite capital | Bridge the full missing amount, then debit satellite `pair.quote` at vault request; pending wallet has no deposited USDC and no shares. |
+| Async satellite deposit exactly matches idle satellite capital | Inject no bridge-out; debit exactly the existing satellite `pair.quote`; primary reserve stays unchanged and no residual satellite quote remains. |
+| Async satellite deposit funded by partial idle satellite capital | Inject only the shortfall; because the shortfall is exact, no residual satellite quote remains after the request unless there was extra idle quote beyond the partial amount. |
+| Async satellite deposit smaller than idle satellite capital | Inject no bridge-out; direct wallet assertions and reconciliation see only the residual available bridge capital in the wallet. |
+| Multiple satellite buys on the same chain, including async vault and spot | Aggregate the chain shortfall once; effective execution runs bridge-out before both buys; async deposit spends quote at request while spot buy settles normally. |
+| Multiple satellite chains with async vault buys | Size each chain independently; one chain's idle/pending capital must not fund another chain. |
+| Satellite async deposit pending while bridge-back is requested | Bridge-back is capped to available bridge capital only; the setup must include residual bridge capital or a realised satellite sell because pending deposit capital cannot be bridged back. |
+| Satellite async redeem request | Debit vault shares at request, do not credit satellite quote until settlement, and keep expected owner-wallet shares at zero while escrowed. |
+| Partial satellite async redeem | Escrow only the redeemed shares; remaining shares stay in the wallet/position and bridge accounting stays unchanged until quote is credited. |
+| Full satellite async redeem | Escrow all shares at request; close the vault position only after settlement credits quote, without losing bridge capital. |
+| Satellite async redeem plus same-chain satellite buy/deposit | Do not net the async redeem sell against same-cycle satellite buys. New buys need idle bridge capital or a bridge-out; pending redeem proceeds arrive only after settlement. |
+| Satellite async redeem plus same-cycle bridge-back | Do not bridge back redemption proceeds in the request cycle; only already-available satellite USDC may bridge back. |
+| Satellite async redeem settlement followed by bridge-back | After settlement credits satellite `pair.quote`, later bridge-back can move only the newly available quote. |
+| Same-cycle rotation from satellite async vault to primary or other satellite assets | New buys are capped to actually available cash/bridge capital; pending redeem proceeds are not counted. |
+| Pending deposit settlement | Settlement credits shares at settlement-cycle price and does not debit quote again. |
+| Pending redeem settlement | Settlement credits quote at settlement-cycle price and does not debit shares again. |
+| Drifting-price pending deposit | Pending value stays at committed quote; settlement mints fewer or more shares at the settlement price without an equity jump. |
+| Drifting-price pending redeem | Pending value follows the current share price; settlement credits quote at the same price without an extra claim-time jump. |
+| Drained bridge position after exact deposit | When available bridge capital reaches zero, the bridge bookkeeping position may close or disappear from expected balances, but wallet and expected balances must both treat satellite quote as zero and direct wallet assertions must pin that edge case. |
+| Synchronous satellite vault or spot trades | Existing CCTP bridge sizing and wallet behaviour stay unchanged. |
+| Home-chain async vault deposit/redeem | Request-time wallet movement works without CCTP and existing same-chain async invariants still pass. |
+| HyperCore-native vaults | Remain outside CCTP and ERC-7540/Ostium request-time wallet changes. |
+| Underfunded bridge-out | Raise `NotEnoughMoney` early with the missing amount after idle satellite capital is deducted. |
+
+## Implementation steps
+
+1. Add cross-chain async vault regression coverage.
+
+   Use `tests/ethereum/test_cctp_bridge_cash_aware.py` for planner and
+   request-time wallet regressions unless the file becomes unwieldy. It already
+   has the CCTP bridge-pair helpers and wallet/state setup needed for the new
+   synthetic satellite vault pair. If the cases are split to a new
+   `tests/ethereum/test_cctp_async_vault_accounting.py` module, move shared
+   helpers into a `tradeexecutor/testing` module instead of importing from the
+   tests tree.
+
+   Start with a minimal failing sequence:
+
+   - primary-chain USDC reserve,
+   - CCTP bridge pair to a satellite USDC,
+   - satellite async vault pair quoted in the satellite USDC,
+   - bridge-out followed by an async vault deposit that remains pending.
+
+   The test must assert the CCTP bridge-out has settled into the satellite
+   simulated wallet before the vault request runs. Otherwise the test would
+   exercise an unsettled CCTP failure instead of the async-vault accounting
+   bug.
+
+   Do not rely on `verify_balances()` alone: when available bridge capital is
+   zero the expected map may not contain the satellite quote asset. Add direct
+   wallet assertions for satellite `pair.quote` and `pair.base` after the
+   request, and use the overfunded-idle case as the main residual bridge-capital
+   reconciliation regression.
+
+   Then extend the coverage around that helper:
+
+   - no idle satellite capital: full bridge-out, pending deposit clean,
+   - exact idle satellite capital: no bridge-out, no residual satellite quote,
+   - partial idle satellite capital: bridge only the exact missing amount and
+     leave no residual satellite quote,
+   - overfunded idle satellite capital: leave residual available bridge capital
+     in both wallet and expected balances,
+   - mixed same-chain spot buy plus async vault buy: a single aggregate
+     bridge-out, followed by normal spot settlement and pending vault request,
+   - two satellite chains: independent bridge sizing and wallet reconciliation
+     for each chain,
+   - missing primary reserve: `NotEnoughMoney` reports the post-idle shortfall.
+
+2. Add async redeem and bridge-back regression coverage.
+
+   Extend the scenario helpers to open and settle an async satellite vault
+   deposit, then request a redeem:
+
+   - redeem request debits `pair.base` shares from the simulated wallet,
+   - owner-wallet expected shares are zero while the redeem is pending,
+   - satellite `pair.quote` is not credited until settlement,
+   - same-cycle bridge-back is capped to pre-existing available satellite USDC,
+     not the pending redeem proceeds,
+   - same-cycle satellite buys/deposits are not funded by pending redeem
+     proceeds; they need existing idle bridge capital or an injected bridge-out,
+   - after redeem settlement, a later bridge-back can move the received
+     satellite `pair.quote`,
+   - partial redeem keeps the remaining share balance and bridge accounting
+     correct,
+   - full redeem closes the vault position without losing bridge capital.
+
+3. Add settlement, pricing, and ordering assertions.
+
+   For every cross-chain async case, pin the ordering and lifecycle explicitly:
+
+   - effective backtest execution runs bridge-outs before bridge-dependent
+     satellite buys/deposits, even if the raw sort key is later adjusted by the
+     sequential CCTP execution path,
+   - effective bridge-back execution happens before bridge-outs but can use only
+     available bridge capital,
+   - async deposits/redeems enter `vault_settlement_pending` instead of
+     `success` on request,
+   - settlement does not happen in the same cycle unless the existing backtest
+     resolver rules allow it,
+   - settlement uses settlement-cycle pricing,
+   - settlement never repeats request-time wallet debits,
+   - drifting-price deposit settlement keeps equity continuous by converting
+     the committed quote into the settlement-price share quantity,
+   - drifting-price redeem settlement keeps equity continuous by valuing the
+     escrowed shares at the same price used for the credited quote,
+   - pending-value accounting is direction-aware: pending deposits contribute a
+     fixed committed-quote value through `get_vault_settlement_pending_value()`,
+     while pending redeems do not add pending value and instead remain valued as
+     share exposure through the position valuation path,
+   - `calculate_total_equity()`, `get_vault_settlement_pending_value()`,
+     bridge position quantity, bridge allocated capital, and wallet balances
+     remain mutually consistent before request, during pending, and after
+     settlement.
+
+4. Change async request simulation.
+
+   Update `BacktestExecution.simulate_async_vault_request()` so:
+
+   - deposit requests debit `pair.quote` from the simulated wallet immediately,
+   - the debit represents reserve/quote moving into the vault deposit queue and
+     becoming unavailable until settlement,
+   - redeem requests debit `pair.base` from the simulated wallet immediately,
+   - the exact debited deposit quote and exact escrowed redeem share quantity
+     are written to trade metadata for settlement to consume,
+   - full redeem requests record the actual wallet share balance, including
+     dust, so settlement closes the position cleanly,
+   - partial redeem requests record the planned quantity after any request-time
+     dust adjustment,
+   - no shares/reserve proceeds are credited until delayed settlement.
+   - the debit token is always derived from the vault pair, not from the home reserve currency.
+
+5. Change async settlement simulation.
+
+   Update `_settle_async_vault_trade()` so:
+
+   - deposit settlement uses the recorded request reserve amount, not the
+     current wallet `pair.quote` balance,
+   - deposit settlement only credits `pair.base` shares,
+   - deposit settlement removes the current settlement-time wallet quote
+     dust-adjust/debit path; after request-time debit, wallet quote is residual
+     capital, not the queued deposit,
+   - redeem settlement uses the recorded escrowed request quantity, not the
+     current wallet `pair.base` balance,
+   - full redeem settlement uses the request-time actual wallet share balance
+     recorded on the trade, not a stale planned quantity,
+   - partial redeem settlement uses the request-time adjusted planned quantity
+     recorded on the trade,
+   - redeem settlement only credits `pair.quote` reserve,
+   - settlement still uses the current settlement-cycle price,
+   - trade success still records both executed quantity and executed reserve for portfolio accounting.
+   - settlement never repeats the request-time wallet debit.
+
+6. Make pending-request expected balances explicit.
+
+   Ensure the expected-balance path used by the backtest wallet check and
+   account-correction helpers models async pending requests symmetrically:
+
+   - pending deposits: owner wallet should no longer hold the deposited
+     `pair.quote`, and should not yet hold `pair.base` shares,
+   - pending redeems: owner wallet should no longer hold escrowed `pair.base`
+     shares, and should not yet hold the redeemed `pair.quote`.
+
+   If the existing helpers already produce this outcome after request-time
+   wallet movement, add assertions that pin the behaviour so it is not
+   accidental.
+
+   Add explicit expected-balance assertions for the bridge assets as well:
+
+   - CCTP bridge positions should expect only available bridge capital in both
+     backtest wallet checks and `check-accounts` / `correct-accounts`
+     expected-balance paths,
+   - the reconciliation contract is:
+     `wallet satellite pair.quote == bridge_position.get_available_bridge_capital() == expected bridge asset quantity`,
+     clamped/omitted as zero when the bridge position has no available capital,
+   - `tradeexecutor.strategy.asset.get_asset_amounts()` must not expect the
+     full gross CCTP bridge position quantity when part of it is allocated to
+     satellite positions or pending async deposits,
+   - implement this contract from available bridge capital directly rather than
+     subtracting pending deposits independently in multiple places, to avoid
+     double-subtracting queued quote,
+   - committed async-deposit quote must be absent from both owner wallet and
+     available bridge capital,
+   - pending-redeem proceeds must be absent until settlement credits them.
+
+7. Keep CCTP planner scope narrow.
+
+   Preserve the planner responsibility from PR #1543:
+
+   - bridge-outs are sized as the missing amount after existing idle satellite bridge capital,
+   - bridge-backs are capped to capital that can actually be bridged back,
+   - same-cycle async redeem proceeds are not treated as bridge-back capital or
+     same-chain satellite-buy funding,
+   - when computing satellite `chain_flows`, async vault sell trades must be
+     distinguished from synchronous sells; pending async sells do not add
+     spendable positive flow until settlement credits `pair.quote`,
+   - bridge sizing is per destination chain and never netted across chains,
+   - no target-sizing logic is moved into the planner,
+   - no new deployable-per-chain abstraction is added.
+
+8. Update existing tests.
+
+   Update tests that currently assert delayed wallet movement for async deposits/redeems:
+
+   - pending deposit: wallet reserve should be debited at request time and shares remain zero,
+   - pending redeem: wallet shares should be debited at request time and reserve proceeds remain uncredited,
+   - equity should remain continuous through the pending window.
+   - same-chain async vault tests should still prove the delayed settlement
+     lifecycle, current-price settlement, and alpha-model pending guards.
+   - drifting-price lifecycle assertions belong in
+     `tests/backtest/test_backtest_async_vault.py`,
+   - account-correction / expected-balance assertions belong in
+     `tests/ethereum/test_vault_settlement_lifecycle.py`,
+   - planner and request-time CCTP wallet assertions belong in
+     `tests/ethereum/test_cctp_bridge_cash_aware.py`.
+
+   Before editing tests, grep for all delayed-wallet assumptions so the change
+   is comprehensive:
+
+   ```shell
+   rg -n "wallet.*not.*debit|not debited|not credited|until claim|wallet_reserve|wallet_shares|simulated wallet" tests tradeexecutor .claude/docs
+   ```
+
+9. Update documentation.
+
+   Update `.claude/docs/vault-deposit-redeem.md` so the backtesting section states:
+
+   - the simulated wallet mirrors request-time token movement,
+   - settlement delays still control when shares/proceeds are credited and trades become successful,
+   - satellite-chain vault deposits spend `pair.quote`, not the home reserve currency.
+   - CCTP bridge positions expose available satellite quote only; quote already
+     committed to pending async deposits and quote not yet received from pending
+     async redeems are not bridgeable.
+
+   Add and maintain `.claude/docs/deposit-cases.md` as the focused checklist
+   for CCTP + async vault deposit cases. It should describe each idle-capital,
+   bridge, pending-deposit, redeem-interaction, settlement, and reconciliation
+   case and how the implementation handles it.
+
+## Verification
+
+Run targeted tests only:
+
+```shell
+source .local-test.env && PYTHONPATH="$(pwd):$PYTHONPATH" poetry run pytest tests/ethereum/test_cctp_bridge_cash_aware.py
+source .local-test.env && PYTHONPATH="$(pwd):$PYTHONPATH" poetry run pytest tests/backtest/test_backtest_async_vault.py
+source .local-test.env && PYTHONPATH="$(pwd):$PYTHONPATH" poetry run pytest tests/backtest/test_cctp_backtest_sequential.py
+source .local-test.env && PYTHONPATH="$(pwd):$PYTHONPATH" poetry run pytest tests/ethereum/test_vault_settlement_lifecycle.py
+source .local-test.env && PYTHONPATH="$(pwd):$PYTHONPATH" poetry run pytest tests/units_tests/test_cross_chain_satellite_async_settlement.py
+```
+
+Run `tests/ethereum/test_cctp_bridge_cash_aware.py` first because it is the
+focused regression target. The `tests/units_tests` path is intentional and
+already exists in this repository; run
+`tests/units_tests/test_cross_chain_satellite_async_settlement.py` as an
+existing cross-chain async control-flow regression, not because this fix creates
+that file.
+
+## Non-goals
+
+- Do not add strategy-level per-chain deployable liquidity.
+- Do not change alpha-model target equity semantics.
+- Do not make the CCTP planner responsible for portfolio construction.
+- Do not change live CCTP settlement semantics while fixing backtest wallet accounting.
+- Do not change HyperCore-native vault bridge handling.
+- Do not add rejected or failed async vault request simulation to backtests in
+  this fix; the planned backtest coverage is successful delayed settlement.
+- Do not run the whole test suite for this fix.

--- a/.claude/docs/deposit-cases.md
+++ b/.claude/docs/deposit-cases.md
@@ -1,0 +1,106 @@
+# Deposit cases
+
+This document lists the CCTP + async vault deposit cases this fix must cover
+and how each case should be handled. It complements
+`cctp-async-vault-accounting-plan.md`.
+
+## Core rules
+
+The strategy still works from global target equity. There is no
+strategy-facing "deployable per-chain liquidity" concept.
+
+CCTP bridge trades move capital between chains. Vault deposit trades consume
+the vault pair's quote token on the vault chain. For a satellite vault, that
+means the deposited token is satellite USDC (`pair.quote`), not the home-chain
+reserve asset.
+
+The CCTP planner should:
+
+- size bridge-outs from the missing satellite-chain quote after existing idle
+  satellite bridge capital is counted,
+- cap bridge-backs to currently available bridge capital,
+- ignore capital already committed to pending async vault deposits,
+- ignore quote not yet received from pending async redeems,
+- treat async vault sells as unavailable until their delayed settlement credits
+  `pair.quote`, even if same-cycle satellite buys are also planned,
+- keep sizing per satellite chain and never directly net satellite liquidity
+  across chains.
+
+Async vault backtesting should:
+
+- debit `pair.quote` from the simulated wallet at deposit request time,
+- treat the debit as reserve/quote moving into the vault deposit queue,
+- record the exact queued quote amount on the trade for settlement,
+- exclude queued deposit quote from spendable cash, bridgeable capital, and
+  owner-wallet expected balances,
+- leave `pair.base` shares at zero until settlement,
+- keep the portfolio ledger's pending deposit value in equity,
+- credit shares at settlement-cycle price,
+- never debit quote again at settlement.
+
+## Deposit cases
+
+| Case | Setup | Handling |
+|------|-------|----------|
+| No idle satellite quote | Satellite vault buy is requested and no bridge position exists for that chain. | Inject a bridge-out for the full planned deposit amount. Execute bridge-out before the vault request. Debit satellite `pair.quote` at request. Pending wallet has no deposited quote and no shares. |
+| Exact idle satellite quote | Existing available bridge capital equals the planned deposit amount. | Inject no bridge-out. Debit the exact idle satellite `pair.quote` at request. Primary reserve is unchanged. No residual satellite quote remains available. |
+| Partial idle satellite quote | Existing available bridge capital is less than the planned deposit amount. | Inject one bridge-out for `planned_deposit - available_bridge_capital`. Because the shortfall is exact, no residual satellite quote remains after the request unless unrelated idle quote was also present. |
+| Overfunded idle satellite quote | Existing available bridge capital is greater than the planned deposit amount. | Inject no bridge-out. Debit only the planned deposit amount at request. Residual satellite quote remains visible as available bridge capital and must pass wallet reconciliation. |
+| Drained bridge position | A deposit exactly consumes all available bridge capital. | The bridge bookkeeping position may be closed or omitted from expected balances by the existing lifecycle, but wallet satellite quote and expected bridge asset quantity must both be zero. Tests should assert the wallet balance directly because zero-quantity assets may be absent from the expected map. |
+| Multiple vault deposits on one satellite chain | Two or more async vault buys are planned on the same destination chain. | Aggregate required quote for the chain. Inject one bridge-out for the chain shortfall. Each vault request debits its own `pair.quote`; each pending deposit carries its own pending value. |
+| Mixed spot buy and async vault deposit on one satellite chain | A satellite spot buy and satellite async vault buy are planned in the same cycle. | Aggregate the chain shortfall once. Effective backtest execution must run bridge-out before both buys. The spot buy settles normally; the vault buy debits quote at request and remains pending. |
+| Multiple satellite chains | Async vault buys are planned on more than one satellite chain. | Size each chain independently. Idle or pending capital on one satellite cannot be directly netted against another satellite. Idle capital can only fund another satellite after it is bridged back through the primary chain and then bridged out to the target chain. Each bridge pair and wallet quote balance must reconcile per chain. |
+| Pending deposit then bridge-back | A satellite async vault deposit is pending and a bridge-back is requested before it settles. | Bridge-back can use only available bridge capital. The test setup needs residual available quote or a realised satellite sell; quote committed to the pending deposit is not bridgeable and must not be counted by the planner. |
+| Deposit settles after price drift | The vault price changes between request and settlement. | Pending value remains the committed quote amount. Settlement mints shares at the settlement-cycle price so settled share value equals committed quote value. No extra equity jump is introduced at claim. |
+| Same-chain async vault deposit | The async vault lives on the primary chain and needs no CCTP bridge. | Apply the same request-time wallet debit rule using `pair.quote`. Existing same-chain delayed settlement and alpha-model pending guards must still pass. |
+| Synchronous satellite vault deposit | A satellite vault is synchronous, not ERC-7540/Ostium-style async. | Keep existing synchronous execution: no `vault_settlement_pending` request stage and no async request-time wallet special case. CCTP bridge sizing is unchanged. |
+
+## Redeem cases that affect deposits
+
+Redeem handling matters because redeem proceeds can be mistaken for deposit
+funding or bridge-back capital.
+
+| Case | Setup | Handling |
+|------|-------|----------|
+| Pending satellite async redeem | A satellite vault redeem has requested settlement but not claimed quote. | Debit `pair.base` shares at request. Do not credit satellite `pair.quote` until settlement. Planner must not use pending proceeds for new deposits or bridge-backs. |
+| Partial satellite async redeem | Only part of the vault share position is redeemed. | Escrow only redeemed shares. Remaining shares stay in the wallet and position. No new bridge capital appears until settlement credits quote. |
+| Full satellite async redeem | The whole vault share position is redeemed. | Escrow the actual wallet share balance at request, including dust, and record that escrowed amount on the trade. Close the vault position only after settlement credits quote. The credited quote becomes available bridge capital after settlement. |
+| Redeem plus same-chain satellite buy/deposit | A satellite async vault redeem and a same-chain satellite buy or deposit are planned in the same cycle. | Do not net the pending redeem against the buy/deposit. The buy/deposit needs existing idle bridge capital or a bridge-out. Redeem proceeds arrive only after settlement. |
+| Redeem plus same-cycle bridge-back | A redeem is requested and a bridge-back is also planned in the same cycle. | Bridge-back is capped to pre-existing available satellite quote. Pending redeem proceeds cannot fund the same-cycle bridge-back. |
+| Redeem settlement then later bridge-back | A pending redeem settles before a later cycle plans a bridge-back. | Settlement credits satellite `pair.quote`; a later bridge-back may move the newly available quote subject to normal bridge-capital accounting. |
+
+## Reconciliation expectations
+
+During a pending deposit:
+
+- owner wallet should not hold the deposited `pair.quote`,
+- the deposited `pair.quote` is in the vault deposit queue, not in reserves,
+- owner wallet should not hold not-yet-minted `pair.base`,
+- portfolio equity includes the pending deposit value,
+- CCTP expected balances include only residual available bridge capital in both
+  backtest wallet checks and account-correction paths.
+- the bridge reconciliation contract is
+  `wallet satellite pair.quote == available bridge capital == expected bridge asset quantity`,
+  with zero available capital represented either as an omitted asset or an
+  explicit zero.
+
+During a pending redeem:
+
+- owner wallet should not hold escrowed `pair.base`,
+- owner wallet should not hold not-yet-claimed `pair.quote`,
+- portfolio equity still values the share exposure until settlement,
+- pending redeem value follows the current share price through the position
+  valuation path, not through deposit-style pending value,
+- CCTP expected balances must not include pending redeem proceeds.
+
+After settlement:
+
+- deposits credit only `pair.base` shares,
+- redeems credit only `pair.quote`,
+- settlement never repeats the request-time debit,
+- deposit settlement uses the recorded request amount, not the residual wallet
+  quote balance,
+- redeem settlement uses the recorded escrowed amount, not the residual wallet
+  share balance,
+- wallet balances, bridge capital, position quantity, and total equity should
+  all agree.

--- a/.claude/docs/vault-deposit-redeem.md
+++ b/.claude/docs/vault-deposit-redeem.md
@@ -106,9 +106,9 @@ naively: our books hold the full share quantity while the wallet holds none,
 because the vault escrowed them. The expected-balance calculation therefore
 subtracts escrowed-in-redemption shares, so a clean state reads as clean —
 and an account correction can never mistake an escrow for a lost position
-and close it mid-settlement. (Backtests balance the same books differently:
-the simulated wallet is not touched until settlement, as described in the
-backtesting section below.)
+and close it mid-settlement. Backtests follow the same reconciliation model:
+the simulated wallet is debited on the request cycle and settlement only
+credits the claim output.
 
 ### Writing a strategy against an async vault
 
@@ -201,8 +201,10 @@ The simulation mirrors the live lifecycle:
 
 - On the request cycle the trade is marked `vault_settlement_pending` with a
   settlement due time of *cycle timestamp + delay*. The simulated wallet is
-  deliberately not touched yet — only the cash ledger is debited — so wallet
-  and position reconciliation stay consistent through the pending window.
+  debited immediately: a deposit removes the vault quote token from the wallet
+  into the deposit queue, and a redemption removes the vault share token into
+  the redeem queue. The exact request amount is recorded on the trade and is
+  the input for later settlement.
 - On each later cycle the backtest's settlement resolver (the same hook the
   live runner calls) settles every trade whose due time has arrived. The
   earliest a trade can settle is the *next* cycle, even with a zero delay,
@@ -210,8 +212,10 @@ The simulation mirrors the live lifecycle:
 - Settlement executes at the price valid *at settlement time*, not at request
   time, so a long queue delay realises whatever the share price did in
   between — exactly the economics the delay exists to model. After settling,
-  the position is revalued at the settlement price so equity is immediately
-  correct.
+  only the claim output is credited to the simulated wallet: deposit claims
+  mint shares, redeem claims pay quote token. The request input is not debited
+  a second time. The position is revalued at the settlement price so equity is
+  immediately correct.
 
 ## Live trading
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,9 +7,16 @@ working on that area:
 
 | Doc | Description |
 |-----|-------------|
+| `.claude/docs/agent-tricks-and-troubleshooting.md` | Required before invoking Claude CLI or Codex CLI for plan, code, or pull request reviews |
 | `.claude/docs/cli-command.md` | CLI command patterns for trade-executor |
 | `.claude/docs/vault-deposit-redeem.md` | Synchronous and async (ERC-7540 / Lagoon / Ostium) vault deposit and redeem flows |
 | `.claude/docs/hypercore-vault.md` | HyperCore native vault execution — properties, data structures, deposit/withdrawal phases, HyperEVM interactions, modules and diagrams |
+
+## Agent review workflows
+
+- Before calling Claude CLI or Codex CLI to review a plan, code change, pull request, or local diff, **always read** `.claude/docs/agent-tricks-and-troubleshooting.md` first.
+- Follow its recommended invocation patterns for plan reviews, code reviews, PR reviews, tool restrictions, timeouts, and handling silent or hanging agent runs.
+- Do not fall back to generic `claude --help`, plugin docs, or ad-hoc CLI flags until the local troubleshooting doc has been checked.
 
 ## English
 

--- a/tests/backtest/test_backtest_async_vault.py
+++ b/tests/backtest/test_backtest_async_vault.py
@@ -355,8 +355,9 @@ def test_backtest_async_vault_two_stage_lifecycle():
     1. Build a single async vault pair with a flat price and a 2-day settlement delay.
     2. Run a deposit-hold-redeem strategy and snapshot state before every cycle.
     3. Assert the deposit and redeem each settled a full delay after their request.
-    4. Assert the pending-window accounting: cash debited, value counted as pending,
-       simulated wallet shares/reserve only move at claim, equity continuous.
+    4. Assert the pending-window accounting: cash debited, request asset moved
+       to the vault queue immediately, claim output credited at settlement,
+       equity continuous.
     5. Assert exactly one deposit and one redeem (no double-trading) and a clean close.
     """
 
@@ -382,9 +383,10 @@ def test_backtest_async_vault_two_stage_lifecycle():
     assert deposit_delay >= SETTLEMENT_DELAY, f"Deposit settled too fast: {deposit_delay}"
     assert redeem_delay >= SETTLEMENT_DELAY, f"Redeem settled too fast: {redeem_delay}"
 
-    # 4. Pending-window accounting. A pending deposit: cash already debited, value
-    #    counted as pending, but the simulated wallet has not moved yet. We deposit
-    #    half the initial cash, keeping the other half as a buffer.
+    # 4. Pending-window accounting. A pending deposit: cash and simulated wallet
+    #    reserve are already debited, value is counted as pending, and shares are
+    #    credited only at settlement. We deposit half the initial cash, keeping the
+    #    other half as a buffer.
     deposit_amount = INITIAL_DEPOSIT * 0.5
     deposit_pending = [
         s for s in hook.snapshots
@@ -394,7 +396,7 @@ def test_backtest_async_vault_two_stage_lifecycle():
     for s in deposit_pending:
         assert s["cash"] == pytest.approx(deposit_amount, abs=1e-6)  # cash ledger debited at request
         assert s["wallet_shares"] == pytest.approx(0.0, abs=1e-9)    # shares not credited until claim
-        assert s["wallet_reserve"] == pytest.approx(INITIAL_DEPOSIT, abs=1e-6)  # wallet reserve not debited yet
+        assert s["wallet_reserve"] == pytest.approx(deposit_amount, abs=1e-6)  # request reserve moved to queue
         assert s["open_positions"] == 1
 
     # After the deposit settles: shares credited, wallet reserve partially spent, nothing pending.
@@ -424,6 +426,7 @@ def test_backtest_async_vault_two_stage_lifecycle():
     assert redeem_pending, "Expected a redeem-pending cycle (position held but settlement pending)"
     for s in redeem_pending:
         assert s["expected_base"] == pytest.approx(0.0, abs=1e-9), f"Escrowed shares not subtracted: {s}"
+        assert s["wallet_shares"] == pytest.approx(0.0, abs=1e-9), f"Redeem request did not debit wallet shares: {s}"
     # While merely holding (settled, no pending), expected on-chain balance == full quantity.
     holding = [
         s for s in hook.snapshots
@@ -615,7 +618,7 @@ def test_backtest_async_vault_partial_redeem_and_increase():
     for s in redeem_pending:
         assert s["expected_base"] == pytest.approx(25.0, abs=1e-9)
         assert s["available_quantity"] == pytest.approx(25.0, abs=1e-9)
-        assert s["wallet_shares"] == pytest.approx(50.0, abs=1e-9)
+        assert s["wallet_shares"] == pytest.approx(25.0, abs=1e-9)
 
     # 4. Partial redeem settled: position stays open with the residual half.
     assert len(state.portfolio.open_positions) == 1

--- a/tests/ethereum/test_cctp_bridge_cash_aware.py
+++ b/tests/ethereum/test_cctp_bridge_cash_aware.py
@@ -28,10 +28,13 @@ from unittest.mock import MagicMock
 
 import pytest
 
+from tradeexecutor.analysis.cctp import assert_bridge_coverage
 from tradeexecutor.backtest.backtest_execution import BacktestExecution
 from tradeexecutor.backtest.backtest_routing import BacktestRoutingIgnoredModel, BacktestRoutingState
 from tradeexecutor.backtest.simulated_wallet import SimulatedWallet
 from tradeexecutor.ethereum.cctp.planner import inject_cctp_bridge_trades
+from tradeexecutor.strategy.account_correction import calculate_total_assets
+from tradeexecutor.strategy.asset import get_asset_amounts
 from tradeexecutor.state.identifier import (
     AssetIdentifier,
     TradingPairIdentifier,
@@ -39,7 +42,7 @@ from tradeexecutor.state.identifier import (
 )
 from tradeexecutor.state.portfolio import NotEnoughMoney
 from tradeexecutor.state.state import State
-from tradeexecutor.state.trade import TradeExecution, TradeType
+from tradeexecutor.state.trade import TradeExecution, TradeStatus, TradeType
 
 #: Arbitrum native USDC — the portfolio reserve / primary chain
 USDC_ARBITRUM_ADDRESS = "0xaf88d065e77c8cc2239327c5edb3a432268e5831"
@@ -47,8 +50,12 @@ USDC_ARBITRUM_ADDRESS = "0xaf88d065e77c8cc2239327c5edb3a432268e5831"
 #: Base native USDC — satellite chain stablecoin
 USDC_BASE_ADDRESS = "0x833589fcd6edb6e08f4c7c32d4f71b54bda02913"
 
+#: Optimism native USDC — second satellite chain stablecoin
+USDC_OPTIMISM_ADDRESS = "0x0b2c639c533813f4aa9d7837caf62653d097ff85"
+
 PRIMARY_CHAIN_ID = 42161  # Arbitrum
 SATELLITE_CHAIN_ID = 8453  # Base
+SECOND_SATELLITE_CHAIN_ID = 10  # Optimism
 
 TS = datetime.datetime(2025, 1, 1, 12, 0, 0)
 
@@ -76,6 +83,17 @@ def usdc_base() -> AssetIdentifier:
 
 
 @pytest.fixture()
+def usdc_optimism() -> AssetIdentifier:
+    """USDC on Optimism — another satellite chain stablecoin."""
+    return AssetIdentifier(
+        chain_id=SECOND_SATELLITE_CHAIN_ID,
+        address=USDC_OPTIMISM_ADDRESS,
+        token_symbol="USDC",
+        decimals=6,
+    )
+
+
+@pytest.fixture()
 def cctp_pair(usdc_arbitrum: AssetIdentifier, usdc_base: AssetIdentifier) -> TradingPairIdentifier:
     """CCTP bridge pair: Arbitrum -> Base."""
     return TradingPairIdentifier(
@@ -84,6 +102,21 @@ def cctp_pair(usdc_arbitrum: AssetIdentifier, usdc_base: AssetIdentifier) -> Tra
         pool_address="0x28b5a0e9c621a5badaa536219b3a228c8168cf5d",
         exchange_address="0x28b5a0e9c621a5badaa536219b3a228c8168cf5d",
         internal_id=1,
+        fee=0,
+        kind=TradingPairKind.cctp_bridge,
+        other_data={"bridge_protocol": "cctp"},
+    )
+
+
+@pytest.fixture()
+def optimism_cctp_pair(usdc_arbitrum: AssetIdentifier, usdc_optimism: AssetIdentifier) -> TradingPairIdentifier:
+    """CCTP bridge pair: Arbitrum -> Optimism."""
+    return TradingPairIdentifier(
+        base=usdc_optimism,
+        quote=usdc_arbitrum,
+        pool_address="0x28b5a0e9c621a5badaa536219b3a228c8168cf5e",
+        exchange_address="0x28b5a0e9c621a5badaa536219b3a228c8168cf5e",
+        internal_id=5,
         fee=0,
         kind=TradingPairKind.cctp_bridge,
         other_data={"bridge_protocol": "cctp"},
@@ -111,6 +144,47 @@ def satellite_pair(usdc_base: AssetIdentifier) -> TradingPairIdentifier:
         internal_id=2,
         fee=0,
         kind=TradingPairKind.spot_market_hold,
+    )
+
+
+@pytest.fixture()
+def primary_pair(usdc_arbitrum: AssetIdentifier) -> TradingPairIdentifier:
+    """A primary-chain spot pair on Arbitrum, quoted in native USDC."""
+    base = AssetIdentifier(
+        chain_id=PRIMARY_CHAIN_ID,
+        address="0x0000000000000000000000000000000000000077",
+        token_symbol="primaryARB",
+        decimals=18,
+    )
+    return TradingPairIdentifier(
+        base=base,
+        quote=usdc_arbitrum,
+        pool_address="0x0000000000000000000000000000000000000088",
+        exchange_address="0x0000000000000000000000000000000000000099",
+        internal_id=4,
+        fee=0,
+        kind=TradingPairKind.spot_market_hold,
+    )
+
+
+@pytest.fixture()
+def satellite_vault_pair(usdc_base: AssetIdentifier) -> TradingPairIdentifier:
+    """An override-only async satellite vault pair on Base."""
+    share = AssetIdentifier(
+        chain_id=SATELLITE_CHAIN_ID,
+        address="0x0000000000000000000000000000000000000044",
+        token_symbol="vBASE",
+        decimals=18,
+    )
+    return TradingPairIdentifier(
+        base=share,
+        quote=usdc_base,
+        pool_address="0x0000000000000000000000000000000000000055",
+        exchange_address="0x0000000000000000000000000000000000000066",
+        internal_id=3,
+        fee=0,
+        kind=TradingPairKind.vault,
+        other_data={"vault_protocol": "test_async_vault"},
     )
 
 
@@ -191,6 +265,36 @@ def _create_satellite_buy(
         reserve_currency_price=1.0,
     )
     return buy
+
+
+def _create_primary_buy(
+    state: State,
+    primary_pair: TradingPairIdentifier,
+    usdc_arbitrum: AssetIdentifier,
+    reserve: Decimal,
+) -> TradeExecution:
+    """Create (but do not execute) a primary-chain spot buy."""
+    _, buy, _ = state.create_trade(
+        strategy_cycle_at=TS,
+        pair=primary_pair,
+        quantity=None,
+        reserve=reserve,
+        assumed_price=1.0,
+        trade_type=TradeType.rebalance,
+        reserve_currency=usdc_arbitrum,
+        reserve_currency_price=1.0,
+    )
+    return buy
+
+
+def _async_vault_execution(wallet: SimulatedWallet, satellite_vault_pair: TradingPairIdentifier) -> BacktestExecution:
+    """Create a backtest executor that treats ``satellite_vault_pair`` as async."""
+    return BacktestExecution(
+        wallet=wallet,
+        vault_settlement_delay_overrides={
+            satellite_vault_pair.pool_address: datetime.timedelta(days=2),
+        },
+    )
 
 
 def test_bridge_out_funds_from_idle_satellite_capital(
@@ -288,6 +392,92 @@ def test_bridge_out_nets_against_partial_idle_capital(
     assert bridge_out.pair.get_destination_chain_id() == SATELLITE_CHAIN_ID
 
 
+@pytest.mark.timeout(300)
+def test_bridge_out_nets_against_same_cycle_satellite_spot_sell(
+    usdc_arbitrum: AssetIdentifier,
+    usdc_base: AssetIdentifier,
+    cctp_pair: TradingPairIdentifier,
+    satellite_pair: TradingPairIdentifier,
+    satellite_vault_pair: TradingPairIdentifier,
+):
+    """A synchronous satellite spot sell reduces the same-cycle vault deposit bridge-out.
+
+    1. Bridge 500 USDC to Base and deploy it into a satellite spot position,
+       leaving only 500 USDC on the primary chain.
+    2. In one later cycle, plan a non-closing 500 USDC spot sell and a 1_000
+       USDC async satellite vault deposit.
+    3. Inject CCTP trades and assert only the missing 500 USDC is bridged out.
+    4. Execute the cycle and assert the vault request consumes the sell proceeds
+       and bridge-out proceeds without leaving extra deployable Base USDC.
+    """
+    wallet = SimulatedWallet()
+    wallet.set_balance(usdc_arbitrum, Decimal(1_000))
+    state = _make_state(usdc_arbitrum, Decimal(1_000))
+    execution = _async_vault_execution(wallet, satellite_vault_pair)
+
+    # 1. Bridge 500 USDC to Base and deploy it into a satellite spot position.
+    _establish_idle_satellite_capital(state, execution, wallet, cctp_pair, usdc_arbitrum, Decimal(500))
+    spot_buy = _create_satellite_buy(state, satellite_pair, usdc_arbitrum, Decimal(500))
+    routing_model, routing_state = _routing(wallet, usdc_arbitrum)
+    execution.execute_trades(
+        ts=TS,
+        state=state,
+        trades=[spot_buy],
+        routing_model=routing_model,
+        routing_state=routing_state,
+        check_balances=True,
+    )
+    reserve = state.portfolio.get_default_reserve_position()
+    bridge_position = state.portfolio.get_bridge_position_for_chain(SATELLITE_CHAIN_ID)
+    assert reserve.quantity == Decimal(500)
+    assert bridge_position.get_available_bridge_capital() == Decimal(0)
+
+    # 2. Plan a non-closing spot sell and a larger async satellite vault deposit.
+    spot_position = state.portfolio.get_open_position_for_pair(satellite_pair)
+    _, spot_sell, _ = state.create_trade(
+        strategy_cycle_at=TS,
+        pair=satellite_pair,
+        quantity=-spot_position.get_quantity(),
+        reserve=None,
+        assumed_price=1.0,
+        trade_type=TradeType.rebalance,
+        reserve_currency=usdc_arbitrum,
+        reserve_currency_price=1.0,
+        position=spot_position,
+        closing=False,
+    )
+    vault_buy = _create_satellite_buy(state, satellite_vault_pair, usdc_arbitrum, Decimal(1_000))
+    universe = _make_mock_universe([cctp_pair, satellite_pair, satellite_vault_pair])
+
+    # 3. Inject CCTP trades and assert only the missing 500 USDC is bridged out.
+    result = inject_cctp_bridge_trades(
+        state=state,
+        trades=[spot_sell, vault_buy],
+        strategy_universe=universe,
+        primary_chain_id=PRIMARY_CHAIN_ID,
+        ts=TS,
+        reserve_asset=usdc_arbitrum,
+    )
+    bridge_trades = [t for t in result if t.pair.is_cctp_bridge()]
+    assert len(bridge_trades) == 1
+    assert bridge_trades[0].is_buy()
+    assert bridge_trades[0].planned_reserve == Decimal(500)
+
+    # 4. Execute the cycle and assert no extra deployable Base USDC remains.
+    execution.execute_trades(
+        ts=TS,
+        state=state,
+        trades=sorted(result, key=lambda t: t.get_execution_sort_position()),
+        routing_model=routing_model,
+        routing_state=routing_state,
+        check_balances=True,
+    )
+    assert vault_buy.get_status() == TradeStatus.vault_settlement_pending
+    assert wallet.get_balance(usdc_base) == Decimal(0)
+    assert bridge_position.get_available_bridge_capital() == Decimal(0)
+    assert state.portfolio.get_vault_settlement_pending_value() == pytest.approx(1_000.0, abs=1e-6)
+
+
 def test_bridge_out_raises_clearly_when_underfunded(
     usdc_arbitrum: AssetIdentifier,
     cctp_pair: TradingPairIdentifier,
@@ -320,16 +510,15 @@ def test_bridge_back_capped_to_available_bridge_capital(
     cctp_pair: TradingPairIdentifier,
     satellite_pair: TradingPairIdentifier,
 ):
-    """A bridge-back is capped to available bridge capital, not the full net sell.
+    """A bridge-back is capped when a satellite sell executes after bridge-backs.
 
-    Protects in-flight satellite deposits: when a net sell exceeds the currently
-    available bridge capital (because the rest is committed to a not-yet-settled
-    deposit), only the available amount may be bridged back. The remainder
-    bridges back on a later cycle once the deposit settles.
+    Non-closing spot sells sort after CCTP bridge-backs. Their proceeds are not
+    available for same-cycle bridge-back sizing, so only the currently idle
+    bridge capital may be bridged back.
 
     1. Bridge 10_000 to the satellite, then deploy 7_000 into a satellite buy,
        leaving 3_000 available bridge capital.
-    2. Ask to bridge back the whole 7_000 position via a net sell.
+    2. Ask to sell the whole 7_000 position as a non-closing late sell.
     3. Assert the injected bridge-back is capped to 3_000, not 7_000.
     """
     wallet = SimulatedWallet()
@@ -352,7 +541,71 @@ def test_bridge_back_capped_to_available_bridge_capital(
     bridge_pos = state.portfolio.get_bridge_position_for_chain(SATELLITE_CHAIN_ID)
     assert bridge_pos.get_available_bridge_capital() == Decimal(3_000)
 
-    # 2. Net sell of the whole 7_000 satellite position.
+    # 2. Net sell of the whole 7_000 satellite position as a non-closing late sell.
+    sat_pos = state.portfolio.get_open_position_for_pair(satellite_pair)
+    _, sell, _ = state.create_trade(
+        strategy_cycle_at=TS,
+        pair=satellite_pair,
+        quantity=-sat_pos.get_quantity(),
+        reserve=None,
+        assumed_price=1.0,
+        trade_type=TradeType.rebalance,
+        reserve_currency=usdc_arbitrum,
+        reserve_currency_price=1.0,
+        position=sat_pos,
+        closing=False,
+    )
+    universe = _make_mock_universe([cctp_pair, satellite_pair])
+    result = inject_cctp_bridge_trades(
+        state=state,
+        trades=[sell],
+        strategy_universe=universe,
+        primary_chain_id=PRIMARY_CHAIN_ID,
+        ts=TS,
+        reserve_asset=usdc_arbitrum,
+    )
+
+    # 3. Bridge-back capped to the 3_000 available, not the full 7_000 net sell.
+    bridge_backs = [t for t in result if t.pair.is_cctp_bridge()]
+    assert len(bridge_backs) == 1
+    assert bridge_backs[0].is_sell()
+    assert bridge_backs[0].planned_quantity == Decimal(-3_000)
+
+
+@pytest.mark.timeout(300)
+def test_closing_satellite_sell_can_fund_same_cycle_bridge_back(
+    usdc_arbitrum: AssetIdentifier,
+    cctp_pair: TradingPairIdentifier,
+    satellite_pair: TradingPairIdentifier,
+):
+    """A closing satellite sell can be bridged back in the same cycle.
+
+    1. Bridge 10_000 to the satellite, then deploy 7_000 into a satellite buy,
+       leaving 3_000 available bridge capital.
+    2. Ask to close the whole 7_000 satellite position.
+    3. Assert the injected bridge-back includes the 7_000 closing sell proceeds.
+    """
+    wallet = SimulatedWallet()
+    wallet.set_balance(usdc_arbitrum, Decimal(50_000))
+    state = _make_state(usdc_arbitrum, Decimal(50_000))
+    execution = BacktestExecution(wallet=wallet)
+
+    # 1. Park 10_000 on the satellite, deploy 7_000 -> 3_000 available.
+    _establish_idle_satellite_capital(state, execution, wallet, cctp_pair, usdc_arbitrum, Decimal(10_000))
+    buy = _create_satellite_buy(state, satellite_pair, usdc_arbitrum, Decimal(7_000))
+    routing_model, routing_state = _routing(wallet, usdc_arbitrum)
+    execution.execute_trades(
+        ts=TS,
+        state=state,
+        trades=[buy],
+        routing_model=routing_model,
+        routing_state=routing_state,
+        check_balances=False,
+    )
+    bridge_pos = state.portfolio.get_bridge_position_for_chain(SATELLITE_CHAIN_ID)
+    assert bridge_pos.get_available_bridge_capital() == Decimal(3_000)
+
+    # 2. Close the whole 7_000 satellite position.
     sat_pos = state.portfolio.get_open_position_for_pair(satellite_pair)
     _, sell, _ = state.create_trade(
         strategy_cycle_at=TS,
@@ -376,8 +629,684 @@ def test_bridge_back_capped_to_available_bridge_capital(
         reserve_asset=usdc_arbitrum,
     )
 
-    # 3. Bridge-back capped to the 3_000 available, not the full 7_000 net sell.
+    # 3. Bridge-back includes the 7_000 closing sell proceeds.
     bridge_backs = [t for t in result if t.pair.is_cctp_bridge()]
     assert len(bridge_backs) == 1
     assert bridge_backs[0].is_sell()
-    assert bridge_backs[0].planned_quantity == Decimal(-3_000)
+    assert bridge_backs[0].planned_quantity == Decimal(-7_000)
+
+
+@pytest.mark.timeout(300)
+def test_satellite_sell_reopens_closed_bridge_position(
+    usdc_arbitrum: AssetIdentifier,
+    usdc_base: AssetIdentifier,
+    cctp_pair: TradingPairIdentifier,
+    satellite_pair: TradingPairIdentifier,
+):
+    """A satellite sell reopens a closed bridge position for returned USDC.
+
+    1. Bridge 1_000 USDC to Base and deploy it all into a satellite position.
+    2. Close the now-zero-available bridge position to mimic earlier accounting.
+    3. Sell 250 of the satellite position.
+    4. Assert the sell credits Base USDC and reopens the bridge position with
+       250 available bridge capital.
+    """
+    wallet = SimulatedWallet()
+    wallet.set_balance(usdc_arbitrum, Decimal(2_000))
+    state = _make_state(usdc_arbitrum, Decimal(2_000))
+    execution = BacktestExecution(wallet=wallet)
+
+    # 1. Bridge 1_000 USDC to Base and deploy it all into a satellite position.
+    _establish_idle_satellite_capital(state, execution, wallet, cctp_pair, usdc_arbitrum, Decimal(1_000))
+    buy = _create_satellite_buy(state, satellite_pair, usdc_arbitrum, Decimal(1_000))
+    routing_model, routing_state = _routing(wallet, usdc_arbitrum)
+    execution.execute_trades(
+        ts=TS,
+        state=state,
+        trades=[buy],
+        routing_model=routing_model,
+        routing_state=routing_state,
+        check_balances=True,
+    )
+    bridge_position = state.portfolio.get_bridge_position_for_chain(SATELLITE_CHAIN_ID)
+    assert bridge_position.get_available_bridge_capital() == Decimal(0)
+
+    # 2. Close the now-zero-available bridge position to mimic earlier accounting.
+    state.portfolio.close_position(bridge_position, TS)
+    assert state.portfolio.get_bridge_position_for_chain(SATELLITE_CHAIN_ID) is None
+
+    # 3. Sell 250 of the satellite position.
+    satellite_position = state.portfolio.get_open_position_for_pair(satellite_pair)
+    _, sell, _ = state.create_trade(
+        strategy_cycle_at=TS,
+        pair=satellite_pair,
+        quantity=Decimal(-250),
+        reserve=None,
+        assumed_price=1.0,
+        trade_type=TradeType.rebalance,
+        reserve_currency=usdc_arbitrum,
+        reserve_currency_price=1.0,
+        position=satellite_position,
+        closing=False,
+    )
+    execution.execute_trades(
+        ts=TS,
+        state=state,
+        trades=[sell],
+        routing_model=routing_model,
+        routing_state=routing_state,
+        check_balances=True,
+    )
+
+    # 4. Assert the bridge position was reopened for the returned Base USDC.
+    reopened_bridge_position = state.portfolio.get_bridge_position_for_chain(SATELLITE_CHAIN_ID)
+    assert sell.is_success()
+    assert wallet.get_balance(usdc_base) == Decimal(250)
+    assert reopened_bridge_position is bridge_position
+    assert reopened_bridge_position.get_available_bridge_capital() == Decimal(250)
+    assert calculate_total_assets(state.portfolio)[usdc_base] == Decimal(250)
+
+
+@pytest.mark.timeout(300)
+def test_primary_buy_funded_from_idle_satellite_bridge_capital(
+    usdc_arbitrum: AssetIdentifier,
+    usdc_base: AssetIdentifier,
+    cctp_pair: TradingPairIdentifier,
+    primary_pair: TradingPairIdentifier,
+):
+    """Idle satellite bridge capital funds a primary-chain buy shortfall.
+
+    1. Bridge 5_000 USDC to Base, leaving no primary-chain reserve.
+    2. Plan a 4_000 primary-chain buy and inject CCTP trades.
+    3. Execute the bridge-back and primary buy.
+    4. Assert only the missing primary amount was bridged back and the buy did
+       not drive the primary USDC wallet negative.
+    """
+    wallet = SimulatedWallet()
+    wallet.set_balance(usdc_arbitrum, Decimal(5_000))
+    state = _make_state(usdc_arbitrum, Decimal(5_000))
+    execution = BacktestExecution(wallet=wallet)
+
+    # 1. Bridge 5_000 USDC to Base, leaving no primary-chain reserve.
+    _establish_idle_satellite_capital(state, execution, wallet, cctp_pair, usdc_arbitrum, Decimal(5_000))
+    reserve = state.portfolio.get_default_reserve_position()
+    bridge_position = state.portfolio.get_bridge_position_for_chain(SATELLITE_CHAIN_ID)
+    assert reserve.quantity == Decimal(0)
+    assert wallet.get_balance(usdc_arbitrum) == Decimal(0)
+    assert bridge_position.get_available_bridge_capital() == Decimal(5_000)
+
+    # 2. Plan a 4_000 primary-chain buy and inject CCTP trades.
+    buy = _create_primary_buy(state, primary_pair, usdc_arbitrum, Decimal(4_000))
+    universe = _make_mock_universe([cctp_pair, primary_pair])
+    result = inject_cctp_bridge_trades(
+        state=state,
+        trades=[buy],
+        strategy_universe=universe,
+        primary_chain_id=PRIMARY_CHAIN_ID,
+        ts=TS,
+        reserve_asset=usdc_arbitrum,
+    )
+    bridge_trades = [t for t in result if t.pair.is_cctp_bridge()]
+    assert len(bridge_trades) == 1
+    assert bridge_trades[0].is_sell()
+    assert bridge_trades[0].planned_quantity == Decimal(-4_000)
+
+    # 3. Execute the bridge-back and primary buy.
+    routing_model, routing_state = _routing(wallet, usdc_arbitrum)
+    execution.execute_trades(
+        ts=TS,
+        state=state,
+        trades=sorted(result, key=lambda t: t.get_execution_sort_position()),
+        routing_model=routing_model,
+        routing_state=routing_state,
+        check_balances=True,
+    )
+
+    # 4. Assert request-time wallet and bridge-capital accounting.
+    assert buy.is_success()
+    assert wallet.get_balance(usdc_arbitrum) == Decimal(0)
+    assert wallet.get_balance(usdc_base) == Decimal(1_000)
+    assert reserve.quantity == Decimal(0)
+    assert bridge_position.get_available_bridge_capital() == Decimal(1_000)
+
+
+@pytest.mark.timeout(300)
+def test_cross_satellite_bridge_out_funded_from_other_idle_satellite_capital(
+    usdc_arbitrum: AssetIdentifier,
+    usdc_base: AssetIdentifier,
+    usdc_optimism: AssetIdentifier,
+    cctp_pair: TradingPairIdentifier,
+    optimism_cctp_pair: TradingPairIdentifier,
+    primary_pair: TradingPairIdentifier,
+    satellite_pair: TradingPairIdentifier,
+):
+    """Idle capital on one satellite can fund another satellite's bridge-out.
+
+    1. Bridge 8_000 USDC to Optimism, leaving 2_000 primary-chain reserve.
+    2. Plan a 3_000 primary buy and a 6_000 Base buy.
+    3. Inject CCTP trades.
+    4. Execute all trades.
+    5. Assert Optimism bridged back 7_000, Base bridged out 6_000, and both
+       buys executed without a primary wallet underflow.
+    """
+    wallet = SimulatedWallet()
+    wallet.set_balance(usdc_arbitrum, Decimal(10_000))
+    state = _make_state(usdc_arbitrum, Decimal(10_000))
+    execution = BacktestExecution(wallet=wallet)
+
+    # 1. Bridge 8_000 USDC to Optimism, leaving 2_000 primary-chain reserve.
+    _establish_idle_satellite_capital(state, execution, wallet, optimism_cctp_pair, usdc_arbitrum, Decimal(8_000))
+    reserve = state.portfolio.get_default_reserve_position()
+    optimism_bridge_position = state.portfolio.get_bridge_position_for_chain(SECOND_SATELLITE_CHAIN_ID)
+    assert reserve.quantity == Decimal(2_000)
+    assert optimism_bridge_position.get_available_bridge_capital() == Decimal(8_000)
+
+    # 2. Plan a 3_000 primary buy and a 6_000 Base buy.
+    primary_buy = _create_primary_buy(state, primary_pair, usdc_arbitrum, Decimal(3_000))
+    base_buy = _create_satellite_buy(state, satellite_pair, usdc_arbitrum, Decimal(6_000))
+
+    # 3. Inject CCTP trades.
+    universe = _make_mock_universe([cctp_pair, optimism_cctp_pair, primary_pair, satellite_pair])
+    result = inject_cctp_bridge_trades(
+        state=state,
+        trades=[primary_buy, base_buy],
+        strategy_universe=universe,
+        primary_chain_id=PRIMARY_CHAIN_ID,
+        ts=TS,
+        reserve_asset=usdc_arbitrum,
+    )
+    bridge_trades = [t for t in result if t.pair.is_cctp_bridge()]
+    bridge_backs = [t for t in bridge_trades if t.is_sell()]
+    bridge_outs = [t for t in bridge_trades if t.is_buy()]
+    assert len(bridge_backs) == 1
+    assert bridge_backs[0].pair.get_destination_chain_id() == SECOND_SATELLITE_CHAIN_ID
+    assert bridge_backs[0].planned_quantity == Decimal(-7_000)
+    assert len(bridge_outs) == 1
+    assert bridge_outs[0].pair.get_destination_chain_id() == SATELLITE_CHAIN_ID
+    assert bridge_outs[0].planned_reserve == Decimal(6_000)
+
+    # 4. Execute all trades.
+    routing_model, routing_state = _routing(wallet, usdc_arbitrum)
+    execution.execute_trades(
+        ts=TS,
+        state=state,
+        trades=sorted(result, key=lambda t: t.get_execution_sort_position()),
+        routing_model=routing_model,
+        routing_state=routing_state,
+        check_balances=True,
+    )
+
+    # 5. Assert bridge capital and wallet accounting.
+    base_bridge_position = state.portfolio.get_position_by_id(bridge_outs[0].position_id)
+    assert primary_buy.is_success()
+    assert base_buy.is_success()
+    assert wallet.get_balance(usdc_arbitrum) == Decimal(0)
+    assert wallet.get_balance(usdc_base) == Decimal(0)
+    assert wallet.get_balance(usdc_optimism) == Decimal(1_000)
+    assert reserve.quantity == Decimal(0)
+    assert base_bridge_position.get_available_bridge_capital() == Decimal(0)
+    assert optimism_bridge_position.get_available_bridge_capital() == Decimal(1_000)
+
+
+@pytest.mark.timeout(300)
+def test_dust_available_bridge_capital_does_not_create_bridge_back(
+    usdc_arbitrum: AssetIdentifier,
+    cctp_pair: TradingPairIdentifier,
+    satellite_pair: TradingPairIdentifier,
+):
+    """Dust available bridge capital is ignored instead of creating a bridge-back.
+
+    1. Bridge 1_000 USDC to Base and deploy it all into a satellite position.
+    2. Leave only 1E-23 available bridge capital to mimic Decimal dust.
+    3. Plan a non-closing satellite sell whose proceeds sort after bridge-backs.
+    4. Assert the planner skips the dust bridge-back trade.
+    """
+    wallet = SimulatedWallet()
+    wallet.set_balance(usdc_arbitrum, Decimal(2_000))
+    state = _make_state(usdc_arbitrum, Decimal(2_000))
+    execution = BacktestExecution(wallet=wallet)
+
+    # 1. Bridge 1_000 USDC to Base and deploy it all into a satellite position.
+    _establish_idle_satellite_capital(state, execution, wallet, cctp_pair, usdc_arbitrum, Decimal(1_000))
+    buy = _create_satellite_buy(state, satellite_pair, usdc_arbitrum, Decimal(1_000))
+    routing_model, routing_state = _routing(wallet, usdc_arbitrum)
+    execution.execute_trades(
+        ts=TS,
+        state=state,
+        trades=[buy],
+        routing_model=routing_model,
+        routing_state=routing_state,
+        check_balances=True,
+    )
+
+    # 2. Leave only 1E-23 available bridge capital to mimic Decimal dust.
+    bridge_position = state.portfolio.get_bridge_position_for_chain(SATELLITE_CHAIN_ID)
+    bridge_position.bridge_capital_allocated = bridge_position.get_quantity() - Decimal("1E-23")
+    assert bridge_position.get_available_bridge_capital() == Decimal("1E-23")
+
+    # 3. Plan a non-closing satellite sell whose proceeds sort after bridge-backs.
+    satellite_position = state.portfolio.get_open_position_for_pair(satellite_pair)
+    _, sell, _ = state.create_trade(
+        strategy_cycle_at=TS,
+        pair=satellite_pair,
+        quantity=-satellite_position.get_quantity(),
+        reserve=None,
+        assumed_price=1.0,
+        trade_type=TradeType.rebalance,
+        reserve_currency=usdc_arbitrum,
+        reserve_currency_price=1.0,
+        position=satellite_position,
+        closing=False,
+    )
+    universe = _make_mock_universe([cctp_pair, satellite_pair])
+    result = inject_cctp_bridge_trades(
+        state=state,
+        trades=[sell],
+        strategy_universe=universe,
+        primary_chain_id=PRIMARY_CHAIN_ID,
+        ts=TS,
+        reserve_asset=usdc_arbitrum,
+    )
+
+    # 4. Assert the planner skips the dust bridge-back trade.
+    assert [t for t in result if t.pair.is_cctp_bridge()] == []
+
+
+@pytest.mark.timeout(300)
+def test_primary_shortfall_dust_after_bridge_back_is_ignored(
+    usdc_arbitrum: AssetIdentifier,
+    cctp_pair: TradingPairIdentifier,
+    primary_pair: TradingPairIdentifier,
+):
+    """Sub-epsilon primary shortfall dust after bridge-back does not fail planning.
+
+    1. Bridge 1_000 USDC to Base, leaving no primary reserve.
+    2. Plan a primary buy whose reserve need is 1_000 plus 1E-23 dust.
+    3. Inject CCTP trades.
+    4. Assert the planner bridges back the real 1_000 amount and ignores the
+       remaining dust shortfall.
+    """
+    wallet = SimulatedWallet()
+    wallet.set_balance(usdc_arbitrum, Decimal(1_000))
+    state = _make_state(usdc_arbitrum, Decimal(1_000))
+    execution = BacktestExecution(wallet=wallet)
+
+    # 1. Bridge 1_000 USDC to Base, leaving no primary reserve.
+    _establish_idle_satellite_capital(state, execution, wallet, cctp_pair, usdc_arbitrum, Decimal(1_000))
+    reserve = state.portfolio.get_default_reserve_position()
+    bridge_position = state.portfolio.get_bridge_position_for_chain(SATELLITE_CHAIN_ID)
+    assert reserve.quantity == Decimal(0)
+    assert bridge_position.get_available_bridge_capital() == Decimal(1_000)
+
+    # 2. Plan a primary buy whose reserve need is 1_000 plus 1E-23 dust.
+    buy = _create_primary_buy(
+        state,
+        primary_pair,
+        usdc_arbitrum,
+        Decimal("1000.00000000000000000000001"),
+    )
+
+    # 3. Inject CCTP trades.
+    universe = _make_mock_universe([cctp_pair, primary_pair])
+    result = inject_cctp_bridge_trades(
+        state=state,
+        trades=[buy],
+        strategy_universe=universe,
+        primary_chain_id=PRIMARY_CHAIN_ID,
+        ts=TS,
+        reserve_asset=usdc_arbitrum,
+    )
+
+    # 4. Assert the planner bridges back the real 1_000 amount.
+    bridge_backs = [t for t in result if t.pair.is_cctp_bridge() and t.is_sell()]
+    assert len(bridge_backs) == 1
+    assert bridge_backs[0].planned_quantity == Decimal(-1_000)
+
+
+@pytest.mark.timeout(300)
+def test_closing_satellite_sell_can_fund_same_cycle_primary_buy(
+    usdc_arbitrum: AssetIdentifier,
+    usdc_base: AssetIdentifier,
+    cctp_pair: TradingPairIdentifier,
+    satellite_pair: TradingPairIdentifier,
+    primary_pair: TradingPairIdentifier,
+):
+    """A closing satellite sell can bridge back and fund a primary-chain buy.
+
+    1. Bridge 10_000 USDC to Base and deploy it all into a satellite position,
+       leaving no primary reserve.
+    2. In one cycle, close the satellite position and plan a 6_000 primary buy.
+    3. Inject and execute CCTP trades.
+    4. Assert the primary buy succeeds from the bridge-back proceeds.
+    """
+    wallet = SimulatedWallet()
+    wallet.set_balance(usdc_arbitrum, Decimal(10_000))
+    state = _make_state(usdc_arbitrum, Decimal(10_000))
+    execution = BacktestExecution(wallet=wallet)
+
+    # 1. Bridge 10_000 USDC to Base and deploy it all into a satellite position.
+    _establish_idle_satellite_capital(state, execution, wallet, cctp_pair, usdc_arbitrum, Decimal(10_000))
+    buy = _create_satellite_buy(state, satellite_pair, usdc_arbitrum, Decimal(10_000))
+    routing_model, routing_state = _routing(wallet, usdc_arbitrum)
+    execution.execute_trades(
+        ts=TS,
+        state=state,
+        trades=[buy],
+        routing_model=routing_model,
+        routing_state=routing_state,
+        check_balances=True,
+    )
+    reserve = state.portfolio.get_default_reserve_position()
+    assert reserve.quantity == Decimal(0)
+    assert wallet.get_balance(usdc_arbitrum) == Decimal(0)
+
+    # 2. In one cycle, close the satellite position and plan a 6_000 primary buy.
+    satellite_position = state.portfolio.get_open_position_for_pair(satellite_pair)
+    _, sell, _ = state.create_trade(
+        strategy_cycle_at=TS,
+        pair=satellite_pair,
+        quantity=-satellite_position.get_quantity(),
+        reserve=None,
+        assumed_price=1.0,
+        trade_type=TradeType.rebalance,
+        reserve_currency=usdc_arbitrum,
+        reserve_currency_price=1.0,
+        position=satellite_position,
+        closing=True,
+    )
+    primary_buy = _create_primary_buy(state, primary_pair, usdc_arbitrum, Decimal(6_000))
+
+    # 3. Inject and execute CCTP trades.
+    universe = _make_mock_universe([cctp_pair, satellite_pair, primary_pair])
+    result = inject_cctp_bridge_trades(
+        state=state,
+        trades=[sell, primary_buy],
+        strategy_universe=universe,
+        primary_chain_id=PRIMARY_CHAIN_ID,
+        ts=TS,
+        reserve_asset=usdc_arbitrum,
+    )
+    bridge_backs = [t for t in result if t.pair.is_cctp_bridge() and t.is_sell()]
+    assert len(bridge_backs) == 1
+    assert bridge_backs[0].planned_quantity == Decimal(-10_000)
+    execution.execute_trades(
+        ts=TS,
+        state=state,
+        trades=sorted(result, key=lambda t: t.get_execution_sort_position()),
+        routing_model=routing_model,
+        routing_state=routing_state,
+        check_balances=True,
+    )
+
+    # 4. Assert the primary buy succeeds from the bridge-back proceeds.
+    assert sell.is_success()
+    assert primary_buy.is_success()
+    assert wallet.get_balance(usdc_arbitrum) == Decimal(4_000)
+    assert wallet.get_balance(usdc_base) == Decimal(0)
+    assert reserve.quantity == Decimal(4_000)
+
+
+def test_assert_bridge_coverage_allows_satellite_vault_without_same_cycle_bridge(
+    usdc_arbitrum: AssetIdentifier,
+    cctp_pair: TradingPairIdentifier,
+    satellite_vault_pair: TradingPairIdentifier,
+):
+    """Bridge coverage analysis allows idle-capital satellite vault cycles.
+
+    1. Bridge 5_000 USDC to Base in one cycle.
+    2. Plan a later Base vault deposit that reuses the idle bridge capital.
+    3. Run the notebook bridge coverage assertion.
+    4. Assert the later vault cycle is flagged as having no same-cycle bridge,
+       but the assertion still passes because the run has CCTP coverage.
+    """
+    wallet = SimulatedWallet()
+    wallet.set_balance(usdc_arbitrum, Decimal(10_000))
+    state = _make_state(usdc_arbitrum, Decimal(10_000))
+    execution = BacktestExecution(wallet=wallet)
+
+    # 1. Bridge 5_000 USDC to Base in one cycle.
+    _establish_idle_satellite_capital(state, execution, wallet, cctp_pair, usdc_arbitrum, Decimal(5_000))
+
+    # 2. Plan a later Base vault deposit that reuses the idle bridge capital.
+    later_ts = TS + datetime.timedelta(days=1)
+    state.create_trade(
+        strategy_cycle_at=later_ts,
+        pair=satellite_vault_pair,
+        quantity=None,
+        reserve=Decimal(3_000),
+        assumed_price=1.0,
+        trade_type=TradeType.rebalance,
+        reserve_currency=usdc_arbitrum,
+        reserve_currency_price=1.0,
+    )
+
+    # 3. Run the notebook bridge coverage assertion.
+    cycle_df = assert_bridge_coverage(
+        state.portfolio.get_all_trades(),
+        primary_chain_id=PRIMARY_CHAIN_ID,
+    )
+
+    # 4. Assert the later vault cycle is flagged as having no same-cycle bridge.
+    later_cycle = cycle_df.loc[cycle_df["cycle"] == later_ts].iloc[0]
+    assert later_cycle["bridge_trades"] == 0
+    assert later_cycle["satellite_vault_trades"] == 1
+    assert bool(later_cycle["satellite_vaults_without_same_cycle_bridge"]) is True
+
+
+@pytest.mark.timeout(300)
+def test_async_vault_deposit_uses_idle_satellite_bridge_capital(
+    usdc_arbitrum: AssetIdentifier,
+    usdc_base: AssetIdentifier,
+    cctp_pair: TradingPairIdentifier,
+    satellite_vault_pair: TradingPairIdentifier,
+):
+    """An async satellite vault deposit consumes only missing bridge capital.
+
+    1. Bridge 12_000 USDC to Base and leave it idle in the bridge position.
+    2. Plan a 10_000 Base vault deposit and inject CCTP trades.
+    3. Execute the deposit request.
+    4. Assert no redundant bridge-out was injected and the request debited the
+       simulated Base USDC wallet immediately, leaving only idle bridge capital.
+    """
+    wallet = SimulatedWallet()
+    wallet.set_balance(usdc_arbitrum, Decimal(25_000))
+    state = _make_state(usdc_arbitrum, Decimal(25_000))
+    execution = _async_vault_execution(wallet, satellite_vault_pair)
+
+    # 1. Bridge 12_000 USDC to Base and leave it idle in the bridge position.
+    _establish_idle_satellite_capital(state, execution, wallet, cctp_pair, usdc_arbitrum, Decimal(12_000))
+    bridge_position = state.portfolio.get_bridge_position_for_chain(SATELLITE_CHAIN_ID)
+    assert bridge_position.get_available_bridge_capital() == Decimal(12_000)
+
+    # 2. Plan a 10_000 Base vault deposit and inject CCTP trades.
+    buy = _create_satellite_buy(state, satellite_vault_pair, usdc_arbitrum, Decimal(10_000))
+    universe = _make_mock_universe([cctp_pair, satellite_vault_pair])
+    result = inject_cctp_bridge_trades(
+        state=state,
+        trades=[buy],
+        strategy_universe=universe,
+        primary_chain_id=PRIMARY_CHAIN_ID,
+        ts=TS,
+        reserve_asset=usdc_arbitrum,
+    )
+    assert [t for t in result if t.pair.is_cctp_bridge()] == []
+
+    # 3. Execute the deposit request.
+    routing_model, routing_state = _routing(wallet, usdc_arbitrum)
+    execution.execute_trades(
+        ts=TS,
+        state=state,
+        trades=result,
+        routing_model=routing_model,
+        routing_state=routing_state,
+        check_balances=True,
+    )
+
+    # 4. Assert request-time wallet and bridge-capital accounting.
+    assert buy.get_status() == TradeStatus.vault_settlement_pending
+    assert wallet.get_balance(usdc_base) == Decimal(2_000)
+    assert wallet.get_balance(satellite_vault_pair.base) == Decimal(0)
+    assert bridge_position.bridge_capital_allocated == Decimal(10_000)
+    assert bridge_position.get_available_bridge_capital() == Decimal(2_000)
+    assert calculate_total_assets(state.portfolio)[usdc_base] == Decimal(2_000)
+    assert dict(get_asset_amounts(bridge_position))[usdc_base] == Decimal(2_000)
+    assert state.portfolio.get_vault_settlement_pending_value() == pytest.approx(10_000.0, abs=1e-6)
+
+
+@pytest.mark.timeout(300)
+def test_async_vault_deposit_bridges_only_missing_satellite_capital(
+    usdc_arbitrum: AssetIdentifier,
+    usdc_base: AssetIdentifier,
+    cctp_pair: TradingPairIdentifier,
+    satellite_vault_pair: TradingPairIdentifier,
+):
+    """An async satellite vault deposit bridges the missing amount, then queues it.
+
+    1. Start with primary reserve only and plan a 10_000 Base vault deposit.
+    2. Inject CCTP trades.
+    3. Execute the bridge-out and vault deposit request in one batch.
+    4. Assert the bridge-out equals the missing amount and the deposit request
+       leaves no deployable Base USDC in the simulated wallet.
+    """
+    wallet = SimulatedWallet()
+    wallet.set_balance(usdc_arbitrum, Decimal(25_000))
+    state = _make_state(usdc_arbitrum, Decimal(25_000))
+    execution = _async_vault_execution(wallet, satellite_vault_pair)
+
+    # 1. Start with primary reserve only and plan a 10_000 Base vault deposit.
+    buy = _create_satellite_buy(state, satellite_vault_pair, usdc_arbitrum, Decimal(10_000))
+    universe = _make_mock_universe([cctp_pair, satellite_vault_pair])
+
+    # 2. Inject CCTP trades.
+    result = inject_cctp_bridge_trades(
+        state=state,
+        trades=[buy],
+        strategy_universe=universe,
+        primary_chain_id=PRIMARY_CHAIN_ID,
+        ts=TS,
+        reserve_asset=usdc_arbitrum,
+    )
+    bridge_trades = [t for t in result if t.pair.is_cctp_bridge()]
+    assert len(bridge_trades) == 1
+    assert bridge_trades[0].is_buy()
+    assert bridge_trades[0].planned_reserve == Decimal(10_000)
+
+    # 3. Execute the bridge-out and vault deposit request in one batch.
+    routing_model, routing_state = _routing(wallet, usdc_arbitrum)
+    execution.execute_trades(
+        ts=TS,
+        state=state,
+        trades=sorted(result, key=lambda t: t.get_execution_sort_position()),
+        routing_model=routing_model,
+        routing_state=routing_state,
+        check_balances=True,
+    )
+
+    # 4. Assert request-time wallet and bridge-capital accounting.
+    bridge_position = state.portfolio.get_bridge_position_for_chain(SATELLITE_CHAIN_ID)
+    assert buy.get_status() == TradeStatus.vault_settlement_pending
+    assert wallet.get_balance(usdc_base) == Decimal(0)
+    assert wallet.get_balance(satellite_vault_pair.base) == Decimal(0)
+    assert bridge_position.bridge_capital_allocated == Decimal(10_000)
+    assert bridge_position.get_available_bridge_capital() == Decimal(0)
+    assert usdc_base not in calculate_total_assets(state.portfolio)
+    assert get_asset_amounts(bridge_position) == []
+    assert state.portfolio.get_vault_settlement_pending_value() == pytest.approx(10_000.0, abs=1e-6)
+
+
+@pytest.mark.timeout(300)
+def test_async_vault_redeem_does_not_fund_same_cycle_satellite_buy(
+    usdc_arbitrum: AssetIdentifier,
+    usdc_base: AssetIdentifier,
+    cctp_pair: TradingPairIdentifier,
+    satellite_pair: TradingPairIdentifier,
+    satellite_vault_pair: TradingPairIdentifier,
+):
+    """An async vault redeem cannot fund another satellite buy in the same cycle.
+
+    1. Bridge 10_000 USDC to Base, request an 8_000 async vault deposit and
+       settle it to establish an override-only async vault position.
+    2. In one later cycle, request a full async redeem and a 6_000 Base spot buy.
+    3. Inject CCTP trades.
+    4. Assert the planner ignores the async redeem proceeds and bridges only the
+       4_000 shortfall above the 2_000 idle Base bridge capital.
+    5. Execute the cycle and assert the redeem request debited wallet shares
+       immediately while no Base USDC proceeds appeared yet.
+    """
+    wallet = SimulatedWallet()
+    wallet.set_balance(usdc_arbitrum, Decimal(30_000))
+    state = _make_state(usdc_arbitrum, Decimal(30_000))
+    execution = _async_vault_execution(wallet, satellite_vault_pair)
+
+    # 1. Bridge 10_000 USDC to Base, request an 8_000 async vault deposit and settle it.
+    _establish_idle_satellite_capital(state, execution, wallet, cctp_pair, usdc_arbitrum, Decimal(10_000))
+    vault_buy = _create_satellite_buy(state, satellite_vault_pair, usdc_arbitrum, Decimal(8_000))
+    routing_model, routing_state = _routing(wallet, usdc_arbitrum)
+    execution.execute_trades(
+        ts=TS,
+        state=state,
+        trades=[vault_buy],
+        routing_model=routing_model,
+        routing_state=routing_state,
+        check_balances=True,
+    )
+    execution.resolve_pending_vault_settlements(
+        state=state,
+        ts=TS + datetime.timedelta(days=3),
+        pricing_model=None,
+    )
+    vault_position = state.portfolio.get_open_position_for_pair(satellite_vault_pair)
+    bridge_position = state.portfolio.get_bridge_position_for_chain(SATELLITE_CHAIN_ID)
+    assert vault_buy.is_success()
+    assert vault_position.has_async_vault_flow()
+    assert wallet.get_balance(satellite_vault_pair.base) == Decimal(8_000)
+    assert bridge_position.get_available_bridge_capital() == Decimal(2_000)
+
+    # 2. In one later cycle, request a full async redeem and a 6_000 Base spot buy.
+    cycle_ts = TS + datetime.timedelta(days=4)
+    _, vault_sell, _ = state.create_trade(
+        strategy_cycle_at=cycle_ts,
+        pair=satellite_vault_pair,
+        quantity=-vault_position.get_quantity(),
+        reserve=None,
+        assumed_price=1.0,
+        trade_type=TradeType.rebalance,
+        reserve_currency=usdc_arbitrum,
+        reserve_currency_price=1.0,
+        position=vault_position,
+        closing=True,
+    )
+    spot_buy = _create_satellite_buy(state, satellite_pair, usdc_arbitrum, Decimal(6_000))
+
+    # 3. Inject CCTP trades.
+    universe = _make_mock_universe([cctp_pair, satellite_pair, satellite_vault_pair])
+    result = inject_cctp_bridge_trades(
+        state=state,
+        trades=[vault_sell, spot_buy],
+        strategy_universe=universe,
+        primary_chain_id=PRIMARY_CHAIN_ID,
+        ts=cycle_ts,
+        reserve_asset=usdc_arbitrum,
+    )
+
+    # 4. Assert the planner ignores the async redeem proceeds.
+    bridge_trades = [t for t in result if t.pair.is_cctp_bridge()]
+    assert len(bridge_trades) == 1
+    assert bridge_trades[0].is_buy()
+    assert bridge_trades[0].planned_reserve == Decimal(4_000)
+
+    # 5. Execute the cycle and assert request-time redeem accounting.
+    execution.execute_trades(
+        ts=cycle_ts,
+        state=state,
+        trades=sorted(result, key=lambda t: t.get_execution_sort_position()),
+        routing_model=routing_model,
+        routing_state=routing_state,
+        check_balances=True,
+    )
+    assert vault_sell.get_status() == TradeStatus.vault_settlement_pending
+    assert wallet.get_balance(satellite_vault_pair.base) == Decimal(0)
+    assert wallet.get_balance(usdc_base) == Decimal(0)
+    assert bridge_position.get_available_bridge_capital() == Decimal(0)
+    assert dict(get_asset_amounts(vault_position))[satellite_vault_pair.base] == Decimal(0)
+    assert state.portfolio.get_vault_settlement_pending_value() == pytest.approx(0.0, abs=1e-6)

--- a/tests/ethereum/test_correct_accounts_cctp_bridge.py
+++ b/tests/ethereum/test_correct_accounts_cctp_bridge.py
@@ -30,7 +30,7 @@ from web3.contract import Contract
 from eth_defi.hotwallet import HotWallet
 from eth_defi.provider.anvil import AnvilLaunch, launch_anvil
 from eth_defi.chain import install_chain_middleware
-from eth_defi.token import create_token
+from eth_defi.token import DEFAULT_TOKEN_CACHE, TokenDetails, create_token
 from eth_defi.trace import assert_transaction_success_with_explanation
 from tradingstrategy.chain import ChainId
 from typer.main import get_command
@@ -42,6 +42,18 @@ from tradeexecutor.utils.hex import hexbytes_to_hex_str
 
 
 # --- Fixtures ---
+
+
+def _poison_default_token_cache(web3: Web3, token_address: str) -> str:
+    """Insert wrong 18-decimal metadata for a token into the process-global cache."""
+    cache_key = TokenDetails.generate_cache_key(web3.eth.chain_id, token_address)
+    DEFAULT_TOKEN_CACHE[cache_key] = {
+        "name": "Wrong cached token",
+        "symbol": "WRONG",
+        "supply": 1,
+        "decimals": 18,
+    }
+    return cache_key
 
 
 @pytest.fixture()
@@ -212,6 +224,8 @@ def environment(
 def test_correct_accounts_cctp_bridge(
     environment: dict,
     state_file: Path,
+    web3_dest: Web3,
+    usdc_dest: Contract,
 ):
     """Test correct-accounts auto-creates and corrects bridge position.
 
@@ -224,13 +238,14 @@ def test_correct_accounts_cctp_bridge(
 
     Flow:
     1. Run ``cli init`` to create empty state
-    2. Run ``cli correct-accounts`` which auto-creates bridge position
+    2. Poison the global token metadata cache with wrong destination token decimals.
+    3. Run ``cli correct-accounts`` which auto-creates bridge position
        from universe and corrects both reserve and bridge to match
        on-chain balances on their respective chains
-    3. Verify reserve = 5,000 (source USDC remaining after bridge)
-    4. Verify bridge position = 5,000 (destination USDC)
-    5. Verify total portfolio = 10,000
-    6. Verify trade counts and balance updates
+    4. Read back the corrected state.
+    5. Verify reserve = 5,000 (source USDC remaining after bridge)
+    6. Verify bridge position = 5,000 (destination USDC)
+    7. Verify total portfolio, trade counts and balance updates
     """
     cli = get_command(app)
 
@@ -243,47 +258,49 @@ def test_correct_accounts_cctp_bridge(
     assert len(initial_state.portfolio.open_positions) == 0, \
         "State should have no positions after init"
 
-    # Step 2: Run correct-accounts (should auto-create bridge position and correct balances)
-    with patch.dict(os.environ, environment, clear=True):
-        with pytest.raises(SystemExit) as e:
-            cli.main(args=["correct-accounts"])
-        assert e.value.code == 0, f"CLI command failed with exit code {e.value.code}"
+    # Step 2: Poison the global token metadata cache with wrong destination token decimals.
+    cache_key = _poison_default_token_cache(web3_dest, usdc_dest.address)
+    try:
+        # Step 3: Run correct-accounts (should auto-create bridge position and correct balances)
+        with patch.dict(os.environ, environment, clear=True):
+            with pytest.raises(SystemExit) as e:
+                cli.main(args=["correct-accounts"])
+            assert e.value.code == 0, f"CLI command failed with exit code {e.value.code}"
+    finally:
+        DEFAULT_TOKEN_CACHE.pop(cache_key, None)
 
-    # Step 3: Read back corrected state
+    # Step 4: Read back corrected state
     final_state = State.read_json_file(state_file)
 
-    # Verify reserve was initialised and corrected to on-chain source balance
+    # Step 5: Verify reserve was initialised and corrected to on-chain source balance
     # (5000 remaining after bridging 5000 from original 10000)
     final_reserve = final_state.portfolio.get_default_reserve_position()
     assert final_reserve is not None, "Reserve should exist after correct-accounts"
     assert float(final_reserve.quantity) == pytest.approx(5_000, rel=0.02), \
         f"Reserve expected ~5000, got {final_reserve.quantity}"
 
-    # Verify bridge position was auto-created
+    # Step 6: Verify bridge position was auto-created and corrected to the on-chain dest balance.
     assert len(final_state.portfolio.open_positions) == 1, \
         f"Expected 1 open position, got {len(final_state.portfolio.open_positions)}"
     bridge_position = list(final_state.portfolio.open_positions.values())[0]
     assert bridge_position.pair.kind == TradingPairKind.cctp_bridge, \
         f"Expected cctp_bridge position, got {bridge_position.pair.kind}"
 
-    # Verify bridge position was corrected to on-chain dest balance (5000 bridged)
     final_bridge_qty = bridge_position.get_quantity()
     assert float(final_bridge_qty) == pytest.approx(5_000, rel=0.02), \
         f"Bridge position expected ~5000, got {final_bridge_qty}"
 
-    # Verify total portfolio = reserve + bridge = 10,000
+    # Step 7: Verify total portfolio, trade counts and balance updates.
     total_portfolio = float(final_reserve.quantity) + float(final_bridge_qty)
     assert total_portfolio == pytest.approx(10_000, rel=0.02), \
         f"Total portfolio expected ~10000, got {total_portfolio}"
 
-    # Verify bridge position has exactly 1 trade (auto-creation)
     trades = list(bridge_position.trades.values())
     assert len(trades) == 1, \
         f"Expected exactly 1 trade on bridge position, got {len(trades)}"
     assert "Auto-created by correct-accounts for CCTP bridge" in (trades[0].notes or ""), \
         f"Expected auto-creation notes, got: {trades[0].notes}"
 
-    # Verify balance updates were recorded for the correction
     assert len(bridge_position.balance_updates) == 1, \
         f"Expected 1 balance update for bridge position, got {len(bridge_position.balance_updates)}"
     assert len(final_state.sync.accounting.balance_update_refs) >= 1, \
@@ -307,8 +324,9 @@ def test_lagoon_fetch_onchain_balances_multichain_routing(
     1. Create a mock LagoonVaultSyncModel with web3_source as home chain.
     2. Set web3config with connections for source (Arbitrum) and dest (Base).
     3. Create assets: source-chain USDC and dest-chain USDC.
-    4. Call fetch_onchain_balances with both assets.
-    5. Verify both balances are correctly detected on their respective chains.
+    4. Poison the global token metadata cache with wrong destination token decimals.
+    5. Call fetch_onchain_balances with both assets.
+    6. Verify both balances are correctly detected on their respective chains.
     """
     from eth_defi.erc_4626.vault_protocol.lagoon.vault import LagoonVault
     from tradeexecutor.ethereum.lagoon.vault import LagoonVaultSyncModel
@@ -349,15 +367,22 @@ def test_lagoon_fetch_onchain_balances_multichain_routing(
         decimals=6,
     )
 
-    # 4. Call fetch_onchain_balances with assets from both chains.
-    #    Before the fix, this crashed with TokenDetailError because
-    #    dest_usdc was queried on the source chain where it doesn't exist.
-    balances = list(sync_model.fetch_onchain_balances(
-        [source_usdc, dest_usdc],
-        filter_zero=False,
-    ))
+    # 4. Poison the global token metadata cache with wrong destination token decimals.
+    cache_key = _poison_default_token_cache(web3_dest, usdc_dest.address)
+    try:
+        # 5. Call fetch_onchain_balances with assets from both chains.
+        #    Before the routing fix, this crashed with TokenDetailError because
+        #    dest_usdc was queried on the source chain where it doesn't exist.
+        #    Before the raw-balance fix, this returned 5e-09 when an earlier test
+        #    polluted Anvil's shared token metadata cache with 18 decimals.
+        balances = list(sync_model.fetch_onchain_balances(
+            [source_usdc, dest_usdc],
+            filter_zero=False,
+        ))
+    finally:
+        DEFAULT_TOKEN_CACHE.pop(cache_key, None)
 
-    # 5. Verify both balances detected correctly (5000 each from hot_wallet fixture)
+    # 6. Verify both balances detected correctly (5000 each from hot_wallet fixture)
     balance_map = {b.asset.chain_id: float(b.amount) for b in balances}
     assert ChainId.arbitrum.value in balance_map, "Source chain balance not found"
     assert ChainId.base.value in balance_map, "Dest chain balance not found"

--- a/tests/mainnet_fork/test_rebalance_vault_yield.py
+++ b/tests/mainnet_fork/test_rebalance_vault_yield.py
@@ -8,11 +8,13 @@ from unittest import mock
 
 import pytest
 from pytest import FixtureRequest
+from pytest_mock import MockerFixture
 
 from eth_defi.provider.anvil import AnvilLaunch, launch_anvil
 
 from tradeexecutor.cli.main import app
 from tradeexecutor.utils.hex import hexbytes_to_hex_str
+from tradingstrategy.client import Client
 
 
 pytestmark = pytest.mark.skipif(not os.environ.get("JSON_RPC_BASE") or not os.environ.get("TRADING_STRATEGY_API_KEY"), reason="Set JSON_RPC_POLYGON and TRADING_STRATEGY_API_KEY environment variables to run this test")
@@ -36,7 +38,7 @@ def anvil(request: FixtureRequest) -> AnvilLaunch:
 
 
 @pytest.fixture()
-def state_file(tmp_path) -> Path:
+def state_file(tmp_path: Path) -> Path:
     """Make a copy of the state file with the broken vault on a new test cycle"""
     template = Path(__file__).resolve().parent / "yield-manager-aave-bug.json"
     assert template.exists(), f"State dump missing: {template}"
@@ -59,7 +61,7 @@ def environment(
     anvil: AnvilLaunch,
     state_file: Path,
     strategy_file: Path,
-    persistent_test_client,
+    persistent_test_client: Client,
     ) -> dict:
     """Passed to init and start commands as environment variables"""
     # Set up the configuration for the live trader
@@ -83,6 +85,10 @@ def environment(
         "RUN_SINGLE_CYCLE": "true",  # Run only one cycle"
         "MIN_GAS_BALANCE": "0.0",   # Disable gas balance check
         "DISABLE_BROADCAST": "true",  # Disable wait_and_broadcast_multiple_nodes() broadcast as we do not have real private key
+        # Trading Strategy website data may lag wall-clock time by more than
+        # one day in CI; this test exercises rebalance transaction generation,
+        # not the live data freshness alert.
+        "MAX_DATA_DELAY_MINUTES": str(3 * 24 * 60),
     }
     return environment
 
@@ -90,12 +96,25 @@ def environment(
 @pytest.mark.slow_test_group
 def test_rebalance_vault_yield(
     environment: dict,
-    mocker,
+    mocker: MockerFixture,
 ):
     """Run one cycle and generate a rebalance transaction for the vault yield.
 
-    - Make sure money is withdrawn from Aave and deposited to the vaults.
+    This mainnet-fork regression test verifies that the damaged vault-yield
+    state can generate the next rebalance transactions without crashing.
+
+    1. Patch the process environment with the forked RPC, copied state file and
+       deterministic test settings.
+    2. Run one `trade-executor start` cycle.
+    3. Confirm the command completes, proving money can be withdrawn from Aave
+       and redeployed to the vaults.
     """
 
+    # 1. Patch the process environment with the forked RPC, copied state file and
+    # deterministic test settings.
     mocker.patch.dict("os.environ", environment, clear=True)
+
+    # 2. Run one `trade-executor start` cycle.
+    # 3. Confirm the command completes, proving money can be withdrawn from Aave
+    # and redeployed to the vaults.
     app(["start"], standalone_mode=False)

--- a/tests/test_cctp_in_transit_status.py
+++ b/tests/test_cctp_in_transit_status.py
@@ -19,7 +19,7 @@ from tradeexecutor.state.identifier import (
     TradingPairKind,
 )
 from tradeexecutor.state.state import State
-from tradeexecutor.state.trade import TradeExecution, TradeStatus, TradeType
+from tradeexecutor.state.trade import CCTP_BRIDGE_ORDER_BUMP, TradeExecution, TradeStatus, TradeType
 
 
 USDC_ARBITRUM_ADDRESS = "0xaf88d065e77c8cC2239327C5EDb3A432268e5831"
@@ -179,7 +179,7 @@ def test_get_execution_sort_position_cctp_bridge(
     # 1. Create a bridge-out (buy) trade and check sort position is in +30M range
     buy_trade = _create_bridge_trade(state, cctp_pair, usdc_arbitrum, Decimal(500), ts)
     buy_sort = buy_trade.get_execution_sort_position()
-    assert buy_sort == buy_trade.trade_id + 30_000_000
+    assert buy_sort == buy_trade.trade_id + CCTP_BRIDGE_ORDER_BUMP
 
     # First bridge-out must complete before we can test bridge-back
     state.start_execution(ts, buy_trade)
@@ -199,13 +199,13 @@ def test_get_execution_sort_position_cctp_bridge(
         state, cctp_pair, usdc_arbitrum, Decimal(500), ts, sell=True,
     )
     sell_sort = sell_trade.get_execution_sort_position()
-    assert sell_sort == -sell_trade.trade_id - 30_000_000
+    assert sell_sort == -sell_trade.trade_id - CCTP_BRIDGE_ORDER_BUMP
 
     # 3. Verify bridge sell with closing=True still uses bridge phase, not close phase
     sell_trade.closing = True
     closing_sort = sell_trade.get_execution_sort_position()
     # Must still be in the bridge range, not the generic close range (-100M)
-    assert closing_sort == -sell_trade.trade_id - 30_000_000
+    assert closing_sort == -sell_trade.trade_id - CCTP_BRIDGE_ORDER_BUMP
 
 
 def test_mark_bridge_in_transit(

--- a/tradeexecutor/analysis/cctp.py
+++ b/tradeexecutor/analysis/cctp.py
@@ -67,11 +67,12 @@ def assert_bridge_coverage(
     trades: Iterable[TradeExecution],
     primary_chain_id: int,
 ) -> pd.DataFrame:
-    """Assert every cycle with satellite vault trades also has CCTP bridge trades.
+    """Assert a cross-chain vault run has satellite vaults and CCTP bridge trades.
 
-    This validates the bridge-trade injection path: when the strategy
-    allocates to vaults on satellite chains, CCTP bridge trades must be
-    generated in the same cycle to fund the deposits.
+    This validates that the run exercised the bridge-trade injection path. A
+    satellite vault cycle no longer needs a bridge trade in the same cycle:
+    existing idle satellite bridge capital can fund the vault trade, and the
+    CCTP planner should bridge only the missing amount.
 
     :param trades:
         All trades from the backtest portfolio.
@@ -80,10 +81,11 @@ def assert_bridge_coverage(
         Chain ID of the primary reserve chain (e.g. ``ChainId.ethereum.value``).
 
     :return:
-        Per-cycle summary DataFrame with trade counts.
+        Per-cycle summary DataFrame with trade counts and a boolean flag for
+        satellite vault cycles that reused existing bridge capital.
 
     :raise AssertionError:
-        If any cycle has satellite vault trades but no bridge trades.
+        If the run has no satellite vault trades or no CCTP bridge trades.
     """
     rows = []
     for trade in trades:
@@ -105,16 +107,14 @@ def assert_bridge_coverage(
         satellite_vault_trades=("is_satellite_vault", "sum"),
         traded_value_usd=("value_usd", "sum"),
     ).reset_index()
+    cycle_df["satellite_vaults_without_same_cycle_bridge"] = (
+        (cycle_df["satellite_vault_trades"] > 0)
+        & (cycle_df["bridge_trades"] == 0)
+    )
 
     cycles_with_satellite_vaults = cycle_df[cycle_df["satellite_vault_trades"] > 0]
-    cycles_missing_bridges = cycles_with_satellite_vaults[
-        cycles_with_satellite_vaults["bridge_trades"] == 0
-    ]
 
     assert len(cycles_with_satellite_vaults) > 0, "Expected satellite vault trades"
-    assert len(cycles_missing_bridges) == 0, (
-        f"{len(cycles_missing_bridges)} cycle(s) have satellite vault trades "
-        f"but no CCTP bridge trades:\n{cycles_missing_bridges}"
-    )
+    assert cycle_df["bridge_trades"].sum() > 0, "Expected CCTP bridge trades"
 
     return cycle_df

--- a/tradeexecutor/backtest/backtest_execution.py
+++ b/tradeexecutor/backtest/backtest_execution.py
@@ -173,10 +173,27 @@ class BacktestExecution(ExecutionModel):
         # quote = trade.pair.quote
 
         # For satellite chain trades funded via a CCTP bridge, the on-chain
-        # token spent is the pair's quote token (e.g. USDC on Base), not the
-        # portfolio reserve currency (e.g. USDC on Arbitrum).
+        # token spent/received is the satellite quote token (e.g. USDC on Base),
+        # not the portfolio reserve currency (e.g. USDC on Arbitrum).
+        #
+        # Do not infer this from quote != reserve_currency: normal multi-hop
+        # spot pairs like AAVE-WETH can still be funded from the USDC reserve.
         bridge_position = state.portfolio.get_bridge_position_for_chain(trade.pair.chain_id)
-        if bridge_position is not None or trade.pair.quote != trade.reserve_currency:
+        has_closed_bridge_position = (
+            trade.is_sell()
+            and bridge_position is None
+            and trade.pair.quote != trade.reserve_currency
+            and any(
+                p.pair.is_cctp_bridge()
+                and p.pair.get_destination_chain_id() == trade.pair.chain_id
+                for p in state.portfolio.closed_positions.values()
+            )
+        )
+        bridge_funded_buy = trade.bridge_currency_allocated is not None
+        satellite_sell_returning_to_bridge = trade.is_sell() and (
+            bridge_position is not None or has_closed_bridge_position
+        )
+        if bridge_funded_buy or satellite_sell_returning_to_bridge:
             reserve = trade.pair.quote
         else:
             reserve = trade.reserve_currency

--- a/tradeexecutor/backtest/backtest_execution.py
+++ b/tradeexecutor/backtest/backtest_execution.py
@@ -12,7 +12,12 @@ from eth_defi.erc_4626.core import ERC4626Feature
 from tradeexecutor.backtest.backtest_routing import BacktestRoutingModel, BacktestRoutingState
 from tradeexecutor.backtest.simulated_wallet import SimulatedWallet, OutOfSimulatedBalance
 from tradeexecutor.state.state import State
-from tradeexecutor.state.trade import TradeExecution, TradeStatus
+from tradeexecutor.state.trade import (
+    TradeExecution,
+    TradeStatus,
+    VAULT_SETTLEMENT_REQUEST_QUANTITY_KEY,
+    VAULT_SETTLEMENT_REQUEST_RESERVE_KEY,
+)
 from tradeexecutor.state.types import Percent
 from tradeexecutor.strategy.account_correction import calculate_total_assets
 from tradeexecutor.strategy.execution_model import ExecutionModel, AutoClosingOrderUnsupported
@@ -171,7 +176,7 @@ class BacktestExecution(ExecutionModel):
         # token spent is the pair's quote token (e.g. USDC on Base), not the
         # portfolio reserve currency (e.g. USDC on Arbitrum).
         bridge_position = state.portfolio.get_bridge_position_for_chain(trade.pair.chain_id)
-        if bridge_position is not None:
+        if bridge_position is not None or trade.pair.quote != trade.reserve_currency:
             reserve = trade.pair.quote
         else:
             reserve = trade.reserve_currency
@@ -387,21 +392,42 @@ class BacktestExecution(ExecutionModel):
     def simulate_async_vault_request(self, ts: datetime.datetime, state: State, trade: TradeExecution) -> None:
         """Stage 1 of a two-stage async vault deposit/redeem in backtest.
 
-        Records the deposit/redeem request as pending settlement **without** touching
-        the simulated wallet. For a deposit the state reserve ledger has already been
-        debited by ``start_execution()``; for a redeem the shares stay in the position
-        and wallet. The wallet share/reserve balances move only at simulated claim time
-        in :py:meth:`resolve_pending_vault_settlements`, once the configured delay has
-        elapsed.
+        Records the deposit/redeem request as pending settlement and moves the
+        request asset out of the simulated wallet immediately. For a deposit,
+        the pair quote token enters the vault deposit queue. For a redeem, the
+        pair base shares enter the vault redeem queue. Settlement later credits
+        only the claim output, using the exact amount debited here as its input.
 
         :param ts:
             Strategy cycle timestamp (request time).
         """
         assert trade.is_vault(), f"simulate_async_vault_request(): not a vault trade {trade}"
+        pair = trade.pair
+        base = pair.base
+        reserve = pair.quote
+
+        if trade.is_buy():
+            request_reserve = trade.planned_reserve
+            assert request_reserve > 0, f"Expected a positive async vault deposit reserve for trade {trade}"
+            self.wallet.update_balance(reserve, -request_reserve, f"vault deposit request #{trade.trade_id}")
+            trade.other_data[VAULT_SETTLEMENT_REQUEST_RESERVE_KEY] = str(request_reserve)
+        else:
+            base_balance = self.wallet.get_balance(base.address)
+            if trade.closing and base_balance > 0:
+                request_quantity = -base_balance
+            else:
+                request_quantity, _ = fix_sell_token_amount(base_balance, trade.planned_quantity)
+            assert request_quantity < 0, f"Expected a negative async vault redeem quantity for trade {trade}"
+            trade.planned_quantity = request_quantity
+            trade.planned_reserve = abs(request_quantity) * Decimal(str(trade.planned_price))
+            self.wallet.update_balance(base, request_quantity, f"vault redeem request #{trade.trade_id}")
+            trade.other_data[VAULT_SETTLEMENT_REQUEST_QUANTITY_KEY] = str(request_quantity)
+
         settles_at = self._get_settlement_due(trade.pair, ts)
         trade.other_data["vault_settlement_estimated_at"] = settles_at.isoformat()
-        # mark_vault_settlement_pending() sets vault_settlement_pending_at, vault_async_flow,
-        # vault_chain_id and vault_direction. No protocol ticket data exists in backtest.
+        # mark_vault_settlement_pending() sets vault_settlement_pending_at,
+        # vault_async_flow, vault_chain_id and vault_direction. No protocol
+        # ticket data exists in backtest.
         state.mark_vault_settlement_pending(ts, trade, ticket_data={})
         logger.info(
             "Backtest async vault request: trade #%d (%s), settles at %s",
@@ -488,34 +514,25 @@ class BacktestExecution(ExecutionModel):
 
         if trade.is_buy():
             # Deposit: realise shares at the current (settlement-time) price.
+            executed_reserve = trade.get_vault_settlement_request_reserve()
             if pricing_model is not None:
-                settlement_price = pricing_model.get_buy_price(ts, pair, trade.planned_reserve).price
+                settlement_price = pricing_model.get_buy_price(ts, pair, executed_reserve).price
             else:
                 settlement_price = float(trade.planned_price)
-            executed_reserve = trade.planned_reserve
-            # Decimal rounding drift between the state cash ledger and the
-            # simulated wallet accumulates over many settlements; settle with
-            # what the wallet holds when the difference is dust.
-            reserve_balance = self.wallet.get_balance(reserve.address)
-            if reserve_balance < executed_reserve <= reserve_balance + Decimal("0.000001"):
-                executed_reserve = reserve_balance
             executed_quantity = executed_reserve / Decimal(str(settlement_price))
-            # Wallet: receive shares, pay the committed reserve. The state cash
-            # ledger was already debited at request time (start_execution); this
-            # debits the simulated wallet so the two stay in sync post-settlement.
+            # Wallet: receive shares. The committed reserve already left the
+            # wallet at request time and must not be debited a second time.
             self.wallet.update_balance(base, executed_quantity, f"vault deposit settle #{trade.trade_id}")
-            self.wallet.update_balance(reserve, -executed_reserve, f"vault deposit settle #{trade.trade_id}")
         else:
             # Redeem: realise reserve at the current (settlement-time) price.
+            executed_quantity = trade.get_vault_settlement_request_quantity()
             if pricing_model is not None:
-                settlement_price = pricing_model.get_sell_price(ts, pair, abs(trade.planned_quantity)).price
+                settlement_price = pricing_model.get_sell_price(ts, pair, abs(executed_quantity)).price
             else:
                 settlement_price = float(trade.planned_price)
-            base_balance = self.wallet.get_balance(base.address)
-            executed_quantity, _ = fix_sell_token_amount(base_balance, trade.planned_quantity)
             executed_reserve = abs(executed_quantity) * Decimal(str(settlement_price))
-            # Wallet: give up shares (executed_quantity is negative), receive reserve.
-            self.wallet.update_balance(base, executed_quantity, f"vault redeem settle #{trade.trade_id}")
+            # Wallet: receive reserve. The shares already left the wallet at
+            # request time and must not be debited a second time.
             self.wallet.update_balance(reserve, executed_reserve, f"vault redeem settle #{trade.trade_id}")
 
         executed_price = float(abs(executed_reserve / executed_quantity)) if executed_quantity else float(settlement_price)

--- a/tradeexecutor/ethereum/cctp/planner.py
+++ b/tradeexecutor/ethereum/cctp/planner.py
@@ -17,6 +17,7 @@ unnecessary round-trips when sells and buys partially cancel out.
 
 import datetime
 import logging
+from dataclasses import dataclass
 from collections import defaultdict
 from decimal import Decimal
 
@@ -27,30 +28,75 @@ from tradeexecutor.state.identifier import (
 )
 from tradeexecutor.state.portfolio import NotEnoughMoney
 from tradeexecutor.state.state import State
-from tradeexecutor.state.trade import TradeExecution, TradeType
+from tradeexecutor.state.trade import CCTP_BRIDGE_ORDER_BUMP, TradeExecution, TradeType
+from tradeexecutor.utils.accuracy import SUM_EPSILON, sum_decimal
 
 logger = logging.getLogger(__name__)
 
 
-def _find_bridge_pair(
+@dataclass
+class ChainLiquidity:
+    """CCTP liquidity planning ledger for one satellite chain."""
+
+    net_flow: Decimal = Decimal(0)
+    satellite_buys: Decimal = Decimal(0)
+    satellite_sells_before_buy: Decimal = Decimal(0)
+    early_satellite_sells: Decimal = Decimal(0)
+    available_bridge_capital: Decimal = Decimal(0)
+    free_idle_bridge_capital: Decimal = Decimal(0)
+    bridge_back_amount: Decimal = Decimal(0)
+
+    @property
+    def available_before_bridge_back(self) -> Decimal:
+        """Satellite-side cash visible by the bridge-back phase."""
+        return self.available_bridge_capital + self.early_satellite_sells
+
+    @property
+    def satellite_sells_after_bridge_back_before_buy(self) -> Decimal:
+        """Sells that release too late for bridge-backs, but early enough for buys."""
+        return max(self.satellite_sells_before_buy - self.early_satellite_sells, Decimal(0))
+
+    @property
+    def available_before_buy(self) -> Decimal:
+        """Satellite-side cash available before same-cycle satellite buys."""
+        return self.available_bridge_capital + self.satellite_sells_before_buy
+
+    @property
+    def satellite_buy_bridge_back_time_need(self) -> Decimal:
+        """Buy demand that must remain funded before bridge-backs execute."""
+        return max(
+            self.satellite_buys - self.satellite_sells_after_bridge_back_before_buy,
+            Decimal(0),
+        )
+
+    @property
+    def satellite_bridge_shortfall(self) -> Decimal:
+        """How much satellite buy demand still needs a bridge-out."""
+        return max(self.satellite_buys - self.available_before_buy, Decimal(0))
+
+    def prepare(self, available_bridge_capital: Decimal) -> None:
+        """Initialise free bridge-back capital after reserving buy funding."""
+        self.available_bridge_capital = available_bridge_capital
+        self.free_idle_bridge_capital = max(
+            self.available_before_bridge_back - self.satellite_buy_bridge_back_time_need,
+            Decimal(0),
+        )
+
+    def reserve_bridge_back(self, amount: Decimal) -> None:
+        """Reserve free idle satellite capital for a CCTP bridge-back."""
+        self.bridge_back_amount += amount
+        self.free_idle_bridge_capital -= amount
+
+
+def _bridge_pairs_by_destination(
     pairs: list[TradingPairIdentifier],
-    destination_chain_id: int,
-) -> TradingPairIdentifier | None:
-    """Find the CCTP bridge pair targeting a specific destination chain.
-
-    :param pairs:
-        All trading pairs available in the strategy universe.
-
-    :param destination_chain_id:
-        The chain ID of the destination (satellite) chain.
-
-    :return:
-        The bridge pair, or ``None`` if no bridge pair exists for that chain.
-    """
-    for pair in pairs:
-        if pair.kind == TradingPairKind.cctp_bridge and pair.get_destination_chain_id() == destination_chain_id:
-            return pair
-    return None
+) -> dict[int, TradingPairIdentifier]:
+    """Map destination chain id to its CCTP bridge pair."""
+    return {
+        pair.get_destination_chain_id(): pair
+        for pair in pairs
+        if pair.kind == TradingPairKind.cctp_bridge
+    }
 
 
 def _available_bridge_capital(state: State, chain_id: int) -> Decimal:
@@ -72,6 +118,41 @@ def _available_bridge_capital(state: State, chain_id: int) -> Decimal:
     if bridge_position is None:
         return Decimal(0)
     return max(bridge_position.get_available_bridge_capital(), Decimal(0))
+
+
+def _open_bridge_chain_ids(state: State) -> set[int]:
+    """Which satellite chains currently have open CCTP bridge capital."""
+    return {
+        position.pair.get_destination_chain_id()
+        for position in state.portfolio.open_positions.values()
+        if position.pair.is_cctp_bridge()
+    }
+
+
+def _is_meaningful_bridge_amount(amount: Decimal) -> bool:
+    """Is this amount large enough to become a CCTP trade."""
+    return amount > SUM_EPSILON
+
+
+def _trade_releases_before_bridge_back(trade: TradeExecution) -> bool:
+    """Does this satellite sell release bridge capital before bridge-backs run."""
+    return trade.get_execution_sort_position() < -CCTP_BRIDGE_ORDER_BUMP
+
+
+def _is_async_vault_sell_waiting_for_settlement(state: State, trade: TradeExecution) -> bool:
+    """Does this sell request produce reserve only after async vault settlement?"""
+    if not trade.is_sell() or not trade.is_vault():
+        return False
+    if trade.other_data.get("vault_async_flow"):
+        return True
+    if trade.pair.is_async_vault():
+        return True
+
+    position = state.portfolio.get_position_by_id(trade.position_id)
+    if position is not None and position.has_async_vault_flow():
+        return True
+
+    return False
 
 
 def inject_cctp_bridge_trades(
@@ -131,13 +212,13 @@ def inject_cctp_bridge_trades(
         Original trades are not modified.
     """
 
-    # Pre-fetch all pairs from the universe so we only iterate once
-    all_pairs = list(strategy_universe.iterate_pairs())
+    # Pre-fetch bridge pairs from the universe so we only iterate once.
+    bridge_pairs = _bridge_pairs_by_destination(list(strategy_universe.iterate_pairs()))
 
     # 1. Group trades by chain and compute net capital flow per satellite chain.
     #    Also track primary-chain reserve in/outflows so bridge-outs can be
     #    bounded by what the primary chain can actually fund.
-    chain_flows: dict[int, Decimal] = defaultdict(lambda: Decimal(0))
+    liquidity_by_chain: defaultdict[int, ChainLiquidity] = defaultdict(ChainLiquidity)
     primary_sells = Decimal(0)
     primary_buys = Decimal(0)
 
@@ -145,11 +226,18 @@ def inject_cctp_bridge_trades(
         trade_chain_id = trade.pair.chain_id
         value = trade.planned_reserve if trade.planned_reserve else Decimal(str(trade.get_planned_value()))
         value = abs(value)
+        async_vault_sell_waiting = _is_async_vault_sell_waiting_for_settlement(state, trade)
 
         if trade_chain_id == primary_chain_id:
             # Primary-chain sells free reserve (they execute before bridge-outs);
             # primary-chain buys consume it (they execute after bridge-outs).
             if trade.is_sell():
+                if async_vault_sell_waiting:
+                    logger.info(
+                        "Ignoring primary-chain async vault sell #%d for same-cycle reserve planning",
+                        trade.trade_id,
+                    )
+                    continue
                 primary_sells += value
             else:
                 primary_buys += value
@@ -161,24 +249,47 @@ def inject_cctp_bridge_trades(
             continue
 
         if trade.is_sell():
+            if async_vault_sell_waiting:
+                logger.info(
+                    "Ignoring async vault sell #%d on chain %d for same-cycle CCTP liquidity planning",
+                    trade.trade_id,
+                    trade_chain_id,
+                )
+                continue
             # Sell frees up capital — positive flow means excess to bridge back
-            chain_flows[trade_chain_id] += value
+            liquidity = liquidity_by_chain[trade_chain_id]
+            liquidity.net_flow += value
+            liquidity.satellite_sells_before_buy += value
+            if _trade_releases_before_bridge_back(trade):
+                liquidity.early_satellite_sells += value
         else:
             # Buy consumes capital — negative flow means deficit to bridge out
-            chain_flows[trade_chain_id] -= value
+            liquidity = liquidity_by_chain[trade_chain_id]
+            liquidity.net_flow -= value
+            liquidity.satellite_buys += value
 
     bridge_trades: list[TradeExecution] = []
+
+    # Satellite buys spend idle satellite bridge capital before they need a
+    # bridge-out. Keep that already-spoken-for capital out of primary buy
+    # funding, otherwise a primary-chain buy could steal the USDC that a
+    # same-cycle satellite buy is about to allocate.
+    for chain_id in _open_bridge_chain_ids(state):
+        liquidity_by_chain[chain_id]
+    for chain_id, liquidity in liquidity_by_chain.items():
+        liquidity.prepare(_available_bridge_capital(state, chain_id))
 
     # 2. Bridge-backs first (net-sell satellites). These free capital back onto
     #    the primary chain and execute before bridge-outs, so their proceeds are
     #    available to fund same-cycle bridge-outs.
     total_bridge_back = Decimal(0)
-    for chain_id in sorted(chain_flows):
-        net_flow = chain_flows[chain_id]
+    for chain_id in sorted(liquidity_by_chain):
+        liquidity = liquidity_by_chain[chain_id]
+        net_flow = liquidity.net_flow
         if net_flow <= 0:
             continue
 
-        bridge_pair = _find_bridge_pair(all_pairs, chain_id)
+        bridge_pair = bridge_pairs.get(chain_id)
         if bridge_pair is None:
             logger.warning(
                 "No CCTP bridge pair found for destination chain %d, "
@@ -187,21 +298,18 @@ def inject_cctp_bridge_trades(
             )
             continue
 
-        # Never bridge back more than the per-chain available bridge capital:
+        # Never bridge back more than the per-chain free bridge capital:
         # bridging back the full net sell would move satellite USDC that an
         # in-flight deposit on the same chain still needs to settle, starving it
         # (OutOfSimulatedBalance at deposit settlement). Any excess net sell
         # stays on the satellite and bridges back once the deposits have settled.
         #
-        # Known limitation (conservative): proceeds from *synchronous* satellite
-        # sells in this same cycle land in available_bridge_capital only at
-        # execution (after this planner runs), so they are not counted here and a
-        # bridge-back that should follow them may under-bridge for one cycle. The
-        # correct model distinguishes already-idle / sync-released-this-cycle /
-        # pending-async capital — see the cross-chain reconciliation follow-up.
-        available = _available_bridge_capital(state, chain_id)
+        # Non-closing satellite spot sells release after bridge-backs, so they
+        # cannot fund same-cycle bridge-backs. They are still counted later when
+        # sizing bridge-outs, because they execute before same-chain buys.
+        available = liquidity.free_idle_bridge_capital
         amount = min(net_flow, available)
-        if amount <= 0:
+        if not _is_meaningful_bridge_amount(amount):
             logger.info(
                 "Skipping bridge-back for chain %d: net sell %s exceeds available bridge capital %s",
                 chain_id,
@@ -210,9 +318,85 @@ def inject_cctp_bridge_trades(
             )
             continue
 
-        # amount > 0 implies available > 0, so a bridge position exists.
+        liquidity.reserve_bridge_back(amount)
+        total_bridge_back += amount
+
+    # Primary-chain buys and bridge-outs both need primary-chain USDC. If the
+    # primary reserve is short, pull only the missing amount back from genuinely
+    # idle satellite bridge capital. This prevents notebook failures where
+    # deployable capital existed only as idle satellite USDC, but no satellite
+    # net sell was present to trigger a bridge-back.
+    try:
+        current_primary_reserve = state.portfolio.get_reserve_position(reserve_asset).quantity
+    except KeyError:
+        current_primary_reserve = Decimal(0)
+
+    total_satellite_bridge_shortfall = sum_decimal(
+        liquidity.satellite_bridge_shortfall
+        for liquidity in liquidity_by_chain.values()
+    )
+    primary_cash_needed = primary_buys + total_satellite_bridge_shortfall
+    primary_shortfall = sum_decimal([
+        primary_cash_needed,
+        -current_primary_reserve,
+        -primary_sells,
+        -total_bridge_back,
+    ])
+    if _is_meaningful_bridge_amount(primary_shortfall):
+        for chain_id in sorted(liquidity_by_chain):
+            if not _is_meaningful_bridge_amount(primary_shortfall):
+                break
+            liquidity = liquidity_by_chain[chain_id]
+            available = liquidity.free_idle_bridge_capital
+            amount = min(primary_shortfall, available)
+            if not _is_meaningful_bridge_amount(amount):
+                continue
+            bridge_pair = bridge_pairs.get(chain_id)
+            if bridge_pair is None:
+                logger.warning(
+                    "No CCTP bridge pair found for destination chain %d, "
+                    "skipping primary-shortfall bridge-back",
+                    chain_id,
+                )
+                continue
+            liquidity.reserve_bridge_back(amount)
+            total_bridge_back += amount
+            primary_shortfall -= amount
+            logger.info(
+                "Reserved bridge-back of %s from chain %d to fund primary-chain cash needs",
+                amount,
+                chain_id,
+            )
+
+    if _is_meaningful_bridge_amount(primary_shortfall):
+        raise NotEnoughMoney(
+            f"Cannot fund primary-chain cash needs: need {primary_cash_needed} "
+            f"(primary buys {primary_buys} + satellite bridge shortfalls "
+            f"{total_satellite_bridge_shortfall}), but only "
+            f"{current_primary_reserve + primary_sells + total_bridge_back} primary "
+            f"reserve is available after primary sells and idle satellite bridge-backs "
+            f"(reserve {current_primary_reserve} + primary sells {primary_sells} + "
+            f"bridge-backs {total_bridge_back})"
+        )
+
+    for chain_id in sorted(liquidity_by_chain):
+        liquidity = liquidity_by_chain[chain_id]
+        amount = liquidity.bridge_back_amount
+        if not _is_meaningful_bridge_amount(amount):
+            continue
+
+        bridge_pair = bridge_pairs.get(chain_id)
+        if bridge_pair is None:
+            logger.warning(
+                "No CCTP bridge pair found for destination chain %d, "
+                "skipping bridge injection",
+                chain_id,
+            )
+            continue
+
         bridge_position = state.portfolio.get_bridge_position_for_chain(chain_id)
-        closing = amount >= available
+        available = liquidity.available_before_bridge_back
+        closing = available - amount <= SUM_EPSILON
 
         _, trade, _ = state.create_trade(
             strategy_cycle_at=ts,
@@ -233,7 +417,6 @@ def inject_cctp_bridge_trades(
             chain_id,
             closing,
         )
-        total_bridge_back += amount
         bridge_trades.append(trade)
 
     # 3. Compute the primary-chain reserve available to fund bridge-outs.
@@ -250,27 +433,28 @@ def inject_cctp_bridge_trades(
     #    live — the early ``NotEnoughMoney`` guard below is then less effective,
     #    but execution still enforces funding (``move_capital_from_reserves...``
     #    raises ``NotEnoughMoney`` at ``start_execution``), so it is never unsafe.
-    try:
-        current_primary_reserve = state.portfolio.get_reserve_position(reserve_asset).quantity
-    except KeyError:
-        current_primary_reserve = Decimal(0)
-
-    fundable_primary = current_primary_reserve + primary_sells + total_bridge_back - primary_buys
+    fundable_primary = sum_decimal([
+        current_primary_reserve,
+        primary_sells,
+        total_bridge_back,
+        -primary_buys,
+    ])
     if fundable_primary < 0:
         fundable_primary = Decimal(0)
 
-    # 4. Bridge-outs (net-buy satellites). Fund the satellite buys from capital
-    #    already idle on the satellite first (tracked as available bridge
-    #    capital), and only bridge out the remaining shortfall — never more than
-    #    the primary chain can fund. Process chains in a deterministic order so
+    # 4. Bridge-outs (net-buy satellites). Fund satellite buys from capital
+    #    already idle on the satellite and same-cycle synchronous sells first,
+    #    and only bridge out the remaining shortfall — never more than the
+    #    primary chain can fund. Process chains in a deterministic order so
     #    that, under a primary-reserve shortage, it is reproducible which chain
     #    is reported as underfunded.
-    for chain_id in sorted(chain_flows):
-        net_flow = chain_flows[chain_id]
+    for chain_id in sorted(liquidity_by_chain):
+        liquidity = liquidity_by_chain[chain_id]
+        net_flow = liquidity.net_flow
         if net_flow >= 0:
             continue
 
-        bridge_pair = _find_bridge_pair(all_pairs, chain_id)
+        bridge_pair = bridge_pairs.get(chain_id)
         if bridge_pair is None:
             logger.warning(
                 "No CCTP bridge pair found for destination chain %d, "
@@ -282,30 +466,38 @@ def inject_cctp_bridge_trades(
         required = abs(net_flow)
 
         # Fund the satellite buys from capital already idle on the satellite
-        # first; only the remaining shortfall needs bridging.
-        idle_satellite_capital = _available_bridge_capital(state, chain_id)
+        # and synchronous same-chain sells first; only the remaining shortfall
+        # needs bridging.
+        satellite_side_funding = liquidity.available_before_buy
 
-        shortfall = required - idle_satellite_capital
-        if shortfall <= 0:
+        shortfall = liquidity.satellite_bridge_shortfall
+        if not _is_meaningful_bridge_amount(shortfall):
             # Capital already parked on the satellite covers the net buy; the
             # satellite buy allocates from the bridge position at execution.
             logger.info(
-                "Skipping bridge-out for chain %d: idle satellite capital %s covers net buy %s",
+                "Skipping bridge-out for chain %d: satellite-side funding %s covers satellite buys %s",
                 chain_id,
-                idle_satellite_capital,
-                required,
+                satellite_side_funding,
+                liquidity.satellite_buys,
             )
             continue
 
         if shortfall > fundable_primary:
-            raise NotEnoughMoney(
-                f"Cannot fund CCTP bridge-out to chain {chain_id}: "
-                f"need {shortfall} (net buy {required} - idle satellite capital "
-                f"{idle_satellite_capital}), but only {fundable_primary} primary "
-                f"reserve is available (reserve {current_primary_reserve} + "
-                f"primary sells {primary_sells} + bridge-backs {total_bridge_back} "
-                f"- primary buys {primary_buys})"
-            )
+            if shortfall - fundable_primary <= SUM_EPSILON:
+                shortfall = fundable_primary
+            else:
+                raise NotEnoughMoney(
+                    f"Cannot fund CCTP bridge-out to chain {chain_id}: "
+                    f"need {shortfall} (satellite buys {liquidity.satellite_buys} - "
+                    f"satellite-side funding before buys {satellite_side_funding}; "
+                    f"net buy {required}), but only {fundable_primary} primary "
+                    f"reserve is available (current reserve {current_primary_reserve} + "
+                    f"primary sells {primary_sells} + bridge-backs {total_bridge_back} "
+                    f"- primary buys {primary_buys})"
+                )
+
+        if not _is_meaningful_bridge_amount(shortfall):
+            continue
 
         amount = shortfall
         fundable_primary -= amount
@@ -322,10 +514,11 @@ def inject_cctp_bridge_trades(
         )
 
         logger.info(
-            "Injected bridge-out buy of %s for chain %d (idle satellite capital %s, net buy %s)",
+            "Injected bridge-out buy of %s for chain %d (satellite-side funding %s, satellite buys %s, net buy %s)",
             amount,
             chain_id,
-            idle_satellite_capital,
+            satellite_side_funding,
+            liquidity.satellite_buys,
             required,
         )
         bridge_trades.append(trade)

--- a/tradeexecutor/ethereum/cctp/planner.py
+++ b/tradeexecutor/ethereum/cctp/planner.py
@@ -99,6 +99,14 @@ def _bridge_pairs_by_destination(
     }
 
 
+def _find_bridge_pair(
+    pairs: list[TradingPairIdentifier],
+    destination_chain_id: int,
+) -> TradingPairIdentifier | None:
+    """Find the CCTP bridge pair for a satellite destination chain."""
+    return _bridge_pairs_by_destination(pairs).get(destination_chain_id)
+
+
 def _available_bridge_capital(state: State, chain_id: int) -> Decimal:
     """Per-chain available bridge capital, clamped to be non-negative.
 

--- a/tradeexecutor/ethereum/onchain_balance.py
+++ b/tradeexecutor/ethereum/onchain_balance.py
@@ -3,7 +3,7 @@
 import logging
 from typing import List, Iterable
 
-from eth_defi.balances import fetch_erc20_balances_fallback
+from eth_defi.balances import fetch_erc20_balances_by_token_list
 from eth_defi.chain import fetch_block_timestamp
 from eth_defi.provider.broken_provider import get_block_tip_latency
 
@@ -54,16 +54,16 @@ def fetch_address_balances(
 
     token_addresses = [asset.address for asset in assets]
 
-    balances = fetch_erc20_balances_fallback(
+    raw_balances = fetch_erc20_balances_by_token_list(
         web3,
         address,
         token_addresses,
         block_identifier=block_number,
-        decimalise=True,
+        decimalise=False,
     )
 
     for asset in assets:
-        amount = balances[asset.address]
+        amount = asset.convert_to_decimal(raw_balances[asset.address])
 
         if filter_zero and amount == 0:
             continue

--- a/tradeexecutor/state/portfolio.py
+++ b/tradeexecutor/state/portfolio.py
@@ -1058,6 +1058,35 @@ class Portfolio:
                     return position
         return None
 
+    def reopen_closed_bridge_position_for_chain(self, chain_id: int, reopened_at: datetime.datetime) -> "TradingPosition | None":
+        """Reopen the latest closed CCTP bridge position for a destination chain.
+
+        Async satellite vault settlements can return USDC after the bridge
+        position was closed at zero available capital. The returned USDC is still
+        satellite-chain bridge capital, so the old bridge position must become
+        open again to carry the available balance.
+        """
+        candidates = [
+            position
+            for position in self.closed_positions.values()
+            if position.pair.kind == TradingPairKind.cctp_bridge
+            and position.pair.get_destination_chain_id() == chain_id
+        ]
+        if not candidates:
+            return None
+
+        position = max(candidates, key=lambda p: p.closed_at or p.opened_at)
+        logger.info(
+            "Reopening closed CCTP bridge position #%d for chain %d after satellite capital returned",
+            position.position_id,
+            chain_id,
+        )
+        del self.closed_positions[position.position_id]
+        position.closed_at = None
+        position.last_trade_at = reopened_at
+        self.open_positions[position.position_id] = position
+        return position
+
     def move_capital_from_bridge_to_spot_trade(
             self,
             trade: "TradeExecution",

--- a/tradeexecutor/state/position.py
+++ b/tradeexecutor/state/position.py
@@ -742,12 +742,15 @@ class TradingPosition(GenericPosition):
         # (only is_success counts). Subtract their quantity so strategies
         # don't submit duplicate withdrawal requests.
         vault_pending_sells = sum_decimal([
-            t.get_position_quantity()
+            t.get_vault_settlement_request_quantity()
             for t in self.trades.values()
             if t.is_vault_settlement_in_flight() and t.is_sell()
         ])
 
-        return planned + live + vault_pending_sells
+        available = planned + live + vault_pending_sells
+        if vault_pending_sells < 0 and available < 0:
+            return Decimal(0)
+        return available
 
     def has_pending_vault_settlement(self) -> bool:
         """Does this position have an async vault deposit/redeem request in flight?
@@ -807,7 +810,7 @@ class TradingPosition(GenericPosition):
             US dollar amount debited from reserves and waiting in the vault's deposit queue.
         """
         return sum(
-            float(t.planned_reserve)
+            float(t.get_vault_settlement_request_reserve())
             for t in self.trades.values()
             if t.is_vault_settlement_in_flight() and t.is_buy()
         )
@@ -2556,7 +2559,8 @@ class TradingPosition(GenericPosition):
         :return:
             (Asset id, amount) iterables
         """
-        assert self.is_open() or self.is_frozen()
+        if self.is_exchange_account():
+            return
         if self.pair.is_cctp_bridge():
             # Bridge positions hold destination chain USDC.
             # Only the available (unallocated) portion is still in the wallet;
@@ -2565,8 +2569,22 @@ class TradingPosition(GenericPosition):
             if available > 0:
                 yield self.pair.base, available
         elif self.is_spot():
-            yield self.pair.base, self.get_quantity()
+            # Hypercore vault positions are API-tracked, not on-chain.
+            if self.pair.is_hyperliquid_vault():
+                return
+            held_quantity = self.get_quantity()
+            if self.is_vault():
+                held_quantity += sum_decimal([
+                    t.get_vault_settlement_request_quantity()
+                    for t in self.trades.values()
+                    if t.is_vault_settlement_in_flight() and t.is_sell()
+                ])
+            if self.is_vault() and held_quantity < 0:
+                held_quantity = Decimal(0)
+            yield self.pair.base, held_quantity
         elif self.is_credit_supply():
+            if not self.loan:
+                return
             yield self.loan.collateral.asset, self.loan.get_collateral_quantity()
         elif self.is_short():
             yield self.loan.collateral.asset, self.loan.get_collateral_quantity()

--- a/tradeexecutor/state/state.py
+++ b/tradeexecutor/state/state.py
@@ -999,6 +999,11 @@ class State:
         if (trade.is_spot() or trade.is_vault()) and trade.is_sell():
             # For satellite chain trades, return capital to bridge position
             bridge_position = self.portfolio.get_bridge_position_for_chain(trade.pair.chain_id)
+            if bridge_position is None and trade.pair.quote != trade.reserve_currency:
+                bridge_position = self.portfolio.reopen_closed_bridge_position_for_chain(
+                    trade.pair.chain_id,
+                    executed_at,
+                )
             if bridge_position is not None:
                 self.portfolio.return_capital_to_bridge(trade)
             else:

--- a/tradeexecutor/state/trade.py
+++ b/tradeexecutor/state/trade.py
@@ -27,6 +27,11 @@ from tradeexecutor.utils.accuracy import QUANTITY_EPSILON
 logger = logging.getLogger()
 
 
+CCTP_BRIDGE_ORDER_BUMP = 30_000_000
+VAULT_SETTLEMENT_REQUEST_RESERVE_KEY = "vault_settlement_request_reserve"
+VAULT_SETTLEMENT_REQUEST_QUANTITY_KEY = "vault_settlement_request_quantity"
+
+
 class TradeType(enum.Enum):
     """What kind of trade execution this was."""
 
@@ -1073,6 +1078,20 @@ class TradeExecution:
             and status in (TradeStatus.started, TradeStatus.broadcasted)
         )
 
+    def get_vault_settlement_request_reserve(self) -> Decimal:
+        """Get the quote amount committed by an async vault deposit request."""
+        value = self.other_data.get(VAULT_SETTLEMENT_REQUEST_RESERVE_KEY)
+        if value is None:
+            return self.planned_reserve
+        return Decimal(str(value))
+
+    def get_vault_settlement_request_quantity(self) -> Decimal:
+        """Get the share quantity escrowed by an async vault redeem request."""
+        value = self.other_data.get(VAULT_SETTLEMENT_REQUEST_QUANTITY_KEY)
+        if value is None:
+            return self.get_position_quantity()
+        return Decimal(str(value))
+
     def is_short(self) -> bool:
         """This is margined short trade."""
         return self.pair.kind.is_shorting()
@@ -1367,15 +1386,13 @@ class TradeExecution:
         credit_order_bump = 200_000_000
         close_order_bump = 100_000_000
         vault_order_bump = 50_000_000
-        bridge_order_bump = 30_000_000
-
         if self.pair.is_cctp_bridge():
             if self.is_sell():
                 # Bridge-backs: after vault withdrawals (-50M), before spot sells
-                return -self.trade_id - bridge_order_bump
+                return -self.trade_id - CCTP_BRIDGE_ORDER_BUMP
             else:
                 # Bridge-outs: after regular buys, before vault deposits (+50M)
-                return self.trade_id + bridge_order_bump
+                return self.trade_id + CCTP_BRIDGE_ORDER_BUMP
 
         if self.is_credit_supply() and TradeFlag.close in self.flags:
             # Always withdraw credit to cash in hand first,

--- a/tradeexecutor/strategy/asset.py
+++ b/tradeexecutor/strategy/asset.py
@@ -15,9 +15,7 @@ from tradeexecutor.state.identifier import AssetIdentifier, TradingPairIdentifie
 from tradeexecutor.state.position import TradingPosition
 from tradeexecutor.state.reserve import ReservePosition
 from tradeexecutor.state.state import State
-from tradeexecutor.state.trade import TradeStatus
 from tradeexecutor.strategy.trading_strategy_universe import TradingStrategyUniverse, translate_trading_pair
-from tradeexecutor.utils.accuracy import sum_decimal
 
 
 logger = logging.getLogger(__name__)
@@ -151,42 +149,7 @@ def map_onchain_asset_to_position(
 
 def get_asset_amounts(p: TradingPosition) -> List[Tuple[AssetIdentifier, Decimal]]:
     """What tokens this position should hold in a wallet."""
-    if p.is_spot() or p.is_vault():
-        # Hypercore vault positions are API-tracked, not on-chain
-        if p.pair.is_hyperliquid_vault():
-            return []
-        # Async vault redeems (vault_settlement_pending sells) have already moved
-        # shares out of the owner wallet into the vault escrow via requestRedeem(),
-        # but get_quantity() still counts them (only is_success trades reduce it).
-        # Subtract the escrowed shares so the expected on-chain owner balance matches
-        # reality and check-accounts does not raise a false mismatch. Sell quantities
-        # are negative, matching TradingPosition.get_available_trading_quantity().
-        vault_pending_sells = sum_decimal([
-            t.get_position_quantity()
-            for t in p.trades.values()
-            if t.get_status() == TradeStatus.vault_settlement_pending and t.is_sell()
-        ])
-        return [(p.pair.base, p.get_quantity() + vault_pending_sells)]
-    elif p.is_short():
-        return [
-            (p.pair.base, p.loan.get_borrowed_quantity()),
-            (p.pair.quote, p.loan.get_collateral_quantity()),
-        ]
-    elif p.is_credit_supply():
-        # Some frozen positions might not have loan
-        if not p.loan:
-            return []
-        return [
-            (p.pair.base, p.loan.get_collateral_quantity()),
-        ]
-    elif p.is_exchange_account():
-        # Exchange account positions are not on-chain, skip them
-        return []
-    elif p.pair.is_cctp_bridge():
-        # Bridge positions hold destination USDC on-chain
-        return [(p.pair.base, p.get_quantity())]
-    else:
-        raise NotImplementedError()
+    return list(p.get_held_assets())
 
 
 def get_onchain_assets(pair: TradingPairIdentifier) -> List[AssetIdentifier]:


### PR DESCRIPTION
## Why

PR #1543 fixed part of the cross-chain CCTP accounting flow, but async satellite vault deposits still exposed gaps between the planner, portfolio ledger, simulated wallet, and wallet reconciliation.

The main issue was that vault deposit requests moved capital out of reserves/bridge accounting while the simulated wallet still appeared to hold the same token until settlement. This made reconciliation see false wallet mismatches during the pending window. The CCTP planner also needed to bridge only the missing satellite-chain amount, while preserving trade-sort ordering across sells, bridge-backs, bridge-outs, and vault requests.

## Lessons learnt

CCTP planning needs separate timing views of satellite cash. Capital available before bridge-backs is not the same as capital available before same-chain buys, because non-closing synchronous satellite sells execute after bridge-backs but before vault deposits.

Async vault requests should model the live lifecycle at request time: deposits debit the vault quote token into the deposit queue, redeems debit the vault share token into the redeem queue, and settlement only credits the claim output.

The strategy layer should not get a separate deployable per-chain liquidity concept. Target equity stays global; generated trades and their execution sort order move capital between chains and positions.

## Summary

- Add CCTP per-chain liquidity planning that bridges only missing satellite-chain capital and accounts for idle bridge capital, synchronous same-chain sells, pending async vault requests, and primary-chain shortfalls.
- Debit simulated wallet balances immediately for async vault deposit and redeem requests, then credit only the claim output at settlement.
- Adjust expected wallet asset accounting for CCTP bridge positions, async vault request queues, HyperCore vaults, and closed-position reconciliation.
- Add focused regression coverage for bridge sizing, async vault request accounting, wallet reconciliation, delayed settlement, and the notebook-surfaced edge cases.
- Document the implementation plan, deposit/redeem cases, and the required local agent review workflow.

## Unrelated test fixes for CI green

- Allow the vault-yield mainnet-fork regression test to tolerate normal Trading Strategy website data publication lag, so it does not fail solely because the latest liquidity sample is one day behind wall-clock time.
