### PR TITLE
Cross-chain vault sizing fixes and skipped-signal diagnostics

### DIFF
--- a/strategies/xchain-master-vault.py
+++ b/strategies/xchain-master-vault.py
@@ -74,6 +74,7 @@ from tradeexecutor.strategy.chart.standard.alpha_model import (
     alpha_model_diagnostics,
     missed_vault_deposit_redemption_events,
     missed_vault_deposit_redemption_timeline,
+    skipped_signals,
 )
 from tradeexecutor.strategy.chart.standard.cycle_snapshot import latest_cycle_snapshot
 from tradeexecutor.strategy.chart.standard.equity_curve import (
@@ -376,9 +377,13 @@ def decide_trades(input: StrategyInput) -> list[TradeExecution]:
         execution_context=input.execution_context,
         same_cycle_cash_buffer_usd=parameters.cross_chain_cash_buffer_usd,
     )
-    missed_vault_events = alpha_model.get_missed_vault_events()
-    if missed_vault_events:
-        state.visualisation.add_calculations(timestamp, {"missed_vault_events": missed_vault_events})
+    state.visualisation.add_calculations(
+        timestamp,
+        {
+            "missed_vault_events": alpha_model.get_missed_vault_events(),
+            "unallocatable_signals": alpha_model.get_unallocatable_signals(),
+        },
+    )
 
     if input.is_visualisation_enabled():
         try:
