### PR TITLE
feat: improve backtest asset-weight reporting

### DIFF
--- a/strategies/hyper-ai-v2.py
+++ b/strategies/hyper-ai-v2.py
@@ -763,34 +763,30 @@ def create_charts(
 
 tags = {StrategyTag.beta, StrategyTag.live, StrategyTag.closed_source}
 
-name = "Hyper AI v2"
+name = "Hyper AI"
 
-short_description = "Positive-Sharpe gated vault-of-vaults strategy on Hyperliquid"
+short_description = "Vault-of-vaults allocating across Hyperliquid ecosystem"
 
 icon = ""
 
 long_description = """
-# Hyper AI v2 strategy
+# Hyper AI strategy
 
-A diversified yield strategy that allocates across Hyperliquid native vaults, gating
-vault admission on a positive trailing 180-day Sharpe ratio and ranking survivors with
-an age-ramp weighting.
+A diversified yield strategy that allocates across Hyperliquid native vaults using
+robustness criteria.
 
 ## Strategy features
 
-- **Positive-Sharpe gate**: Vaults must show a positive trailing 180-day Sharpe ratio to be admitted
-- **Survivor-first selection**: Vaults must also pass TVL, age, and trading availability filters
-- **Age-ramp weighting**: Younger vaults receive lower weights, ramping up over 0.875 years
+- **Survivor-first selection**: Vaults must pass TVL, age, and trading availability filters
+- **Age-ramp weighting**: Younger vaults receive lower weights, ramping up over 0.75 years
 - **Daily rebalancing**: Adjusts positions daily based on inclusion criteria and signal weights
-- **Size-risk capped sizing**: TVL-based per-position cap prevents over-concentration
+- **Waterfall sizing**: Capped waterfall normalisation prevents over-concentration
 - **Redemption-aware**: Target value accounts for pending redemptions
 
 ## Risk parameters
 
 - Maximum 20 positions at any time
 - 98% allocation target
-- 20% maximum concentration per asset
-- 20% per-position cap of pool TVL
-- 7,500 USD minimum vault TVL, ~46 day minimum vault age
-- 5 USD minimum vault deposit (Hyperliquid hard floor)
+- 12% maximum portfolio concentration per one allocated vault
+- 20% maximum TVL participation of a target vault
 """

--- a/tests/strategy/test_asset_weight_legend.py
+++ b/tests/strategy/test_asset_weight_legend.py
@@ -201,6 +201,48 @@ def test_capital_time_allocation_is_weighted_by_time_between_samples() -> None:
     assert allocations == pytest.approx({"Intermittent vault": 100 / 3, "Constant vault": 200 / 3})
 
 
+def test_legend_sort_does_not_reorder_chart_traces() -> None:
+    """Keep reserve-like entries first while retaining the chart stacking order.
+
+    The legend prioritises cash and queue entries, whereas the trace sequence
+    controls the stacked-area chart itself. Verify that sorting its legend rows
+    changes only the annotation order, leaving the original trace sequence
+    intact.
+    """
+    figure = go.Figure(
+        [
+            go.Scatter(name="Directional vault", x=[0, 1], y=[80, 80]),
+            go.Scatter(name="Cash", x=[0, 1], y=[5, 5]),
+            go.Scatter(name="Queue venue", x=[0, 1], y=[15, 15]),
+        ],
+    )
+    entries = [
+        AssetWeightLegendEntry(trace.name, "#00ff66", None, None)
+        for trace in figure.data
+    ]
+
+    add_asset_weight_legend(
+        figure,
+        entries,
+        legend_sort_key=lambda label, allocation: (
+            {"Cash": 0, "Queue venue": 1}.get(label, 2),
+            -allocation,
+            label,
+        ),
+    )
+
+    assert [trace.name for trace in figure.data] == [
+        "Directional vault",
+        "Cash",
+        "Queue venue",
+    ]
+    assert [annotation.text.split(":", 1)[0] for annotation in figure.layout.annotations[5:]] == [
+        "Cash",
+        "Queue venue",
+        "Directional vault",
+    ]
+
+
 def test_cross_chain_vault_repeats_the_legend_row_for_each_chain(tmp_path) -> None:
     """gTrade's Base and Arbitrum allocations get separate legend rows.
 

--- a/tradeexecutor/backtest/backtest_execution.py
+++ b/tradeexecutor/backtest/backtest_execution.py
@@ -233,11 +233,10 @@ class BacktestExecution(ExecutionModel):
             else:
                 type = "spot buy"
             self.wallet.update_balance(base, executed_quantity, f"{type} trade #{trade.trade_id}")
-            # Tolerate sub-raw-unit rounding dust on the reserve debit, same as the
-            # async vault deposit path. CCTP bridge sizing can leave the reserve a
-            # fraction of a raw unit short of the planned buy, which must not crash
-            # the backtest.
-            raw_unit_epsilon = reserve.convert_to_decimal(2)
+            # Tolerate raw-unit rounding dust on the reserve debit. CCTP bridge
+            # sizing can leave the reserve a few raw units short of the planned
+            # buy after amount flooring, which must not crash the backtest.
+            raw_unit_epsilon = reserve.convert_to_decimal(10)
             self.wallet.update_balance(reserve, -executed_reserve, f"{type} trade #{trade.trade_id}", epsilon=raw_unit_epsilon)
         else:
             if trade.is_credit_supply():

--- a/tradeexecutor/backtest/backtest_report_template.ipynb
+++ b/tradeexecutor/backtest/backtest_report_template.ipynb
@@ -348,7 +348,7 @@
    "outputs": [],
    "execution_count": null,
    "source": [
-    "from tradeexecutor.analysis.weights import calculate_asset_weights, visualise_weights\n",
+    "from tradeexecutor.analysis.weights import LegendMode, calculate_asset_weights, visualise_weights\n",
     "\n",
     "weights_series = calculate_asset_weights(state)\n",
     "\n",
@@ -356,7 +356,9 @@
     "    weights_series,\n",
     "    normalised=False,\n",
     "    include_reserves=True,\n",
-    "    template=\"plotly_white\"\n",
+    "    template=\"plotly_white\",\n",
+    "    # Keep the report legend as a vertical right-side list.\n",
+    "    legend_mode=LegendMode.side,\n",
     ")\n",
     "fig.show()"
    ]

--- a/tradeexecutor/strategy/chart/asset_weight_legend.py
+++ b/tradeexecutor/strategy/chart/asset_weight_legend.py
@@ -413,6 +413,7 @@ def add_asset_weight_legend(
     *,
     chain_icon_resolver: Callable[[int], str | None] = resolve_chain_icon_data_url,
     legend_layout: Literal["horizontal", "vertical"] = "horizontal",
+    legend_sort_key: Callable[[str, float], tuple] | None = None,
 ) -> None:
     """Replace a native legend with aligned allocation and identity columns.
 
@@ -432,6 +433,9 @@ def add_asset_weight_legend(
     :param legend_layout:
         ``"horizontal"`` for the compact right-side legend or ``"vertical"``
         for the enlarged below-chart legend.
+    :param legend_sort_key:
+        Optional key for legend rows. Receives the trace label and its
+        capital-time allocation percentage. The chart trace order is unchanged.
     """
     if legend_layout not in {"horizontal", "vertical"}:
         raise ValueError(f"Unsupported asset-weight legend layout: {legend_layout}")
@@ -447,6 +451,13 @@ def add_asset_weight_legend(
         for trace in figure.data
         for entry in entries_by_label.get(trace.name, [None])
     ]
+    if legend_sort_key:
+        legend_rows.sort(
+            key=lambda row: legend_sort_key(
+                row[0].name,
+                capital_time_allocations.get(row[0].name, 0.0),
+            ),
+        )
     row_count = max(len(legend_rows), 1)
     if legend_layout == "horizontal":
         row_step = (ROW_TOP_Y - ROW_BOTTOM_Y) / max(row_count - 1, 1)


### PR DESCRIPTION
## Why

Backtest report asset-weight charts need an explicit vertical legend so report layout does not depend on a library default. This PR also collects the pending legend-ordering, CCTP rounding, and Hyper AI metadata changes.

## Lessons learnt

- Legend ordering must not alter trace ordering, because trace order controls stacked-area semantics.
- CCTP amount flooring can leave several raw reserve units of rounding dust.
- Report layout defaults should be expressed explicitly in the notebook template.
- Dependency pins must retain the curator artwork required by report coverage checks.

## Summary

- Configure the CLI backtest report template with a vertical right-side asset-weight legend.
- Sort asset-weight legend rows independently of chart traces, with regression coverage.
- Tolerate CCTP reserve rounding dust and refresh Hyper AI metadata.
- Retain the dependency pin that includes the curator legend assets.