### PR TITLE
fix: GMX AI equity curve spikes from out-of-phase reserve/GMX sync

### DIFF
--- a/tests/cli/test_cli_stats_refresh_post_valuation.py
+++ b/tests/cli/test_cli_stats_refresh_post_valuation.py
@@ -1,8 +1,7 @@
 """CLI coverage for stats refresh post-valuation scheduling.
 
-Post-valuation treasury settlement during the background stats refresh is
-enabled by universe-driven detection: a Lagoon-style sync model (async
-deposits) combined with GMX exchange account pairs in the strategy universe.
+Post-valuation treasury settlement during the background stats refresh runs
+automatically for all Lagoon-style vaults (sync models with async deposits).
 There is no environment variable to configure.
 """
 
@@ -17,8 +16,6 @@ import pytest
 from tradeexecutor.cli import loop as loop_module
 from tradeexecutor.cli.loop import ExecutionLoop
 from tradeexecutor.cli.main import app
-from tradeexecutor.exchange_account.gmx import create_gmx_exchange_account_pair
-from tradeexecutor.state.identifier import AssetIdentifier
 from tradeexecutor.state.state import State
 from tradeexecutor.strategy.dummy import DummyExecutionModel
 from tradeexecutor.strategy.sync_model import DummySyncModel
@@ -62,18 +59,6 @@ class FakeLagoonVaultSyncModel(DummySyncModel):
         return []
 
 