@@ -657,6 +662,7 @@ def create_charts(
     charts.register(positions_at_end, ChartKind.state_all_pairs)
     charts.register(last_messages, ChartKind.state_all_pairs)
     charts.register(alpha_model_diagnostics, ChartKind.state_all_pairs)
+    charts.register(skipped_signals, ChartKind.state_all_pairs)
     charts.register(missed_vault_deposit_redemption_events, ChartKind.state_all_pairs)
     charts.register(missed_vault_deposit_redemption_timeline, ChartKind.state_all_pairs)
     charts.register(pending_vault_settlements, ChartKind.state_all_pairs)

--- a/tests/backtest/test_indicator.py
+++ b/tests/backtest/test_indicator.py
@@ -944,6 +944,49 @@ def test_get_indicators_combined(strategy_universe):
     assert list(pair_ids.unique()) == [1, 2]
 
 
+def test_dependency_resolver_get_indicators_combined_with_empty_pair(strategy_universe):
+    """Empty pair series do not shift the pair ids of later series."""
+
+    class Parameters:
+        pass
+
+    def sparse_value(close: pd.Series, pair: TradingPairIdentifier) -> pd.Series:
+        if pair.internal_id == 1:
+            return pd.Series(dtype="float64", index=pd.DatetimeIndex([]))
+        return close
+
+    def sparse_universe(dependency_resolver: IndicatorDependencyResolver) -> pd.Series:
+        return dependency_resolver.get_indicator_data_pairs_combined("sparse_value")
+
+    def create_indicators(
+        timestamp,
+        parameters,
+        strategy_universe,
+        execution_context,
+    ) -> IndicatorSet:
+        indicator_set = IndicatorSet()
+        indicator_set.add("sparse_value", sparse_value, order=1)
+        indicator_set.add(
+            "sparse_universe",
+            sparse_universe,
+            source=IndicatorSource.dependencies_only_universe,
+            order=2,
+        )
+        return indicator_set
+
+    indicators = calculate_and_load_indicators_inline(
+        strategy_universe=strategy_universe,
+        parameters=StrategyParameters.from_class(Parameters),
+        create_indicators=create_indicators,
+        max_workers=1,
+        storage=MemoryIndicatorStorage(strategy_universe.get_cache_key()),
+    )
+
+    series = indicators.get_indicator_series("sparse_universe", unlimited=True)
+    pair_ids = series.index.get_level_values("pair_id")
+    assert list(pair_ids.unique()) == [2]
+
+
 def test_calculate_indicators_tvl(strategy_universe):
     """Test calculate_and_load_indicators_inline() """
 

--- a/tests/ethereum/test_cctp_bridge_cash_aware.py
+++ b/tests/ethereum/test_cctp_bridge_cash_aware.py
@@ -407,6 +407,34 @@ def test_bridge_out_uses_bridge_pair_decimals_when_reserve_asset_decimals_are_wr
     assert bridge_trades[0].planned_reserve == Decimal("1000")
 
 
+def test_sub_usdc_trade_dust_cctp_bridge_out_is_allowed(
+    usdc_arbitrum: AssetIdentifier,
+    cctp_pair: TradingPairIdentifier,
+    satellite_pair: TradingPairIdentifier,
+):
+    """CCTP bridge-outs below generic USDC trade dust are valid transfers.
+
+    A long cross-chain phase-aware backtest produced a 0.066557 USDC bridge-out.
+    Generic USDC trade dust is 0.1, but CCTP only needs raw-unit precision.
+    """
+    state = _make_state(usdc_arbitrum, Decimal(1))
+    buy = _create_satellite_buy(state, satellite_pair, usdc_arbitrum, Decimal("0.066557"))
+    universe = _make_mock_universe([cctp_pair, satellite_pair])
+
+    result = inject_cctp_bridge_trades(
+        state=state,
+        trades=[buy],
+        strategy_universe=universe,
+        primary_chain_id=PRIMARY_CHAIN_ID,
+        ts=TS,
+        reserve_asset=usdc_arbitrum,
+    )
+
+    bridge_trades = [t for t in result if t.pair.is_cctp_bridge()]
+    assert len(bridge_trades) == 1
+    assert bridge_trades[0].planned_reserve == Decimal("0.066557")
+
+
 def test_bridge_out_nets_against_partial_idle_capital(
     usdc_arbitrum: AssetIdentifier,
     cctp_pair: TradingPairIdentifier,

--- a/tests/test_rebalance.py
+++ b/tests/test_rebalance.py
@@ -36,6 +36,7 @@ from tradeexecutor.analysis.vault_missed_events import (
     analyse_missed_vault_deposit_redemption_events,
     format_missed_vault_deposit_redemption_events,
 )
+from tradeexecutor.analysis.unallocatable_signals import calculate_unallocatable_signal_weights
 from tradeexecutor.strategy import size_risk_model
 from tradeexecutor.strategy.alpha_model import AlphaModel, TradingPairSignalFlags
 from tradeexecutor.strategy.fixed_size_risk import FixedSizeRiskModel
@@ -1999,6 +2000,18 @@ def test_alpha_model_skips_buy_when_vault_deposits_closed(
             "missed_usd": 2500.0,
         }
     ]
+    assert alpha_model.get_unallocatable_signals() == [
+        {
+            "asset_label": signal.pair.get_chart_label(),
+            "pair_ticker": signal.pair.get_ticker(),
+            "vault_name": signal.pair.get_vault_name(),
+            "vault_address": signal.pair.pool_address,
+            "target_weight": 1.0,
+            "target_usd": 2500.0,
+            "unallocatable_weight": 1.0,
+            "unallocatable_usd": 2500.0,
+        }
+    ]
 
 
 def test_alpha_model_allows_sell_when_vault_deposits_closed_but_redemptions_open(
@@ -2765,6 +2778,40 @@ def test_analyse_missed_vault_deposit_redemption_event_timeline(start_ts: dateti
     assert "$1,250.00" in html
     assert "$300.00" in html
     assert "1.250000e+03" not in html
+
+
+def test_calculate_unallocatable_signal_weights(start_ts: datetime.datetime) -> None:
+    """Check blocked allocation weights are retained across strategy cycles."""
+    state = State()
+    state.visualisation.add_calculations(
+        start_ts,
+        {
+            "unallocatable_signals": [
+                {
+                    "asset_label": "Vault A",
+                    "unallocatable_weight": 0.25,
+                },
+            ],
+        },
+    )
+    state.visualisation.add_calculations(
+        start_ts + datetime.timedelta(days=1),
+        {
+            "unallocatable_signals": [
+                {
+                    "asset_label": "Vault B",
+                    "unallocatable_weight": 0.10,
+                },
+            ],
+        },
+    )
+
+    weights = calculate_unallocatable_signal_weights(state)
+
+    assert weights.loc[(pd.Timestamp(start_ts), "Vault A")] == pytest.approx(0.25)
+    assert weights.loc[(pd.Timestamp(start_ts), "Vault B")] == pytest.approx(0.0)
+    assert weights.loc[(pd.Timestamp(start_ts + datetime.timedelta(days=1)), "Vault A")] == pytest.approx(0.0)
+    assert weights.loc[(pd.Timestamp(start_ts + datetime.timedelta(days=1)), "Vault B")] == pytest.approx(0.10)
 
 
 def test_update_old_weights_reads_position_value_once(

--- a/tests/units_tests/test_phase_aware_charts.py
+++ b/tests/units_tests/test_phase_aware_charts.py
@@ -26,11 +26,16 @@ from tradeexecutor.state.trade import TradeExecution, TradeType
 from tradeexecutor.strategy.alpha_model import AlphaModel, TradingPairSignal, format_signals
 from tradeexecutor.strategy.chart.definition import ChartInput
 from tradeexecutor.strategy.chart.standard.weight import equity_curve_by_asset
-from tradeexecutor.strategy.chart.standard.vault import pending_trigger_queue
+from tradeexecutor.strategy.chart.standard.vault import (
+    pending_trigger_queue,
+    phase_aware_queue_duration,
+    phase_aware_queue_duration_summary,
+)
 from tradeexecutor.strategy.execution_context import unit_test_execution_context
 from tradeexecutor.strategy.phase_aware import (
     EVENT_PARK,
     EVENT_PROMOTE,
+    EVENT_CLOSE,
     EVENT_REDEEM_BLOCK,
     EVENT_REDEEM_CLEAR,
     QueueVaultEvent,
@@ -161,6 +166,62 @@ def test_pending_trigger_queue_empty_without_events():
     # 1-2. No events -> empty frame.
     _fig, df = pending_trigger_queue(ChartInput(execution_context=unit_test_execution_context, state=state))
     assert df.empty
+
+
+def test_phase_aware_queue_duration_summary():
+    """phase_aware_queue_duration_summary reports completed and open wait intervals.
+
+    1. Vault 601 parks for three days and promotes.
+    2. Vault 602 parks, updates the parked amount, and is still open at the last stats timestamp.
+    3. The summary reports duration, episode counts, max queued USD, and USD-days.
+    """
+    start = datetime.datetime(2024, 1, 1)
+    one_day = datetime.timedelta(days=1)
+    state = State()
+
+    append_queue_event(state.other_data, QueueVaultEvent(EVENT_PARK, 601, 5000.0, 1, timestamp=(start + one_day).isoformat()))
+    append_queue_event(state.other_data, QueueVaultEvent(EVENT_PROMOTE, 601, 5000.0, 4, timestamp=(start + 4 * one_day).isoformat()))
+    append_queue_event(state.other_data, QueueVaultEvent(EVENT_PARK, 602, 2000.0, 2, timestamp=(start + 2 * one_day).isoformat()))
+    append_queue_event(state.other_data, QueueVaultEvent(EVENT_PARK, 602, 3000.0, 3, timestamp=(start + 3 * one_day).isoformat()))
+
+    for n in range(6):
+        state.stats.portfolio.append(PortfolioStatistics(calculated_at=start + n * one_day, total_equity=10_000.0))
+
+    df = phase_aware_queue_duration_summary(ChartInput(execution_context=unit_test_execution_context, state=state))
+
+    row_601 = df.loc[df["Vault id"] == 601].iloc[0]
+    assert row_601["Episodes"] == 1
+    assert row_601["Promoted"] == 1
+    assert row_601["Open"] == 0
+    assert row_601["Average wait days"] == pytest.approx(3.0)
+    assert row_601["USD days"] == pytest.approx(15_000.0)
+
+    row_602 = df.loc[df["Vault id"] == 602].iloc[0]
+    assert row_602["Episodes"] == 1
+    assert row_602["Promoted"] == 0
+    assert row_602["Open"] == 1
+    assert row_602["Average wait days"] == pytest.approx(3.0)
+    assert row_602["Max queued USD"] == pytest.approx(3000.0)
+    assert row_602["USD days"] == pytest.approx(8_000.0)
+
+
+def test_phase_aware_queue_duration_chart_and_closed_wait():
+    """phase_aware_queue_duration returns a chart and counts abandoned waits as closed."""
+    start = datetime.datetime(2024, 1, 1)
+    one_day = datetime.timedelta(days=1)
+    state = State()
+
+    append_queue_event(state.other_data, QueueVaultEvent(EVENT_PARK, 701, 1000.0, 1, timestamp=(start + one_day).isoformat()))
+    append_queue_event(state.other_data, QueueVaultEvent(EVENT_CLOSE, 701, 0.0, 3, timestamp=(start + 3 * one_day).isoformat()))
+    for n in range(4):
+        state.stats.portfolio.append(PortfolioStatistics(calculated_at=start + n * one_day, total_equity=10_000.0))
+
+    fig, df = phase_aware_queue_duration(ChartInput(execution_context=unit_test_execution_context, state=state))
+
+    assert fig is not None
+    row = df.loc[df["Vault id"] == 701].iloc[0]
+    assert row["Closed"] == 1
+    assert row["Average wait days"] == pytest.approx(2.0)
 
 
 def test_format_signals_phase_aware_columns():

--- a/tradeexecutor/analysis/unallocatable_signals.py
+++ b/tradeexecutor/analysis/unallocatable_signals.py
@@ -1,0 +1,58 @@
+"""Analyse portfolio allocations blocked by unavailable trading venues."""
+
+from __future__ import annotations
+
+import pandas as pd
+
+from tradeexecutor.state.state import State
+
+
+def calculate_unallocatable_signal_weights(
+    state: State,
+) -> pd.Series:
+    """Build a time series of blocked allocation weights by asset.
+
+    Each strategy cycle must persist ``unallocatable_signals`` in its
+    visualisation calculations. Missing assets are explicitly represented as
+    zero, so a stacked-area chart shows when an unavailable opportunity ended.
+    """
+    timestamps = []
+    rows = []
+
+    for timestamp, calculations in state.visualisation.calculations.items():
+        timestamp = pd.Timestamp(timestamp, unit="s")
+        timestamps.append(timestamp)
+        for signal in calculations.get("unallocatable_signals", []):
+            weight = float(signal.get("unallocatable_weight", 0.0) or 0.0)
+            if weight <= 0:
+                continue
+
+            rows.append({
+                "timestamp": timestamp,
+                "asset": signal.get("asset_label") or signal.get("pair_ticker") or "Unknown asset",
+                "weight": weight,
+            })
+
+    if not timestamps:
+        return pd.Series(
+            dtype="float64",
+            index=pd.MultiIndex.from_arrays([[], []], names=["timestamp", "asset"]),
+        )
+
+    assets = sorted({row["asset"] for row in rows})
+    if not assets:
+        return pd.Series(
+            dtype="float64",
+            index=pd.MultiIndex.from_arrays([[], []], names=["timestamp", "asset"]),
+        )
+
+    index = pd.MultiIndex.from_product(
+        [sorted(set(timestamps)), assets],
+        names=["timestamp", "asset"],
+    )
+    weights = pd.DataFrame(rows).groupby(["timestamp", "asset"])["weight"].sum()
+    weights = weights.reindex(index, fill_value=0.0)
+    weights.attrs["reserve_asset_symbol"] = ""
+    weights.attrs["credit_supply_symbols"] = []
+    weights.attrs["vault_symbols"] = []
+    return weights

--- a/tradeexecutor/analysis/weights.py
+++ b/tradeexecutor/analysis/weights.py
@@ -148,6 +148,8 @@ def visualise_weights(
     reserve_asset_colour='#aaa',
     extra_colours: dict[str, str] | None = None,
     extra_sort_order: dict[str, int] | None = None,
+    chart_title: str | None = None,
+    y_axis_title: str | None = None,
     clean=False,
 ) -> Figure:
     """Draw a chart of weights.
@@ -211,10 +213,10 @@ def visualise_weights(
 
     fig = px.area(
         df,
-        title=f'Asset weights (%), {reserve_text}' if normalised else f'Asset weights (USD), {reserve_text}',
+        title=chart_title or (f'Asset weights (%), {reserve_text}' if normalised else f'Asset weights (USD), {reserve_text}'),
         labels={
             'index': 'Time',
-            'value': '% of portfolio' if normalised else 'US dollar size',
+            'value': y_axis_title or ('% of portfolio' if normalised else 'US dollar size'),
         },
         color_discrete_sequence=color_palette,
         template=template,

--- a/tradeexecutor/backtest/backtest_execution.py
+++ b/tradeexecutor/backtest/backtest_execution.py
@@ -233,7 +233,12 @@ class BacktestExecution(ExecutionModel):
             else:
                 type = "spot buy"
             self.wallet.update_balance(base, executed_quantity, f"{type} trade #{trade.trade_id}")
-            self.wallet.update_balance(reserve, -executed_reserve, f"{type} trade #{trade.trade_id}")
+            # Tolerate sub-raw-unit rounding dust on the reserve debit, same as the
+            # async vault deposit path. CCTP bridge sizing can leave the reserve a
+            # fraction of a raw unit short of the planned buy, which must not crash
+            # the backtest.
+            raw_unit_epsilon = reserve.convert_to_decimal(2)
+            self.wallet.update_balance(reserve, -executed_reserve, f"{type} trade #{trade.trade_id}", epsilon=raw_unit_epsilon)
         else:
             if trade.is_credit_supply():
                 type = "credit recall"

--- a/tradeexecutor/backtest/backtest_execution.py
+++ b/tradeexecutor/backtest/backtest_execution.py
@@ -426,7 +426,13 @@ class BacktestExecution(ExecutionModel):
         if trade.is_buy():
             request_reserve = trade.planned_reserve
             assert request_reserve > 0, f"Expected a positive async vault deposit reserve for trade {trade}"
-            self.wallet.update_balance(reserve, -request_reserve, f"vault deposit request #{trade.trade_id}")
+            raw_unit_epsilon = reserve.convert_to_decimal(2)
+            self.wallet.update_balance(
+                reserve,
+                -request_reserve,
+                f"vault deposit request #{trade.trade_id}",
+                epsilon=raw_unit_epsilon,
+            )
             trade.other_data[VAULT_SETTLEMENT_REQUEST_RESERVE_KEY] = str(request_reserve)
         else:
             base_balance = self.wallet.get_balance(base.address)

--- a/tradeexecutor/ethereum/cctp/planner.py
+++ b/tradeexecutor/ethereum/cctp/planner.py
@@ -29,6 +29,7 @@ from tradeexecutor.state.identifier import (
 from tradeexecutor.state.portfolio import NotEnoughMoney
 from tradeexecutor.state.state import State
 from tradeexecutor.state.trade import CCTP_BRIDGE_ORDER_BUMP, TradeExecution, TradeType
+from tradeexecutor.strategy.dust import get_dust_epsilon_for_pair
 from tradeexecutor.utils.accuracy import sum_decimal
 
 logger = logging.getLogger(__name__)
@@ -151,6 +152,14 @@ def _is_meaningful_bridge_amount(amount: Decimal, asset: AssetIdentifier) -> boo
     dust, even when it is larger than Decimal calculation epsilon.
     """
     return amount >= _get_raw_unit(asset)
+
+
+def _is_meaningful_bridge_trade_amount(amount: Decimal, bridge_pair: TradingPairIdentifier) -> bool:
+    """Is this amount large enough to pass bridge trade creation."""
+    return (
+        _is_meaningful_bridge_amount(amount, bridge_pair.base)
+        and abs(amount) > get_dust_epsilon_for_pair(bridge_pair)
+    )
 
 
 def _is_token_dust(amount: Decimal, asset: AssetIdentifier) -> bool:
@@ -374,7 +383,7 @@ def inject_cctp_bridge_trades(
         # minus same-cycle satellite buy needs).
         available = liquidity.free_idle_bridge_capital
         amount = _floor_to_raw_units(min(net_flow, available), bridge_pair.base)
-        if not _is_meaningful_bridge_amount(amount, bridge_pair.base):
+        if not _is_meaningful_bridge_trade_amount(amount, bridge_pair):
             logger.info(
                 "Skipping bridge-back for chain %d: net sell %s exceeds available bridge capital %s",
                 chain_id,
@@ -417,12 +426,12 @@ def inject_cctp_bridge_trades(
                     chain_id,
                 )
                 continue
-            if not _is_meaningful_bridge_amount(primary_shortfall, bridge_pair.quote):
+            if not _is_meaningful_bridge_trade_amount(primary_shortfall, bridge_pair):
                 break
             liquidity = liquidity_by_chain[chain_id]
             available = liquidity.free_idle_bridge_capital
             amount = _floor_to_raw_units(min(primary_shortfall, available), bridge_pair.quote)
-            if not _is_meaningful_bridge_amount(amount, bridge_pair.quote):
+            if not _is_meaningful_bridge_trade_amount(amount, bridge_pair):
                 continue
             liquidity.reserve_bridge_back(amount)
             total_bridge_back += amount
@@ -455,7 +464,7 @@ def inject_cctp_bridge_trades(
                 chain_id,
             )
             continue
-        if not _is_meaningful_bridge_amount(amount, bridge_pair.base):
+        if not _is_meaningful_bridge_trade_amount(amount, bridge_pair):
             continue
 
         bridge_position = state.portfolio.get_bridge_position_for_chain(chain_id)
@@ -539,7 +548,7 @@ def inject_cctp_bridge_trades(
         satellite_side_funding = liquidity.available_before_buy
 
         shortfall = liquidity.satellite_bridge_shortfall
-        if not _is_meaningful_bridge_amount(shortfall, bridge_pair.quote):
+        if not _is_meaningful_bridge_trade_amount(shortfall, bridge_pair):
             # Capital already parked on the satellite covers the net buy; the
             # satellite buy allocates from the bridge position at execution.
             logger.info(
@@ -564,11 +573,11 @@ def inject_cctp_bridge_trades(
                     f"- primary buys {primary_buys})"
                 )
 
-        if not _is_meaningful_bridge_amount(shortfall, bridge_pair.quote):
+        if not _is_meaningful_bridge_trade_amount(shortfall, bridge_pair):
             continue
 
         amount = _floor_to_raw_units(shortfall, bridge_pair.quote)
-        if not _is_meaningful_bridge_amount(amount, bridge_pair.quote):
+        if not _is_meaningful_bridge_trade_amount(amount, bridge_pair):
             continue
         fundable_primary -= amount
 

--- a/tradeexecutor/strategy/alpha_model.py
+++ b/tradeexecutor/strategy/alpha_model.py
@@ -2454,6 +2454,39 @@ class AlphaModel:
 
         return rows
 
+    def get_unallocatable_signals(self) -> list[dict]:
+        """Return positive rebalance targets blocked by venue availability.
+
+        The unallocatable weight is the blocked positive adjustment as a share of
+        this cycle's investable equity. It deliberately differs from the signal's
+        full target weight: an existing 5 % position targeted at 12 % has only
+        7 % of the portfolio unallocatable.
+        """
+        if not self.investable_equity:
+            return []
+
+        rows = []
+        for signal in self.iterate_signals():
+            if TradingPairSignalFlags.cannot_deposit not in signal.flags:
+                continue
+
+            unallocatable_usd = signal.position_adjust_usd
+            if unallocatable_usd <= 0:
+                continue
+
+            rows.append({
+                "asset_label": signal.pair.get_chart_label(),
+                "pair_ticker": signal.pair.get_ticker(),
+                "vault_name": signal.pair.get_vault_name(),
+                "vault_address": signal.pair.pool_address,
+                "target_weight": signal.normalised_weight,
+                "target_usd": signal.position_target,
+                "unallocatable_weight": unallocatable_usd / self.investable_equity,
+                "unallocatable_usd": unallocatable_usd,
+            })
+
+        return rows
+
     def get_flag_diagnostics_data(self) -> dict:
         """Get statistics explanation to add to the report of alpha model thinking.
 

--- a/tradeexecutor/strategy/chart/standard/alpha_model.py
+++ b/tradeexecutor/strategy/chart/standard/alpha_model.py
@@ -5,6 +5,7 @@ import plotly.express as px
 from pandas.io.formats.style import Styler
 from plotly.graph_objects import Figure
 
+from tradeexecutor.analysis.unallocatable_signals import calculate_unallocatable_signal_weights
 from tradeexecutor.analysis.vault_missed_events import (
     analyse_missed_vault_deposit_redemption_event_timeline,
     analyse_missed_vault_deposit_redemption_events,
@@ -12,6 +13,7 @@ from tradeexecutor.analysis.vault_missed_events import (
 )
 from tradeexecutor.strategy.alpha_model import format_signals
 from tradeexecutor.strategy.chart.definition import ChartInput
+from tradeexecutor.analysis.weights import visualise_weights
 
 
 def alpha_model_diagnostics(
@@ -26,6 +28,30 @@ def alpha_model_diagnostics(
         return pd.DataFrame([])
     df = format_signals(alpha_model, signal_type="all")
     return df
+
+
+def skipped_signals(input: ChartInput) -> Figure:
+    """Show allocation weights blocked because the venue could not accept deposits."""
+    weights = calculate_unallocatable_signal_weights(input.state)
+    if weights.empty:
+        fig = Figure()
+        fig.update_layout(
+            title="Skipped signals (allocation weight)",
+            xaxis_title="Time",
+            yaxis_title="% of investable equity",
+            template="plotly_dark",
+        )
+        return fig
+
+    fig = visualise_weights(
+        weights,
+        normalised=False,
+        include_reserves=False,
+        chart_title="Skipped signals (allocation weight)",
+        y_axis_title="% of investable equity",
+    )
+    fig.update_yaxes(tickformat=".0%")
+    return fig
 
 
 def missed_vault_deposit_redemption_events(input: ChartInput) -> Styler:

--- a/tradeexecutor/strategy/chart/standard/vault.py
+++ b/tradeexecutor/strategy/chart/standard/vault.py
@@ -346,6 +346,210 @@ def pending_trigger_queue(input: ChartInput) -> tuple[Figure, pd.DataFrame]:
     return fig, df
 
 
+def _resolve_vault_label(input: ChartInput, vault_internal_id: int) -> dict:
+    """Resolve a queue-event vault id to display metadata."""
+    pair = None
+    strategy_universe = None
+    if input.strategy_input_indicators is not None:
+        strategy_universe = input.strategy_universe
+
+    if strategy_universe is not None:
+        try:
+            pair = strategy_universe.get_pair_by_id(vault_internal_id)
+        except KeyError:
+            pair = None
+
+    if pair is None:
+        return {
+            "Vault id": vault_internal_id,
+            "Vault": f"Vault {vault_internal_id}",
+            "Ticker": str(vault_internal_id),
+            "Protocol": "",
+            "Chain": "",
+        }
+
+    return {
+        "Vault id": vault_internal_id,
+        "Vault": pair.get_vault_name() or pair.get_ticker(),
+        "Ticker": pair.get_ticker(),
+        "Protocol": pair.get_vault_protocol() or "",
+        "Chain": pair.chain_id,
+    }
+
+
+def _build_queue_wait_intervals(input: ChartInput) -> pd.DataFrame:
+    """Build deposit-wait intervals from phase-aware park/promote/close events."""
+    state = input.state
+    if state is None:
+        return pd.DataFrame()
+
+    event_ts = [
+        (pd.Timestamp(e.timestamp), e)
+        for e in iter_all_events(state.other_data)
+        if e.timestamp is not None and e.kind in (EVENT_PARK, EVENT_PROMOTE, EVENT_CLOSE)
+    ]
+    if not event_ts:
+        return pd.DataFrame()
+    event_ts.sort(key=lambda pair: pair[0])
+
+    stats_timestamps = [pd.Timestamp(ps.calculated_at) for ps in state.stats.portfolio if ps.calculated_at is not None]
+    if stats_timestamps:
+        final_ts = max(stats_timestamps)
+    elif input.end_at is not None:
+        final_ts = pd.Timestamp(input.end_at)
+    else:
+        final_ts = max(ts for ts, _event in event_ts)
+
+    open_waits: dict[int, dict] = {}
+    rows = []
+
+    def _accrue(wait: dict, ts: pd.Timestamp) -> None:
+        elapsed_days = max((ts - wait["last_update"]).total_seconds() / 86400, 0.0)
+        wait["usd_days"] += wait["usd"] * elapsed_days
+        wait["last_update"] = ts
+
+    def _close_wait(vault_id: int, end_ts: pd.Timestamp, event_kind: str) -> None:
+        wait = open_waits.pop(vault_id, None)
+        if wait is None:
+            return
+        _accrue(wait, end_ts)
+        duration_days = max((end_ts - wait["started_at"]).total_seconds() / 86400, 0.0)
+        metadata = _resolve_vault_label(input, vault_id)
+        rows.append({
+            **metadata,
+            "Started at": wait["started_at"],
+            "Ended at": end_ts,
+            "Status": "promoted" if event_kind == EVENT_PROMOTE else "closed",
+            "Duration days": duration_days,
+            "Start USD": wait["start_usd"],
+            "End USD": wait["usd"],
+            "Max USD": wait["max_usd"],
+            "USD days": wait["usd_days"],
+            "Updates": wait["updates"],
+        })
+
+    for ts, event in event_ts:
+        vault_id = event.vault_internal_id
+        if event.kind == EVENT_PARK:
+            wait = open_waits.get(vault_id)
+            if wait is None:
+                open_waits[vault_id] = {
+                    "started_at": ts,
+                    "last_update": ts,
+                    "start_usd": event.usd,
+                    "usd": event.usd,
+                    "max_usd": event.usd,
+                    "usd_days": 0.0,
+                    "updates": 1,
+                }
+            else:
+                _accrue(wait, ts)
+                wait["usd"] = event.usd
+                wait["max_usd"] = max(wait["max_usd"], event.usd)
+                wait["updates"] += 1
+        elif event.kind in (EVENT_PROMOTE, EVENT_CLOSE):
+            _close_wait(vault_id, ts, event.kind)
+
+    for vault_id in list(open_waits):
+        wait = open_waits.pop(vault_id)
+        _accrue(wait, final_ts)
+        duration_days = max((final_ts - wait["started_at"]).total_seconds() / 86400, 0.0)
+        metadata = _resolve_vault_label(input, vault_id)
+        rows.append({
+            **metadata,
+            "Started at": wait["started_at"],
+            "Ended at": pd.NaT,
+            "Status": "open",
+            "Duration days": duration_days,
+            "Start USD": wait["start_usd"],
+            "End USD": wait["usd"],
+            "Max USD": wait["max_usd"],
+            "USD days": wait["usd_days"],
+            "Updates": wait["updates"],
+        })
+
+    if not rows:
+        return pd.DataFrame()
+
+    df = pd.DataFrame(rows)
+    return df.sort_values(["Started at", "Vault id"]).reset_index(drop=True)
+
+
+def phase_aware_queue_duration_summary(input: ChartInput) -> pd.DataFrame:
+    """Average phase-aware queue wait duration by target vault."""
+    intervals = _build_queue_wait_intervals(input)
+    if intervals.empty:
+        return pd.DataFrame()
+
+    group_cols = ["Vault id", "Vault", "Ticker", "Protocol", "Chain"]
+    rows = []
+    for key, group in intervals.groupby(group_cols, dropna=False, sort=False):
+        duration = group["Duration days"]
+        usd_days = group["USD days"].sum()
+        max_usd = group["Max USD"].max()
+        start_usd = group["Start USD"].mean()
+        rows.append({
+            "Vault id": key[0],
+            "Vault": key[1],
+            "Ticker": key[2],
+            "Protocol": key[3],
+            "Chain": key[4],
+            "Episodes": len(group),
+            "Promoted": int((group["Status"] == "promoted").sum()),
+            "Closed": int((group["Status"] == "closed").sum()),
+            "Open": int((group["Status"] == "open").sum()),
+            "Average wait days": duration.mean(),
+            "Median wait days": duration.median(),
+            "Max wait days": duration.max(),
+            "Average start USD": start_usd,
+            "Max queued USD": max_usd,
+            "USD days": usd_days,
+        })
+
+    df = pd.DataFrame(rows)
+    return df.sort_values(["USD days", "Average wait days"], ascending=[False, False]).reset_index(drop=True)
+
+
+def phase_aware_queue_duration(input: ChartInput) -> tuple[Figure, pd.DataFrame]:
+    """Average phase-aware queue wait duration by target vault."""
+    df = phase_aware_queue_duration_summary(input)
+    if df.empty:
+        fig = Figure()
+        fig.update_layout(
+            title="Phase-aware queue wait duration by target vault",
+            xaxis_title="Average wait days",
+            yaxis_title="Target vault",
+            template="plotly_dark",
+        )
+        return fig, df
+
+    fig = px.bar(
+        df.sort_values("Average wait days", ascending=True),
+        x="Average wait days",
+        y="Vault",
+        orientation="h",
+        color="Status" if "Status" in df.columns else "Protocol",
+        title="Average phase-aware queue wait duration by target vault",
+        labels={
+            "Average wait days": "Average wait days",
+            "Vault": "Target vault",
+            "Protocol": "Protocol",
+        },
+        hover_data={
+            "Episodes": True,
+            "Promoted": True,
+            "Closed": True,
+            "Open": True,
+            "Max wait days": ":.2f",
+            "USD days": ":,.2f",
+            "Max queued USD": ":$,.2f",
+        },
+        template="plotly_dark",
+    )
+    fig.update_layout(yaxis={"categoryorder": "total ascending"})
+    return fig, df
+
+
 def vault_data_freshness(input: ChartInput) -> pd.DataFrame:
     """Data freshness timestamps for all vault pairs showing candle and TVL staleness.
 

--- a/tradeexecutor/strategy/dust.py
+++ b/tradeexecutor/strategy/dust.py
@@ -82,7 +82,9 @@ def get_dust_epsilon_for_pair(pair: TradingPairIdentifier) -> Decimal:
 
     """
 
-    if pair.is_vault():
+    if pair.is_cctp_bridge():
+        return DEFAULT_DUST_EPSILON
+    elif pair.is_vault():
         return DEFAULT_VAULT_EPSILON
 
     return get_dust_epsilon_for_asset(pair.base)

--- a/tradeexecutor/strategy/pandas_trader/indicator.py
+++ b/tradeexecutor/strategy/pandas_trader/indicator.py
@@ -1869,11 +1869,15 @@ class IndicatorDependencyResolver:
             raise IndicatorCalculationFailed(f"get_indicator_data_pairs_combined() cannot be called if the indicator {name} is not pair based")
 
         series_map = {pair.internal_id: self.get_indicator_data(name, pair=pair, parameters=parameters) for pair in self.strategy_universe.iterate_pairs()}
-        series_list = [s for s in series_map.values() if len(s) > 0]
-        pair_ids = list(series_map.keys())
+        series_items = [(pair_id, series) for pair_id, series in series_map.items() if len(series) > 0]
+
+        if not series_items:
+            return pd.Series(dtype="float64", index=pd.MultiIndex.from_arrays([[], []], names=["pair_id", "timestamp"]))
+
+        pair_ids = [pair_id for pair_id, _series in series_items]
+        series_list = [series for _pair_id, series in series_items]
 
         with warnings.catch_warnings():
-            # FutureWarning: The behavior of pd.concat with len(keys) != len(objs) is deprecated. In a future version this will raise instead of truncating to the smaller of the two sequences
             warnings.simplefilter(action='ignore', category=FutureWarning)
             combined = pd.concat(series_list, keys=pair_ids, names=['pair_id', 'timestamp'])
         return combined


### PR DESCRIPTION
## Why

A batch of independent follow-up fixes and diagnostics for the cross-chain / vault
strategy path had accumulated in the working tree. They are grouped here as one PR,
one commit per concern, so each is reviewable in isolation.

Two themes:

- **Correctness of sizing** — CCTP bridge trades and async vault deposit debits
  could act on sub-dust amounts, producing noise trades and spurious balance
  underflows.
- **Operator visibility** — when a venue cannot accept deposits the allocation is
  silently dropped, and queue-vault deposit waits were not charted. Both are now
  surfaced.

Plus a stability fix for indicator combination on empty input.

## Lessons learnt

- Bridge/deposit sizing must gate on **both** the one-raw-unit floor **and** the
  pair dust epsilon. Checking only the raw-unit floor let sub-dust amounts through
  and spawned meaningless bridge trades; `abs(amount) > dust_epsilon` is the second
  gate that was missing.
- "Unallocatable" weight is the *blocked positive adjustment* as a share of
  investable equity, **not** the signal's full target weight — an existing 5 %
  position targeted at 12 % has only 7 % unallocatable. Charting the full target
  would overstate the missed opportunity.
- `pd.concat` on an empty list of series raises; the all-empty case needs an
  explicit correctly-typed empty `MultiIndex` return, otherwise universes where no
  pair yet has indicator data blow up instead of degrading gracefully.
- The CCTP dust-aware sizing (1) shifts bridged USDC by fractions of a raw unit,
  which surfaced a **pre-existing** fragility: the backtest spot-buy reserve debit
  had no rounding tolerance (unlike the sell path's `sell_amount_epsilon_fix` and
  the async deposit debit), so a ~5e-7 USDC dust tripped `OutOfSimulatedBalance` in
  `test_capped_waterfall_phase_aware_notebook`. Fixed by giving the spot-buy debit
  the same two-raw-unit epsilon (6). Confirmed on CI: master passes with today's
  data, so the regression is our code, not data flakiness.
- A `web3-ethereum-defi` submodule bump was also dropped from this branch — it was
  unrelated to the code changes and does not belong in a mixed PR. (It is *not* the
  cause of the notebook failure: the dust is bit-identical with and without the
  bump, i.e. CCTP checks out the pinned submodule regardless.)

## Summary

Six self-contained commits:

1. **Make CCTP bridge sizing dust-aware** — new
   `_is_meaningful_bridge_trade_amount()` combines the raw-unit floor with a
   dust-epsilon check and replaces the bare raw-unit check at every bridge sizing
   gate; CCTP bridge pairs get a default dust epsilon
   (`ethereum/cctp/planner.py`, `strategy/dust.py`, test).

2. **Skipped-signal (unallocatable weight) diagnostics** — 
   `AlphaModel.get_unallocatable_signals()` records per-cycle blocked allocation
   weight; new `unallocatable_signals` analysis module and `skipped_signals`
   stacked-area chart; `visualise_weights()` gains `chart_title` / `y_axis_title`
   overrides; wired into `xchain-master-vault` (`analysis/unallocatable_signals.py`,
   `strategy/alpha_model.py`, `chart/standard/alpha_model.py`, `analysis/weights.py`,
   `strategies/xchain-master-vault.py`, test).

3. **Phase-aware queue deposit-wait duration charts** — reconstruct deposit-wait
   intervals from the durable park/promote/close event log; new
   `phase_aware_queue_duration` and `phase_aware_queue_duration_summary` charts
   (`chart/standard/vault.py`, test).

4. **Fix `get_indicator_data_pairs_combined()` on all-empty input** — return a
   typed empty `MultiIndex` series instead of feeding `pd.concat` an empty list
   (`pandas_trader/indicator.py`, test).

5. **Async vault deposit debit epsilon in backtest** — pass a two-raw-unit epsilon
   to `wallet.update_balance()` to avoid spurious underflow on deposit requests
   (`backtest/backtest_execution.py`).

6. **Spot-buy reserve debit epsilon in backtest** — same two-raw-unit tolerance on
   the spot buy reserve debit, so CCTP sizing rounding dust does not crash the
   backtest (`backtest/backtest_execution.py`). See Lessons learnt.

Not included: a `web3-ethereum-defi` submodule bump (dropped — see Lessons learnt),
a local `.claude/settings.json` curl-permission tweak, and a `.claude/plans/`
working note were intentionally left out of the branch.
