### PR TITLE
Improve asset-weight chart legend

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -111,6 +111,7 @@ source .local-test.env && PYTHONPATH="$(pwd):$PYTHONPATH" poetry run pytest test
 
 ## Pull requests
 
+- For pull request, issue, CI, and merge work, use the `git` and `gh` command-line tools; no plugins are required.
 - Pull request description must have sections Why (the rational of change), Lessons learnt (memory) and Summary (what was changed). No test plan or verification section. Use Markdown formatting, headings.
 - When updating a pull request description, prefer `gh api` with the REST pull request endpoint instead of `gh pr edit --body`, because `gh pr edit` can fail with `GraphQL: Projects (classic) is being deprecated ... (repository.pullRequest.projectCards)`. Write longer descriptions to a temporary Markdown file and run `gh api repos/:owner/:repo/pulls/{pr-number} --method PATCH -F body=@/tmp/pr-body.md`.
 - Only push changes to remote when asked, never update pull requess automatically.

--- a/tests/strategy/test_asset_weight_legend.py
+++ b/tests/strategy/test_asset_weight_legend.py
@@ -4,6 +4,7 @@ from base64 import b64decode, b64encode
 from collections import Counter
 
 import plotly.graph_objects as go
+import pytest
 from tradingstrategy.chain import ChainId
 from tradingstrategy.vault import VaultMetadata
 
@@ -16,10 +17,31 @@ from tradeexecutor.strategy.chart.asset_weight_legend import (
     IDENTITY_ICON_WIDTH,
     NAME_X,
     PROTOCOL_X,
+    ROW_BOTTOM_Y,
     ROW_FONT_SIZE,
+    ROW_TOP_Y,
+    VERTICAL_ALLOCATION_ICON_WIDTH,
+    VERTICAL_ALLOCATION_X,
+    VERTICAL_BASE_CHART_HEIGHT,
+    VERTICAL_CHAIN_X,
+    VERTICAL_COLUMN_GAP_PX,
+    VERTICAL_CURATOR_X,
+    VERTICAL_FIGURE_WIDTH,
+    VERTICAL_LEGEND_BOTTOM_MARGIN_PX,
+    VERTICAL_LEGEND_TOP_MARGIN_PX,
+    VERTICAL_HEADER_FONT_SIZE,
+    VERTICAL_IDENTITY_ICON_WIDTH,
+    VERTICAL_NAME_GAP_PX,
+    VERTICAL_NAME_X,
+    VERTICAL_PLOT_LEFT_MARGIN_PX,
+    VERTICAL_PLOT_WIDTH_PX,
+    VERTICAL_PROTOCOL_X,
+    VERTICAL_ROW_FONT_SIZE,
+    VERTICAL_ROW_HEIGHT_PX,
     AssetWeightLegendEntry,
     add_asset_weight_legend,
     allocation_swatch_data_url,
+    calculate_capital_time_allocation_percentages,
     merge_asset_weight_legend_entries,
 )
 from tradeexecutor.strategy.chart.vault_legend import get_vault_logo_coverage
@@ -157,8 +179,35 @@ def test_allocation_swatch_uses_trace_fill_and_plotly_replace_pattern() -> None:
     assert "<pattern" in svg
 
 
-def test_merged_cross_chain_vault_keeps_all_chain_and_protocol_icons(tmp_path) -> None:
-    """gTrade's Base and Arbitrum allocations share one chart label."""
+def test_capital_time_allocation_is_weighted_by_time_between_samples() -> None:
+    """Capital-time allocation uses elapsed time instead of a sample average.
+
+    1. Build two traces with unequal values and irregular sample times.
+    2. Integrate their USD allocations over the two intervals.
+    3. Check the legend allocation percentages use the resulting area share.
+    """
+    # 1. Build two traces with unequal values and irregular sample times.
+    figure = go.Figure(
+        [
+            go.Scatter(name="Intermittent vault", x=[0, 1, 3], y=[100, 0, 100]),
+            go.Scatter(name="Constant vault", x=[0, 1, 3], y=[100, 100, 100]),
+        ],
+    )
+
+    # 2. Integrate their USD allocations over the two intervals.
+    allocations = calculate_capital_time_allocation_percentages(figure)
+
+    # 3. Check the legend allocation percentages use the resulting area share.
+    assert allocations == pytest.approx({"Intermittent vault": 100 / 3, "Constant vault": 200 / 3})
+
+
+def test_cross_chain_vault_repeats_the_legend_row_for_each_chain(tmp_path) -> None:
+    """gTrade's Base and Arbitrum allocations get separate legend rows.
+
+    1. Create one aggregated chart trace with metadata from two chains.
+    2. Split its legend entries by chain while keeping the trace aggregation.
+    3. Render the legend and check every row has one aligned chain icon.
+    """
     gtrade_metadata = next(
         metadata
         for metadata in _xchain2_mock_metadata()
@@ -172,11 +221,10 @@ def test_merged_cross_chain_vault_keeps_all_chain_and_protocol_icons(tmp_path) -
         ],
     )
 