-def make_gmx_universe() -> SimpleNamespace:
-    """Universe stub containing a real GMX exchange account pair for detection."""
-    usdc = AssetIdentifier(
-        chain_id=42161,
-        address="0x0000000000000000000000000000000000000001",
-        token_symbol="USDC",
-        decimals=6,
-    )
-    gmx_pair = create_gmx_exchange_account_pair(quote=usdc)
-    return SimpleNamespace(reserve_assets=[], iterate_pairs=lambda: [gmx_pair])
-
-
 def make_cli_environment(strategy_path: Path, state_file: Path, cache_path: Path) -> dict:
     """CLI environment for a stats-refresh unit test run."""
     return {
@@ -96,10 +81,9 @@ def make_cli_environment(strategy_path: Path, state_file: Path, cache_path: Path
 def patch_cli_startup(
     monkeypatch: pytest.MonkeyPatch,
     fake_sync_model: DummySyncModel,
-    universe: SimpleNamespace,
     calls: list[tuple],
 ) -> None:
-    """Patch CLI start-up so the live loop runs offline with the given sync model and universe."""
+    """Patch CLI start-up so the live loop runs offline with the given sync model."""
     from tradeexecutor.cli.commands import start as start_module
 
     def fake_create_execution_and_sync_model(**kwargs):
@@ -112,7 +96,7 @@ def patch_cli_startup(
         return state
 
     def fake_warm_up_live_trading(self: ExecutionLoop):
-        return universe
+        return SimpleNamespace(reserve_assets=[])
 
     def fake_refresh_live_run_state(
         self: ExecutionLoop,
@@ -162,7 +146,7 @@ def patch_cli_startup(
     monkeypatch.setattr(loop_module, "display_strategy_universe", lambda universe: pd.DataFrame())
 
 
-def test_cli_stats_refresh_post_valuation_runs_once_for_lagoon_gmx(
+def test_cli_stats_refresh_post_valuation_runs_once_for_lagoon(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -170,12 +154,12 @@ def test_cli_stats_refresh_post_valuation_runs_once_for_lagoon_gmx(
 
     A statistics point written before treasury settlement combines a stale reserve
     balance with a fresh position valuation and records a spurious NAV spike when an
-    external system has moved cash in or out of the vault. For a Lagoon vault whose
-    universe trades GMX through an exchange account pair (detected from the universe,
-    no environment variable), the refresh must revalue first (statistics held back),
-    settle treasury, then write statistics once.
+    external system (e.g. FreqTrade on GMX) has moved cash in or out of the vault.
+    Settlement runs automatically for any Lagoon-style vault (async deposits detected
+    from the sync model, no environment variable): the refresh must revalue first
+    (statistics held back), settle treasury, then write statistics once.
 
-    1. Patch CLI start-up so it runs offline with a fake Lagoon sync model and a GMX universe, recording the call order.
+    1. Patch CLI start-up so it runs offline with a fake Lagoon sync model, recording the call order.
     2. Run `start` with a tiny stats refresh interval and the unit-testing shutdown hook enabled.
     3. Verify the call order is: revalue without statistics, treasury settlement, revalue with statistics.
     4. Verify one stats refresh and one post-valuation settlement were persisted in state.
@@ -188,8 +172,8 @@ def test_cli_stats_refresh_post_valuation_runs_once_for_lagoon_gmx(
     calls: list[tuple] = []
     fake_sync_model = FakeLagoonVaultSyncModel(calls)
 
-    # 1. Patch CLI start-up so it runs offline with a fake Lagoon sync model and a GMX universe.
-    patch_cli_startup(monkeypatch, fake_sync_model, make_gmx_universe(), calls)
+    # 1. Patch CLI start-up so it runs offline with a fake Lagoon sync model.
+    patch_cli_startup(monkeypatch, fake_sync_model, calls)
 
     # 2. Run `start` with a tiny stats refresh interval and the unit-testing shutdown hook enabled.
     environment = make_cli_environment(strategy_path, state_file, cache_path)
@@ -211,31 +195,30 @@ def test_cli_stats_refresh_post_valuation_runs_once_for_lagoon_gmx(
     assert state.uptime.post_valuation_settlements_completed == 1
 
 
-def test_cli_stats_refresh_post_valuation_skipped_without_gmx(
+def test_cli_stats_refresh_post_valuation_skipped_for_non_lagoon(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Stats refresh skips post-valuation settlement when the universe has no GMX pairs.
+    """Stats refresh skips post-valuation settlement for non-Lagoon strategies.
 
-    Post-valuation settlement is driven purely by universe detection, so a Lagoon
-    vault trading only spot pairs must keep the plain refresh path: one statistics
-    write, never held back, and no treasury settlement.
+    Settlement is driven by the sync model's async deposit capability, so a
+    strategy without async deposits (e.g. hot wallet) must keep the plain refresh
+    path: one statistics write, never held back, and no treasury settlement.
 
-    1. Patch CLI start-up so it runs offline with a fake Lagoon sync model and a universe without GMX pairs.
+    1. Patch CLI start-up so it runs offline with a non-Lagoon sync model.
     2. Run `start` with the same tiny stats refresh interval and unit-testing shutdown hook.
     3. Verify a single statistics write happened with statistics never held back and no treasury settlement.
     4. Verify the stats refresh counter increments once and the settlement counter stays at zero.
     """
     strategy_path = Path(os.path.join(os.path.dirname(__file__), "..", "..", "strategies", "test_only", "quickswap_dummy.py"))
-    state_file = tmp_path / "stats_refresh_post_valuation_no_gmx.json"
+    state_file = tmp_path / "stats_refresh_post_valuation_non_lagoon.json"
     cache_path = tmp_path / "cache"
 
     calls: list[tuple] = []
-    fake_sync_model = FakeLagoonVaultSyncModel(calls)
+    fake_sync_model = DummySyncModel()
 
-    # 1. Patch CLI start-up with a Lagoon sync model but a universe without GMX pairs.
-    universe = SimpleNamespace(reserve_assets=[])
-    patch_cli_startup(monkeypatch, fake_sync_model, universe, calls)
+    # 1. Patch CLI start-up so it runs offline with a non-Lagoon sync model.
+    patch_cli_startup(monkeypatch, fake_sync_model, calls)
 
     # 2. Run `start` with the same tiny stats refresh interval and unit-testing shutdown hook.
     environment = make_cli_environment(strategy_path, state_file, cache_path)
@@ -248,7 +231,6 @@ def test_cli_stats_refresh_post_valuation_skipped_without_gmx(
     assert calls == [
         ("update_position_valuations", False),
     ]
-    assert fake_sync_model.sync_treasury_calls == []
 
     # 4. Verify the stats refresh counter increments once and the settlement counter stays at zero.
     assert state.uptime.stats_refresh_completed == 1

--- a/tests/cli/test_cli_stats_refresh_post_valuation.py
+++ b/tests/cli/test_cli_stats_refresh_post_valuation.py
@@ -33,17 +33,26 @@ def test_cli_stats_refresh_post_valuation_runs_once_for_lagoon(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Stats refresh can drive one Lagoon post-valuation settlement in unit tests.
+    """Stats refresh writes statistics once, after Lagoon post-valuation settlement.
 
-    1. Patch CLI start-up so it runs offline with a fake Lagoon sync model.
+    A statistics point written before treasury settlement combines a stale reserve
+    balance with a fresh position valuation and records a spurious NAV spike when an
+    external system has moved cash in or out of the vault. The refresh must therefore
+    revalue first (statistics held back), settle treasury, then write statistics once.
+
+    1. Patch CLI start-up so it runs offline with a fake Lagoon sync model, recording the call order.
     2. Run `start` with a tiny stats refresh interval and the unit-testing shutdown hook enabled.
-    3. Verify one stats refresh and one post-valuation settlement were persisted in state.
+    3. Verify the call order is: revalue without statistics, treasury settlement, revalue with statistics.
+    4. Verify one stats refresh and one post-valuation settlement were persisted in state.
     """
     from tradeexecutor.cli.commands import start as start_module
 
     strategy_path = Path(os.path.join(os.path.dirname(__file__), "..", "..", "strategies", "test_only", "quickswap_dummy.py"))
     state_file = tmp_path / "stats_refresh_post_valuation_lagoon.json"
     cache_path = tmp_path / "cache"
+
+    # Shared event log capturing the order of valuation and settlement calls
+    calls: list[tuple] = []
 
     class FakeLagoonVaultSyncModel(DummySyncModel):
         def __init__(self) -> None:
@@ -62,6 +71,8 @@ def test_cli_stats_refresh_post_valuation_runs_once_for_lagoon(
             post_valuation=False,
         ):
             self.sync_treasury_calls.append(post_valuation)
+            calls.append(("sync_treasury", post_valuation))
+            # A reconciliation-only pass legitimately returns no balance updates
             return []
 
     fake_sync_model = FakeLagoonVaultSyncModel()
@@ -94,7 +105,9 @@ def test_cli_stats_refresh_post_valuation_runs_once_for_lagoon(
         universe,
         execution_mode=None,
         interest=True,
+        skip_statistics=False,
     ) -> None:
+        calls.append(("update_position_valuations", skip_statistics))
         return None
 
     def fake_tick(
@@ -146,7 +159,14 @@ def test_cli_stats_refresh_post_valuation_runs_once_for_lagoon(
 
     state = State.from_json(state_file.read_text())
 
-    # 3. Verify one stats refresh and one post-valuation settlement were persisted in state.
+    # 3. Verify the call order is: revalue without statistics, treasury settlement, revalue with statistics.
+    assert calls == [
+        ("update_position_valuations", True),
+        ("sync_treasury", True),
+        ("update_position_valuations", False),
+    ]
+
+    # 4. Verify one stats refresh and one post-valuation settlement were persisted in state.
     assert fake_sync_model.sync_treasury_calls == [True]
     assert state.uptime.stats_refresh_completed == 1
     assert state.uptime.post_valuation_settlements_completed == 1
@@ -198,7 +218,10 @@ def test_cli_stats_refresh_post_valuation_ignored_for_non_lagoon(
         universe,
         execution_mode=None,
         interest=True,
+        skip_statistics=False,
     ) -> None:
+        # A non-Lagoon refresh must never hold back the statistics write
+        assert skip_statistics is False
         return None
 
     def fake_tick(

--- a/tests/cli/test_cli_stats_refresh_post_valuation.py
+++ b/tests/cli/test_cli_stats_refresh_post_valuation.py
@@ -1,4 +1,10 @@
-"""CLI coverage for stats refresh post-valuation scheduling."""
+"""CLI coverage for stats refresh post-valuation scheduling.
+
+Post-valuation treasury settlement during the background stats refresh is
+enabled by universe-driven detection: a Lagoon-style sync model (async
+deposits) combined with GMX exchange account pairs in the strategy universe.
+There is no environment variable to configure.
+"""
 
 import os
 from pathlib import Path
@@ -11,6 +17,8 @@ import pytest
 from tradeexecutor.cli import loop as loop_module
 from tradeexecutor.cli.loop import ExecutionLoop
 from tradeexecutor.cli.main import app
+from tradeexecutor.exchange_account.gmx import create_gmx_exchange_account_pair
+from tradeexecutor.state.identifier import AssetIdentifier
 from tradeexecutor.state.state import State
 from tradeexecutor.strategy.dummy import DummyExecutionModel
 from tradeexecutor.strategy.sync_model import DummySyncModel
@@ -29,53 +37,70 @@ class FakeWeb3Config:
         return self._default
 
 
-def test_cli_stats_refresh_post_valuation_runs_once_for_lagoon(
-    tmp_path: Path,
+class FakeLagoonVaultSyncModel(DummySyncModel):
+    """Lagoon-like sync model stub recording treasury sync calls in a shared event log."""
+
+    def __init__(self, calls: list[tuple] | None = None) -> None:
+        self.sync_treasury_calls: list[bool] = []
+        self.calls = calls if calls is not None else []
+        self.abort_lagoon_settlement_on_frozen_positions = False
+
+    def has_async_deposits(self):
+        return True
+
+    def sync_treasury(
+        self,
+        strategy_cycle_ts,
+        state: State,
+        supported_reserves=None,
+        end_block=None,
+        post_valuation=False,
+    ):
+        self.sync_treasury_calls.append(post_valuation)
+        self.calls.append(("sync_treasury", post_valuation))
+        # A reconciliation-only pass legitimately returns no balance updates
+        return []
+
+
+def make_gmx_universe() -> SimpleNamespace:
+    """Universe stub containing a real GMX exchange account pair for detection."""
+    usdc = AssetIdentifier(
+        chain_id=42161,
+        address="0x0000000000000000000000000000000000000001",
+        token_symbol="USDC",
+        decimals=6,
+    )
+    gmx_pair = create_gmx_exchange_account_pair(quote=usdc)
+    return SimpleNamespace(reserve_assets=[], iterate_pairs=lambda: [gmx_pair])
+
+
+def make_cli_environment(strategy_path: Path, state_file: Path, cache_path: Path) -> dict:
+    """CLI environment for a stats-refresh unit test run."""
+    return {
+        "STRATEGY_FILE": strategy_path.as_posix(),
+        "STATE_FILE": state_file.as_posix(),
+        "RESET_STATE": "true",
+        "ASSET_MANAGEMENT_MODE": "dummy",
+        "CACHE_PATH": cache_path.as_posix(),
+        "UNIT_TESTING": "true",
+        "LOG_LEVEL": "disabled",
+        "CHECK_ACCOUNTS": "false",
+        "SYNC_TREASURY_ON_STARTUP": "false",
+        "STATS_REFRESH_MINUTES": "0.0001",
+        "STATS_REFRESH_UNIT_TESTING": "true",
+        "POSITION_TRIGGER_CHECK_MINUTES": "0",
+        "CYCLE_DURATION": "1d",
+    }
+
+
+def patch_cli_startup(
     monkeypatch: pytest.MonkeyPatch,
+    fake_sync_model: DummySyncModel,
+    universe: SimpleNamespace,
+    calls: list[tuple],
 ) -> None:
-    """Stats refresh writes statistics once, after Lagoon post-valuation settlement.
-
-    A statistics point written before treasury settlement combines a stale reserve
-    balance with a fresh position valuation and records a spurious NAV spike when an
-    external system has moved cash in or out of the vault. The refresh must therefore
-    revalue first (statistics held back), settle treasury, then write statistics once.
-
-    1. Patch CLI start-up so it runs offline with a fake Lagoon sync model, recording the call order.
-    2. Run `start` with a tiny stats refresh interval and the unit-testing shutdown hook enabled.
-    3. Verify the call order is: revalue without statistics, treasury settlement, revalue with statistics.
-    4. Verify one stats refresh and one post-valuation settlement were persisted in state.
-    """
+    """Patch CLI start-up so the live loop runs offline with the given sync model and universe."""
     from tradeexecutor.cli.commands import start as start_module
-
-    strategy_path = Path(os.path.join(os.path.dirname(__file__), "..", "..", "strategies", "test_only", "quickswap_dummy.py"))
-    state_file = tmp_path / "stats_refresh_post_valuation_lagoon.json"
-    cache_path = tmp_path / "cache"
-
-    # Shared event log capturing the order of valuation and settlement calls
-    calls: list[tuple] = []
-
-    class FakeLagoonVaultSyncModel(DummySyncModel):
-        def __init__(self) -> None:
-            self.sync_treasury_calls: list[bool] = []
-            self.abort_lagoon_settlement_on_frozen_positions = False
-
-        def has_async_deposits(self):
-            return True
-
-        def sync_treasury(
-            self,
-            strategy_cycle_ts,
-            state: State,
-            supported_reserves=None,
-            end_block=None,
-            post_valuation=False,
-        ):
-            self.sync_treasury_calls.append(post_valuation)
-            calls.append(("sync_treasury", post_valuation))
-            # A reconciliation-only pass legitimately returns no balance updates
-            return []
-
-    fake_sync_model = FakeLagoonVaultSyncModel()
 
     def fake_create_execution_and_sync_model(**kwargs):
         return DummyExecutionModel(SimpleNamespace()), fake_sync_model, None, None
@@ -87,7 +112,7 @@ def test_cli_stats_refresh_post_valuation_runs_once_for_lagoon(
         return state
 
     def fake_warm_up_live_trading(self: ExecutionLoop):
-        return SimpleNamespace(reserve_assets=[])
+        return universe
 
     def fake_refresh_live_run_state(
         self: ExecutionLoop,
@@ -136,24 +161,38 @@ def test_cli_stats_refresh_post_valuation_runs_once_for_lagoon(
     monkeypatch.setattr(ExecutionLoop, "tick", fake_tick)
     monkeypatch.setattr(loop_module, "display_strategy_universe", lambda universe: pd.DataFrame())
 
-    environment = {
-        "STRATEGY_FILE": strategy_path.as_posix(),
-        "STATE_FILE": state_file.as_posix(),
-        "RESET_STATE": "true",
-        "ASSET_MANAGEMENT_MODE": "dummy",
-        "CACHE_PATH": cache_path.as_posix(),
-        "UNIT_TESTING": "true",
-        "LOG_LEVEL": "disabled",
-        "CHECK_ACCOUNTS": "false",
-        "SYNC_TREASURY_ON_STARTUP": "false",
-        "STATS_REFRESH_MINUTES": "0.0001",
-        "STATS_REFRESH_POST_VALUATION": "true",
-        "STATS_REFRESH_UNIT_TESTING": "true",
-        "POSITION_TRIGGER_CHECK_MINUTES": "0",
-        "CYCLE_DURATION": "1d",
-    }
+
+def test_cli_stats_refresh_post_valuation_runs_once_for_lagoon_gmx(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Stats refresh writes statistics once, after Lagoon post-valuation settlement.
+
+    A statistics point written before treasury settlement combines a stale reserve
+    balance with a fresh position valuation and records a spurious NAV spike when an
+    external system has moved cash in or out of the vault. For a Lagoon vault whose
+    universe trades GMX through an exchange account pair (detected from the universe,
+    no environment variable), the refresh must revalue first (statistics held back),
+    settle treasury, then write statistics once.
+
+    1. Patch CLI start-up so it runs offline with a fake Lagoon sync model and a GMX universe, recording the call order.
+    2. Run `start` with a tiny stats refresh interval and the unit-testing shutdown hook enabled.
+    3. Verify the call order is: revalue without statistics, treasury settlement, revalue with statistics.
+    4. Verify one stats refresh and one post-valuation settlement were persisted in state.
+    """
+    strategy_path = Path(os.path.join(os.path.dirname(__file__), "..", "..", "strategies", "test_only", "quickswap_dummy.py"))
+    state_file = tmp_path / "stats_refresh_post_valuation_lagoon.json"
+    cache_path = tmp_path / "cache"
+
+    # Shared event log capturing the order of valuation and settlement calls
+    calls: list[tuple] = []
+    fake_sync_model = FakeLagoonVaultSyncModel(calls)
+
+    # 1. Patch CLI start-up so it runs offline with a fake Lagoon sync model and a GMX universe.
+    patch_cli_startup(monkeypatch, fake_sync_model, make_gmx_universe(), calls)
 
     # 2. Run `start` with a tiny stats refresh interval and the unit-testing shutdown hook enabled.
+    environment = make_cli_environment(strategy_path, state_file, cache_path)
     with mock.patch.dict("os.environ", environment, clear=True):
         app(["start"], standalone_mode=False)
 
@@ -172,106 +211,45 @@ def test_cli_stats_refresh_post_valuation_runs_once_for_lagoon(
     assert state.uptime.post_valuation_settlements_completed == 1
 
 
-def test_cli_stats_refresh_post_valuation_ignored_for_non_lagoon(
+def test_cli_stats_refresh_post_valuation_skipped_without_gmx(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Stats refresh unit testing still exits cleanly when post-valuation is disabled by sync model.
+    """Stats refresh skips post-valuation settlement when the universe has no GMX pairs.
 
-    1. Patch CLI start-up so it runs offline with a non-Lagoon sync model.
+    Post-valuation settlement is driven purely by universe detection, so a Lagoon
+    vault trading only spot pairs must keep the plain refresh path: one statistics
+    write, never held back, and no treasury settlement.
+
+    1. Patch CLI start-up so it runs offline with a fake Lagoon sync model and a universe without GMX pairs.
     2. Run `start` with the same tiny stats refresh interval and unit-testing shutdown hook.
-    3. Verify the stats refresh counter increments once and settlement counter stays at zero.
+    3. Verify a single statistics write happened with statistics never held back and no treasury settlement.
+    4. Verify the stats refresh counter increments once and the settlement counter stays at zero.
     """
-    from tradeexecutor.cli.commands import start as start_module
-
     strategy_path = Path(os.path.join(os.path.dirname(__file__), "..", "..", "strategies", "test_only", "quickswap_dummy.py"))
-    state_file = tmp_path / "stats_refresh_post_valuation_dummy.json"
+    state_file = tmp_path / "stats_refresh_post_valuation_no_gmx.json"
     cache_path = tmp_path / "cache"
 
-    fake_sync_model = DummySyncModel()
+    calls: list[tuple] = []
+    fake_sync_model = FakeLagoonVaultSyncModel(calls)
 
-    def fake_create_execution_and_sync_model(**kwargs):
-        return DummyExecutionModel(SimpleNamespace()), fake_sync_model, None, None
-
-    def fake_setup(self: ExecutionLoop) -> State:
-        state = self.init_state()
-        self.runner = SimpleNamespace(check_accounts=lambda universe, state: None)
-        self.universe_model = SimpleNamespace()
-        return state
-
-    def fake_warm_up_live_trading(self: ExecutionLoop):
-        return SimpleNamespace(reserve_assets=[])
-
-    def fake_refresh_live_run_state(
-        self: ExecutionLoop,
-        state: State,
-        visualisation: bool = False,
-        universe=None,
-        cycle_duration=None,
-    ) -> None:
-        return None
-
-    def fake_update_position_valuations(
-        self: ExecutionLoop,
-        clock,
-        state: State,
-        universe,
-        execution_mode=None,
-        interest=True,
-        skip_statistics=False,
-    ) -> None:
-        # A non-Lagoon refresh must never hold back the statistics write
-        assert skip_statistics is False
-        return None
-
-    def fake_tick(
-        self: ExecutionLoop,
-        unrounded_timestamp,
-        cycle_duration,
-        state: State,
-        cycle: int,
-        live: bool,
-        existing_universe=None,
-        strategy_cycle_timestamp=None,
-        extra_debug_data=None,
-        indicators=None,
-    ):
-        return existing_universe
-
-    monkeypatch.setattr(start_module, "create_web3_config", lambda **kwargs: FakeWeb3Config())
-    monkeypatch.setattr(start_module, "configure_default_chain", lambda web3config, mod: None)
-    monkeypatch.setattr(start_module, "create_execution_and_sync_model", fake_create_execution_and_sync_model)
-    monkeypatch.setattr(start_module, "create_client", lambda **kwargs: (object(), None))
-    monkeypatch.setattr(ExecutionLoop, "setup", fake_setup)
-    monkeypatch.setattr(ExecutionLoop, "warm_up_live_trading", fake_warm_up_live_trading)
-    monkeypatch.setattr(ExecutionLoop, "refresh_live_run_state", fake_refresh_live_run_state)
-    monkeypatch.setattr(ExecutionLoop, "update_position_valuations", fake_update_position_valuations)
-    monkeypatch.setattr(ExecutionLoop, "tick", fake_tick)
-    monkeypatch.setattr(loop_module, "display_strategy_universe", lambda universe: pd.DataFrame())
-
-    environment = {
-        "STRATEGY_FILE": strategy_path.as_posix(),
-        "STATE_FILE": state_file.as_posix(),
-        "RESET_STATE": "true",
-        "ASSET_MANAGEMENT_MODE": "dummy",
-        "CACHE_PATH": cache_path.as_posix(),
-        "UNIT_TESTING": "true",
-        "LOG_LEVEL": "disabled",
-        "CHECK_ACCOUNTS": "false",
-        "SYNC_TREASURY_ON_STARTUP": "false",
-        "STATS_REFRESH_MINUTES": "0.0001",
-        "STATS_REFRESH_POST_VALUATION": "true",
-        "STATS_REFRESH_UNIT_TESTING": "true",
-        "POSITION_TRIGGER_CHECK_MINUTES": "0",
-        "CYCLE_DURATION": "1d",
-    }
+    # 1. Patch CLI start-up with a Lagoon sync model but a universe without GMX pairs.
+    universe = SimpleNamespace(reserve_assets=[])
+    patch_cli_startup(monkeypatch, fake_sync_model, universe, calls)
 
     # 2. Run `start` with the same tiny stats refresh interval and unit-testing shutdown hook.
+    environment = make_cli_environment(strategy_path, state_file, cache_path)
     with mock.patch.dict("os.environ", environment, clear=True):
         app(["start"], standalone_mode=False)
 
     state = State.from_json(state_file.read_text())
 
-    # 3. Verify the stats refresh counter increments once and settlement counter stays at zero.
+    # 3. Verify a single statistics write happened with statistics never held back and no treasury settlement.
+    assert calls == [
+        ("update_position_valuations", False),
+    ]
+    assert fake_sync_model.sync_treasury_calls == []
+
+    # 4. Verify the stats refresh counter increments once and the settlement counter stays at zero.
     assert state.uptime.stats_refresh_completed == 1
     assert state.uptime.post_valuation_settlements_completed == 0

--- a/tests/exchange_account/test_gmx_exchange_account.py
+++ b/tests/exchange_account/test_gmx_exchange_account.py
@@ -66,10 +66,10 @@ def test_gmx_pair_protocol_detection(usdc):
 def test_has_gmx_exchange_account_pairs(usdc: AssetIdentifier):
     """Universe-driven GMX detection finds GMX exchange account pairs and nothing else.
 
-    The live execution loop uses this detection to enable post-valuation
-    treasury settlement without any environment variable, so the check must be
-    positive exactly when the strategy universe trades GMX through an
-    exchange account pair.
+    EthereumPairConfigurator uses this detection to auto-wire the GMX value
+    functions without any environment variable, so the check must be positive
+    exactly when the strategy universe trades GMX through an exchange account
+    pair.
 
     1. Build a universe stub containing a GMX exchange account pair and verify detection is positive.
     2. Build a universe stub with only a spot pair and verify detection is negative.

--- a/tests/exchange_account/test_gmx_exchange_account.py
+++ b/tests/exchange_account/test_gmx_exchange_account.py
@@ -1,12 +1,14 @@
 """Unit tests for GMX exchange account pair creation and metadata."""
 
+from types import SimpleNamespace
+
 import pytest
 
 from eth_defi.gmx.contracts import get_contract_addresses
 from eth_defi.token import USDC_NATIVE_TOKEN
 
-from tradeexecutor.exchange_account.gmx import create_gmx_exchange_account_pair
-from tradeexecutor.state.identifier import AssetIdentifier, TradingPairKind
+from tradeexecutor.exchange_account.gmx import create_gmx_exchange_account_pair, has_gmx_exchange_account_pairs
+from tradeexecutor.state.identifier import AssetIdentifier, TradingPairIdentifier, TradingPairKind
 
 #: Arbitrum mainnet chain ID
 ARBITRUM_CHAIN_ID = 42161
@@ -59,3 +61,39 @@ def test_gmx_pair_protocol_detection(usdc):
         is_testnet=False,
     )
     assert pair_mainnet.get_exchange_account_config()["exchange_is_testnet"] is False
+
+
+def test_has_gmx_exchange_account_pairs(usdc: AssetIdentifier):
+    """Universe-driven GMX detection finds GMX exchange account pairs and nothing else.
+
+    The live execution loop uses this detection to enable post-valuation
+    treasury settlement without any environment variable, so the check must be
+    positive exactly when the strategy universe trades GMX through an
+    exchange account pair.
+
+    1. Build a universe stub containing a GMX exchange account pair and verify detection is positive.
+    2. Build a universe stub with only a spot pair and verify detection is negative.
+    3. Verify a universe object without iterate_pairs() (non-trading stub) is negative.
+    """
+    # 1. Build a universe stub containing a GMX exchange account pair and verify detection is positive.
+    gmx_pair = create_gmx_exchange_account_pair(quote=usdc)
+    spot_pair = TradingPairIdentifier(
+        base=AssetIdentifier(chain_id=ARBITRUM_CHAIN_ID, address="0x0000000000000000000000000000000000000005", token_symbol="WETH", decimals=18),
+        quote=usdc,
+        pool_address="0x0000000000000000000000000000000000000006",
+        exchange_address="0x0000000000000000000000000000000000000007",
+        internal_id=2,
+        internal_exchange_id=2,
+        fee=0.0005,
+        kind=TradingPairKind.spot_market_hold,
+        exchange_name="uniswap-v3",
+    )
+    gmx_universe = SimpleNamespace(iterate_pairs=lambda: [spot_pair, gmx_pair])
+    assert has_gmx_exchange_account_pairs(gmx_universe) is True
+
+    # 2. Build a universe stub with only a spot pair and verify detection is negative.
+    spot_universe = SimpleNamespace(iterate_pairs=lambda: [spot_pair])
+    assert has_gmx_exchange_account_pairs(spot_universe) is False
+
+    # 3. Verify a universe object without iterate_pairs() (non-trading stub) is negative.
+    assert has_gmx_exchange_account_pairs(SimpleNamespace(reserve_assets=[])) is False

--- a/tests/units_tests/test_valuation_update.py
+++ b/tests/units_tests/test_valuation_update.py
@@ -1,0 +1,83 @@
+"""Unit tests for position valuation update statistics recording."""
+
+import datetime
+
+import pytest
+
+from tradeexecutor.state.state import State
+from tradeexecutor.strategy.execution_context import unit_test_execution_context
+from tradeexecutor.strategy.routing import RoutingState
+from tradeexecutor.strategy.universe_model import StrategyExecutionUniverse
+from tradeexecutor.strategy.valuation import ValuationModel
+from tradeexecutor.strategy.valuation_update import update_position_valuations
+
+
+class NoOpRoutingState(RoutingState):
+    """Routing state stand-in — the portfolio has no open positions, so routing is never used."""
+
+    def __init__(self, universe: StrategyExecutionUniverse):
+        super().__init__(universe)
+
+
+class NoOpValuationModel(ValuationModel):
+    """Valuation model stand-in — never called because the portfolio has no open positions."""
+
+    def __call__(self, ts, position):
+        raise NotImplementedError("No open positions to value in this test")
+
+
+@pytest.fixture()
+def universe() -> StrategyExecutionUniverse:
+    """Minimal strategy universe with no reserve assets."""
+    return StrategyExecutionUniverse(reserve_assets=[])
+
+
+@pytest.fixture()
+def state() -> State:
+    """Empty portfolio state with no recorded statistics."""
+    return State()
+
+
+def test_update_position_valuations_skip_statistics(
+    state: State,
+    universe: StrategyExecutionUniverse,
+):
+    """skip_statistics controls whether a portfolio statistics entry is recorded.
+
+    The live stats refresh holds back the statistics write until treasury settlement
+    has reconciled reserve cash to on-chain, so a stale reserve balance is never
+    combined with a fresh position valuation in a recorded statistics point.
+
+    1. Call update_position_valuations() with skip_statistics=True on an empty portfolio.
+    2. Verify no portfolio statistics entry was recorded.
+    3. Call update_position_valuations() again with the default skip_statistics=False.
+    4. Verify exactly one portfolio statistics entry was recorded.
+    """
+    ts = datetime.datetime(2026, 7, 9, 6, 0)
+
+    # 1. Call update_position_valuations() with skip_statistics=True on an empty portfolio.
+    update_position_valuations(
+        timestamp=ts,
+        state=state,
+        universe=universe,
+        execution_context=unit_test_execution_context,
+        valuation_model=NoOpValuationModel(),
+        routing_state=NoOpRoutingState(universe),
+        skip_statistics=True,
+    )
+
+    # 2. Verify no portfolio statistics entry was recorded.
+    assert len(state.stats.portfolio) == 0
+
+    # 3. Call update_position_valuations() again with the default skip_statistics=False.
+    update_position_valuations(
+        timestamp=ts,
+        state=state,
+        universe=universe,
+        execution_context=unit_test_execution_context,
+        valuation_model=NoOpValuationModel(),
+        routing_state=NoOpRoutingState(universe),
+    )
+
+    # 4. Verify exactly one portfolio statistics entry was recorded.
+    assert len(state.stats.portfolio) == 1

--- a/tradeexecutor/cli/commands/start.py
+++ b/tradeexecutor/cli/commands/start.py
@@ -139,7 +139,6 @@ def start(
     stop_loss_check_frequency: Optional[TimeBucket] = typer.Option(None, envvar="STOP_LOSS_CYCLE_DURATION", help="Override live/backtest stop loss check frequency. If not given read from the strategy module."),
     cycle_offset_minutes: int = typer.Option(8, envvar="CYCLE_OFFSET_MINUTES", help="How many minutes we wait after the tick before executing the tick step"),
     stats_refresh_minutes: float = typer.Option(60.0, envvar="STATS_REFRESH_MINUTES", help="How often we refresh position statistics. Default to once in an hour."),
-    stats_refresh_post_valuation: bool = typer.Option(False, "--stats-refresh-post-valuation", envvar="STATS_REFRESH_POST_VALUATION", help="After a background stats refresh, also run the Lagoon post-valuation settlement path."),
     stats_refresh_unit_testing: bool = typer.Option(False, "--stats-refresh-unit-testing", envvar="STATS_REFRESH_UNIT_TESTING", help="Unit testing helper: exit after the first background stats refresh has completed."),
     cycle_duration: CycleDuration = typer.Option(None, envvar="CYCLE_DURATION", help="How long strategy tick cycles use to execute the strategy. While strategy modules offer their own cycle duration value, you can override it here for unit testing."),
     position_trigger_check_minutes: int = typer.Option(3.0, envvar="POSITION_TRIGGER_CHECK_MINUTES", help="How often we check for take profit/stop loss triggers. Default to once in 3 minutes. Set 0 to disable."),
@@ -588,12 +587,6 @@ def start(
             type(sync_model).__name__,
         )
 
-    if stats_refresh_post_valuation and not isinstance(sync_model, LagoonVaultSyncModel):
-        logger.warning(
-            "--stats-refresh-post-valuation only applies to Lagoon vaults; "
-            "ignoring it for sync model %s",
-            type(sync_model).__name__,
-        )
 
     if stats_refresh_unit_testing and not unit_testing:
         logger.warning(
@@ -627,7 +620,6 @@ def start(
         max_data_delay=max_data_delay,
         trade_immediately=trade_immediately,
         stats_refresh_frequency=stats_refresh_frequency,
-        stats_refresh_post_valuation=stats_refresh_post_valuation,
         stats_refresh_unit_testing=stats_refresh_unit_testing,
         position_trigger_check_frequency=position_trigger_check_frequency,
         run_state=run_state,

--- a/tradeexecutor/cli/loop.py
+++ b/tradeexecutor/cli/loop.py
@@ -27,6 +27,7 @@ from tradingstrategy.timebucket import TimeBucket
 from tradeexecutor.analysis.pair import display_strategy_universe
 from tradeexecutor.cli.watchdog import create_watchdog_registry, register_worker, mark_alive, start_background_watchdog, \
     WatchdogMode
+from tradeexecutor.exchange_account.gmx import has_gmx_exchange_account_pairs
 from tradeexecutor.state.metadata import Metadata
 from tradeexecutor.state.types import Percent
 from tradeexecutor.statistics.in_memory_statistics import refresh_run_state
@@ -205,7 +206,6 @@ class ExecutionLoop:
             strategy_factory: Optional[StrategyFactory],
             cycle_duration: CycleDuration,
             stats_refresh_frequency: Optional[datetime.timedelta],
-            stats_refresh_post_valuation: bool = False,
             stats_refresh_unit_testing: bool = False,
             position_trigger_check_frequency: Optional[datetime.timedelta],
             max_data_delay: Optional[datetime.timedelta] = None,
@@ -1614,13 +1614,18 @@ class ExecutionLoop:
 
             try:
                 ts = native_datetime_utc_now()
+
+                # Post-valuation settlement is needed when an external system
+                # (FreqTrade) moves reserve cash outside the trade executor.
+                # The strategy universe itself drives the detection —
+                # no environment variable to misconfigure between deployments.
+                post_settlement = self.sync_model.has_async_deposits() and has_gmx_exchange_account_pairs(universe)
+
                 logger.info(
                     "Starting live position valuation refresh at %s, post valuation settlement: %s",
                     ts,
-                    self.stats_refresh_post_valuation,
+                    post_settlement,
                 )
-
-                post_settlement = self.stats_refresh_post_valuation and self.sync_model.has_async_deposits()
 
                 # Revalue positions first so sync_treasury()'s position freshness check
                 # and on-chain NAV posting see fresh valuations, but hold the statistics
@@ -1695,12 +1700,11 @@ class ExecutionLoop:
         start_time = datetime.datetime(1970, 1, 1)
         logger.info(
             "Live scheduler configuration: cycle_duration=%s, strategy_cycle_trigger=%s, "
-            "stats_refresh_frequency=%s, stats_refresh_post_valuation=%s, "
+            "stats_refresh_frequency=%s, "
             "position_trigger_check_frequency=%s",
             self.cycle_duration,
             self.strategy_cycle_trigger,
             self.stats_refresh_frequency,
-            self.stats_refresh_post_valuation,
             self.position_trigger_check_frequency,
         )
 

--- a/tradeexecutor/cli/loop.py
+++ b/tradeexecutor/cli/loop.py
@@ -713,6 +713,7 @@ class ExecutionLoop:
             universe: StrategyExecutionUniverse,
             execution_mode: ExecutionMode = None,
             interest=True,
+            skip_statistics: bool = False,
     ):
         """Revalue positions and update statistics.
 
@@ -723,6 +724,12 @@ class ExecutionLoop:
 
         :param execution_mode:
             Legacy argument, ignored.
+
+        :param skip_statistics:
+            Revalue positions but hold the statistics write.
+
+            Used by :py:func:`live_positions` when post-valuation treasury
+            settlement must reconcile reserve cash first.
         """
 
         if execution_mode is None:
@@ -760,6 +767,7 @@ class ExecutionLoop:
             routing_state=routing_state,
             valuation_model=valuation_model,
             long_short_metrics_latest=long_short_metrics_latest,
+            skip_statistics=skip_statistics,
         )
 
         # Check that state is good before writing it to the disk.
@@ -1612,12 +1620,19 @@ class ExecutionLoop:
                     self.stats_refresh_post_valuation,
                 )
 
-                self.update_position_valuations(ts, state, universe, execution_context.mode)
-                state.uptime.record_stats_refresh_complete()
+                post_settlement = self.stats_refresh_post_valuation and self.sync_model.has_async_deposits()
 
-                if self.stats_refresh_post_valuation and self.sync_model.has_async_deposits():
+                # Revalue positions first so sync_treasury()'s position freshness check
+                # and on-chain NAV posting see fresh valuations, but hold the statistics
+                # write until treasury settlement has reconciled reserve cash to on-chain.
+                # Writing statistics before reconciliation combines a stale reserve balance
+                # with a fresh position valuation and records a spurious NAV spike when
+                # an external system (e.g. FreqTrade) has moved cash in or out of the vault.
+                self.update_position_valuations(ts, state, universe, execution_context.mode, skip_statistics=post_settlement)
+
+                if post_settlement:
                     logger.info("Running post-valuation treasury settlement after live position valuation refresh")
-                    balance_updates = self.sync_model.sync_treasury(
+                    self.sync_model.sync_treasury(
                         ts,
                         state,
                         list(universe.reserve_assets),
@@ -1625,9 +1640,11 @@ class ExecutionLoop:
                     )
                     state.uptime.record_post_valuation_settlement_complete()
 
-                    if balance_updates:
-                        self.update_position_valuations(ts, state, universe, execution_context.mode)
-                        state.uptime.record_stats_refresh_complete()
+                    # The single statistics write of this refresh:
+                    # reconciled reserve cash + freshly revalued positions.
+                    self.update_position_valuations(ts, state, universe, execution_context.mode)
+
+                state.uptime.record_stats_refresh_complete()
 
                 self.store.sync(state)
 

--- a/tradeexecutor/cli/loop.py
+++ b/tradeexecutor/cli/loop.py
@@ -1615,10 +1615,13 @@ class ExecutionLoop:
             try:
                 ts = native_datetime_utc_now()
 
-                # Post-valuation settlement is needed when an external system
-                # (FreqTrade) moves reserve cash outside the trade executor.
-                # The strategy universe itself drives the detection —
-                # no environment variable to misconfigure between deployments.
+                # Post-valuation settlement is needed for GMX strategies, where an
+                # external FreqTrade instance moves reserve cash between the Lagoon
+                # Safe and GMX outside the trade executor, leaving the tracked
+                # reserve balance stale until sync_treasury() reconciles it on-chain.
+                # The strategy universe itself drives the detection — no environment
+                # variable to misconfigure between deployments. See
+                # https://github.com/tradingstrategy-ai/trade-executor/pull/1558#issuecomment-4925733588
                 post_settlement = self.sync_model.has_async_deposits() and has_gmx_exchange_account_pairs(universe)
 
                 logger.info(

--- a/tradeexecutor/cli/loop.py
+++ b/tradeexecutor/cli/loop.py
@@ -27,7 +27,6 @@ from tradingstrategy.timebucket import TimeBucket
 from tradeexecutor.analysis.pair import display_strategy_universe
 from tradeexecutor.cli.watchdog import create_watchdog_registry, register_worker, mark_alive, start_background_watchdog, \
     WatchdogMode
-from tradeexecutor.exchange_account.gmx import has_gmx_exchange_account_pairs
 from tradeexecutor.state.metadata import Metadata
 from tradeexecutor.state.types import Percent
 from tradeexecutor.statistics.in_memory_statistics import refresh_run_state
@@ -1615,14 +1614,16 @@ class ExecutionLoop:
             try:
                 ts = native_datetime_utc_now()
 
-                # Post-valuation settlement is needed for GMX strategies, where an
-                # external FreqTrade instance moves reserve cash between the Lagoon
-                # Safe and GMX outside the trade executor, leaving the tracked
-                # reserve balance stale until sync_treasury() reconciles it on-chain.
-                # The strategy universe itself drives the detection — no environment
-                # variable to misconfigure between deployments. See
+                # Post-valuation settlement runs automatically for all Lagoon-style
+                # vaults (async deposits) — no environment variable to misconfigure
+                # between deployments. It reconciles reserve cash from on-chain before
+                # the statistics point is written. This matters most for GMX strategies,
+                # where an external FreqTrade instance moves reserve cash between the
+                # Lagoon Safe and GMX outside the trade executor, leaving the tracked
+                # reserve balance stale; recording statistics before reconciliation
+                # produced spurious NAV spikes on the public equity curve. See
                 # https://github.com/tradingstrategy-ai/trade-executor/pull/1558#issuecomment-4925733588
-                post_settlement = self.sync_model.has_async_deposits() and has_gmx_exchange_account_pairs(universe)
+                post_settlement = self.sync_model.has_async_deposits()
 
                 logger.info(
                     "Starting live position valuation refresh at %s, post valuation settlement: %s",

--- a/tradeexecutor/ethereum/ethereum_protocol_adapters.py
+++ b/tradeexecutor/ethereum/ethereum_protocol_adapters.py
@@ -884,13 +884,9 @@ class EthereumPairConfigurator(PairConfigurator):
         This enables GMX support without requiring ``GMX_ENABLED=true``
         in the CLI — the universe itself drives discovery.
         """
-        has_gmx = False
-        for pair in strategy_universe.iterate_pairs():
-            if pair.is_exchange_account() and pair.get_exchange_account_protocol() == "gmx":
-                has_gmx = True
-                break
+        from tradeexecutor.exchange_account.gmx import create_gmx_account_value_func, create_gmx_vault_valuation_func, has_gmx_exchange_account_pairs
 
-        if not has_gmx:
+        if not has_gmx_exchange_account_pairs(strategy_universe):
             return
 
         # Check if existing func already handles GMX
@@ -902,7 +898,6 @@ class EthereumPairConfigurator(PairConfigurator):
             "pass execution_model to EthereumPairConfigurator"
 
         # Auto-create GMX value func from the execution model
-        from tradeexecutor.exchange_account.gmx import create_gmx_account_value_func, create_gmx_vault_valuation_func
         gmx_func = create_gmx_account_value_func(self.execution_model)
         self.account_value_func = gmx_func
 

--- a/tradeexecutor/exchange_account/gmx.py
+++ b/tradeexecutor/exchange_account/gmx.py
@@ -102,21 +102,17 @@ def has_gmx_exchange_account_pairs(strategy_universe) -> bool:
 
     The strategy universe itself drives GMX feature discovery — no environment
     variable or CLI flag is needed, so a misconfigured deployment cannot
-    silently disable GMX-specific accounting. Used to
+    silently disable GMX-specific accounting. Used to auto-wire the GMX value
+    functions in
+    :py:class:`~tradeexecutor.ethereum.ethereum_protocol_adapters.EthereumPairConfigurator`.
 
-    - Auto-wire the GMX value functions in
-      :py:class:`~tradeexecutor.ethereum.ethereum_protocol_adapters.EthereumPairConfigurator`
-
-    - Enable post-valuation treasury settlement in the live stats refresh
-      (:py:mod:`tradeexecutor.cli.loop`)
-
-    Why GMX needs this: GMX positions are opened and closed by an external
-    FreqTrade instance that moves USDC between the Lagoon Safe and GMX without
-    the trade executor knowing. The tracked reserve balance goes stale until
-    treasury settlement reconciles it from on-chain, and any statistics point
-    recorded in between combines stale reserve cash with a fresh GMX position
-    valuation, producing spurious NAV spikes on the public equity curve.
-    Full analysis:
+    Why GMX needs special handling: GMX positions are opened and closed by an
+    external FreqTrade instance that moves USDC between the Lagoon Safe and GMX
+    without the trade executor knowing. The tracked reserve balance goes stale
+    until treasury settlement reconciles it from on-chain, and any statistics
+    point recorded in between combines stale reserve cash with a fresh GMX
+    position valuation, producing spurious NAV spikes on the public equity
+    curve. Full analysis:
     https://github.com/tradingstrategy-ai/trade-executor/pull/1558#issuecomment-4925733588
 
     :param strategy_universe:

--- a/tradeexecutor/exchange_account/gmx.py
+++ b/tradeexecutor/exchange_account/gmx.py
@@ -101,11 +101,23 @@ def has_gmx_exchange_account_pairs(strategy_universe) -> bool:
     """Detect whether a strategy trades GMX through an exchange account pair.
 
     The strategy universe itself drives GMX feature discovery — no environment
-    variable or CLI flag is needed. Used to auto-wire the GMX value functions
-    (:py:class:`~tradeexecutor.ethereum.ethereum_protocol_adapters.EthereumPairConfigurator`)
-    and to enable post-valuation treasury settlement in the live stats refresh,
-    so reserve cash moved by the external FreqTrade instance is reconciled
-    before statistics are recorded.
+    variable or CLI flag is needed, so a misconfigured deployment cannot
+    silently disable GMX-specific accounting. Used to
+
+    - Auto-wire the GMX value functions in
+      :py:class:`~tradeexecutor.ethereum.ethereum_protocol_adapters.EthereumPairConfigurator`
+
+    - Enable post-valuation treasury settlement in the live stats refresh
+      (:py:mod:`tradeexecutor.cli.loop`)
+
+    Why GMX needs this: GMX positions are opened and closed by an external
+    FreqTrade instance that moves USDC between the Lagoon Safe and GMX without
+    the trade executor knowing. The tracked reserve balance goes stale until
+    treasury settlement reconciles it from on-chain, and any statistics point
+    recorded in between combines stale reserve cash with a fresh GMX position
+    valuation, producing spurious NAV spikes on the public equity curve.
+    Full analysis:
+    https://github.com/tradingstrategy-ai/trade-executor/pull/1558#issuecomment-4925733588
 
     :param strategy_universe:
         Strategy universe. Any object without ``iterate_pairs()``

--- a/tradeexecutor/exchange_account/gmx.py
+++ b/tradeexecutor/exchange_account/gmx.py
@@ -97,6 +97,31 @@ def create_gmx_exchange_account_pair(
     )
 
 
+def has_gmx_exchange_account_pairs(strategy_universe) -> bool:
+    """Detect whether a strategy trades GMX through an exchange account pair.
+
+    The strategy universe itself drives GMX feature discovery — no environment
+    variable or CLI flag is needed. Used to auto-wire the GMX value functions
+    (:py:class:`~tradeexecutor.ethereum.ethereum_protocol_adapters.EthereumPairConfigurator`)
+    and to enable post-valuation treasury settlement in the live stats refresh,
+    so reserve cash moved by the external FreqTrade instance is reconciled
+    before statistics are recorded.
+
+    :param strategy_universe:
+        Strategy universe. Any object without ``iterate_pairs()``
+        (e.g. a non-trading universe stub) counts as not using GMX.
+    :return:
+        True if the universe contains at least one GMX exchange account pair.
+    """
+    iterate_pairs = getattr(strategy_universe, "iterate_pairs", None)
+    if iterate_pairs is None:
+        return False
+    for pair in iterate_pairs():
+        if pair.is_exchange_account() and pair.get_exchange_account_protocol() == "gmx":
+            return True
+    return False
+
+
 def create_gmx_account_value_func(
     execution_model=None,
     *,

--- a/tradeexecutor/strategy/valuation_update.py
+++ b/tradeexecutor/strategy/valuation_update.py
@@ -93,7 +93,11 @@ def update_position_valuations(
 
         Used when treasury settlement must reconcile reserve cash to on-chain
         before the statistics point is written, so a stale reserve balance is
-        never combined with a fresh position valuation.
+        never combined with a fresh position valuation. Needed for GMX
+        strategies where an external FreqTrade instance moves reserve cash
+        outside the trade executor; recording statistics before reconciliation
+        produced spurious NAV spikes on the public equity curve. See
+        https://github.com/tradingstrategy-ai/trade-executor/pull/1558#issuecomment-4925733588
     """
 
     # Set up the execution to perform the valuation

--- a/tradeexecutor/strategy/valuation_update.py
+++ b/tradeexecutor/strategy/valuation_update.py
@@ -27,6 +27,7 @@ def update_position_valuations(
     valuation_model: ValuationModel,
     routing_state: RoutingState,
     long_short_metrics_latest: StatisticsTable | None = None,
+    skip_statistics: bool = False,
 ):
     """Revalue positions and update statistics.
 
@@ -86,6 +87,13 @@ def update_position_valuations(
         Needed to calculate short statistics.
 
         Can be None - statistics skipped.
+
+    :param skip_statistics:
+        Revalue positions but do not record a statistics entry.
+
+        Used when treasury settlement must reconcile reserve cash to on-chain
+        before the statistics point is written, so a stale reserve balance is
+        never combined with a fresh position valuation.
     """
 
     # Set up the execution to perform the valuation
@@ -103,6 +111,10 @@ def update_position_valuations(
     with timed_task_context_manager("revalue_portfolio_statistics"):
         logger.info("Updating position valuations")
         revalue_state(state, timestamp, valuation_model)
+
+    if skip_statistics:
+        logger.info("Statistics recording skipped, waiting for treasury settlement")
+        return
 
     with timed_task_context_manager("update_statistics"):
         logger.info("Updating position statistics after revaluation")


### PR DESCRIPTION
# Why

The GMX AI vault equity curve (https://tradingstrategy.ai/strategies/gmx-ai) shows recurring ±33–50% square-wave spikes that are accounting artefacts, not trading PnL. Analysis of the production state (216 consecutive-point share-price jumps > 5%) and executor log pinned the cause to the ordering inside `live_positions()`:

1. `update_position_valuations()` revalued the GMX exchange-account position fresh and **immediately wrote the statistics point** using stale reserve cash — recording a double-count (spike up) or under-count (spike down) whenever FreqTrade had moved USDC between the Lagoon Safe and GMX since the last treasury sync.
2. Post-valuation treasury settlement then ran, detected the reserve mismatch and corrected `reserve_position.quantity` — but the corrective stats re-write was gated on `if balance_updates:`, and a reconciliation-only pass returns `[]`, so the bad point stayed in history for a full stats interval (2 h in production).

Production log evidence (2026-07-09 06:00): stats written at 06:00:02 with share price 2.0952 (stale cash 927.67 + fresh GMX 309.88, double-counted); two seconds later settlement logged `Reserve balance mismatch: portfolio=927.665092, on-chain=617.785604` and computed the correct NAV 927.67 — which never reached the recorded series.

# Summary

- `tradeexecutor/strategy/valuation_update.py`: `update_position_valuations()` gains `skip_statistics: bool = False` — revalue positions but hold back the statistics write.
- `tradeexecutor/cli/loop.py`: `ExecutionLoop.update_position_valuations()` passes the flag through.
- `tradeexecutor/cli/loop.py` `live_positions()`: when post-valuation settlement runs, the refresh now revalues first with statistics held back, runs `sync_treasury(post_valuation=True)` to reconcile reserve cash to on-chain, then writes exactly one statistics point with both NAV components fresh. The `if balance_updates:` guard is removed. Other strategies keep the exact previous code path.
- **`STATS_REFRESH_POST_VALUATION` environment variable removed.** Post-valuation settlement now runs automatically for **all Lagoon-style vaults** (`sync_model.has_async_deposits()`); only `LagoonVaultSyncModel` returns true, so hot-wallet and other non-Lagoon strategies keep the plain single-write path. A misconfigured env flag between deployments can no longer silently reintroduce the spikes, and non-GMX Lagoon vaults get the reserve reconciliation for free.
- New helper `has_gmx_exchange_account_pairs()` in `tradeexecutor/exchange_account/gmx.py`, reused by `EthereumPairConfigurator._auto_discover_gmx()` (the existing "universe drives discovery" precedent).
- Tests: new unit tests for `skip_statistics` and for the GMX universe detection (extends the existing GMX exchange account tests); CLI tests rewritten to assert the call order (`revalue(skip) → sync_treasury → revalue+stats`) for a Lagoon vault, and the plain single-write path for a non-Lagoon strategy.

This shrinks the reserve/position mis-sync window from up to one stats interval (2 h) to the seconds between reconciliation and revaluation. The residual race, GMX valuation failure guarding, and an atomic single-block `nav_override` for statistics remain follow-ups, as does the one-off history cleanup (`correct-history --remove-share-price-outliers --remove-nav-sync-outliers`) on the production state.

The plan was reviewed with Codex CLI (grounded, read-only): core reordering confirmed sound; its findings (skip-stats pass still mutates and saves state, double revaluation is not strictly idempotent, missing settlement test case, other stats writers) are documented in the plan and addressed in the tests.

# Lessons learnt

- Behaviour that must be on for a strategy to account correctly should be derived from the deployment itself (sync model capability, strategy universe), not from an environment variable — `STATS_REFRESH_POST_VALUATION` existed and was even enabled in production, but nothing guaranteed it, and its broken ordering went unnoticed. Automatic detection removes the class of misconfiguration entirely.
- The first detection attempt gated on GMX universe pairs; Codex review flagged that non-GMX Lagoon vaults would lose the settlement path the env var could previously opt them into. Gating on `sync_model.has_async_deposits()` covers all Lagoon vaults with strictly less machinery.
- Gating on `sync_model.calculate_valuation_func` would have been another option but is wrong: it is wired lazily inside `setup_routing()` during the first refresh, so the first statistics point after boot would take the unprotected path.

- Fixing on-chain NAV at settlement does not fix the historical chart series if a separate hourly path records mis-synced snapshots first; the recording path itself must be ordered correctly.
- A corrective re-write gated on `balance_updates` never fires for reconciliation-only treasury passes — `sync_treasury()` mutates `reserve_position.quantity` before `check_nav_update_and_settle_needed()`, so it legitimately returns no balance updates after fixing the reserve.
- External trade execution (FreqTrade) creates USDC flows invisible to the executor, leaving `reserve_position.quantity` stale until on-chain reconciliation; any statistics write between the flow and the reconciliation records a wrong NAV.
- Exchange-account vaults need both NAV components read as close together as possible at every statistics write, not only at daily `sync_treasury()`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
