### PR TITLE
Improve queue venue asset chart legend

### DIFF
--- a/tests/backtest/test_backtest_visualise_weights.py
+++ b/tests/backtest/test_backtest_visualise_weights.py
@@ -219,3 +219,31 @@ def test_visualise_weights(strategy_universe, tmp_path):
     weight_stats = calculate_weights_statistics(weights_series)
     assert isinstance(weight_stats, pd.DataFrame)
 
+
+def test_visualise_weights_extra_reserve_band_order_and_colour():
+    """Reserve-like extra bands can be pinned next to USDC and coloured explicitly."""
+    timestamp = pd.Timestamp("2024-01-01")
+    weights_series = pd.Series(
+        [100.0, 50.0, 25.0],
+        index=pd.MultiIndex.from_tuples(
+            [
+                (timestamp, "USDC"),
+                (timestamp, "Steakhouse USDC queue"),
+                (timestamp, "ETH"),
+            ],
+            names=["timestamp", "asset"],
+        ),
+    )
+    weights_series.attrs["reserve_asset_symbol"] = "USDC"
+    weights_series.attrs["credit_supply_symbols"] = []
+    weights_series.attrs["vault_symbols"] = []
+
+    fig = visualise_weights(
+        weights_series,
+        normalised=False,
+        extra_colours={"Steakhouse USDC queue": "#666"},
+        extra_sort_order={"USDC": -1000, "Steakhouse USDC queue": -999},
+    )
+
+    assert [trace.name for trace in fig.data[:2]] == ["USDC", "Steakhouse USDC queue"]
+    assert fig.data[1].fillcolor == "#666"

--- a/tradeexecutor/analysis/weights.py
+++ b/tradeexecutor/analysis/weights.py
@@ -135,6 +135,8 @@ def visualise_weights(
     legend_mode: LegendMode=LegendMode.side,
     aave_colour='#ccc',
     reserve_asset_colour='#aaa',
+    extra_colours: dict[str, str] | None = None,
+    extra_sort_order: dict[str, int] | None = None,
     clean=False,
 ) -> Figure:
     """Draw a chart of weights.
@@ -161,6 +163,8 @@ def visualise_weights(
     reserve_asset_symbol = weights_series.attrs["reserve_asset_symbol"]
     vault_symbols = weights_series.attrs["vault_symbols"]
     non_volatile_symbols = [weights_series.attrs["reserve_asset_symbol"]] + weights_series.attrs["credit_supply_symbols"]
+    extra_colours = extra_colours or {}
+    extra_sort_order = extra_sort_order or {}
 
     if not include_reserves:
         # Filter out reserve/credit position
@@ -169,6 +173,8 @@ def visualise_weights(
         ]
 
     def sort_key_reserve_first(col_name):
+        if col_name in extra_sort_order:
+            return extra_sort_order[col_name], col_name
         if col_name == reserve_asset_symbol:
             return -1000, col_name
         elif col_name in non_volatile_symbols:
@@ -229,6 +235,8 @@ def visualise_weights(
         )
 
     fig.update_traces(fillcolor=reserve_asset_colour, selector=dict(name=reserve_asset_symbol))
+    for symbol, colour in extra_colours.items():
+        fig.update_traces(fillcolor=colour, selector=dict(name=symbol))
     fig.update_traces(line_width=0)
 
     match legend_mode:

--- a/tradeexecutor/strategy/chart/standard/weight.py
+++ b/tradeexecutor/strategy/chart/standard/weight.py
@@ -15,6 +15,15 @@ from tradeexecutor.strategy.phase_aware import is_queue_vault_position
 #: Band label for the yield-bearing queue venue, split out from directional chain bands and idle cash.
 QUEUE_VENUE_BAND = "Queue venue"
 
+#: Reserve-like colour for YieldManager-managed queue venue positions.
+YIELD_MANAGER_RESERVE_COLOUR = "#666"
+
+
+def _get_queue_asset_label(pair) -> str:
+    """Legend label for a YieldManager venue in asset allocation charts."""
+    venue_name = pair.get_chart_label() or pair.get_ticker()
+    return f"{venue_name} queue"
+
 
 def _calculate_and_cache_weights(input: ChartInput) -> pd.Series:
     """Calculate and cache asset weights for the input."""
@@ -24,6 +33,31 @@ def _calculate_and_cache_weights(input: ChartInput) -> pd.Series:
         weights_series = calculate_asset_weights(state)
         input.cache["weights"] = weights_series
     return weights_series
+
+
+def _calculate_asset_weights_with_queue_venue(input: ChartInput) -> pd.Series:
+    """Calculate asset weights, relabelling YieldManager vault venues as reserve-like bands."""
+    state = input.state
+    weights_series = calculate_asset_weights(state)
+    queue_asset_labels = {
+        p.pair.get_chart_label(): _get_queue_asset_label(p.pair)
+        for p in state.portfolio.get_all_positions()
+        if is_queue_vault_position(p)
+    }
+    if not queue_asset_labels:
+        return weights_series
+
+    df = weights_series.rename("value").reset_index()
+    df["asset"] = df["asset"].replace(queue_asset_labels)
+
+    queue_weights_series = df.set_index(["timestamp", "asset"])["value"].groupby(level=[0, 1]).sum()
+    queue_weights_series.attrs = dict(weights_series.attrs)
+    queue_weights_series.attrs["vault_symbols"] = [
+        symbol
+        for symbol in weights_series.attrs["vault_symbols"]
+        if symbol not in queue_asset_labels.keys()
+    ]
+    return queue_weights_series
 
 
 def volatile_weights_by_percent(
@@ -59,10 +93,21 @@ def equity_curve_by_asset(
 ) -> Figure:
     """Equity curve with assets colored.
     """
-    weights_series = calculate_asset_weights(input.state)
+    reserve_asset_symbol = input.state.portfolio.get_default_reserve_asset()[0].token_symbol
+    weights_series = _calculate_asset_weights_with_queue_venue(input)
+    queue_asset_labels = [
+        _get_queue_asset_label(p.pair)
+        for p in input.state.portfolio.get_all_positions()
+        if is_queue_vault_position(p)
+    ]
     fig = visualise_weights(
         weights_series,
         normalised=False,
+        extra_colours={label: YIELD_MANAGER_RESERVE_COLOUR for label in queue_asset_labels},
+        extra_sort_order={
+            reserve_asset_symbol: -1000,
+            **{label: -999 for label in queue_asset_labels},
+        },
     )
     return fig
 


### PR DESCRIPTION
Summary:
- show YieldManager queue venues in asset allocation legends as '<venue name> queue'
- render queue venue bands as dark-grey reserve-like bands next to USDC
- add a focused chart ordering and colour assertion