### PR TITLE
ci: upgrade GitHub Actions pins

### DIFF
--- a/.github/workflows/devcontainer.yml
+++ b/.github/workflows/devcontainer.yml
@@ -21,12 +21,12 @@ jobs:
     if: false
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v7
         with:
           submodules: 'recursive'
 
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v2
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
@@ -36,7 +36,7 @@ jobs:
         run: echo "RELEASE_VERSION=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
 
       - name: Run Devcontainer build
-        uses: devcontainers/ci@v0.3
+        uses: devcontainers/ci@v0.3.1900000450
         with:
           push: always
           imageName: ghcr.io/tradingstrategy-ai/devcontainer

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -14,7 +14,7 @@ jobs:
     env:
       REGISTRY: ghcr.io
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           # Fetch the top-level submodules (trading-strategy, web3-ethereum-defi,
           # spec). The two nested submodules the image actually needs are checked
@@ -38,14 +38,14 @@ jobs:
           git -C deps/web3-ethereum-defi submodule update --init --depth 1 contracts/lagoon-v0
           git -C deps/trading-strategy submodule update --init --depth 1 tradingstrategy/chains
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
       - name: Read metadata
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: ${{ env.REGISTRY }}/${{ github.repository }}
       - name: Log in to Github Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -54,7 +54,7 @@ jobs:
       - name: Scrape build info
         run: echo "RELEASE_VERSION=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
       - name: Build and push
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           target: tradeexecutor

--- a/.github/workflows/notebook-docker-image.yml
+++ b/.github/workflows/notebook-docker-image.yml
@@ -21,18 +21,18 @@ jobs:
     env:
       REGISTRY: ghcr.io
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v7
         with:
           submodules: 'recursive'
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v4
       - name: Read metadata
         id: meta
-        uses: docker/metadata-action@v4
+        uses: docker/metadata-action@v6
         with:
           images: ${{ env.REGISTRY }}/${{ github.repository }}
       - name: Log in to Github Container Registry
-        uses: docker/login-action@v2
+        uses: docker/login-action@v4
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -41,7 +41,7 @@ jobs:
       - name: Scrape build info
         run: echo "RELEASE_VERSION=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
       - name: Build and push
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@v7
         with:
           context: .
           file: notebook.dockerfile

--- a/.github/workflows/test-slow.yml
+++ b/.github/workflows/test-slow.yml
@@ -12,11 +12,11 @@ jobs:
     runs-on:
       group: Beefy runners
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v7
         with:
           submodules: 'recursive'
       - name: Set up Python 3.14
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.14"
       - name: Install system packages
@@ -24,18 +24,18 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y libxml2-dev libxslt1-dev
       - name: Install Poetry
-        uses: snok/install-poetry@v1
+        uses: snok/install-poetry@v1.4.2
         with:
           virtualenvs-create: true
           virtualenvs-in-project: true
           installer-parallel: true
       - name: Load cached venv
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: .venv
           key: venv-${{ runner.os }}-${{ steps.setup-python.outputs.python-version }}-${{ hashFiles('**/poetry.lock') }}
       - name: Install Foundry
-        uses: foundry-rs/foundry-toolchain@v1
+        uses: foundry-rs/foundry-toolchain@v1.8.0
         with:
           # pick a nightly release from: https://github.com/foundry-rs/foundry/releases
           version: 'v0.3.0'
@@ -66,7 +66,7 @@ jobs:
       # See conftest.persistent_test_client
       - name: Cache datasetes
         id: cache-datasets-load
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: ~/.cache/trading-strategy-tests
           key: cache-datasets
@@ -89,7 +89,7 @@ jobs:
 
       - name: Save datasets
         id: cache-datasets-save
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@v6
         with:
           path: ~/.cache/trading-strategy-tests
           key: cache-datasets

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,12 +14,12 @@ jobs:
     runs-on:
       group: Beefy runners
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v7
         with:
           submodules: 'recursive'
 
       - name: Set up Python 3.14
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.14'
 
@@ -29,7 +29,7 @@ jobs:
           sudo apt-get install -y libxml2-dev libxslt1-dev
 
       - name: Install Poetry
-        uses: snok/install-poetry@v1
+        uses: snok/install-poetry@v1.4.2
         with:
           virtualenvs-create: true
           virtualenvs-in-project: true
