### PR TITLE
fix: report stale liquidity pair details

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -113,6 +113,7 @@ source .local-test.env && PYTHONPATH="$(pwd):$PYTHONPATH" poetry run pytest test
 ## Pull requests
 
 - For pull request, issue, CI, and merge work, use the `git` and `gh` command-line tools; no plugins are required.
+- Do not format code for a pull request.
 - Pull request description must have sections Why (the rational of change), Lessons learnt (memory) and Summary (what was changed). No test plan or verification section. Use Markdown formatting, headings.
 - When updating a pull request description, prefer `gh api` with the REST pull request endpoint instead of `gh pr edit --body`, because `gh pr edit` can fail with `GraphQL: Projects (classic) is being deprecated ... (repository.pullRequest.projectCards)`. Write longer descriptions to a temporary Markdown file and run `gh api repos/:owner/:repo/pulls/{pr-number} --method PATCH -F body=@/tmp/pr-body.md`.
 - Only push changes to remote when asked, never update pull requess automatically.

--- a/tests/test_data_age.py
+++ b/tests/test_data_age.py
@@ -1,7 +1,9 @@
 """Check we correctly handle fresh and expired data."""
 import os
 import datetime
+from unittest.mock import MagicMock
 
+import pandas as pd
 import pytest
 
 from tradeexecutor.strategy.execution_context import ExecutionMode, unit_test_execution_context, unit_test_trading_execution_context
@@ -13,7 +15,9 @@ from tradeexecutor.strategy.trading_strategy_universe import TradingStrategyUniv
 from tradeexecutor.utils.timer import timed_task
 from tradingstrategy.timebucket import TimeBucket
 from eth_defi.compat import native_datetime_utc_now
+from tradingstrategy.universe import Universe
 
+from tradeexecutor.analysis.vault import display_vaults
 
 # https://docs.pytest.org/en/latest/how-to/skipping.html#skip-all-test-functions-of-a-class-or-module
 pytestmark = pytest.mark.skipif(os.environ.get("TRADING_STRATEGY_API_KEY") is None, reason="Set TRADING_STRATEGY_API_KEY environment variable to run this test")
@@ -62,6 +66,84 @@ def test_data_aged(persistent_test_client):
     with pytest.raises(DataTooOld):
         universe_model.check_data_age(ts, universe, best_before_duration)
 
+
+def test_data_aged_liquidity_reports_stale_pair() -> None:
+    """Report the stale liquidity pair so a live-trading failure is actionable.
+
+    1. Create a universe with a named vault pair and stale liquidity samples.
+    2. Run the freshness check with a one-day liquidity tolerance.
+    3. Verify the raised exception identifies both the pair ID and name.
+    """
+    # 1. Create a universe with a named vault pair and stale liquidity samples.
+    pair = MagicMock()
+    pair.pair_id = 123
+    pair.other_data = {"vault_name": "Example vault"}
+    pair.base_token_symbol = "vUSDC"
+    pair.quote_token_symbol = "USDC"
+
+    liquidity = MagicMock()
+    liquidity.df = pd.DataFrame({
+        "pair_id": [123],
+        "timestamp": [pd.Timestamp("2026-07-18")],
+    })
+    liquidity.get_timestamp_range.return_value = (
+        pd.Timestamp("2023-08-28"),
+        pd.Timestamp("2026-07-18"),
+    )
+
+    data_universe = MagicMock(spec=Universe)
+    data_universe.candles = None
+    data_universe.liquidity = liquidity
+    data_universe.pairs.get_pair_by_id.return_value = pair
+    strategy_universe = TradingStrategyUniverse(data_universe=data_universe, reserve_assets=[])
+
+    # 2. Run the freshness check with a one-day liquidity tolerance.
+    with pytest.raises(DataTooOld) as exception_info:
+        TradingStrategyUniverseModel.check_data_age(
+            ts=datetime.datetime(2026, 7, 20),
+            strategy_universe=strategy_universe,
+            best_before_duration=datetime.timedelta(days=2),
+            best_before_duration_liquidity=datetime.timedelta(days=1),
+        )
+
+    # 3. Verify the raised exception identifies both the pair ID and name.
+    exception_message = str(exception_info.value)
+    assert "Pair #123" in exception_message
+    assert "Example vault" in exception_message
+
+
+def test_display_vaults_logs_complete_live_checklist_row() -> None:
+    """Render the full live vault checklist row without pandas abbreviation.
+
+    1. Create a vault diagnostic row with deliberately long pair details.
+    2. Render the checklist in a live-trading execution mode.
+    3. Verify the log output contains the full pair ID and status text.
+    """
+    # 1. Create a vault diagnostic row with deliberately long pair details.
+    pair = MagicMock()
+    pair.internal_id = 123
+    pair.get_vault_name.return_value = "Example vault"
+    pair.get_vault_protocol.return_value = "example_protocol"
+    pair.quote.token_symbol = "USDC"
+
+    status = "No price data found for vault: <Pair #123: Example vault with complete details>"
+    strategy_universe = MagicMock()
+    strategy_universe.get_vault_error.return_value = status
+    strategy_universe.get_pair_by_smart_contract.return_value = pair
+    output = []
+
+    # 2. Render the checklist in a live-trading execution mode.
+    display_vaults(
+        vaults=[(ChainId.ethereum, "0x1234567890123456789012345678901234567890")],
+        strategy_universe=strategy_universe,
+        execution_mode=ExecutionMode.real_trading,
+        printer=output.append,
+    )
+
+    # 3. Verify the log output contains the full pair ID and status text.
+    checklist_output = output[1]
+    assert "123" in checklist_output
+    assert status in checklist_output
 
 
 

