### PR TITLE
fix: report zero PnL for CCTP bridge positions

### DIFF
--- a/tradeexecutor/state/position.py
+++ b/tradeexecutor/state/position.py
@@ -1652,6 +1652,13 @@ class TradingPosition(GenericPosition):
 
     def get_total_profit_usd(self) -> USDollarAmount:
         """Realised + unrealised profit."""
+        if self.pair.is_cctp_bridge():
+            # A CCTP bridge position is a cross-chain capital transfer, not an investment.
+            # Bridging USDC realises no profit or loss (the CCTP fee is zero), so the residual
+            # left by netting "bridge out" buys against "bridge back" sells at average cost is a
+            # reporting artefact rather than PnL. Report exactly zero so the profit breakdown and
+            # weight-allocation tables do not attribute phantom profit to the bridge pair.
+            return 0.0
         if self.is_using_internal_share_price_profit():
             if self.share_price_state is not None:
                 data = self.get_share_price_profit()
@@ -1680,6 +1687,10 @@ class TradingPosition(GenericPosition):
         :return:
             0 if profit calculation cannot be made yet
         """
+
+        # A CCTP bridge transfer has zero PnL by definition (see :py:meth:`get_total_profit_usd`).
+        if self.pair.is_cctp_bridge():
+            return 0.0
 
         # Exchange account positions use placeholder trades ($1) that don't represent real capital.
         if self.is_using_internal_share_price_profit():


### PR DESCRIPTION
## Why

CCTP bridge positions are cross-chain capital transfers, not investments. But `TradingPosition.get_total_profit_usd()` / `get_total_profit_percent()` netted "bridge out" buys against "bridge back" sells at average cost and left a residual that was reported as **phantom profit**.

This was visible in the cross-chain master-vault backtest charts (`scratchpad/xchain2/01-initial.ipynb`):

- `trading_pair_breakdown` reported a large, run-sensitive **Total PnL USD** on the bridge pair (e.g. `+$16,573` on Arbitrum, `+$9,135` on Base) — sometimes *larger than the strategy's total profit*.
- `weight_allocation_statistics` even picked the bridge as the **Biggest winner (position/vault)**.
- Meanwhile the bridge **Total return %** correctly stayed `0.00%`, and headline equity was never affected (bridge positions are marked at transferred value and reconcile to the penny).

## What

Report bridge PnL as exactly zero at the source (`TradingPosition`), so every consumer — profit breakdown, weight statistics, winner/loser selection — is consistent. A zero-fee CCTP transfer has no PnL by definition.

## Effect

Verified against the cross-chain backtest notebook: bridge rows now show `Total PnL USD = 0.00`, the biggest winner is a real vault (gTrade / AQRU Maple), and the headline result is **unchanged** (13.99% return, 1690 trades, 342/342 bridges) — confirming the change is purely a reporting correction. Non-bridge positions are untouched (the guard returns early only for `pair.is_cctp_bridge()`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)