@@ -37,7 +37,7 @@ jobs:
 
       # Do not let Poetry to install again if we do not detect a lock file change
       - name: Load cached venv
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: .venv
           key: venv-${{ runner.os }}-${{ steps.setup-python.outputs.python-version }}-${{ hashFiles('**/poetry.lock') }}
@@ -47,14 +47,14 @@ jobs:
       # See conftest.persistent_test_client
       - name: Cache datasetes
         id: cache-datasets-load
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: ~/.cache/trading-strategy-tests
           key: cache-datasets
 
       # Needed for Anvil / fork tests
       - name: Install Foundry
-        uses: foundry-rs/foundry-toolchain@v1
+        uses: foundry-rs/foundry-toolchain@v1.8.0
         with:
           # pick a nightly release from: https://github.com/foundry-rs/foundry/releases
           # version: 'nightly-de33b6af53005037b463318d2628b5cfcaf39916'
@@ -66,7 +66,7 @@ jobs:
       # Without this step deploy_automated_lagoon_vault() forge builds fail with a
       # soldeer dependency-resolution error (e.g. test_lagoon_ostium_v15_async_lifecycle).
       - name: Cache Lagoon soldeer deps
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: deps/web3-ethereum-defi/contracts/lagoon-v0/dependencies
           key: soldeer-${{ hashFiles('deps/web3-ethereum-defi/contracts/lagoon-v0/soldeer.lock', 'deps/web3-ethereum-defi/contracts/lagoon-v0/foundry.toml') }}
@@ -107,7 +107,7 @@ jobs:
 
       - name: Save datasets
         id: cache-datasets-save
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@v6
         with:
           path: ~/.cache/trading-strategy-tests
           key: cache-datasets

--- a/tradeexecutor/visual/image_output.py
+++ b/tradeexecutor/visual/image_output.py
@@ -9,6 +9,7 @@ import logging
 import webbrowser
 from pathlib import Path
 
+import plotly.io as pio
 from plotly.graph_objects import Figure
 
 
@@ -45,7 +46,9 @@ def render_plotly_figure_as_image_file(
 
     logger.info(f"render_plotly_figure_as_image_file(): {type(figure)} {width}x{height}")
 
-    data = figure.to_image(format, width, height)
+    # Kaleido uses orjson internally and rejects pandas Timestamp values.
+    serialisable_figure = pio.from_json(pio.to_json(figure, validate=False, remove_uids=False))
+    data = serialisable_figure.to_image(format, width, height)
     assert len(data) > 0, "Rendered image data is empty"
 
     logger.info("Plotly/Kaleido rendering done")


### PR DESCRIPTION
## Why

GitHub-hosted workflows were still pinned to several older action versions, including Node.js 20 based releases. This refreshes the workflow dependencies so Python CI, Docker builds, notebook image builds and devcontainer builds run on the current action runtimes.

## Lessons learnt

GitHub Actions JavaScript runtimes are independent of the Python version used by the workflow. A Python build can still emit Node.js deprecation warnings when its reusable actions are implemented in JavaScript and pinned to older major versions.

The upgraded CI image path also surfaced a Plotly/Kaleido compatibility issue: Kaleido serialises figures with `orjson`, which rejects pandas `Timestamp` values unless the figure has first been converted through Plotly's JSON encoder.

Notebook execution under the current Python/Jupyter/Matplotlib stack can fail when calling `Figure.show()` on a Matplotlib figure that is not pyplot-managed. `display(fig)` is the notebook-safe display path for those figures.

## Summary

- Upgrade GitHub-maintained actions to their current major versions across CI, slow tests, Docker, notebook Docker and devcontainer workflows.
- Upgrade Docker actions to their current Node.js 24 based major versions.
- Pin `snok/install-poetry` and `foundry-rs/foundry-toolchain` to current explicit releases.
- Keep `peter-evans/repository-dispatch@v4`, which already uses a current runtime.

## Unrelated test fixes for CI green

- Normalise Plotly figures through Plotly's JSON encoder before Kaleido image rendering so pandas `Timestamp` values do not fail slow chart rendering tests.
- Display the Hyperliquid waterfall release-candidate notebook's Matplotlib equity curve figure with `display(fig)` instead of `fig.show()`.
