### PR TITLE
fix: tolerate sub-raw CCTP bridge dust

### DIFF
--- a/tests/erc_4626/test_vault_trading_e2e.py
+++ b/tests/erc_4626/test_vault_trading_e2e.py
@@ -8,6 +8,7 @@ from typer.main import get_command
 
 from tradeexecutor.cli.main import app
 from tradeexecutor.state.state import State
+from tradeexecutor.strategy.trading_strategy_universe import TradingStrategyUniverseModel
 from tradeexecutor.utils.hex import hexbytes_to_hex_str
 
 
@@ -68,17 +69,30 @@ def test_vault_trading_start(
     state_file,
     web3,
 ):
-    """Run a single cycle of Memecoin index strategy to see everything works.
+    """Run a single Base vault trading cycle.
 
-    - Should attempt to open multiple positions using Enso
+    This test exercises vault trading CLI wiring and accounting, not Trading
+    Strategy remote data freshness.
+
+    1. Patch the process environment with forked RPC and deterministic settings.
+    2. Disable remote market-data freshness checks.
+    3. Initialise and start the CLI.
+    4. Assert the resulting state has one closed position and no frozen positions.
     """
 
     cli = get_command(app)
+
+    # 1. Patch the process environment with forked RPC and deterministic settings.
     mocker.patch.dict("os.environ", environment, clear=True)
+
+    # 2. Disable remote market-data freshness checks.
+    mocker.patch.object(TradingStrategyUniverseModel, "check_data_age", return_value=None)
+
+    # 3. Initialise and start the CLI.
     cli.main(args=["init"], standalone_mode=False)
     cli.main(args=["start"], standalone_mode=False)
 
-    # Read results of 1 cycle of strategy
+    # 4. Assert the resulting state has one closed position and no frozen positions.
     state = State.read_json_file(state_file)
     assert state.cycle == 2
     reserve_position = state.portfolio.get_default_reserve_position()
@@ -86,4 +100,3 @@ def test_vault_trading_start(
     assert len(state.portfolio.frozen_positions) == 0
     assert len(state.portfolio.open_positions) == 0
     assert len(state.portfolio.closed_positions) == 1
-

--- a/tests/ethereum/test_cctp_bridge_cash_aware.py
+++ b/tests/ethereum/test_cctp_bridge_cash_aware.py
@@ -854,10 +854,10 @@ def test_dust_available_bridge_capital_does_not_create_bridge_back(
     cctp_pair: TradingPairIdentifier,
     satellite_pair: TradingPairIdentifier,
 ):
-    """Dust available bridge capital is ignored instead of creating a bridge-back.
+    """Sub-raw-unit available bridge capital is ignored instead of creating a bridge-back.
 
     1. Bridge 1_000 USDC to Base and deploy it all into a satellite position.
-    2. Leave only 1E-23 available bridge capital to mimic Decimal dust.
+    2. Leave only sub-raw-unit available bridge capital to mimic Decimal dust.
     3. Plan a non-closing satellite sell whose proceeds sort after bridge-backs.
     4. Assert the planner skips the dust bridge-back trade.
     """
@@ -879,10 +879,11 @@ def test_dust_available_bridge_capital_does_not_create_bridge_back(
         check_balances=True,
     )
 
-    # 2. Leave only 1E-23 available bridge capital to mimic Decimal dust.
+    # 2. Leave only sub-raw-unit available bridge capital to mimic Decimal dust.
+    dust = Decimal("0.000000000000712654913188")
     bridge_position = state.portfolio.get_bridge_position_for_chain(SATELLITE_CHAIN_ID)
-    bridge_position.bridge_capital_allocated = bridge_position.get_quantity() - Decimal("1E-23")
-    assert bridge_position.get_available_bridge_capital() == Decimal("1E-23")
+    bridge_position.bridge_capital_allocated = bridge_position.get_quantity() - dust
+    assert bridge_position.get_available_bridge_capital() == dust
 
     # 3. Plan a non-closing satellite sell whose proceeds sort after bridge-backs.
     satellite_position = state.portfolio.get_open_position_for_pair(satellite_pair)