--- a/tradeexecutor/analysis/vault.py
+++ b/tradeexecutor/analysis/vault.py
@@ -204,6 +204,7 @@ def display_vaults(
         data.append({
             "Chain": get_chain_name(v[0]),
             "Vault": v[1],
+            "Pair id": vault_pair.internal_id if vault_pair else "-",
             "Name": vault_pair.get_vault_name() if vault_pair else "-",
             "Protocol": vault_pair.get_vault_protocol() if vault_pair else "-",
             "Denomination": vault_pair.quote.token_symbol if vault_pair else "-",
@@ -213,8 +214,8 @@ def display_vaults(
     printer("Vault check list")
     df = pd.DataFrame(data)
     if execution_mode.is_live_trading():
-        # In live trading we can display dataframes directly
-        printer(df)
+        # Do not let pandas abbreviate pair details in Docker logs.
+        printer(df.to_string(index=False, max_colwidth=None))
     else:
         # Backtesting uses HTML output
         display(df)

--- a/tradeexecutor/strategy/trading_strategy_universe.py
+++ b/tradeexecutor/strategy/trading_strategy_universe.py
@@ -2032,7 +2032,27 @@ class TradingStrategyUniverseModel(UniverseModel):
             liquidity_end = liquidity_end.to_pydatetime().replace(tzinfo=None)
 
             if liquidity_end < max_age:
-                raise DataTooOld(f"Liquidity data is too old to work with {liquidity_start} - {liquidity_end}")
+                liquidity_df = data_universe.liquidity.df
+                if "forward_filled" in liquidity_df.columns:
+                    liquidity_df = liquidity_df.loc[~liquidity_df["forward_filled"]]
+
+                latest_liquidity_by_pair = liquidity_df.groupby("pair_id")["timestamp"].max()
+                stale_pairs = []
+                for pair_id, latest_timestamp in latest_liquidity_by_pair.items():
+                    latest_timestamp = latest_timestamp.to_pydatetime().replace(tzinfo=None)
+                    if latest_timestamp < max_age:
+                        try:
+                            pair = data_universe.pairs.get_pair_by_id(int(pair_id))
+                            pair_name = (pair.other_data or {}).get("vault_name") or f"{pair.base_token_symbol}-{pair.quote_token_symbol}"
+                        except Exception:
+                            pair_name = "Unknown pair"
+                        stale_pairs.append(f"Pair #{pair_id}: {pair_name} (latest liquidity {latest_timestamp})")
+
+                stale_pairs_message = "\n".join(stale_pairs)
+                raise DataTooOld(
+                    f"Liquidity data is too old to work with {liquidity_start} - {liquidity_end}\n"
+                    f"Stale liquidity pairs:\n{stale_pairs_message}"
+                )
 
             return min(liquidity_end, candle_end)
 


### PR DESCRIPTION
## Why

Live vault diagnostics abbreviated pandas output, hiding the pair information needed to identify missing price data. Liquidity freshness failures also reported only an aggregate time range, leaving operators unable to identify stale vaults.

## Lessons learnt

Operational exceptions should retain the affected entity identifiers. Diagnostic dataframes sent to application logs need explicit untruncated rendering.

## Summary

- Render the live vault checklist without pandas column abbreviation and include pair IDs.
- Add every stale liquidity pair ID, name, and latest timestamp to `DataTooOld`.
- Preserve the freshness exception if pair metadata cannot be resolved.
- Add focused regression tests for exception and checklist output.
- State that pull requests must not format code.