-    assert len(entries) == 1
-    entry = entries[0]
-    assert entry.chain_id is None
-    assert entry.chain_ids == tuple(sorted((ChainId.base.value, ChainId.arbitrum.value)))
-    assert entry.metadata is gtrade_metadata
+    assert len(entries) == 2
+    assert [entry.chain_id for entry in entries] == [ChainId.base.value, ChainId.arbitrum.value]
+    assert all(entry.chain_ids == (entry.chain_id,) for entry in entries)
+    assert all(entry.metadata is gtrade_metadata for entry in entries)
 
     figure = go.Figure(
         go.Scatter(
@@ -191,16 +239,92 @@ def test_merged_cross_chain_vault_keeps_all_chain_and_protocol_icons(tmp_path) -
     figure.update_layout(template="plotly_dark")
     add_asset_weight_legend(figure, entries, chain_icon_resolver=_mock_chain_icon_data_url)
 
-    gtrade_row_images = [image for image in figure.layout.images if image.y == 0.955]
-    chain_images = [image for image in gtrade_row_images if CHAIN_X - 0.02 < image.x < CHAIN_X + 0.02]
+    chain_images = [image for image in figure.layout.images if image.x == CHAIN_X]
     assert len(chain_images) == 2
-    assert {image.x for image in chain_images} == {CHAIN_X - 0.0099, CHAIN_X + 0.0099}
+    assert sorted(image.y for image in chain_images) == pytest.approx([ROW_BOTTOM_Y, ROW_TOP_Y])
     assert all(image.sizex == IDENTITY_ICON_WIDTH for image in chain_images)
-    assert any(image.x == PROTOCOL_X for image in gtrade_row_images)
-    assert not any(image.x == CURATOR_X for image in gtrade_row_images)
+    protocol_images = [image for image in figure.layout.images if image.x == PROTOCOL_X]
+    assert len(protocol_images) == 2
+    assert not [image for image in figure.layout.images if image.x == CURATOR_X]
+    assert len([image for image in figure.layout.images if image.x == ALLOCATION_X]) == 2
+    assert [annotation.text for annotation in figure.layout.annotations[5:]] == [
+        f'{label}: <span style="color:#aaa">100.0%</span>',
+        f'{label}: <span style="color:#aaa">100.0%</span>',
+    ]
 
     rendered = tmp_path / "gtrade-asset-weight-legend.png"
     figure.write_image(rendered, width=1800, height=900)
+    assert rendered.read_bytes().startswith(b"\x89PNG")
+
+
+def test_vertical_legend_is_below_the_chart_with_doubled_rows(tmp_path) -> None:
+    """The below-chart legend grows the figure and doubles its visual scale.
+
+    1. Create a two-row asset-weight legend.
+    2. Render it using the vertical below-chart layout.
+    3. Check the appended height, below-chart coordinates, and doubled sizes.
+    """
+    # 1. Create a two-row asset-weight legend.
+    metadata = _xchain2_mock_metadata()[0]
+    traces = [
+        go.Scatter(name="Vault A", x=[0, 1], y=[100, 100], fill="tozeroy"),
+        go.Scatter(name="Vault B", x=[0, 1], y=[50, 50], fill="tonexty"),
+    ]
+    entries = [
+        AssetWeightLegendEntry("Vault A", "#00ff66", ChainId.base.value, metadata, annualised_yield_percent=12.5),
+        AssetWeightLegendEntry("Vault B", "#0052ff", ChainId.arbitrum.value, metadata, annualised_yield_percent=-2.5),
+    ]
+    figure = go.Figure(traces)
+    figure.update_layout(template="plotly_dark")
+
+    # 2. Render it using the vertical below-chart layout.
+    add_asset_weight_legend(
+        figure,
+        entries,
+        chain_icon_resolver=_mock_chain_icon_data_url,
+        legend_layout="vertical",
+    )
+
+    # 3. Check the appended height, below-chart coordinates, and doubled sizes.
+    assert figure.layout.height == (
+        VERTICAL_BASE_CHART_HEIGHT
+        + 2 * VERTICAL_ROW_HEIGHT_PX
+        + VERTICAL_LEGEND_TOP_MARGIN_PX
+        + VERTICAL_LEGEND_BOTTOM_MARGIN_PX
+    )
+    assert figure.layout.width == VERTICAL_FIGURE_WIDTH
+    assert figure.layout.margin.l == VERTICAL_PLOT_LEFT_MARGIN_PX
+    assert figure.layout.xaxis.domain == (0, 1)
+    assert all(annotation.y < 0 for annotation in figure.layout.annotations)
+    assert all(annotation.font.size == VERTICAL_HEADER_FONT_SIZE for annotation in figure.layout.annotations[:5])
+    assert all(annotation.font.size == VERTICAL_ROW_FONT_SIZE for annotation in figure.layout.annotations[5:])
+    assert figure.layout.annotations[5].text == 'Vault A: <span style="color:#aaa">allocated <span style="color:#ffd700">66.7%</span>, yield <span style="color:#00ff66">12.5%</span></span>'
+    assert figure.layout.annotations[6].text == 'Vault B: <span style="color:#aaa">allocated <span style="color:#ffd700">33.3%</span>, yield <span style="color:#00ff66">-2.5%</span></span>'
+    assert all(image.sizex == VERTICAL_ALLOCATION_ICON_WIDTH for image in figure.layout.images if image.x == VERTICAL_ALLOCATION_X)
+    assert all(image.sizex == VERTICAL_IDENTITY_ICON_WIDTH for image in figure.layout.images if image.x != VERTICAL_ALLOCATION_X)
+    assert {image.x for image in figure.layout.images}.issubset({
+        VERTICAL_ALLOCATION_X,
+        VERTICAL_CHAIN_X,
+        VERTICAL_PROTOCOL_X,
+        VERTICAL_CURATOR_X,
+    })
+    assert VERTICAL_IDENTITY_ICON_WIDTH * VERTICAL_PLOT_WIDTH_PX == pytest.approx(VERTICAL_ROW_HEIGHT_PX)
+
+    def to_pixels(x: float) -> float:
+        return VERTICAL_PLOT_LEFT_MARGIN_PX + x * VERTICAL_PLOT_WIDTH_PX
+
+    allocation_right = to_pixels(VERTICAL_ALLOCATION_X) + VERTICAL_ALLOCATION_ICON_WIDTH * VERTICAL_PLOT_WIDTH_PX / 2
+    chain_left = to_pixels(VERTICAL_CHAIN_X) - VERTICAL_ROW_HEIGHT_PX / 2
+    protocol_left = to_pixels(VERTICAL_PROTOCOL_X) - VERTICAL_ROW_HEIGHT_PX / 2
+    curator_left = to_pixels(VERTICAL_CURATOR_X) - VERTICAL_ROW_HEIGHT_PX / 2
+    curator_right = to_pixels(VERTICAL_CURATOR_X) + VERTICAL_ROW_HEIGHT_PX / 2
+    assert chain_left - allocation_right == pytest.approx(VERTICAL_COLUMN_GAP_PX)
+    assert protocol_left - (chain_left + VERTICAL_ROW_HEIGHT_PX) == pytest.approx(VERTICAL_COLUMN_GAP_PX)
+    assert curator_left - (protocol_left + VERTICAL_ROW_HEIGHT_PX) == pytest.approx(VERTICAL_COLUMN_GAP_PX)
+    assert to_pixels(VERTICAL_NAME_X) - curator_right == pytest.approx(VERTICAL_NAME_GAP_PX)
+
+    rendered = tmp_path / "vertical-asset-weight-legend.png"
+    figure.write_image(rendered, width=figure.layout.width, height=figure.layout.height)
     assert rendered.read_bytes().startswith(b"\x89PNG")
 
 

--- a/tests/test_multipair.py
+++ b/tests/test_multipair.py
@@ -1,0 +1,42 @@
+"""Tests for multipair analysis helpers."""
+
+import datetime
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from tradeexecutor.analysis.multipair import calculate_pair_annualised_average_yield
+
+
+def test_pair_annualised_average_yield_is_weighted_by_capital_and_time() -> None:
+    """Annualise a pair's yield without compounding short positions.
+
+    1. Create two positions with different principal and holding periods.
+    2. Mock their realised profit and duration data.
+    3. Check the money-time-weighted annualised yield.
+    """
+    # 1. Create two positions with different principal and holding periods.
+    pair = MagicMock()
+    pair.is_cctp_bridge.return_value = False
+    first_position = MagicMock(pair=pair)
+    first_position.get_value_at_open.return_value = 100.0
+    second_position = MagicMock(pair=pair)
+    second_position.get_value_at_open.return_value = 200.0
+    portfolio = MagicMock()
+    portfolio.get_all_positions.return_value = [first_position, second_position]
+
+    # 2. Mock their realised profit and duration data.
+    profit_data = [
+        SimpleNamespace(profit_usd=10.0, duration=datetime.timedelta(days=10)),
+        SimpleNamespace(profit_usd=40.0, duration=datetime.timedelta(days=20)),
+    ]
+    with patch("tradeexecutor.analysis.multipair.calculate_pnl_generic", side_effect=profit_data):
+        yield_percent = calculate_pair_annualised_average_yield(
+            pair,
+            portfolio,
+            datetime.datetime(2026, 1, 1),
+        )
+
+    # 3. Check the money-time-weighted annualised yield.
+    assert yield_percent == pytest.approx(3.65)

--- a/tradeexecutor/analysis/multipair.py
+++ b/tradeexecutor/analysis/multipair.py
@@ -73,6 +73,43 @@ def analyse_pair_trades(
     }
 
 
+def calculate_pair_annualised_average_yield(
+    pair: TradingPairIdentifier,
+    portfolio: Portfolio,
+    end_at: datetime.datetime,
+) -> float:
+    """Calculate the capital- and time-weighted annualised yield for a pair.
+
+    This uses total PnL divided by the sum of each position's opening USD value
+    multiplied by its holding period. It is a simple annualised rate, avoiding
+    the unrealistic compounding caused by annualising individual short-lived
+    positions.
+
+    :return:
+        Annualised average yield as a decimal fraction, where ``0.05`` is 5%.
+    """
+    if pair.is_cctp_bridge():
+        return 0.0
+
+    total_profit_usd = 0.0
+    total_capital_days = 0.0
+    for position in (position for position in portfolio.get_all_positions() if position.pair == pair):
+        profit_data = calculate_pnl_generic(position, end_at=end_at)
+        duration = profit_data.duration
+        capital_at_open = float(position.get_value_at_open())
+        duration_days = duration.total_seconds() / datetime.timedelta(days=1).total_seconds()
+        if capital_at_open <= 0 or duration_days <= 0:
+            continue
+
+        total_profit_usd += float(profit_data.profit_usd)
+        total_capital_days += capital_at_open * duration_days
+
+    if total_capital_days == 0:
+        return 0.0
+
+    return total_profit_usd / total_capital_days * 365
+
+
 def analyse_multipair(
     state: State,
     show_chain: bool = False,

--- a/tradeexecutor/strategy/chart/asset_weight_legend.py
+++ b/tradeexecutor/strategy/chart/asset_weight_legend.py
@@ -9,8 +9,11 @@ from html import escape
 from io import BytesIO
 from math import sqrt
 from pathlib import Path
+from typing import Literal
 from urllib.request import Request, urlopen
 
+import numpy as np
+import pandas as pd
 import tradingstrategy.chain as chain_module
 from PIL import Image, ImageOps
 from plotly.graph_objects import Figure
@@ -37,27 +40,83 @@ class AssetWeightLegendEntry:
     metadata: VaultMetadata | None
 
     #: All chains represented by this trace. A same-named asset may be
-    #: aggregated across chains by the asset-weight chart.
+    #: aggregated across chains by the asset-weight chart, but the static
+    #: legend renders a separate row for every chain.
     chain_ids: tuple[int, ...] = ()
+
+    #: Capital- and time-weighted annualised average yield, in percent.
+    annualised_yield_percent: float = 0.0
 
 
 #: Horizontal centres in Plotly paper coordinates. Header and row elements use
 #: exactly the same values so column alignment does not depend on whitespace.
-ALLOCATION_X = 0.628
-CHAIN_X = 0.660
-PROTOCOL_X = 0.693
-CURATOR_X = 0.726
-NAME_X = 0.753
+ALLOCATION_X = 0.580
+CHAIN_X = 0.609
+PROTOCOL_X = 0.635
+CURATOR_X = 0.661
+NAME_X = 0.682
 
-ROW_TOP_Y = 0.955
-ROW_BOTTOM_Y = 0.035
-HEADER_Y = 0.982
+ROW_TOP_Y = 0.960
+ROW_BOTTOM_Y = 0.025
+HEADER_Y = 0.985
 
-ALLOCATION_ICON_WIDTH = 0.022
-IDENTITY_ICON_WIDTH = 0.018
-MAX_ICON_HEIGHT = 0.024
-HEADER_FONT_SIZE = 12
-ROW_FONT_SIZE = 13
+ALLOCATION_ICON_WIDTH = 0.0293
+IDENTITY_ICON_WIDTH = 0.024
+MAX_ICON_HEIGHT = 0.032
+HEADER_FONT_SIZE = 14
+ROW_FONT_SIZE = 16
+
+#: The below-chart legend keeps the original chart area and appends 40 pixels
+#: of height for each row.
+VERTICAL_FIGURE_WIDTH = 2200
+VERTICAL_BASE_CHART_HEIGHT = 900
+VERTICAL_ROW_HEIGHT_PX = 40
+VERTICAL_HEADER_HEIGHT_PX = 40
+VERTICAL_LEGEND_TOP_MARGIN_PX = 40
+VERTICAL_LEGEND_BOTTOM_MARGIN_PX = 40
+VERTICAL_PLOT_LEFT_MARGIN_PX = 80
+VERTICAL_PLOT_RIGHT_MARGIN_PX = 8
+VERTICAL_PLOT_TOP_MARGIN_PX = 80
+VERTICAL_PLOT_WIDTH_PX = VERTICAL_FIGURE_WIDTH - VERTICAL_PLOT_LEFT_MARGIN_PX - VERTICAL_PLOT_RIGHT_MARGIN_PX
+VERTICAL_PLOT_HEIGHT_PX = VERTICAL_BASE_CHART_HEIGHT - VERTICAL_PLOT_TOP_MARGIN_PX - VERTICAL_HEADER_HEIGHT_PX
+
+#: Identity images use ``contain`` and need a square bounding box. Otherwise a
+#: square logo is centred in a much wider invisible image box, creating the
+#: appearance of excessive padding between legend columns.
+VERTICAL_ALLOCATION_ICON_WIDTH = ALLOCATION_ICON_WIDTH * 2
+VERTICAL_ICON_HEIGHT = VERTICAL_ROW_HEIGHT_PX / VERTICAL_PLOT_HEIGHT_PX
+VERTICAL_IDENTITY_ICON_WIDTH = VERTICAL_ROW_HEIGHT_PX / VERTICAL_PLOT_WIDTH_PX
+VERTICAL_ALLOCATION_ICON_WIDTH_PX = VERTICAL_ALLOCATION_ICON_WIDTH * VERTICAL_PLOT_WIDTH_PX
+VERTICAL_COLUMN_GAP_PX = 12
+VERTICAL_NAME_GAP_PX = 16
+VERTICAL_LEGEND_LEFT_PX = 100
+
+#: Horizontal centres for the below-chart legend, derived from the visible
+#: icon bounds and pixel gaps rather than arbitrary paper-coordinate spacing.
+VERTICAL_ALLOCATION_X = (
+    VERTICAL_LEGEND_LEFT_PX
+    + VERTICAL_ALLOCATION_ICON_WIDTH_PX / 2
+    - VERTICAL_PLOT_LEFT_MARGIN_PX
+) / VERTICAL_PLOT_WIDTH_PX
+VERTICAL_CHAIN_X = (
+    VERTICAL_LEGEND_LEFT_PX
+    + VERTICAL_ALLOCATION_ICON_WIDTH_PX
+    + VERTICAL_COLUMN_GAP_PX
+    + VERTICAL_ROW_HEIGHT_PX / 2
+    - VERTICAL_PLOT_LEFT_MARGIN_PX
+) / VERTICAL_PLOT_WIDTH_PX
+VERTICAL_PROTOCOL_X = VERTICAL_CHAIN_X + (
+    VERTICAL_ROW_HEIGHT_PX + VERTICAL_COLUMN_GAP_PX
+) / VERTICAL_PLOT_WIDTH_PX
+VERTICAL_CURATOR_X = VERTICAL_PROTOCOL_X + (
+    VERTICAL_ROW_HEIGHT_PX + VERTICAL_COLUMN_GAP_PX
+) / VERTICAL_PLOT_WIDTH_PX
+VERTICAL_NAME_X = VERTICAL_CURATOR_X + (
+    VERTICAL_ROW_HEIGHT_PX / 2 + VERTICAL_NAME_GAP_PX
+) / VERTICAL_PLOT_WIDTH_PX
+
+VERTICAL_HEADER_FONT_SIZE = HEADER_FONT_SIZE * 2
+VERTICAL_ROW_FONT_SIZE = ROW_FONT_SIZE * 2
 
 
 def _entry_chain_ids(entry: AssetWeightLegendEntry) -> tuple[int, ...]:
@@ -82,34 +141,45 @@ def _has_same_logo_identity(left: VaultMetadata, right: VaultMetadata) -> bool:
 def merge_asset_weight_legend_entries(
     entries: Iterable[AssetWeightLegendEntry],
 ) -> list[AssetWeightLegendEntry]:
-    """Merge entries whose asset-weight trace shares the same label.
+    """Merge entries whose asset-weight trace shares the same label and chain.
 
-    Asset weights are grouped by their visible label. If a label aggregates
-    the same vault identity on more than one chain, retain its protocol and
-    curator metadata and render every represented chain icon. If identities
-    differ, omit the logo instead of associating a misleading protocol with
-    the aggregate.
+    Asset weights are grouped by their visible label, which means one chart
+    trace can aggregate the same vault on several chains. Keep those chains
+    as separate legend rows: each row has one allocation swatch, chain icon,
+    protocol logo, curator logo, and vault name. If duplicate positions on a
+    single chain disagree about their vault identity, omit the protocol and
+    curator logos rather than associating a misleading identity with the row.
     """
-    merged: dict[str, AssetWeightLegendEntry] = {}
+    merged: dict[tuple[str, int | None], AssetWeightLegendEntry] = {}
     for entry in entries:
-        previous = merged.get(entry.label)
-        if previous is None:
-            merged[entry.label] = entry
-            continue
+        chain_ids = _entry_chain_ids(entry) or (None,)
+        for chain_id in chain_ids:
+            key = (entry.label, chain_id)
+            previous = merged.get(key)
+            if previous is None:
+                merged[key] = AssetWeightLegendEntry(
+                    label=entry.label,
+                    colour=entry.colour,
+                chain_id=chain_id,
+                chain_ids=(chain_id,) if chain_id else (),
+                metadata=entry.metadata,
+                annualised_yield_percent=entry.annualised_yield_percent,
+            )
+                continue
 
-        chain_ids = tuple(sorted(set(_entry_chain_ids(previous)) | set(_entry_chain_ids(entry))))
-        metadata = (
-            previous.metadata
-            if previous.metadata and entry.metadata and _has_same_logo_identity(previous.metadata, entry.metadata)
-            else None
-        )
-        merged[entry.label] = AssetWeightLegendEntry(
-            label=previous.label,
-            colour=previous.colour,
-            chain_id=chain_ids[0] if len(chain_ids) == 1 else None,
-            chain_ids=chain_ids,
-            metadata=metadata,
-        )
+            metadata = (
+                previous.metadata
+                if previous.metadata and entry.metadata and _has_same_logo_identity(previous.metadata, entry.metadata)
+                else None
+            )
+            merged[key] = AssetWeightLegendEntry(
+                label=previous.label,
+                colour=previous.colour,
+                chain_id=chain_id,
+                chain_ids=(chain_id,) if chain_id else (),
+                metadata=metadata,
+                annualised_yield_percent=previous.annualised_yield_percent,
+            )
 
     return list(merged.values())
 
@@ -283,61 +353,196 @@ def resolve_chain_icon_data_url(chain_id: int) -> str | None:
         return None
 
 
+def calculate_capital_time_allocation_percentages(figure: Figure) -> dict[str, float]:
+    """Calculate each trace's share of the portfolio's capital-time allocation.
+
+    The asset-weight chart holds USD values, not normalised percentages. This
+    integrates each trace over the chart's timestamps and divides it by the
+    integrated total portfolio value. Unlike a simple average of sample
+    percentages, irregular time intervals contribute in proportion to their
+    duration.
+
+    Missing trace values represent no allocation and are treated as zero.
+    A single-sample chart has no time interval, so its instantaneous asset
+    weights are used as the best available allocation proxy.
+    """
+    trace_values = [
+        (trace.name, np.nan_to_num(np.asarray(trace.y, dtype=float), nan=0.0, posinf=0.0, neginf=0.0))
+        for trace in figure.data
+        if trace.name and trace.y is not None
+    ]
+    if not trace_values:
+        return {}
+
+    sample_count = len(trace_values[0][1])
+    trace_values = [item for item in trace_values if len(item[1]) == sample_count]
+    if not trace_values or sample_count == 0:
+        return {}
+
+    values = np.vstack([value for _name, value in trace_values])
+    if sample_count == 1:
+        capital_times = values[:, 0]
+    else:
+        x_values = np.asarray(figure.data[0].x)
+        if len(x_values) != sample_count:
+            durations = np.ones(sample_count - 1)
+        elif np.issubdtype(x_values.dtype, np.number):
+            durations = np.diff(x_values.astype(float))
+        elif np.issubdtype(x_values.dtype, np.datetime64):
+            durations = np.diff(x_values.astype("datetime64[ns]").astype("int64")) / 1_000_000_000
+        else:
+            timestamps = pd.to_datetime(x_values)
+            durations = np.diff(timestamps.asi8) / 1_000_000_000
+
+        durations = np.maximum(durations, 0)
+        capital_times = ((values[:, :-1] + values[:, 1:]) / 2 * durations).sum(axis=1)
+
+    total_capital_time = capital_times.sum()
+    if total_capital_time <= 0:
+        return {}
+
+    return {
+        name: float(capital_time / total_capital_time * 100)
+        for (name, _value), capital_time in zip(trace_values, capital_times, strict=True)
+    }
+
+
 def add_asset_weight_legend(
     figure: Figure,
     entries: Iterable[AssetWeightLegendEntry],
     *,
     chain_icon_resolver: Callable[[int], str | None] = resolve_chain_icon_data_url,
+    legend_layout: Literal["horizontal", "vertical"] = "horizontal",
 ) -> None:
     """Replace a native legend with aligned allocation and identity columns.
 
     The Plotly legend cannot render images. This layout puts all column headers
     and icon boxes on fixed paper-coordinate centres, so absent curator logos
-    reserve an empty but aligned slot.
+    reserve an empty but aligned slot. ``"horizontal"`` keeps the compact
+    right-side legend. ``"vertical"`` places doubled-size rows below the chart,
+    adds 40 pixels per row, and leaves 40-pixel top and bottom legend margins.
 
     :param figure:
         Asset-weight figure whose trace names identify legend entries.
     :param entries:
-        Trace metadata, keyed by :attr:`AssetWeightLegendEntry.label`.
+        Trace metadata. Same-named entries on different chains become
+        separate legend rows.
     :param chain_icon_resolver:
         Injectable resolver used by tests to avoid external icon downloads.
+    :param legend_layout:
+        ``"horizontal"`` for the compact right-side legend or ``"vertical"``
+        for the enlarged below-chart legend.
     """
-    entries_by_label = {entry.label: entry for entry in entries}
-    row_count = max(len(figure.data), 1)
-    row_step = (ROW_TOP_Y - ROW_BOTTOM_Y) / max(row_count - 1, 1)
-    icon_height = min(MAX_ICON_HEIGHT, row_step * 0.90)
-    figure_height = max(900, (row_count + 2) * 24)
+    if legend_layout not in {"horizontal", "vertical"}:
+        raise ValueError(f"Unsupported asset-weight legend layout: {legend_layout}")
 
-    figure.update_layout(
-        showlegend=False,
-        width=1800,
-        height=figure_height,
-        margin={"r": 20},
-    )
-    figure.update_xaxes(domain=[0, 0.608])
+    merged_entries = merge_asset_weight_legend_entries(entries)
+    capital_time_allocations = calculate_capital_time_allocation_percentages(figure)
+    entries_by_label: dict[str, list[AssetWeightLegendEntry]] = {}
+    for entry in merged_entries:
+        entries_by_label.setdefault(entry.label, []).append(entry)
+
+    legend_rows = [
+        (trace, entry)
+        for trace in figure.data
+        for entry in entries_by_label.get(trace.name, [None])
+    ]
+    row_count = max(len(legend_rows), 1)
+    if legend_layout == "horizontal":
+        row_step = (ROW_TOP_Y - ROW_BOTTOM_Y) / max(row_count - 1, 1)
+        icon_height = min(MAX_ICON_HEIGHT, row_step * 0.93)
+        figure_height = max(900, (row_count + 1) * 32)
+        allocation_x = ALLOCATION_X
+        chain_x = CHAIN_X
+        protocol_x = PROTOCOL_X
+        curator_x = CURATOR_X
+        name_x = NAME_X
+        header_y = HEADER_Y
+        header_font_size = HEADER_FONT_SIZE
+        row_font_size = ROW_FONT_SIZE
+        allocation_icon_width = ALLOCATION_ICON_WIDTH
+        identity_icon_width = IDENTITY_ICON_WIDTH
+
+        figure.update_layout(
+            showlegend=False,
+            width=1800,
+            height=figure_height,
+            margin={"r": 8},
+        )
+        figure.update_xaxes(domain=[0, 0.560])
+
+        def get_row_y(index: int) -> float:
+            return ROW_TOP_Y - index * row_step
+
+    else:
+        figure_height = (
+            VERTICAL_BASE_CHART_HEIGHT
+            + row_count * VERTICAL_ROW_HEIGHT_PX
+            + VERTICAL_LEGEND_TOP_MARGIN_PX
+            + VERTICAL_LEGEND_BOTTOM_MARGIN_PX
+        )
+        icon_height = VERTICAL_ICON_HEIGHT
+        allocation_x = VERTICAL_ALLOCATION_X
+        chain_x = VERTICAL_CHAIN_X
+        protocol_x = VERTICAL_PROTOCOL_X
+        curator_x = VERTICAL_CURATOR_X
+        name_x = VERTICAL_NAME_X
+        header_y = -(
+            VERTICAL_LEGEND_TOP_MARGIN_PX
+            + VERTICAL_HEADER_HEIGHT_PX / 2
+        ) / VERTICAL_PLOT_HEIGHT_PX
+        header_font_size = VERTICAL_HEADER_FONT_SIZE
+        row_font_size = VERTICAL_ROW_FONT_SIZE
+        allocation_icon_width = VERTICAL_ALLOCATION_ICON_WIDTH
+        identity_icon_width = VERTICAL_IDENTITY_ICON_WIDTH
+
+        figure.update_layout(
+            showlegend=False,
+            width=VERTICAL_FIGURE_WIDTH,
+            height=figure_height,
+            margin={
+                "l": VERTICAL_PLOT_LEFT_MARGIN_PX,
+                "r": VERTICAL_PLOT_RIGHT_MARGIN_PX,
+                "t": VERTICAL_PLOT_TOP_MARGIN_PX,
+                "b": (
+                    VERTICAL_LEGEND_TOP_MARGIN_PX
+                    + VERTICAL_HEADER_HEIGHT_PX
+                    + row_count * VERTICAL_ROW_HEIGHT_PX
+                    + VERTICAL_LEGEND_BOTTOM_MARGIN_PX
+                ),
+            },
+        )
+        figure.update_xaxes(domain=[0, 1])
+
+        def get_row_y(index: int) -> float:
+            return -(
+                VERTICAL_LEGEND_TOP_MARGIN_PX
+                +
+                VERTICAL_HEADER_HEIGHT_PX
+                + (index + 0.5) * VERTICAL_ROW_HEIGHT_PX
+            ) / VERTICAL_PLOT_HEIGHT_PX
 
     for label, x, xanchor in (
-        ("A", ALLOCATION_X, "center"),
-        ("C", CHAIN_X, "center"),
-        ("P", PROTOCOL_X, "center"),
-        ("C", CURATOR_X, "center"),
-        ("Name", NAME_X, "left"),
+        ("A", allocation_x, "center"),
+        ("C", chain_x, "center"),
+        ("P", protocol_x, "center"),
+        ("C", curator_x, "center"),
+        ("Name", name_x, "left"),
     ):
         figure.add_annotation(
             x=x,
-            y=HEADER_Y,
+            y=header_y,
             xref="paper",
             yref="paper",
             text=label,
             showarrow=False,
             xanchor=xanchor,
             yanchor="middle",
-            font={"size": HEADER_FONT_SIZE, "color": "#a8b1c1"},
+            font={"size": header_font_size, "color": "#a8b1c1"},
         )
 
-    for index, trace in enumerate(figure.data):
-        entry = entries_by_label.get(trace.name)
-        y = ROW_TOP_Y - index * row_step
+    for index, (trace, entry) in enumerate(legend_rows):
+        y = get_row_y(index)
         colour = trace.fillcolor or trace.line.color or (entry.colour if entry else "#a8b1c1")
         fillpattern = trace.fillpattern
         allocation_source = allocation_swatch_data_url(
@@ -352,11 +557,11 @@ def add_asset_weight_legend(
         )
         figure.add_layout_image(
             source=allocation_source,
-            x=ALLOCATION_X,
+            x=allocation_x,
             y=y,
             xref="paper",
             yref="paper",
-            sizex=ALLOCATION_ICON_WIDTH,
+            sizex=allocation_icon_width,
             sizey=icon_height,
             xanchor="center",
             yanchor="middle",
@@ -364,13 +569,8 @@ def add_asset_weight_legend(
             layer="above",
         )
 
-        chain_ids = _entry_chain_ids(entry) if entry else ()
-        chain_icon_size = min(IDENTITY_ICON_WIDTH, 0.036 / len(chain_ids)) if chain_ids else IDENTITY_ICON_WIDTH
-        chain_icon_spacing = chain_icon_size * 1.1
-        chain_sources = [
-            chain_icon_resolver(chain_id)
-            for chain_id in chain_ids
-        ]
+        chain_id = entry.chain_id if entry else None
+        chain_source = chain_icon_resolver(chain_id) if chain_id else None
         protocol_source = None
         curator_source = None
         if entry and entry.metadata:
@@ -378,17 +578,11 @@ def add_asset_weight_legend(
             protocol_source = local_png_data_url(logos.protocol) if logos.protocol else None
             curator_source = local_png_data_url(logos.curator) if logos.curator else None
 
-        chain_icon_offset = (len(chain_sources) - 1) * chain_icon_spacing / 2
         icon_specs = [
-            (CHAIN_X - chain_icon_offset + index * chain_icon_spacing, source, chain_icon_size)
-            for index, source in enumerate(chain_sources)
+            (chain_x, chain_source, identity_icon_width),
+            (protocol_x, protocol_source, identity_icon_width),
+            (curator_x, curator_source, identity_icon_width),
         ]
-        icon_specs.extend(
-            (
-                (PROTOCOL_X, protocol_source, IDENTITY_ICON_WIDTH),
-                (CURATOR_X, curator_source, IDENTITY_ICON_WIDTH),
-            ),
-        )
 
         for x, source, icon_width in icon_specs:
             if source:
@@ -407,14 +601,26 @@ def add_asset_weight_legend(
                 )
 
         figure.add_annotation(
-            x=NAME_X,
+            x=name_x,
             y=y,
             xref="paper",
             yref="paper",
-            text=trace.name,
+            text=(
+                (
+                    f'{trace.name}: <span style="color:#aaa">'
+                    f'allocated <span style="color:#ffd700">{capital_time_allocations[trace.name]:.1f}%</span>, '
+                    f'yield <span style="color:#00ff66">{entry.annualised_yield_percent if entry else 0.0:.1f}%</span></span>'
+                )
+                if legend_layout == "vertical" and trace.name in capital_time_allocations
+                else (
+                    f'{trace.name}: <span style="color:#aaa">{capital_time_allocations[trace.name]:.1f}%</span>'
+                    if trace.name in capital_time_allocations
+                    else trace.name
+                )
+            ),
             showarrow=False,
             xanchor="left",
             yanchor="middle",
             align="left",
-            font={"size": ROW_FONT_SIZE, "color": "#e5ecf6"},
+            font={"size": row_font_size, "color": "#e5ecf6"},
         )


### PR DESCRIPTION
## Why

The asset-weight chart needs a compact, readable legend that accurately identifies each vault and communicates capital-time allocation alongside annualised yield.

## Lessons learnt

Plotly's `contain` image sizing can leave large invisible horizontal bounds around square logos. Deriving the vertical legend grid from fixed pixel icon bounds keeps the visible columns aligned and compact.

## Summary

- add chain, protocol, and curator logos with allocation-pattern swatches
- add compact vertical and horizontal legend layouts
- display capital-time allocation and annualised average yield
- add regression coverage for logo, layout, and yield calculations
- document `git` and `gh` as the PR workflow