### PR TITLE
docs: document the synchronous same-cycle cash cap and strategy opt-in

### DIFF
--- a/.claude/docs/alpha-model.md
+++ b/.claude/docs/alpha-model.md
@@ -1,0 +1,228 @@
+# Alpha model
+
+What the synchronous `AlphaModel` does, how a strategy wires it into
+`decide_trades`, and where each stage of the pipeline lives. This is the base
+model documentation; the window-gated subclass has its own deep-dive in
+`phase-aware-alpha-model.md`, and the same-cycle financing caps are covered from
+the strategy side in `vault-deposit-redeem.md`.
+
+The canonical reference implementation is
+[strategies/hyper-ai.py](../../strategies/hyper-ai.py) — a long-only
+vault-of-vaults strategy whose `decide_trades` exercises every stage described
+here. Line references below point at it.
+
+## What it does
+
+`AlphaModel` (in
+[tradeexecutor/strategy/alpha_model.py](../../tradeexecutor/strategy/alpha_model.py))
+turns per-pair conviction numbers into a concrete list of rebalance trades, one
+strategy cycle at a time. The mental model is a four-stage funnel:
+
+```
+signals  ─►  weights  ─►  dollar targets  ─►  trades
+set_signal    assign_weights   calculate_target   generate_rebalance
+select_top    normalise_weights  _positions       _trades_and_triggers
+```
+
+Each cycle the strategy creates a **fresh** `AlphaModel(timestamp)`, feeds it
+raw signals, lets it compute target position values, and asks it to diff those
+targets against the current portfolio. The output is a sorted list of
+`TradeExecution` objects (sells before buys, so sells fund the buys). The model
+instance is also serialised into state per cycle, which is what powers the
+diagnostics charts.
+
+One `TradingPairSignal` object per pair carries the pair through the whole
+funnel: raw `signal`, `raw_weight`, `normalised_weight`, `old_weight` /
+`old_value` (current portfolio), `position_target`, `position_adjust_usd`, and a
+set of diagnostic `TradingPairSignalFlags` explaining every cap or skip applied
+along the way.
+
+## Wiring in decide_trades
+
+The stage order matters. From `hyper-ai.py` (see
+[hyper-ai.py:351-452](../../strategies/hyper-ai.py#L351)), slightly abridged:
+
+```python
+alpha_model = AlphaModel(timestamp, close_position_weight_epsilon=parameters.min_portfolio_weight_pct)
+
+for pair_id in included_pairs:                       # 1. signal generation
+    alpha_model.set_signal(pair, weight_signal_value)
+
+locked = alpha_model.carry_forward_non_redeemable_positions(position_manager)
+portfolio_target = calculate_portfolio_target_value(position_manager, parameters.allocation_pct)
+deployable = max(portfolio_target - locked, 0.0)
+
+alpha_model.select_top_signals(count=parameters.max_assets_in_portfolio)   # 2. selection
+alpha_model.assign_weights(method=weight_passthrouh)                       # 3. weighting
+
+alpha_model.normalise_weights(                                             # 4. normalisation + risk caps
+    investable_equity=deployable,
+    size_risk_model=USDTVLSizeRiskModel(pricing_model, per_position_cap=...),
+    max_weight=parameters.max_concentration_pct,
+    max_positions=parameters.max_assets_in_portfolio,
+    waterfall=True,
+)
+alpha_model.update_old_weights(state.portfolio, ignore_credit=False)       # 5. current portfolio
+alpha_model.calculate_target_positions(position_manager)                   # 6. dollar targets
+
+trades = alpha_model.generate_rebalance_trades_and_triggers(               # 7. trades
+    position_manager,
+    min_trade_threshold=...,
+    individual_rebalance_min_threshold=...,
+    sell_rebalance_min_threshold=...,
+    cap_buys_to_sync_cash=True,          # hyper-ai opts into the sync cash cap
+    sync_cash_headroom_usd=...,
+)
+```
+
+`carry_forward_non_redeemable_positions()` must run **before**
+`select_top_signals()`: it pins positions that cannot be sold this cycle
+(lock-ups, pending settlements) at their current value so top-N selection does
+not evict a position the strategy could not exit anyway, and returns the locked
+value the strategy subtracts from its deployable target.
+
+## Signal generation
+
+`set_signal(pair, alpha, ...)` records one signal per pair. The signal is any
+float the strategy believes in — a momentum score, a trailing Sharpe, or a
+precomputed weight. Zero means "no position / close". Optional per-signal inputs
+include `stop_loss`, `take_profit` and `leverage`.
+
+The model does not compute signals itself; that is indicator work. In
+`hyper-ai.py` the signal is the `age_ramp_weight` indicator (vaults ramp from
+zero weight to full weight over 0.75 years of track record), and pairs first
+pass an `inclusion_criteria` indicator (TVL, age, data-availability filters)
+before `set_signal` is called at all.
+
+## Selection
+
+`select_top_signals(count, threshold)` keeps the `count` strongest signals by
+absolute value (optionally requiring a minimum `threshold`) and discards the
+rest. Carried-forward (non-redeemable) signals occupy slots but are never
+evicted. This is where "we track 120 vaults but hold at most 20 positions"
+happens.
+
+## Weighting
+
+`assign_weights(method)` converts raw signals to unnormalised weights. Methods
+live in [tradeexecutor/strategy/weighting.py](../../tradeexecutor/strategy/weighting.py):
+
+| Method | Weighting |
+|---|---|
+| `weight_by_1_slash_n` | 1/1, 1/2, 1/3… by signal rank (default) |
+| `weight_equal` | equal weight to every included pair |
+| `weight_passthrouh` | signal value used as-is — for strategies whose indicator already outputs a weight (hyper-ai) |
+| `weight_by_1_slash_signal` | inverse of the signal value |
+| `weight_by_softmax` | softmax with a temperature parameter |
+| `weight_by_log` / `weight_by_blend` | log-dampened / blended variants |
+
+## Normalisation and risk caps
+
+`normalise_weights(...)` scales weights to sum to 1.0 and applies every
+portfolio-level risk control in one pass:
+
+- **`investable_equity`** — the dollar pool the weights allocate. The strategy
+  decides what is investable (hyper-ai: `portfolio target − locked capital`).
+- **`max_weight`** (+ optional `max_weight_function`) — per-asset concentration
+  cap; excess weight is redistributed or discarded.
+- **`size_risk_model`** — per-pair dollar caps from market depth. Hyper-ai uses
+  `USDTVLSizeRiskModel` so a position may not exceed a fixed % of the vault's
+  TVL. Discarded allocation is tracked (`size_risk_discarded_value`).
+- **`max_positions`** — hard position-count cap after size risk shuffling.
+- **`waterfall=True`** — survivor-first allocation: fill the strongest signal to
+  its cap, then the next, instead of pro-rata scaling everyone down.
+- **`max_protocol_weight`** / `cap_chain_allocation()` — optional per-protocol
+  and per-chain allocation ceilings (flags `capped_by_protocol_allocation`,
+  `capped_by_chain_allocation`).
+
+Signals capped here carry the corresponding flag, so the diagnostics table
+shows *why* a position is smaller than its raw signal implied.
+
+## Old weights and dollar targets
+
+`update_old_weights(portfolio)` records what the portfolio currently holds
+(`old_weight`, `old_value` per signal), so the model knows the starting point.
+Queue/bridge/credit positions can be excluded via predicate — see the
+phase-aware subclass for an example override.
+
+`calculate_target_positions(position_manager)` turns normalised weights into
+`position_target` dollars and the per-pair difference into
+`position_adjust_usd` (positive = buy, negative = sell). Settlement-aware
+details (pending deposits valued into old value, non-redeemable positions
+pinned) are documented in `vault-deposit-redeem.md`.
+
+## Trade generation
+
+`generate_rebalance_trades_and_triggers(position_manager, ...)` diffs targets
+against the portfolio and emits trades, applying gates in this order:
+
+1. **Whole-portfolio gate** — if the largest single adjustment is below
+   `min_trade_threshold`, the entire rebalance is skipped (flag
+   `max_adjust_too_small`). All-or-nothing, because dropping only some legs
+   would break the sells-fund-buys pairing.
+2. **Same-cycle cash caps** — the always-on **async cap** (queued ERC-7540 /
+   Ostium redemptions pay out later, so buys are scaled to the cash that
+   actually arrives; flag `capped_by_pending_settlement_cash`) and the
+   **opt-in sync cap** (`cap_buys_to_sync_cash=True`: sells dropped by the
+   min-trade gate free no cash either, so buys are scaled to the sells that
+   actually execute; flag `capped_by_sync_cash`). Opt-in rules and the worked
+   hyper-ai example live in `vault-deposit-redeem.md`.
+3. **Per-signal gates** — problematic/frozen pairs, buys whose vault deposit
+   window is closed (`cannot_deposit`), sells below
+   `sell_rebalance_min_threshold` or below the pair dust epsilon
+   (`individual_trade_size_too_small` / `individual_trade_quantity_too_small`),
+   positions with a pending vault settlement (`settlement_pending`), and
+   positions not yet redeemable (`cannot_redeem`).
+4. **Emission** — position closes for signals under
+   `close_position_weight_epsilon`, adjust trades for the rest, plus optional
+   stop-loss/take-profit triggers. Trades are returned sorted by
+   `get_execution_sort_position()`: credit withdrawals → closes → vault
+   redemptions → sells → bridge legs → buys → vault deposits → credit supply,
+   so cash is always released before it is spent.
+
+Thresholds exist because tiny rebalances cost more in fees and execution risk
+than they earn: hyper-ai floors both at Hyperliquid's $5 hard minimum
+([hyper-ai.py:178-220](../../strategies/hyper-ai.py#L178)).
+
+## Diagnostics and charts
+
+Every stage writes its reasoning onto the signal, and the per-cycle model
+snapshot is stored in state, so post-hoc "why did it trade like that?" is
+answerable without re-running the strategy:
+
+- **`format_signals(alpha_model)`** — one DataFrame row per signal: raw signal,
+  old/new weight, target value, adjust, flags, pending settlement columns. This
+  is the primary debugging table.
+- **`alpha_model_diagnostics`** chart
+  ([chart/standard/alpha_model.py](../../tradeexecutor/strategy/chart/standard/alpha_model.py))
+  — renders that table for the last cycle in the web/notebook UI. Related:
+  `skipped_signals` (weights blocked by closed deposit windows) and
+  `missed_vault_deposit_redemption_events` / `_timeline`.
+- **Weight charts** ([chart/standard/weight.py](../../tradeexecutor/strategy/chart/standard/weight.py))
+  — `equity_curve_by_asset` (stacked equity bands per asset, curator/chain
+  symbols in the legend), `equity_curve_by_chain`, and
+  `weight_allocation_statistics`.
+- **Strategy thinking** — hyper-ai composes a per-cycle text report (cash,
+  redeemable capital, investable equity, allocated value, discarded-by-liquidity
+  value, trades decided; [hyper-ai.py:465-514](../../strategies/hyper-ai.py#L465))
+  and stores it via `state.visualisation.add_message`, surfaced by the
+  `last_messages` chart.
+- **Flag rollup** — `get_flag_diagnostics_data()` aggregates flag counts per
+  cycle; `get_unallocatable_signals()` and `get_missed_vault_events()` expose
+  liquidity-capped and window-blocked allocations.
+
+Chart registration happens in the strategy's `create_charts()`
+([hyper-ai.py:779-807](../../strategies/hyper-ai.py#L779)); everything above is
+registered there and rendered in backtest notebooks and the live web UI alike.
+
+## Cross-references
+
+| Doc / code | What it covers |
+|---|---|
+| [strategies/hyper-ai.py](../../strategies/hyper-ai.py) | Reference implementation of the full pipeline (long-only, vault universe, waterfall + TVL size risk, sync cash cap opt-in) |
+| `phase-aware-alpha-model.md` | `PhaseAwareAlphaModel` subclass: window-gated deposits parked in a queue vault, the three base hooks, correctness invariants |
+| `vault-deposit-redeem.md` | Async vault lifecycle, settlement-aware sizing, both same-cycle cash caps and the sync-cap opt-in rules |
+| [tradeexecutor/strategy/alpha_model.py](../../tradeexecutor/strategy/alpha_model.py) | `AlphaModel`, `TradingPairSignal`, `TradingPairSignalFlags`, `format_signals` |
+| [tradeexecutor/strategy/weighting.py](../../tradeexecutor/strategy/weighting.py) | Weighting methods and weight normalisation helpers |
+| [tradeexecutor/strategy/size_risk_model.py](../../tradeexecutor/strategy/size_risk_model.py) | Size-risk base class; `USDTVLSizeRiskModel` in `tvl_size_risk.py` |
+| [tests/units_tests/test_alpha_model_sync_cash_cap.py](../../tests/units_tests/test_alpha_model_sync_cash_cap.py) | Sync cash cap unit coverage |

--- a/.claude/docs/phase-aware-alpha-model.md
+++ b/.claude/docs/phase-aware-alpha-model.md
@@ -97,7 +97,7 @@ copy-pasting large methods:
 
 | Hook | Base behaviour | Phase-aware override |
 |---|---|---|
-| `_available_same_cycle_cash` | `get_current_cash()` | `+ queue_venue_redeemable()` (invariant 4) |
+| `_available_same_cycle_cash` | `get_current_cash()` | `+ queue_venue_redeemable()` (invariant 4). Feeds **both** same-cycle buy caps — the always-on async cap (`_cap_buys_by_async_sell_proceeds`) and the opt-in sync cap (`_cap_buys_by_realisable_sync_cash`) — so the widening applies to whichever runs. |
 | `_count_position_in_old_weights` | composite predicate (CCTP bridges, credit) | additionally excludes venue pair ids (invariant 2) |
 | `_on_deposit_window_closed` | skip: `cannot_deposit` + `missed_deposit_usd` | **not overridden** — parking happens in `apply_phase_aware_intent` *before* generation, so deferred buys are excluded from the min-trade gate and the cash cap; the base hook remains the degraded/skip path |
 
@@ -228,6 +228,14 @@ Two phase-aware-driven behaviours to know:
   (feature flags, else the position's own settlement history — which also
   catches vaults simulated as async via a backtest delay override).
 
+The base `AlphaModel` also carries an **opt-in synchronous cash cap**
+(`_cap_buys_by_realisable_sync_cash`, `cap_buys_to_sync_cash=True`) that scales
+spot/vault buys down to cash plus the sells that actually execute this cycle —
+excluding sub-threshold trims that the min-trade gate drops. It reads the same
+`_available_same_cycle_cash()` hook, so invariant 4's widening applies to it too;
+a phase-aware strategy may opt in safely for that reason. See the two same-cycle
+financing caps in `vault-deposit-redeem.md` for the strategy-facing opt-in rules.
+
 The venue itself must be **synchronous** (`is_async_vault()` false): a sync
 ERC-4626 redeems same-cycle, which is what makes the promotion funding and the
 invariant-4 widening sound. Avoid Lagoon/Ostium/Gains-style venues.
@@ -334,7 +342,7 @@ Proving idle→productive is the point, so the undeployed slice has structure:
 | File | What |
 |---|---|
 | `tradeexecutor/strategy/phase_aware.py` | `PhaseAwareAlphaModel`, event log (`QueueVaultEvent`, `append_queue_event`, folds), venue identity helpers, `queue_venue_redeemable` |
-| `tradeexecutor/strategy/alpha_model.py` | base `AlphaModel` with the three hooks, `_cap_buys_by_async_sell_proceeds`, `format_signals` columns |
+| `tradeexecutor/strategy/alpha_model.py` | base `AlphaModel` with the three hooks, the always-on `_cap_buys_by_async_sell_proceeds` and the opt-in `_cap_buys_by_realisable_sync_cash` (+ its read-only `_will_sell_execute` / `_is_executable_cash_spending_buy` predicates), `format_signals` columns |
 | `tradeexecutor/strategy/pandas_trader/yield_manager.py` | sweep/release engine, `calculate_yield_management[_safe]`, shared availability helpers, `_is_async_vault_sell` |
 | `tradeexecutor/backtest/vault_windows.py` | `VaultWindowSchedule`, `get_assumed_open_close_time` resolver |
 | `tradeexecutor/backtest/backtest_pricing.py`, `backtest_runner.py`, `backtest_generic_router.py` | `vault_window_overrides` threading into `can_deposit` / `check_redemption` |

--- a/.claude/docs/phase-aware-alpha-model.md
+++ b/.claude/docs/phase-aware-alpha-model.md
@@ -11,7 +11,9 @@ yield-bearing **queue vault**, and re-emits the deposit when the window opens.
 This document explains why the model exists, the architecture and mechanism,
 the correctness invariants an implementer must not undo, how backtest window
 modelling works, and the operator diagnostics. The final section maps the code,
-tests and related documents.
+tests and related documents. For the base synchronous `AlphaModel` pipeline this
+subclass builds on (signals → weights → targets → trades), read
+`.claude/docs/alpha-model.md` first.
 
 **Scope note.** The queue vault here is a vault the strategy *deposits into* as
 a cash home (see `.claude/docs/vault-deposit-redeem.md` for depositor-side vault

--- a/.claude/docs/vault-deposit-redeem.md
+++ b/.claude/docs/vault-deposit-redeem.md
@@ -128,16 +128,50 @@ settlement-aware:
   `pending_redemption_usd` diagnostics, shown as columns in the
   `format_signals()` table and the `alpha_model_diagnostics` chart, and the
   `pending_vault_settlements` chart plots the queued buffers over time.
-- Same-cycle financing is settlement-aware: rebalance buys are normally
-  funded by the cycle's sells executing first, but a redemption requested
-  from an async vault pays out only after settlement. The alpha model scales
-  buys down to the cash that actually arrives this cycle (the
-  `capped_by_pending_settlement_cash` flag) and redeploys the withheld
-  capital on a later cycle once the redemption settles. Async vaults are
-  recognised by their feature flags (`pair.is_async_vault()`) or, for vaults
-  simulated as async only via a backtest delay override, by the
-  `vault_async_flow` stamp on the position's earlier settlement requests
-  (`position.has_async_vault_flow()`).
+- Same-cycle financing is settlement-aware, via two complementary buy caps on
+  `AlphaModel.generate_rebalance_trades_and_triggers()`. Rebalance buys are
+  normally funded by the cycle's sells executing first, but some "sells" free no
+  cash this cycle, and a buy sized as if they did overspends the reserve
+  (`OutOfSimulatedBalance` in backtest, a bounced deposit live):
+  - **Async redemptions** pay out only after settlement. The **async cap**
+    (`_cap_buys_by_async_sell_proceeds`, always on) scales buys down to cash plus
+    synchronous sell proceeds, flags `capped_by_pending_settlement_cash`, and
+    redeploys the withheld capital once the redemption settles. Async vaults are
+    recognised by feature flags (`pair.is_async_vault()`) or, for vaults simulated
+    as async via a backtest delay override, by the `vault_async_flow` stamp on the
+    position's earlier settlement requests (`position.has_async_vault_flow()`).
+  - **Synchronous trims below the sell threshold** are dropped by the per-signal
+    min-trade gate but still free no cash. The **sync cap**
+    (`_cap_buys_by_realisable_sync_cash`, **opt-in** via `cap_buys_to_sync_cash`)
+    scales spot/vault buys down to cash plus the sells that *actually* execute —
+    excluding sub-threshold trims, frozen/problematic/dust/pending-settlement/
+    non-redeemable sells, and async redemptions — and flags `capped_by_sync_cash`.
+    This bites when a strategy rebalances many small positions to ~equal weights and
+    one large underweight buy is funded by several trims that each fall below the
+    threshold (the Hyper AI 2025-08-20 overshoot: a $46.72 buy against $44.10
+    realisable). Classification is read-only — it mirrors the generation loop's own
+    drop gates — so opting in changes nothing for signals it does not scale.
+
+  Both caps read the overridable `_available_same_cycle_cash()` hook, so a subclass
+  that widens the budget (e.g. `PhaseAwareAlphaModel`, adding redeemable queue-venue
+  balance) applies to both.
+
+**Opting a strategy into the sync cap.** Pass `cap_buys_to_sync_cash=True` and a
+`sync_cash_headroom_usd` (a small margin for fee/slippage realisation, e.g.
+`max(0.50, initial_cash * 0.0005)`) to `generate_rebalance_trades_and_triggers()`;
+the default is opt-out, so existing strategies are unchanged until they do. Two
+constraints, both enforced or load-bearing:
+
+- **Supported scope only.** The opt-in asserts every reserve-spending buy is an
+  unleveraged, non-flipping spot or vault buy. Leveraged, short, flip and
+  credit-supply strategies must not opt in — their cash flow is not reserve-linear.
+- **Do not opt in if buys are funded by capital released *after* trade generation
+  and not visible to `_available_same_cycle_cash()`.** A plain-`AlphaModel` +
+  `YieldManager` strategy (e.g. `base-ath-ipor`) releases managed yield only after
+  `generate_rebalance_trades_and_triggers()` returns, so the sync cap — seeing only
+  raw reserve — would wrongly shrink those buys. Such a strategy either stays opted
+  out, or overrides `_available_same_cycle_cash()` to include that funding first
+  (as `PhaseAwareAlphaModel` does for its queue venue).
 
 For hand-rolled (non-AlphaModel) `decide_trades` the manual rules still
 apply:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,6 +9,7 @@ working on that area:
 |-----|-------------|
 | `.claude/docs/agent-tricks-and-troubleshooting.md` | **MANDATORY read before ANY Claude CLI or Codex CLI invocation** (reviews, sanity checks, or one-off runs) |
 | `.claude/docs/cli-command.md` | CLI command patterns for trade-executor |
+| `.claude/docs/alpha-model.md` | Base synchronous `AlphaModel` — the signals → weights → targets → trades pipeline, risk caps, trade generation gates, diagnostics charts, with `hyper-ai.py` as the reference implementation |
 | `.claude/docs/vault-deposit-redeem.md` | Synchronous and async (ERC-7540 / Lagoon / Ostium) vault deposit and redeem flows |
 | `.claude/docs/hypercore-vault.md` | HyperCore native vault execution — properties, data structures, deposit/withdrawal phases, HyperEVM interactions, modules and diagrams |
 | `.claude/docs/phase-aware-alpha-model.md` | Phase-aware alpha model — parking window-gated vault deposits in a yield-bearing queue vault, park/promote event log, correctness invariants, backtest window modelling, diagnostics charts |


### PR DESCRIPTION
## Why

Documentation follow-up to #1566 (the synchronous same-cycle cash cap). That PR added an opt-in cap on `AlphaModel.generate_rebalance_trades_and_triggers()` but the `.claude/docs` reference material only described the pre-existing async cap, and the base `AlphaModel` itself had no doc at all — only its phase-aware subclass did. Anyone deciding whether another strategy should opt in (e.g. `hyper-ai-v2.py`), or touching the rebalance pipeline, needs this written down.

## Lessons learnt

- There are now **two** complementary same-cycle buy caps and they must be documented together: the always-on async cap (proceeds settle later) and the opt-in sync cap (sub-threshold trims free no cash). Both read the same overridable `_available_same_cycle_cash()` hook.
- The load-bearing opt-in rule is easy to get wrong: a strategy that funds buys from `YieldManager` yield released *after* trade generation (e.g. `base-ath-ipor`) must **not** opt in, because the sync cap sees only raw reserve and would shrink those buys — unless it overrides `_available_same_cycle_cash()` as `PhaseAwareAlphaModel` does.
- The subclass (`phase-aware-alpha-model.md`) was documented before the base class — reference docs should cover the base pipeline first, since every invariant in the subclass doc presumes it.

## Summary

- **`alpha-model.md`** (new) — base synchronous `AlphaModel` documentation: the signals → weights → targets → trades pipeline with `hyper-ai.py` as the reference implementation. Sections for signal generation, selection, weighting methods, normalisation and risk caps (size risk, concentration, waterfall, chain/protocol), old weights and dollar targets, trade generation gates (whole-portfolio threshold, both same-cycle cash caps, per-signal gates, execution ordering), and the diagnostics charts (`format_signals`, `alpha_model_diagnostics`, weight charts, strategy thinking). Added to the CLAUDE.md reference-docs table; `phase-aware-alpha-model.md` intro now points to it.
- **`vault-deposit-redeem.md`** — expands the "same-cycle financing is settlement-aware" note into both caps (async + sync), and adds a strategy-facing **opt-in** section: how to pass `cap_buys_to_sync_cash=True` / `sync_cash_headroom_usd`, the supported scope (unleveraged, non-flipping spot/vault buys only), and the funding-order constraint.
- **`phase-aware-alpha-model.md`** — notes both caps feed off `_available_same_cycle_cash`, so invariant-4 widening applies to either and a phase-aware strategy may opt in safely; updates the code map; cross-references the new base doc.

Docs only — no code or test changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Example: opting a strategy into the safe behaviour

The sync cash cap is opt-out by default; nothing changes until a strategy opts in. Two edits, taken verbatim from `strategies/hyper-ai.py` (#1566):

**1. Add the headroom parameter to `Parameters`:**

```python
class Parameters:
    ...
    #: Margin withheld from the same-cycle buy budget by the synchronous cash cap
    #: (``cap_buys_to_sync_cash``): sell proceeds are sized mark-to-market but
    #: execution realises slightly less (fees, price impact, raw-unit rounding).
    #: Derived once at class creation from ``initial_cash`` so it scales across
    #: configured bankrolls — it does not track intra-run treasury growth.
    sync_cash_headroom_usd = max(0.50, initial_cash * 0.0005)
```

**2. Pass the two kwargs in `decide_trades`:**

```python
    trades = alpha_model.generate_rebalance_trades_and_triggers(
        position_manager,
        min_trade_threshold=parameters.individual_rebalance_min_threshold_usd,
        individual_rebalance_min_threshold=parameters.individual_rebalance_min_threshold_usd,
        sell_rebalance_min_threshold=parameters.sell_rebalance_min_threshold_usd,
        execution_context=input.execution_context,
        # Scale buys down to the sells that actually execute this cycle, so a
        # large underweight buy funded by several sub-threshold trims cannot
        # overspend the reserve (OutOfSimulatedBalance in backtest, a bounced
        # deposit live).
        cap_buys_to_sync_cash=True,                                  # NEW
        sync_cash_headroom_usd=parameters.sync_cash_headroom_usd,    # NEW
    )
```

**Before opting in, check both constraints** (detailed in `vault-deposit-redeem.md` in this PR):

- Every reserve-spending buy must be an unleveraged, non-flipping spot or vault buy — the opt-in asserts this; leveraged/short/flip/credit-supply strategies must not opt in.
- Buys must not be funded by capital released *after* trade generation (the plain-`AlphaModel` + `YieldManager` pattern, e.g. `base-ath-ipor`) — unless the strategy overrides `_available_same_cycle_cash()` to include that funding, as `PhaseAwareAlphaModel` does.
