### PR TITLE
fix: avoid NumPy generic-unit timedelta DeprecationWarning in backtest hot path

### DIFF
--- a/tradeexecutor/backtest/backtest_runner.py
+++ b/tradeexecutor/backtest/backtest_runner.py
@@ -1115,9 +1115,9 @@ def guess_data_delay_tolerance(universe: TradingStrategyUniverse) -> pd.Timedelt
     if universe.price_data_delay_tolerance:
         return pd.Timedelta(universe.price_data_delay_tolerance)
     elif universe.data_universe.time_bucket == TimeBucket.d7:
-        data_delay_tolerance = pd.Timedelta("9d")
+        data_delay_tolerance = pd.Timedelta(9, unit="d")
     else:
-        data_delay_tolerance = pd.Timedelta("2d")
+        data_delay_tolerance = pd.Timedelta(2, unit="d")
 
     return data_delay_tolerance
 

--- a/tradeexecutor/strategy/pandas_trader/strategy_input.py
+++ b/tradeexecutor/strategy/pandas_trader/strategy_input.py
@@ -142,7 +142,7 @@ class StrategyInputIndicators:
     def get_price(
         self,
         pair: TradingPairIdentifier | HumanReadableTradingPairDescription |  None = None,
-        data_lag_tolerance=pd.Timedelta(days=7),
+        data_lag_tolerance=pd.Timedelta(7, unit="D"),
         index: int = -1,
         timestamp: pd.Timestamp | None = None,
         column="close",
@@ -227,7 +227,7 @@ class StrategyInputIndicators:
     def get_tvl(
         self,
         pair: TradingPairIdentifier | HumanReadableTradingPairDescription |  None = None,
-        data_lag_tolerance=pd.Timedelta(days=7),
+        data_lag_tolerance=pd.Timedelta(7, unit="D"),
         index: int = -1,
         timestamp: pd.Timestamp | None = None,
     ) -> USDollarPrice | None:
@@ -310,7 +310,7 @@ class StrategyInputIndicators:
         column: str | None = None,
         pair: TradingPairIdentifier | HumanReadableTradingPairDescription | None = None,
         index: int = -1,
-        clock_shift: pd.Timedelta = pd.Timedelta(hours=0),
+        clock_shift: pd.Timedelta = pd.Timedelta(0, unit="h"),
         data_delay_tolerance: pd.Timedelta="auto",
         na_conversion=True,
         parameters: dict=None,
@@ -449,11 +449,15 @@ class StrategyInputIndicators:
             return None
 
         weekly_hack = False
-        if time_frame == pd.Timedelta(days=7):
+        # Use an explicit ``unit=`` to avoid the NumPy "generic" timedelta
+        # DeprecationWarning that ``pd.Timedelta(days=...)`` triggers on
+        # NumPy 2.x. This comparison runs once per decision cycle per pair,
+        # so the bare-int form otherwise floods stderr in optimiser runs.
+        if time_frame == pd.Timedelta(7, unit="D"):
             # TODO: Hot fix for weekly timeframe
             floored = ts.to_period("W").start_time
-            shifted_ts = floored - pd.Timedelta(days=7)
-            data_delay_tolerance = pd.Timedelta(days=14)
+            shifted_ts = floored - pd.Timedelta(7, unit="D")
+            data_delay_tolerance = pd.Timedelta(14, unit="D")
             logger.info("get_indicator_value(): weekly hack, floored %s, shifted %s", floored, shifted_ts)
             weekly_hack = True
         else:


### PR DESCRIPTION
## Problem

`StrategyInputIndicators.get_indicator_value()` constructs `pd.Timedelta(days=7)` on the weekly-timeframe check **once per decision cycle per pair**. On NumPy 2.x, `pd.Timedelta(days=7)` (and the string form `pd.Timedelta("9d")`) emits a `DeprecationWarning`:

> The 'generic' unit for NumPy timedelta is deprecated, and will raise an error in the future. This includes implicit conversion of bare integers.

In a Gaussian-process optimiser run (many parameter combinations × ~340 daily cycles × 6 worker processes) this warning is emitted **millions of times** and captured into the notebook's cell output. One grid-search research notebook reached **1.3 GB** of embedded stderr; `strategy_input.py:452` alone accounted for ~3.5M copies.

## Fix

Switch the affected constructions from the bare-int / string forms to the explicit `pd.Timedelta(N, unit="...")` form, which is warning-free and behaviourally identical:

- `tradeexecutor/strategy/pandas_trader/strategy_input.py` — the per-cycle weekly-timeframe comparison (the dominant source) plus the `get_price`/`get_tvl`/`get_indicator_value` default args.
- `tradeexecutor/backtest/backtest_runner.py` — `guess_data_delay_tolerance()` d7/default tolerances.

## Verification

`pd.Timedelta(N, unit="...")` construction and comparison raise **0** deprecation warnings where the bare form raised on every call (5000/5000 → 0/5000 in a tight loop). The values produced are identical (`pd.Timedelta(7, unit="D") == pd.Timedelta(days=7)`).

Note: other one-time, import-level `pd.Timedelta(...)` constructions elsewhere in the dependency tree also emit this warning, but they fire once per process and do not cause the runtime flood; this PR targets the backtest hot path that produced the multi-gigabyte output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)