@@ -914,17 +915,19 @@ def test_dust_available_bridge_capital_does_not_create_bridge_back(
 
 @pytest.mark.timeout(300)
 def test_primary_shortfall_dust_after_bridge_back_is_ignored(
+    usdc_base: AssetIdentifier,
     usdc_arbitrum: AssetIdentifier,
     cctp_pair: TradingPairIdentifier,
     primary_pair: TradingPairIdentifier,
 ):
-    """Sub-epsilon primary shortfall dust after bridge-back does not fail planning.
+    """Sub-raw-unit primary shortfall dust after bridge-back does not fail execution.
 
     1. Bridge 1_000 USDC to Base, leaving no primary reserve.
-    2. Plan a primary buy whose reserve need is 1_000 plus 1E-23 dust.
+    2. Plan a primary buy whose reserve need is 1_000 plus sub-raw-unit dust.
     3. Inject CCTP trades.
-    4. Assert the planner bridges back the real 1_000 amount and ignores the
-       remaining dust shortfall.
+    4. Execute the bridge-back and primary buy.
+    5. Assert the planner bridged back the real 1_000 amount and the buy was
+       snapped to the actually available raw-token amount.
     """
     wallet = SimulatedWallet()
     wallet.set_balance(usdc_arbitrum, Decimal(1_000))
@@ -938,12 +941,13 @@ def test_primary_shortfall_dust_after_bridge_back_is_ignored(
     assert reserve.quantity == Decimal(0)
     assert bridge_position.get_available_bridge_capital() == Decimal(1_000)
 
-    # 2. Plan a primary buy whose reserve need is 1_000 plus 1E-23 dust.
+    # 2. Plan a primary buy whose reserve need is 1_000 plus sub-raw-unit dust.
+    dust = Decimal("0.000000000000712654913188")
     buy = _create_primary_buy(
         state,
         primary_pair,
         usdc_arbitrum,
-        Decimal("1000.00000000000000000000001"),
+        Decimal(1_000) + dust,
     )
 
     # 3. Inject CCTP trades.
@@ -957,10 +961,27 @@ def test_primary_shortfall_dust_after_bridge_back_is_ignored(
         reserve_asset=usdc_arbitrum,
     )
 
-    # 4. Assert the planner bridges back the real 1_000 amount.
+    # 4. Execute the bridge-back and primary buy.
+    routing_model, routing_state = _routing(wallet, usdc_arbitrum)
+    execution.execute_trades(
+        ts=TS,
+        state=state,
+        trades=sorted(result, key=lambda t: t.get_execution_sort_position()),
+        routing_model=routing_model,
+        routing_state=routing_state,
+        check_balances=True,
+    )
+
+    # 5. Assert the bridge-back and buy used the raw-token amount.
     bridge_backs = [t for t in result if t.pair.is_cctp_bridge() and t.is_sell()]
     assert len(bridge_backs) == 1
     assert bridge_backs[0].planned_quantity == Decimal(-1_000)
+    assert buy.is_success()
+    assert buy.planned_reserve == Decimal(1_000)
+    assert buy.reserve_currency_allocated == Decimal(0)
+    assert wallet.get_balance(usdc_arbitrum) == Decimal(0)
+    assert wallet.get_balance(usdc_base) == Decimal(0)
+    assert reserve.quantity == Decimal(0)
 
 
 @pytest.mark.timeout(300)
@@ -1212,6 +1233,73 @@ def test_async_vault_deposit_bridges_only_missing_satellite_capital(
     assert usdc_base not in calculate_total_assets(state.portfolio)
     assert get_asset_amounts(bridge_position) == []
     assert state.portfolio.get_vault_settlement_pending_value() == pytest.approx(10_000.0, abs=1e-6)
+
+
+@pytest.mark.timeout(300)
+def test_async_vault_deposit_snaps_sub_raw_unit_bridge_shortfall(
+    usdc_arbitrum: AssetIdentifier,
+    usdc_base: AssetIdentifier,
+    cctp_pair: TradingPairIdentifier,
+    satellite_vault_pair: TradingPairIdentifier,
+):
+    """An async vault deposit with sub-raw-unit dust debits only deployable reserve.
+
+    1. Start with exactly 1_000 primary-chain USDC reserve.
+    2. Plan a Base vault deposit for 1_000 USDC plus sub-raw-unit dust.
+    3. Inject CCTP trades and execute the bridge-out and deposit request.
+    4. Assert the bridge-out, allocation and pending deposit request all use
+       1_000 USDC and the Base reserve wallet is debited immediately.
+    """
+    wallet = SimulatedWallet()
+    wallet.set_balance(usdc_arbitrum, Decimal(1_000))
+    state = _make_state(usdc_arbitrum, Decimal(1_000))
+    execution = _async_vault_execution(wallet, satellite_vault_pair)
+
+    # 1. Start with exactly 1_000 primary-chain USDC reserve.
+    reserve = state.portfolio.get_default_reserve_position()
+    assert reserve.quantity == Decimal(1_000)
+
+    # 2. Plan a Base vault deposit for 1_000 USDC plus sub-raw-unit dust.
+    dust = Decimal("0.000000000000712654913188")
+    buy = _create_satellite_buy(state, satellite_vault_pair, usdc_arbitrum, Decimal(1_000) + dust)
+    universe = _make_mock_universe([cctp_pair, satellite_vault_pair])
+
+    # 3. Inject CCTP trades and execute the bridge-out and deposit request.
+    result = inject_cctp_bridge_trades(
+        state=state,
+        trades=[buy],
+        strategy_universe=universe,
+        primary_chain_id=PRIMARY_CHAIN_ID,
+        ts=TS,
+        reserve_asset=usdc_arbitrum,
+    )
+    bridge_trades = [t for t in result if t.pair.is_cctp_bridge()]
+    assert len(bridge_trades) == 1
+    assert bridge_trades[0].is_buy()
+    assert bridge_trades[0].planned_reserve == Decimal(1_000)
+
+    routing_model, routing_state = _routing(wallet, usdc_arbitrum)
+    execution.execute_trades(
+        ts=TS,
+        state=state,
+        trades=sorted(result, key=lambda t: t.get_execution_sort_position()),
+        routing_model=routing_model,
+        routing_state=routing_state,
+        check_balances=True,
+    )
+
+    # 4. Assert allocation and request-time wallet accounting use the deployable amount.
+    bridge_position = state.portfolio.get_bridge_position_for_chain(SATELLITE_CHAIN_ID)
+    assert buy.get_status() == TradeStatus.vault_settlement_pending
+    assert buy.planned_reserve == Decimal(1_000)
+    assert buy.bridge_currency_allocated == Decimal(1_000)
+    assert buy.get_vault_settlement_request_reserve() == Decimal(1_000)
+    assert wallet.get_balance(usdc_arbitrum) == Decimal(0)
+    assert wallet.get_balance(usdc_base) == Decimal(0)
+    assert wallet.get_balance(satellite_vault_pair.base) == Decimal(0)
+    assert reserve.quantity == Decimal(0)
+    assert bridge_position.get_available_bridge_capital() == Decimal(0)
+    assert state.portfolio.get_vault_settlement_pending_value() == pytest.approx(1_000.0, abs=1e-6)
 
 
 @pytest.mark.timeout(300)

--- a/tests/ethereum/test_cctp_bridge_cash_aware.py
+++ b/tests/ethereum/test_cctp_bridge_cash_aware.py
@@ -356,6 +356,57 @@ def test_bridge_out_funds_from_idle_satellite_capital(
     assert bridge_pos.bridge_capital_allocated == Decimal(11_500)
 
 
+def test_bridge_out_uses_bridge_pair_decimals_when_reserve_asset_decimals_are_wrong(
+    usdc_arbitrum: AssetIdentifier,
+    cctp_pair: TradingPairIdentifier,
+    satellite_pair: TradingPairIdentifier,
+):
+    """A generated 6-decimal CCTP pair works with a wrong 18-decimal reserve asset.
+
+    This covers vault-only universes where the reserve asset can inherit
+    fallback 18-decimal metadata, while generated native USDC bridge pairs are
+    correctly normalised to 6 decimals.
+
+    1. Create a reserve asset with the same primary USDC address but wrong 18-decimal metadata.
+    2. Plan a satellite buy that requires bridge-out funding with sub-raw-unit dust.
+    3. Inject CCTP bridge trades.
+    4. Assert the bridge-out is created and floored with bridge-pair USDC precision.
+    """
+
+    # 1. Create a reserve asset with the same primary USDC address but wrong 18-decimal metadata.
+    wrong_decimals_reserve = AssetIdentifier(
+        chain_id=usdc_arbitrum.chain_id,
+        address=usdc_arbitrum.address,
+        token_symbol=usdc_arbitrum.token_symbol,
+        decimals=18,
+    )
+    state = _make_state(wrong_decimals_reserve, Decimal(2_000))
+
+    # 2. Plan a satellite buy that requires bridge-out funding with sub-raw-unit dust.
+    buy = _create_satellite_buy(
+        state,
+        satellite_pair,
+        wrong_decimals_reserve,
+        Decimal("1000.0000009"),
+    )
+    universe = _make_mock_universe([cctp_pair, satellite_pair])
+
+    # 3. Inject CCTP bridge trades.
+    result = inject_cctp_bridge_trades(
+        state=state,
+        trades=[buy],
+        strategy_universe=universe,
+        primary_chain_id=PRIMARY_CHAIN_ID,
+        ts=TS,
+        reserve_asset=wrong_decimals_reserve,
+    )
+
+    # 4. Assert the bridge-out is created and floored with bridge-pair USDC precision.
+    bridge_trades = [t for t in result if t.pair.is_cctp_bridge()]
+    assert len(bridge_trades) == 1
+    assert bridge_trades[0].planned_reserve == Decimal("1000")
+
+
 def test_bridge_out_nets_against_partial_idle_capital(
     usdc_arbitrum: AssetIdentifier,
     cctp_pair: TradingPairIdentifier,

--- a/tests/mainnet_fork/test_rebalance_vault_yield.py
+++ b/tests/mainnet_fork/test_rebalance_vault_yield.py
@@ -13,6 +13,7 @@ from pytest_mock import MockerFixture
 from eth_defi.provider.anvil import AnvilLaunch, launch_anvil
 
 from tradeexecutor.cli.main import app
+from tradeexecutor.strategy.trading_strategy_universe import TradingStrategyUniverseModel
 from tradeexecutor.utils.hex import hexbytes_to_hex_str
 from tradingstrategy.client import Client
 
@@ -85,9 +86,8 @@ def environment(
         "RUN_SINGLE_CYCLE": "true",  # Run only one cycle"
         "MIN_GAS_BALANCE": "0.0",   # Disable gas balance check
         "DISABLE_BROADCAST": "true",  # Disable wait_and_broadcast_multiple_nodes() broadcast as we do not have real private key
-        # Trading Strategy website data may lag wall-clock time by more than
-        # one day in CI; this test exercises rebalance transaction generation,
-        # not the live data freshness alert.
+        # This test exercises rebalance transaction generation, not the live
+        # data freshness alert.
         "MAX_DATA_DELAY_MINUTES": str(3 * 24 * 60),
     }
     return environment
@@ -105,8 +105,9 @@ def test_rebalance_vault_yield(
 
     1. Patch the process environment with the forked RPC, copied state file and
        deterministic test settings.
-    2. Run one `trade-executor start` cycle.
-    3. Confirm the command completes, proving money can be withdrawn from Aave
+    2. Disable remote market-data freshness checks.
+    3. Run one `trade-executor start` cycle.
+    4. Confirm the command completes, proving money can be withdrawn from Aave
        and redeployed to the vaults.
     """
 
@@ -114,7 +115,10 @@ def test_rebalance_vault_yield(
     # deterministic test settings.
     mocker.patch.dict("os.environ", environment, clear=True)
 
-    # 2. Run one `trade-executor start` cycle.
-    # 3. Confirm the command completes, proving money can be withdrawn from Aave
+    # 2. Disable remote market-data freshness checks.
+    mocker.patch.object(TradingStrategyUniverseModel, "check_data_age", return_value=None)
+
+    # 3. Run one `trade-executor start` cycle.
+    # 4. Confirm the command completes, proving money can be withdrawn from Aave
     # and redeployed to the vaults.
     app(["start"], standalone_mode=False)

--- a/tradeexecutor/ethereum/cctp/planner.py
+++ b/tradeexecutor/ethereum/cctp/planner.py
@@ -29,7 +29,7 @@ from tradeexecutor.state.identifier import (
 from tradeexecutor.state.portfolio import NotEnoughMoney
 from tradeexecutor.state.state import State
 from tradeexecutor.state.trade import CCTP_BRIDGE_ORDER_BUMP, TradeExecution, TradeType
-from tradeexecutor.utils.accuracy import SUM_EPSILON, sum_decimal
+from tradeexecutor.utils.accuracy import sum_decimal
 
 logger = logging.getLogger(__name__)
 
@@ -137,9 +137,44 @@ def _open_bridge_chain_ids(state: State) -> set[int]:
     }
 
 
-def _is_meaningful_bridge_amount(amount: Decimal) -> bool:
-    """Is this amount large enough to become a CCTP trade."""
-    return amount > SUM_EPSILON
+def _get_raw_unit(asset: AssetIdentifier) -> Decimal:
+    """Smallest human-readable amount representable by a token raw unit."""
+    return asset.convert_to_decimal(1)
+
+
+def _floor_to_raw_units(amount: Decimal, asset: AssetIdentifier) -> Decimal:
+    """Floor a positive token amount to raw-token precision."""
+    assert amount >= 0
+    return asset.convert_to_decimal(asset.convert_to_raw_amount(amount))
+
+
+def _is_meaningful_bridge_amount(amount: Decimal, asset: AssetIdentifier) -> bool:
+    """Is this amount large enough to become a CCTP trade.
+
+    CCTP burns and mints ERC-20 raw units. Any human-unit fraction smaller than
+    one raw unit would be truncated by the live routing path and is accounting
+    dust, even when it is larger than Decimal calculation epsilon.
+    """
+    return amount >= _get_raw_unit(asset)
+
+
+def _is_token_dust(amount: Decimal, asset: AssetIdentifier) -> bool:
+    """Is this amount below one raw token unit."""
+    return abs(amount) < _get_raw_unit(asset)
+
+
+def _assert_bridge_pair_raw_units_match(bridge_pair: TradingPairIdentifier, reserve_asset: AssetIdentifier) -> None:
+    """CCTP bridge pairs must use the same raw-unit precision on both sides."""
+    assert bridge_pair.base.decimals == reserve_asset.decimals, (
+        f"CCTP bridge destination asset {bridge_pair.base} decimals "
+        f"{bridge_pair.base.decimals} do not match reserve asset "
+        f"{reserve_asset} decimals {reserve_asset.decimals}"
+    )
+    assert bridge_pair.quote.decimals == reserve_asset.decimals, (
+        f"CCTP bridge source asset {bridge_pair.quote} decimals "
+        f"{bridge_pair.quote.decimals} do not match reserve asset "
+        f"{reserve_asset} decimals {reserve_asset.decimals}"
+    )
 
 
 def _trade_releases_before_bridge_back(trade: TradeExecution) -> bool:
@@ -222,6 +257,8 @@ def inject_cctp_bridge_trades(
 
     # Pre-fetch bridge pairs from the universe so we only iterate once.
     bridge_pairs = _bridge_pairs_by_destination(list(strategy_universe.iterate_pairs()))
+    for bridge_pair in bridge_pairs.values():
+        _assert_bridge_pair_raw_units_match(bridge_pair, reserve_asset)
 
     # 1. Group trades by chain and compute net capital flow per satellite chain.
     #    Also track primary-chain reserve in/outflows so bridge-outs can be
@@ -316,8 +353,8 @@ def inject_cctp_bridge_trades(
         # cannot fund same-cycle bridge-backs. They are still counted later when
         # sizing bridge-outs, because they execute before same-chain buys.
         available = liquidity.free_idle_bridge_capital
-        amount = min(net_flow, available)
-        if not _is_meaningful_bridge_amount(amount):
+        amount = _floor_to_raw_units(min(net_flow, available), bridge_pair.base)
+        if not _is_meaningful_bridge_amount(amount, bridge_pair.base):
             logger.info(
                 "Skipping bridge-back for chain %d: net sell %s exceeds available bridge capital %s",
                 chain_id,
@@ -350,14 +387,14 @@ def inject_cctp_bridge_trades(
         -primary_sells,
         -total_bridge_back,
     ])
-    if _is_meaningful_bridge_amount(primary_shortfall):
+    if _is_meaningful_bridge_amount(primary_shortfall, reserve_asset):
         for chain_id in sorted(liquidity_by_chain):
-            if not _is_meaningful_bridge_amount(primary_shortfall):
+            if not _is_meaningful_bridge_amount(primary_shortfall, reserve_asset):
                 break
             liquidity = liquidity_by_chain[chain_id]
             available = liquidity.free_idle_bridge_capital
-            amount = min(primary_shortfall, available)
-            if not _is_meaningful_bridge_amount(amount):
+            amount = _floor_to_raw_units(min(primary_shortfall, available), reserve_asset)
+            if not _is_meaningful_bridge_amount(amount, reserve_asset):
                 continue
             bridge_pair = bridge_pairs.get(chain_id)
             if bridge_pair is None:
@@ -376,7 +413,7 @@ def inject_cctp_bridge_trades(
                 chain_id,
             )
 
-    if _is_meaningful_bridge_amount(primary_shortfall):
+    if _is_meaningful_bridge_amount(primary_shortfall, reserve_asset):
         raise NotEnoughMoney(
             f"Cannot fund primary-chain cash needs: need {primary_cash_needed} "
             f"(primary buys {primary_buys} + satellite bridge shortfalls "
@@ -390,7 +427,7 @@ def inject_cctp_bridge_trades(
     for chain_id in sorted(liquidity_by_chain):
         liquidity = liquidity_by_chain[chain_id]
         amount = liquidity.bridge_back_amount
-        if not _is_meaningful_bridge_amount(amount):
+        if not _is_meaningful_bridge_amount(amount, reserve_asset):
             continue
 
         bridge_pair = bridge_pairs.get(chain_id)
@@ -404,7 +441,11 @@ def inject_cctp_bridge_trades(
 
         bridge_position = state.portfolio.get_bridge_position_for_chain(chain_id)
         available = liquidity.available_before_bridge_back
-        closing = available - amount <= SUM_EPSILON
+        assert amount <= available, (
+            f"CCTP bridge-back amount {amount} exceeds available bridge capital "
+            f"{available} for chain {chain_id}"
+        )
+        closing = _is_token_dust(available - amount, bridge_pair.base)
 
         _, trade, _ = state.create_trade(
             strategy_cycle_at=ts,
@@ -479,7 +520,7 @@ def inject_cctp_bridge_trades(
         satellite_side_funding = liquidity.available_before_buy
 
         shortfall = liquidity.satellite_bridge_shortfall
-        if not _is_meaningful_bridge_amount(shortfall):
+        if not _is_meaningful_bridge_amount(shortfall, reserve_asset):
             # Capital already parked on the satellite covers the net buy; the
             # satellite buy allocates from the bridge position at execution.
             logger.info(
@@ -491,7 +532,7 @@ def inject_cctp_bridge_trades(
             continue
 
         if shortfall > fundable_primary:
-            if shortfall - fundable_primary <= SUM_EPSILON:
+            if _is_token_dust(shortfall - fundable_primary, reserve_asset):
                 shortfall = fundable_primary
             else:
                 raise NotEnoughMoney(
@@ -504,10 +545,12 @@ def inject_cctp_bridge_trades(
                     f"- primary buys {primary_buys})"
                 )
 
-        if not _is_meaningful_bridge_amount(shortfall):
+        if not _is_meaningful_bridge_amount(shortfall, reserve_asset):
             continue
 
-        amount = shortfall
+        amount = _floor_to_raw_units(shortfall, reserve_asset)
+        if not _is_meaningful_bridge_amount(amount, reserve_asset):
+            continue
         fundable_primary -= amount
 
         _, trade, _ = state.create_trade(

--- a/tradeexecutor/ethereum/cctp/planner.py
+++ b/tradeexecutor/ethereum/cctp/planner.py
@@ -163,17 +163,12 @@ def _is_token_dust(amount: Decimal, asset: AssetIdentifier) -> bool:
     return abs(amount) < _get_raw_unit(asset)
 
 
-def _assert_bridge_pair_raw_units_match(bridge_pair: TradingPairIdentifier, reserve_asset: AssetIdentifier) -> None:
+def _assert_bridge_pair_raw_units_match(bridge_pair: TradingPairIdentifier) -> None:
     """CCTP bridge pairs must use the same raw-unit precision on both sides."""
-    assert bridge_pair.base.decimals == reserve_asset.decimals, (
+    assert bridge_pair.base.decimals == bridge_pair.quote.decimals, (
         f"CCTP bridge destination asset {bridge_pair.base} decimals "
-        f"{bridge_pair.base.decimals} do not match reserve asset "
-        f"{reserve_asset} decimals {reserve_asset.decimals}"
-    )
-    assert bridge_pair.quote.decimals == reserve_asset.decimals, (
-        f"CCTP bridge source asset {bridge_pair.quote} decimals "
-        f"{bridge_pair.quote.decimals} do not match reserve asset "
-        f"{reserve_asset} decimals {reserve_asset.decimals}"
+        f"{bridge_pair.base.decimals} do not match source asset "
+        f"{bridge_pair.quote} decimals {bridge_pair.quote.decimals}"
     )
 
 
@@ -258,7 +253,8 @@ def inject_cctp_bridge_trades(
     # Pre-fetch bridge pairs from the universe so we only iterate once.
     bridge_pairs = _bridge_pairs_by_destination(list(strategy_universe.iterate_pairs()))
     for bridge_pair in bridge_pairs.values():
-        _assert_bridge_pair_raw_units_match(bridge_pair, reserve_asset)
+        _assert_bridge_pair_raw_units_match(bridge_pair)
+    primary_bridge_asset = next(iter(bridge_pairs.values())).quote if bridge_pairs else reserve_asset
 
     # 1. Group trades by chain and compute net capital flow per satellite chain.
     #    Also track primary-chain reserve in/outflows so bridge-outs can be
@@ -387,15 +383,8 @@ def inject_cctp_bridge_trades(
         -primary_sells,
         -total_bridge_back,
     ])
-    if _is_meaningful_bridge_amount(primary_shortfall, reserve_asset):
+    if _is_meaningful_bridge_amount(primary_shortfall, primary_bridge_asset):
         for chain_id in sorted(liquidity_by_chain):
-            if not _is_meaningful_bridge_amount(primary_shortfall, reserve_asset):
-                break
-            liquidity = liquidity_by_chain[chain_id]
-            available = liquidity.free_idle_bridge_capital
-            amount = _floor_to_raw_units(min(primary_shortfall, available), reserve_asset)
-            if not _is_meaningful_bridge_amount(amount, reserve_asset):
-                continue
             bridge_pair = bridge_pairs.get(chain_id)
             if bridge_pair is None:
                 logger.warning(
@@ -403,6 +392,13 @@ def inject_cctp_bridge_trades(
                     "skipping primary-shortfall bridge-back",
                     chain_id,
                 )
+                continue
+            if not _is_meaningful_bridge_amount(primary_shortfall, bridge_pair.quote):
+                break
+            liquidity = liquidity_by_chain[chain_id]
+            available = liquidity.free_idle_bridge_capital
+            amount = _floor_to_raw_units(min(primary_shortfall, available), bridge_pair.quote)
+            if not _is_meaningful_bridge_amount(amount, bridge_pair.quote):
                 continue
             liquidity.reserve_bridge_back(amount)
             total_bridge_back += amount
@@ -413,7 +409,7 @@ def inject_cctp_bridge_trades(
                 chain_id,
             )
 
-    if _is_meaningful_bridge_amount(primary_shortfall, reserve_asset):
+    if _is_meaningful_bridge_amount(primary_shortfall, primary_bridge_asset):
         raise NotEnoughMoney(
             f"Cannot fund primary-chain cash needs: need {primary_cash_needed} "
             f"(primary buys {primary_buys} + satellite bridge shortfalls "
@@ -427,9 +423,6 @@ def inject_cctp_bridge_trades(
     for chain_id in sorted(liquidity_by_chain):
         liquidity = liquidity_by_chain[chain_id]
         amount = liquidity.bridge_back_amount
-        if not _is_meaningful_bridge_amount(amount, reserve_asset):
-            continue
-
         bridge_pair = bridge_pairs.get(chain_id)
         if bridge_pair is None:
             logger.warning(
@@ -437,6 +430,8 @@ def inject_cctp_bridge_trades(
                 "skipping bridge injection",
                 chain_id,
             )
+            continue
+        if not _is_meaningful_bridge_amount(amount, bridge_pair.base):
             continue
 
         bridge_position = state.portfolio.get_bridge_position_for_chain(chain_id)
@@ -520,7 +515,7 @@ def inject_cctp_bridge_trades(
         satellite_side_funding = liquidity.available_before_buy
 
         shortfall = liquidity.satellite_bridge_shortfall
-        if not _is_meaningful_bridge_amount(shortfall, reserve_asset):
+        if not _is_meaningful_bridge_amount(shortfall, bridge_pair.quote):
             # Capital already parked on the satellite covers the net buy; the
             # satellite buy allocates from the bridge position at execution.
             logger.info(
@@ -532,7 +527,7 @@ def inject_cctp_bridge_trades(
             continue
 
         if shortfall > fundable_primary:
-            if _is_token_dust(shortfall - fundable_primary, reserve_asset):
+            if _is_token_dust(shortfall - fundable_primary, bridge_pair.quote):
                 shortfall = fundable_primary
             else:
                 raise NotEnoughMoney(
@@ -545,11 +540,11 @@ def inject_cctp_bridge_trades(
                     f"- primary buys {primary_buys})"
                 )
 
-        if not _is_meaningful_bridge_amount(shortfall, reserve_asset):
+        if not _is_meaningful_bridge_amount(shortfall, bridge_pair.quote):
             continue
 
-        amount = _floor_to_raw_units(shortfall, reserve_asset)
-        if not _is_meaningful_bridge_amount(amount, reserve_asset):
+        amount = _floor_to_raw_units(shortfall, bridge_pair.quote)
+        if not _is_meaningful_bridge_amount(amount, bridge_pair.quote):
             continue
         fundable_primary -= amount
 

--- a/tradeexecutor/state/portfolio.py
+++ b/tradeexecutor/state/portfolio.py
@@ -32,6 +32,40 @@ class NotEnoughMoney(Exception):
     """We try to allocate reserve for a buy trade, but do not have cash."""
 
 
+def _is_token_dust_shortfall(shortfall: Decimal, asset: AssetIdentifier) -> bool:
+    """Is the funding shortfall smaller than one raw token unit."""
+    return Decimal(0) < shortfall < asset.convert_to_decimal(1)
+
+
+def _snap_buy_reserve_to_available_if_token_dust(
+    trade: TradeExecution,
+    reserve: Decimal,
+    available: Decimal,
+    funding_asset: AssetIdentifier,
+) -> Decimal:
+    """Snap a buy trade reserve to available capital if only raw-unit dust is missing."""
+    if not trade.is_buy():
+        return reserve
+    if not (trade.is_spot() or trade.is_vault() or trade.pair.is_cctp_bridge()):
+        return reserve
+
+    shortfall = reserve - available
+    if not _is_token_dust_shortfall(shortfall, funding_asset):
+        return reserve
+
+    logger.info(
+        "Snapping trade #%d planned reserve from %s to %s because the shortfall %s %s is below one raw unit",
+        trade.trade_id,
+        reserve,
+        available,
+        shortfall,
+        funding_asset.token_symbol,
+    )
+    trade.planned_reserve = available
+    trade.planned_quantity = available / Decimal(str(trade.planned_price))
+    return available
+
+
 class MultipleOpenPositionsWithAsset(Exception):
     """Multiple open spot positiosn for a single base asset.
 
@@ -1013,6 +1047,14 @@ class Portfolio:
         if trade.is_spot():
             assert abs(float(reserve) - trade.get_planned_value()) < 0.01, f"Trade {trade}: Planned value {trade.get_planned_value()}, but wants to allocate reserve currency for {reserve}"
 
+        if available < reserve:
+            reserve = _snap_buy_reserve_to_available_if_token_dust(
+                trade,
+                reserve,
+                available,
+                trade.reserve_currency,
+            )
+
         if underflow_check:
             if available < reserve:
                 raise NotEnoughMoney(f"Not enough reserves. We have {available}, trade {trade} wants {reserve}")
@@ -1111,6 +1153,14 @@ class Portfolio:
             raise NotEnoughMoney(f"No bridge position found for chain {bridge_chain_id}, trade {trade}")
 
         available = bridge_position.get_available_bridge_capital()
+        if available < reserve:
+            reserve = _snap_buy_reserve_to_available_if_token_dust(
+                trade,
+                reserve,
+                available,
+                trade.pair.quote,
+            )
+
         if underflow_check:
             if available < reserve:
                 raise NotEnoughMoney(


### PR DESCRIPTION
## Why

The cross-chain notebook exposed a CCTP funding edge case where Decimal allocation dust was larger than the global calculation epsilon but smaller than one raw USDC unit. The planner treated this sub-raw-unit amount as deployable cash and execution later attempted to debit it from reserves or bridged capital, causing `NotEnoughMoney` or simulated wallet underflow in otherwise fully funded cycles.

A follow-up review also caught that CCTP bridge pairs generated for vault-only universes may have correct native USDC 6-decimal metadata even when the universe reserve asset still reports fallback 18-decimal metadata. Bridge sizing must therefore use the CCTP bridge pair assets as the authoritative raw-unit source.

## Lessons learnt

CCTP bridge planning and trade allocation need to use token raw-unit precision for stablecoin money movements. Global Decimal epsilon is too small for ERC-20 transfer granularity, and planner-only fixes are incomplete unless execution-time reserve allocation and async vault deposit requests use the same deployable amount.

Reserve asset metadata is not always reliable in vault-only universes. CCTP source and destination bridge assets must agree with each other, but they must not be forced to match possibly stale reserve-asset decimals.

## Summary

- Use raw-token granularity when deciding whether CCTP bridge amounts are meaningful.
- Size and floor injected bridge amounts with CCTP bridge-pair raw-token precision, including vault-only universes where reserve metadata may report wrong decimals.
- Validate CCTP source and destination bridge assets use matching decimals without rejecting a mismatched reserve asset.
- Snap buy/deposit planned reserve to available capital when the only shortage is below one raw token unit.
- Add CCTP bridge, async vault, and wrong reserve-decimal regression coverage for the notebook-sized sub-raw-unit dust cases.

## Unrelated test fixes for CI green

- Mock live market-data freshness checks in two slow vault tests that exercise CLI/vault accounting flows, not Trading Strategy data freshness. These tests were failing because CI data ended on `2026-06-25` while CI ran on `2026-06-28`.
