### PR TITLE
Disable tqdm for static notebook execution

### DIFF
--- a/tests/test_execution_context.py
+++ b/tests/test_execution_context.py
@@ -1,0 +1,65 @@
+import pytest
+
+import tradeexecutor.strategy.execution_context as execution_context_module
+from tradeexecutor.strategy.execution_context import ExecutionContext, ExecutionMode, is_non_interactive_notebook_execution
+
+
+class _FakeParentProcess:
+    def __init__(self, cmdline: list[str]):
+        self._cmdline = cmdline
+
+    def cmdline(self) -> list[str]:
+        return self._cmdline
+
+
+class _FakeCurrentProcess:
+    def __init__(self, parents: list[_FakeParentProcess]):
+        self._parents = parents
+
+    def parents(self) -> list[_FakeParentProcess]:
+        return self._parents
+
+
+def test_progress_bars_disabled_for_jupyter_execute(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Verify static notebook execution does not emit TQDM progress bars.
+
+    1. Patch parent process detection to look like ``jupyter execute``.
+    2. Create a backtest execution context with progress bars enabled.
+    3. Confirm the context suppresses progress bars.
+    """
+
+    # 1. Patch parent process detection to look like ``jupyter execute``.
+    process = _FakeCurrentProcess([
+        _FakeParentProcess(["/usr/bin/jupyter", "execute", "backtest.ipynb"]),
+    ])
+    monkeypatch.setattr(execution_context_module.psutil, "Process", lambda: process)
+
+    # 2. Create a backtest execution context with progress bars enabled.
+    execution_context = ExecutionContext(mode=ExecutionMode.backtesting)
+
+    # 3. Confirm the context suppresses progress bars.
+    assert is_non_interactive_notebook_execution()
+    assert not execution_context.is_progress_bar_enabled()
+
+
+def test_progress_bars_enabled_outside_static_notebook_execution(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Verify normal execution keeps TQDM progress bars available.
+
+    1. Patch parent process detection to look like a regular shell run.
+    2. Create a backtest execution context with progress bars enabled.
+    3. Confirm the context keeps progress bars enabled.
+    """
+
+    # 1. Patch parent process detection to look like a regular shell run.
+    process = _FakeCurrentProcess([
+        _FakeParentProcess(["bash"]),
+        _FakeParentProcess(["poetry", "run", "pytest"]),
+    ])
+    monkeypatch.setattr(execution_context_module.psutil, "Process", lambda: process)
+
+    # 2. Create a backtest execution context with progress bars enabled.
+    execution_context = ExecutionContext(mode=ExecutionMode.backtesting)
+
+    # 3. Confirm the context keeps progress bars enabled.
+    assert not is_non_interactive_notebook_execution()
+    assert execution_context.is_progress_bar_enabled()

--- a/tradeexecutor/backtest/backtest_runner.py
+++ b/tradeexecutor/backtest/backtest_runner.py
@@ -254,7 +254,7 @@ class BacktestSetup:
             indicators=indicator_set,
             parameters=self.parameters,
             max_workers=self.max_workers,
-            verbose=execution_context.progress_bars,
+            verbose=execution_context.is_progress_bar_enabled(),
         )
 
         strategy_input_indicators = StrategyInputIndicators(
@@ -1118,5 +1118,4 @@ def guess_data_delay_tolerance(universe: TradingStrategyUniverse) -> pd.Timedelt
         data_delay_tolerance = pd.Timedelta("2d")
 
     return data_delay_tolerance
-
 

--- a/tradeexecutor/backtest/grid_search.py
+++ b/tradeexecutor/backtest/grid_search.py
@@ -1031,6 +1031,7 @@ def _read_cached_results(
     combinations: List[GridCombination],
     data_retention: GridSearchDataRetention,
     reader_pool_size=16,
+    show_progress=True,
 ) -> Dict[GridCombination, GridSearchResult]:
     """Read grid search results that are available on a disk from previous run.
 
@@ -1059,11 +1060,16 @@ def _read_cached_results(
     # Label too long for Datalore
     label = ", ".join(p.name for p in combinations[0].searchable_parameters)
     print(f"Using grid search cache {combinations[0].result_path}, for indicators {label}")
-    with tqdm(total=len(task_args), desc=f"Reading cached search results w/ {reader_pool_size} threads") as progress_bar:
+    progress_bar = tqdm(total=len(task_args), desc=f"Reading cached search results w/ {reader_pool_size} threads") if show_progress else None
+    try:
         # Extract results from the parallel task queue
         for task in tm.as_completed():
             results[task.args[0]] = task.result
-            progress_bar.update()
+            if progress_bar:
+                progress_bar.update()
+    finally:
+        if progress_bar:
+            progress_bar.close()
 
     return results
 
@@ -1158,7 +1164,8 @@ def perform_grid_search(
         )
 
     # Load grid search results we have already completed before crash / break / previous strategy parameters
-    cached_results = _read_cached_results(combinations, data_retention, reader_pool_size)
+    show_progress = verbose and execution_context.is_progress_bar_enabled()
+    cached_results = _read_cached_results(combinations, data_retention, reader_pool_size, show_progress=show_progress)
     logger.info("Read %d cached results", len(cached_results))
 
     if len(cached_results) == len(combinations):
@@ -1208,7 +1215,7 @@ def perform_grid_search(
             # Too wide for Datalore notebooks
             # label = ", ".join(p.name for p in combinations[0].searchable_parameters)
 
-            if verbose:
+            if show_progress:
                 progress_bar = tqdm(total=len(task_args))
                 progress_bar.set_postfix({"processes": max_workers})
                 progress_bar.display()

--- a/tradeexecutor/backtest/optimiser.py
+++ b/tradeexecutor/backtest/optimiser.py
@@ -735,7 +735,8 @@ def perform_optimisation(
 
     print(f"Optimiser search result cache is {result_path}\nIndicator cache is {indicator_storage.get_disk_cache_path()}")
 
-    with tqdm(total=iterations, desc=f"Optimising {name}, search space is {len(search_space)} variables, using {max_workers} CPUs") as progress_bar:
+    progress_bar = tqdm(total=iterations, desc=f"Optimising {name}, search space is {len(search_space)} variables, using {max_workers} CPUs") if execution_context.is_progress_bar_enabled() else None
+    try:
         for i in range(0, iterations):
 
             iteration_started = native_datetime_utc_now()
@@ -782,8 +783,12 @@ def perform_optimisation(
                 all_results.append(result)
 
             best_so_far: OptimiserSearchResult = min([r for r in all_results if not r.filtered], default=None)  # Get the best value for "bull days matched"
-            progress_bar.set_postfix({"Best so far": best_so_far.get_original_value() if best_so_far else "-"})
-            progress_bar.update()
+            if progress_bar:
+                progress_bar.set_postfix({"Best so far": best_so_far.get_original_value() if best_so_far else "-"})
+                progress_bar.update()
+    finally:
+        if progress_bar:
+            progress_bar.close()
 
     # Cleans up Loky backend hanging in pytest
     # https://stackoverflow.com/a/77130505/315168

--- a/tradeexecutor/cli/loop.py
+++ b/tradeexecutor/cli/loop.py
@@ -1133,7 +1133,7 @@ class ExecutionLoop:
                 "PnL": f"{rolling_profit * 100:.2f}%",
             })
 
-        if not self.execution_context.grid_search and self.execution_context.progress_bars:
+        if not self.execution_context.grid_search and self.execution_context.is_progress_bar_enabled():
             # In grid search do not display
             # progress bar for individual backtests
             progress_bar = tqdm(total=seconds)

--- a/tradeexecutor/strategy/execution_context.py
+++ b/tradeexecutor/strategy/execution_context.py
@@ -5,13 +5,18 @@
 - Any instrumentation like task duration tracing needed for the run
 """
 import enum
+import logging
 from dataclasses import dataclass
 from typing import Callable
+
+import psutil
 from packaging import version
 
 from tradeexecutor.strategy.engine_version import TradingStrategyEngineVersion
 from tradeexecutor.strategy.parameters import StrategyParameters
 from tradeexecutor.utils.timer import timed_task
+
+logger = logging.getLogger(__name__)
 
 
 class ExecutionMode(enum.Enum):
@@ -132,6 +137,35 @@ class ExecutionMode(enum.Enum):
 _version_check_cache: dict[tuple, bool] = {}
 
 
+def is_non_interactive_notebook_execution() -> bool:
+    """Detect notebook execution that records terminal output as static text.
+
+    ``jupyter execute`` and ``nbconvert`` execute through an IPython kernel, but
+    the saved notebook receives plain stream output. TQDM carriage-return
+    updates then become one stored line per update.
+    """
+
+    try:
+        current_process = psutil.Process()
+        for parent in current_process.parents():
+            try:
+                cmdline = parent.cmdline()
+            except (psutil.AccessDenied, psutil.NoSuchProcess):
+                continue
+
+            command = " ".join(cmdline).lower()
+
+            if "jupyter" in command and "execute" in command:
+                return True
+
+            if "nbconvert" in command:
+                return True
+    except Exception as e:
+        logger.debug("Could not detect notebook execution mode: %s", e)
+
+    return False
+
+
 @dataclass(slots=True)
 class ExecutionContext:
     """Information about the strategy execution environment.
@@ -249,6 +283,17 @@ class ExecutionContext:
         - By default, disabled for the grid search/optimiser for the speed
         """
         return self.force_visualisation or not(self.grid_search or self.optimiser)
+
+    def is_progress_bar_enabled(self) -> bool:
+        """Should TQDM progress bars be rendered in this execution context."""
+
+        if not self.progress_bars:
+            return False
+
+        if is_non_interactive_notebook_execution():
+            return False
+
+        return True
 
     @property
     def live_trading(self) -> bool:


### PR DESCRIPTION
## Why

Backtest notebooks run through `jupyter execute` or `nbconvert` record stream output as static notebook text. TQDM carriage-return updates therefore become one saved output line per progress iteration, which can make executed notebooks very noisy and large.

## Lessons learnt

The existing `ExecutionContext.progress_bars` flag already controls most backtest progress output, but call sites needed a runtime-aware check so static notebook execution can suppress TQDM while interactive notebooks and normal terminal runs keep it.

## Summary

- Add static notebook execution detection for `jupyter execute` and `nbconvert` parent processes.
- Route backtest, indicator, grid-search, and optimiser progress decisions through `ExecutionContext.is_progress_bar_enabled()`.
- Add focused tests for progress-bar suppression in static notebook execution and preservation in normal runs.
