### PR TITLE
docs: HyperCore deposit verification NAV-drift tolerance

### DIFF
--- a/.claude/docs/hypercore-vault.md
+++ b/.claude/docs/hypercore-vault.md
@@ -156,6 +156,33 @@ sequenceDiagram
     end
 ```
 
+### Deposit verification tolerance and NAV drift
+
+`wait_for_vault_deposit_confirmation` confirms a deposit into an *existing*
+vault position by checking that our USD equity increased by roughly the
+deposited amount, accepting a shortfall of
+`max(tolerance, expected_deposit * relative_tolerance)` — see
+`DEFAULT_VAULT_DEPOSIT_RELATIVE_TOLERANCE` in `eth_defi.hyperliquid.api`.
+
+The subtle part: the "increase" is measured against a **baseline equity
+snapshotted minutes earlier** (before phase 1). Live perp-trading vaults (e.g.
+copy-trading leader vaults) mark-to-market every block, so the vault's
+*existing* holdings drift in value during the confirmation window. That drift
+is subtracted from the apparent deposit, so a fully-credited deposit can look
+short if the vault's own NAV ticked down in the meantime.
+
+**Production incident (trade #1240, Loop Fund vault, 2026-07-01).** An
+8.06806 USDC deposit was credited essentially to the cent — the equity jump
+across two consecutive polls was 8.06608 USDC — but the ~750 USDC pre-existing
+position had already marked down ~0.22 USDC (≈0.03%) versus the baseline. The
+apparent increase against the stale baseline was only ~7.85 USDC, short of the
+old 1% (0.08 USDC) band, so verification timed out, raised
+`HypercoreDepositVerificationError`, and crashed the whole live loop even though
+the funds were safely in the vault. The relative tolerance was raised to **5%**
+to absorb normal perp-vault volatility over the window while still catching
+genuinely rejected deposits (which show ~0% increase, not a few-percent
+shortfall).
+
 ## Withdrawal (sell) flow
 
 A withdrawal walks USDC back from the vault to the HyperEVM Safe through three


### PR DESCRIPTION
## Why

Companion documentation for [web3-ethereum-defi#1174](https://github.com/tradingstrategy-ai/web3-ethereum-defi/pull/1174), which widens the HyperCore vault deposit verification relative tolerance from 1% to 5%.

A live production loop crashed on **2026-07-01 19:47:39** while depositing into a HyperCore native vault, even though the deposit had succeeded and the funds were safely in the vault. The behaviour was non-obvious enough (a landed deposit reported as a failure that halts the whole loop) that it warrants a dedicated section in the HyperCore reference doc.

### Root cause

`wait_for_vault_deposit_confirmation` confirms a deposit into an existing vault position by checking that USD equity increased by roughly the deposited amount, measured against a **baseline snapshotted minutes earlier** (pre phase 1). Live perp-trading vaults mark-to-market every block, so the vault's *existing* holdings drift during the confirmation window and that drift is subtracted from the apparent deposit.

Trade **#1240** (Loop Fund vault): an 8.06806 USDC deposit was credited to the cent — the equity jump across two consecutive polls was 8.06608 USDC — but the pre-existing ~750 USDC position had marked down ~0.22 USDC (≈0.03%) versus the stale baseline, so the apparent increase was only ~7.85 USDC, short of the old 1% (0.08 USDC) band. Verification timed out, raised `HypercoreDepositVerificationError`, and crashed the live loop.

## Lessons learnt

- Absolute equity-increase checks against a stale baseline are unreliable for assets that mark-to-market every block; the metric conflates the deposit with the vault's own NAV change.
- A genuinely rejected deposit shows ~0% increase, clearly distinguishable from a landed deposit with a few-percent NAV shortfall — hence 5% is a safe band.

## Summary

- Added a "Deposit verification tolerance and NAV drift" subsection to `.claude/docs/hypercore-vault.md` documenting the mechanism and the trade #1240 incident.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
