### PR TITLE
fix: integrate eth-defi vault test capabilities

### DIFF
--- a/docs/plans/trade-executor-vault-test-follow-ups.md
+++ b/docs/plans/trade-executor-vault-test-follow-ups.md
@@ -1,0 +1,485 @@
+# Trade-executor vault test follow-up plan
+
+## Objective
+
+Make `trade-executor vault-test-trade` consume eth-defi vault capabilities and
+flow results through their shared interfaces, and ensure the command reports
+trade-executor bookkeeping or preflight outcomes accurately.
+
+This plan covers only changes in the trade-executor repository. Protocol
+adapters, protocol ABIs, custom event decoding and new eth-defi capability
+fields are owned by the separate eth-defi workstream documented in
+`docs/plans/eth-defi-vault-test-follow-ups.md`.
+
+The 2026-07-23 cross-chain rerun covered 129 vault IDs. It exposed these
+trade-executor issues:
+
+| Priority | Finding | Observed impact |
+|---|---|---:|
+| P0 | Vault-test diagnostic positions enter normal statistics serialisation | 56 of the 64 `receipt_analysis_failed` rows |
+| P0 | Synchronous routing bypasses `VaultDepositManager.analyse_deposit()` and `analyse_redemption()` | Five successful Ember deposits and one successful YieldNest deposit were reported as failures |
+| P1 | A successful transaction from an earlier lifecycle step makes a later failure look like receipt analysis | D2 availability and cSigma capacity were both reported as `receipt_analysis_failed` |
+| P1 | Explicitly unsupported adapter directions reach execution | Upshift multi-asset became `execution_failed` |
+| P1 | Async simulation output does not distinguish an unrequested full lifecycle from a manager without an Anvil settlement driver | 28 Lagoon rows used the same broad unsupported status |
+
+## Scope
+
+In scope:
+
+- `tradeexecutor/cli/vault_trade/` attempt preparation, execution and result
+  classification.
+- `tradeexecutor/cli/testtrade.py` support for running a test trade without
+  updating strategy statistics.
+- `tradeexecutor/ethereum/vault/vault_routing.py` consumption of the shared
+  eth-defi receipt-analysis contract.
+- Shared trade-executor helpers needed to translate eth-defi flow analysis into
+  `State.mark_trade_success()`.
+- Persisted vault-test result strings, report details and focused regression
+  tests.
+- A final rerun of the same 129-vault list.
+
+Out of scope:
+
+- Implementing or changing Ember, YieldNest, Upshift, cSigma, D2, Lagoon or
+  other protocol adapters in eth-defi.
+- Decoding protocol-specific custom errors in trade-executor.
+- Treating an on-chain revert as successful because the vault is otherwise
+  supported.
+- Changing global `TradingPosition.is_spot()`, `TradeAnalysis` or equity-curve
+  semantics to understand vault-test diagnostic positions.
+- Automatically enabling privileged Anvil settlement without the existing
+  `--settle-async-on-anvil` opt-in.
+- Changing normal `perform-test-trade` statistics behaviour.
+
+## Dependency contract with eth-defi
+
+The implementation must use shared eth-defi contracts and must not branch on a
+protocol name or vault address.
+
+The current submodule already provides:
+
+- `VaultDepositManager.analyse_deposit(tx_hash, ticket)`.
+- `VaultDepositManager.analyse_redemption(tx_hash, ticket)`.
+- `DepositRedeemEventAnalysis` and `DepositRedeemEventFailure`.
+- `VaultDepositManagerCapability` with directional deposit and redemption
+  support.
+- `VaultBase.get_deposit_manager_capability()`.
+- `VaultFlowUnavailable` with structured direction, requested amount and
+  available amount fields.
+- `UnsupportedVaultSimulation`.
+- `VaultBase.fetch_deposit_closed_reason()`.
+
+The separate eth-defi agent is expected to provide or correct:
+
+1. Protocol-specific receipt analysis for Ember and YieldNest.
+2. An explicit unsupported capability and reason for Upshift multi-asset
+   deposits until an implementation exists.
+3. A protocol-neutral immediate deposit/redemption capacity query.
+4. An explicit capability describing safe Anvil settlement support by
+   direction or ticket type.
+5. Structured availability errors for adapters such as D2 where a pricing
+   estimate is currently rejected with a plain `ValueError`.
+
+eth-defi is a development submodule dependency of trade-executor. Coordinate
+the two workstreams by updating the submodule pointer after the eth-defi agent
+lands each shared API. Do not add runtime version checks, minimum-version
+requirements, `hasattr()` compatibility paths or fallbacks for older eth-defi
+revisions.
+
+Within the current shared contract:
+
+- `None` capability means semantically unknown, not unsupported.
+- Generic exception classification remains the final failure fallback.
+- No fallback may parse protocol-specific exception messages.
+
+The receipt-analysis cutover requires the current eth-defi manager contract.
+`VaultDepositManager.analyse_deposit()` and `analyse_redemption()` are abstract,
+and the generic `ERC4626DepositManager` supplies the standards-compliant default.
+Concrete managers therefore cannot be instantiated without implementations.
+Use the methods directly from the checked-out submodule. Do not retain a
+fallback from a manager analysis error to
+`analyse_4626_flow_transaction()`: that would silently reinterpret a
+protocol-specific parser failure as a generic ERC-4626 success and recreate the
+dispatch bug this plan removes.
+
+## Result contract
+
+Add these persisted outcomes to `VAULT_TEST_RESULTS`:
+
+| Result | Meaning |
+|---|---|
+| `adapter_unsupported` | eth-defi explicitly states that the requested direction is not implemented |
+| `redemption_capacity_limited` | The requested immediate redemption exceeds current protocol capacity |
+| `async_request_only` | The configured simulation confirmed an async request without requesting its full lifecycle |
+
+Retain the existing outcomes:
+
+- `deposit_closed` for a known closed deposit window, paused deposit or zero
+  current deposit capacity.
+- `redemption_unavailable` for a known closed redemption window.
+- `async_request_only` when the default simulation deliberately verifies only
+  an async request.
+- `simulation_unsupported_async` only when a full async lifecycle was requested
+  but no safe Anvil settlement driver is available.
+- `receipt_analysis_failed` only when a mined status-1 transaction exists and
+  its protocol adapter cannot produce a valid flow analysis for that same
+  transaction.
+- `execution_failed` only when no more specific typed or evidence-based outcome
+  applies.
+
+Every typed outcome must preserve a concise `detail`. Capacity results must also
+retain requested and available raw amounts in JSON-safe form. Add a structured
+`outcome_data` mapping to `vault_test_attempt` for such fields instead of
+requiring reporters to parse `detail`.
+
+Example:
+
+```json
+{
+  "result": "redemption_capacity_limited",
+  "detail": "Immediate redemption capacity is below the requested amount",
+  "outcome_data": {
+    "direction": "redeem",
+    "requested_raw_amount": "907757",
+    "available_raw_amount": "45388"
+  }
+}
+```
+
+Keep older state readable. Unknown future result values and missing
+`outcome_data` must continue to round-trip unchanged.
+
+## Work item 1: isolate vault-test diagnostics from statistics
+
+### Problem
+
+`make_test_trade()` serialises long/short statistics after several execution
+steps. A dedicated vault-test state also contains closed diagnostic positions
+created by `record_attempt_result()`. These positions deliberately have no
+trades, so normal analytics eventually call `TradingPosition.is_spot()` and
+assert:
+
+`Cannot determine if position is long or short because there are no trades`
+
+This is a caller-boundary problem. General analytics should continue to assume
+that normal portfolio positions contain trades.
+
+### Changes
+
+1. Add a keyword-only `update_statistics_after_trade: bool = True` argument to
+   `make_test_trade()`.
+2. Extract the repeated statistics update into one small helper and guard all
+   current buy, sell, short and cross-chain call sites with the new option.
+3. Pass `False` from both `VaultTestBatchRunner._execute_simulated()` and
+   `_execute_real()`.
+4. Keep all other callers on the default `True`, including the public
+   `perform-test-trade` command and trade UI.
+5. Do not remove diagnostic positions from state and do not teach statistics
+   modules about `vault_test_attempt` or `TradingPosition.simulated`.
+
+### Tests
+
+- Unit-test that `make_test_trade()` does not call statistics serialisation when
+  the option is false.
+- Unit-test that the default path still updates statistics.
+- Add a vault-test regression with an existing no-trade diagnostic position and
+  verify a later attempt reaches its real execution outcome.
+
+## Work item 2: consume adapter receipt analysis
+
+### Problem
+
+The synchronous branch of `VaultRouting.settle_trade()` calls
+`analyse_4626_flow_transaction()` directly. This ignores the already shared
+`VaultDepositManager` analysis interface and rejects successful protocol event
+variants.
+
+The asynchronous settlement resolver already calls the manager methods, but it
+has separate amount-to-trade conversion logic. The synchronous and asynchronous
+paths must agree on signs, prices and token amounts.
+
+### Changes
+
+1. Dispatch overridden manager receipt analysers with:
+   - `deposit_manager.analyse_deposit(HexBytes(tx_hash), None)` for a
+     synchronous deposit; and
+   - `deposit_manager.analyse_redemption(HexBytes(tx_hash), None)` for a
+     synchronous redemption.
+   Keep the existing generic ERC-4626 analyser only for managers that inherit
+   it unchanged: the Safe wrapper path needs a ticket that synchronous trades
+   do not persist yet.
+2. Extract a pure trade-executor helper with a signature equivalent to
+   `convert_vault_flow_analysis(direction, analysis)` that converts
+   `DepositRedeemEventAnalysis` into:
+   - positive reserve and share quantities for a deposit;
+   - positive reserve and negative share quantity for a redemption; and
+   - a positive reserve-per-share execution price.
+3. Use the conversion helper in both synchronous routing and
+   `settlement_retry.py`. Keep async-only bookkeeping, such as pending-capital
+   allocation, refunds and clearing `vault_settlement_pending_at`, in the
+   settlement resolver.
+4. Keep receipt handling outside the pure conversion helper. The routing or
+   settlement caller owns receipt-status validation and, for the synchronous
+   path, calculates gas cost from `gasUsed * effectiveGasPrice`. Do not require
+   the eth-defi analysis object to imitate `TradeSuccess`.
+5. Introduce a trade-executor `VaultReceiptAnalysisError` at this boundary. It
+   must identify the direction and transaction hash without embedding the full
+   receipt. Raise it when adapter analysis throws or returns an invalid result
+   for a status-1 receipt.
+6. Treat `DepositRedeemEventFailure` as a failed trade with its supplied
+   evidence when the receipt itself failed. A failure object for a status-1
+   receipt is an invalid analysis result and raises `VaultReceiptAnalysisError`.
+7. Validate non-zero denomination and share amounts before marking success.
+   Keep cross-chain quote-token handling in decimal amounts; do not compare the
+   source-chain reserve address with a satellite token address.
+8. Keep the direct generic analyser import only for the documented Safe-wrapper
+   compatibility path.
+
+### Tests
+
+- Unit-test deposit and redemption sign/price conversion.
+- Extend synchronous vault routing tests with a mocked manager returning
+  `DepositRedeemEventAnalysis`; assert exact executed amounts and price.
+- Assert synchronous gas cost is calculated from the matching confirmed
+  receipt.
+- Test reverted `DepositRedeemEventFailure`, malformed status-1 analysis and an
+  adapter exception separately.
+- Assert that the latter two raise `VaultReceiptAnalysisError` carrying the
+  matching transaction hash.
+- Keep the existing async settlement lifecycle tests green and add assertions
+  showing both paths use the same conversion helper.
+- Once the eth-defi adapter branch is integrated, run one Ethereum-fork Ember
+  deposit to prove the adapter method is dispatched.
+
+## Work item 3: preflight explicit adapter support
+
+### Problem
+
+An explicitly unsupported manager shape can currently reach pricing or
+execution and become `execution_failed`. Unknown support and known unsupported
+support must not be conflated.
+
+### Changes
+
+1. After `_choose_operation()` determines `deposit` or `redeem`, inspect
+   `vault.get_deposit_manager_capability()` before pricing or transaction
+   construction.
+2. If the capability explicitly sets the selected direction to `False`, record
+   `adapter_unsupported` as a terminal result and include the eth-defi reason
+   when available.
+3. If the capability is `None`, continue through the existing path. Do not infer
+   support by checking whether a method is overridden.
+4. Do not catch arbitrary `NotImplementedError` globally: programming errors
+   and incomplete unknown adapters must remain visible.
+
+### Tests
+
+- Explicit unsupported deposit and redemption directions produce
+  `adapter_unsupported` without constructing a transaction.
+- Unknown capability continues into normal execution.
+- A supported direction is not blocked because the opposite direction is
+  unsupported.
+
+## Work item 4: normalise availability and capacity outcomes
+
+### Problem
+
+The generic evidence classifier is intentionally phase-based. It cannot by
+itself distinguish a closed vault or capacity limit from an execution bug.
+D2 currently reaches buy pricing before its live funding-window reason becomes
+a terminal result. cSigma reaches transaction construction with an amount above
+`maxRedeem(owner)`.
+
+### Changes
+
+1. Add a vault-test-specific typed-outcome normaliser that accepts the original
+   exception and walks its cause chain before calling
+   `classify_vault_test_failure()`.
+2. Map `VaultReceiptAnalysisError` to `receipt_analysis_failed`. This explicit
+   boundary, not the presence of any earlier status-1 receipt, establishes that
+   receipt analysis failed.
+3. Map structured `VaultFlowUnavailable` using its fields:
+   - deposit availability to `deposit_closed`;
+   - redemption availability to `redemption_unavailable`; and
+   - a redemption with requested and lower available raw amounts to
+     `redemption_capacity_limited`.
+4. Preserve the structured raw amounts in `outcome_data` as decimal strings.
+5. Before requesting a buy price, query
+   `vault.fetch_deposit_closed_reason()`. A non-empty reason produces
+   `deposit_closed` with the exact reason. Catch only the documented
+   unavailable/read exceptions; unexpected adapter errors must still fail.
+6. Once the shared eth-defi capacity query is available, run it before creating
+   a synchronous redemption. Do not silently resize the redemption in this
+   change: partial redemption changes the requested lifecycle and must remain an
+   explicit future feature.
+7. Keep status-0 transaction evidence authoritative so a real revert cannot be
+   hidden by a broad preflight catch.
+8. Remove the rule that any status-1 transaction implies
+   `receipt_analysis_failed`. A multi-step attempt may have a successful bridge
+   or deposit followed by an unrelated pricing, construction or statistics
+   error.
+
+Classification precedence must be deterministic:
+
+1. A status-0 transaction created by the failing operation is
+   `transaction_reverted`.
+2. `VaultReceiptAnalysisError` is `receipt_analysis_failed`.
+3. Structured `VaultFlowUnavailable` maps by direction and capacity fields.
+4. Explicit capability or live closure preflights terminate before execution.
+5. The phase/evidence classifier handles everything else.
+
+When an attempt contains transactions from multiple lifecycle operations,
+status-0 evidence must be associated with the current operation or transaction
+boundary. An earlier reverted or successful bridge/deposit must not relabel a
+later failure. Record the current operation's starting trade/transaction IDs in
+`VaultAttemptContext`, or advance an equivalent evidence cursor before each
+operation, and classify only evidence after that cursor.
+
+### Tests
+
+- D2-style dynamic closure is recorded before pricing and retains the next-open
+  reason.
+- Structured deposit closure, redemption closure and redemption capacity map to
+  distinct outcomes.
+- Capacity raw amounts survive state JSON round-trip and report export.
+- A status-0 receipt still wins as `transaction_reverted`.
+- A successful earlier deposit followed by a capacity or pricing failure does
+  not become `receipt_analysis_failed`.
+- A `VaultReceiptAnalysisError` for a matching status-1 receipt does become
+  `receipt_analysis_failed`.
+- An unrelated `ValueError`, `AssertionError` or `NotImplementedError` is not
+  normalised by message text.
+
+## Work item 5: clarify async simulation outcomes
+
+### Problem
+
+Without `--settle-async-on-anvil`, an async deposit-only simulation is a chosen
+test scope, not evidence that the adapter lacks simulation support. With the
+flag, a manager may still lack a safe driver.
+
+### Changes
+
+1. Keep `--settle-async-on-anvil` as the explicit full-lifecycle opt-in.
+2. When the flag is false, record `async_request_only` with detail such as
+   `Full async lifecycle was not requested`; do not claim the manager is
+   unsupported.
+3. When the flag is true and eth-defi explicitly reports no safe driver, record
+   `simulation_unsupported_async` with direction and manager detail.
+4. After the eth-defi workstream adds `supports_anvil_settlement`, update the
+   submodule and use the field directly as a preflight. Keep
+   `UnsupportedVaultSimulation` handling for a supported driver that rejects
+   the concrete provider or ticket at runtime.
+5. Do not auto-enable force settlement based solely on protocol or on the
+   presence of a `force_settle` method.
+
+Do not overload `success_simulated`, because the full deposit/redemption
+lifecycle did not complete.
+
+### Tests
+
+- Async request-only mode records its configured scope in `detail`.
+- Full-lifecycle mode with a supported driver proceeds to claim/redemption.
+- Full-lifecycle mode with `UnsupportedVaultSimulation` records a terminal
+  unsupported result and continues the batch.
+- A settlement exception other than `UnsupportedVaultSimulation` remains a
+  real execution or transaction failure.
+
+## Work item 6: reporting and compatibility
+
+1. Extend report and TUI presentation for `adapter_unsupported` and
+   `redemption_capacity_limited`.
+2. Export `outcome_data` unchanged in the JSON report.
+3. Keep existing result strings readable and retain unknown future values.
+4. Ensure report rows do not infer a result from display text when the raw
+   attempt result exists.
+5. Document the result meanings in the vault-test command/module documentation.
+
+### Tests
+
+- New result strings round-trip through state JSON and retain display labels.
+- `outcome_data` exports unchanged through `export_vault_test_report()`.
+- TUI/report rows display both new outcomes without deriving the persisted raw
+  result from display text.
+- An unknown future result and missing `outcome_data` remain backwards
+  compatible.
+
+## Implementation order
+
+1. Isolate vault-test statistics updates. This removes the largest false error
+   bucket without waiting for eth-defi.
+2. Consume manager receipt analysis and share amount conversion between sync
+   and async settlement.
+3. Add result schema and typed outcome normalisation.
+4. Add explicit adapter support and capacity preflights as their eth-defi
+   capability changes land.
+5. Clarify async simulation reporting.
+6. Update report presentation and run focused tests.
+7. Rerun the 129-vault list.
+
+Keep commits reviewable along these boundaries. Isolate each eth-defi submodule
+pointer update from the trade-executor consumer changes that follow it; do not
+introduce a separate package-version requirement.
+
+## Verification
+
+Use the parent repository Poetry environment and put this worktree first on
+`PYTHONPATH`:
+
+```shell
+source /home/mikko/code/trade-executor/.local-test.env
+PYTHONPATH="/home/mikko/code/trade-executor-pr1574-ethdefi-vault-support:$PYTHONPATH" \
+  poetry run pytest tests/cli/test_vault_test_trade.py -n auto
+```
+
+Run focused routing and settlement tests individually:
+
+```shell
+source /home/mikko/code/trade-executor/.local-test.env
+PYTHONPATH="/home/mikko/code/trade-executor-pr1574-ethdefi-vault-support:$PYTHONPATH" \
+  poetry run pytest tests/ethereum/test_vault_settlement_lifecycle.py -n auto
+```
+
+Run the existing simulated CLI fork test after unit coverage:
+
+```shell
+source /home/mikko/code/trade-executor/.local-test.env
+PYTHONPATH="/home/mikko/code/trade-executor-pr1574-ethdefi-vault-support:$PYTHONPATH" \
+  poetry run pytest tests/lagoon/test_lagoon_e2e.py \
+  -k vault_test_trade_simulated_deploys_lagoon_on_fork
+```
+
+Finally rerun the same 129 explicit vault IDs twice:
+
+1. Request-only/default mode, to verify configured async outcomes.
+2. `--settle-async-on-anvil`, to verify capability-aware full lifecycle
+   handling.
+
+Compare the new report with
+`/tmp/vault-test-pr1351-rerun-zbzRqL/report.json` when that temporary artefact is
+still available.
+
+## Acceptance criteria
+
+- No vault result fails because long/short statistics inspect a diagnostic
+  no-trade position.
+- Synchronous routing uses overridden `VaultDepositManager` receipt analysis;
+  unchanged generic ERC-4626 manager implementations retain the documented
+  Safe-wrapper compatibility analyser.
+- Ember status-1 deposits become successful once the eth-defi adapter change is
+  present.
+- YieldNest status-1 deposits become successful once its eth-defi ABI/parser
+  change is present.
+- D2 closed funding windows report `deposit_closed` before pricing.
+- cSigma insufficient immediate redemption capacity reports
+  `redemption_capacity_limited` with raw requested and available amounts once
+  the shared eth-defi capacity query or structured exception is available.
+- Explicitly unsupported Upshift multi-asset deposits report
+  `adapter_unsupported` once eth-defi publishes the capability.
+- Async request-only and unsupported full-lifecycle simulations are
+  distinguishable.
+- `receipt_analysis_failed` requires a successful mined receipt plus failed or
+  invalid adapter analysis.
+- A real status-0 receipt remains `transaction_reverted`.
+- The batch continues after every non-infrastructure terminal outcome.
+- Existing state files and unknown result values continue to round-trip.

--- a/docs/plans/trade-executor-vault-test-remaining-fixes.md
+++ b/docs/plans/trade-executor-vault-test-remaining-fixes.md
@@ -1,0 +1,413 @@
+# Trade-executor vault test remaining fixes
+
+## Objective
+
+Complete the remaining trade-executor work exposed by the 129-vault cross-chain
+simulation run after integrating the eth-defi vault support from PR #1357.
+
+The implementation must:
+
+- execute synchronous vault flows through the selected eth-defi deposit manager;
+- settle asynchronous request trades without assuming standard ERC-4626 selectors;
+- classify unsupported adapters and closed deposit windows before pricing;
+- bridge back only the USDC actually received from a satellite vault redemption;
+- preserve transaction-evidence precedence within the operation that failed; and
+- rerun adapter-dependent failures after the corresponding eth-defi fixes land.
+
+The target is trustworthy simulation and diagnostics, not an artificial 100%
+success rate. Live deposit closures, allow-list restrictions and deliberate
+request-only asynchronous results remain valid terminal outcomes.
+
+## Evidence and scope
+
+The latest run covered 129 vaults and produced:
+
+| Result | Count | Interpretation |
+|---|---:|---|
+| `success simulated` | 49 | Complete deposit and redemption simulation |
+| `async_request_only` | 29 | Expected request-only result without forced settlement |
+| `receipt_analysis_failed` | 2 | eth-defi event analysis gap |
+| `execution_failed` | 10 | Mixed trade-executor and adapter gaps |
+| `transaction_reverted` | 5 | Three satellite bridge-back sizing failures plus two adapter-specific failures |
+| `deposit_closed` | 20 | Live vault restriction |
+| `whitelisting-needed` | 14 | Live account restriction |
+| `simulation_unsupported_async` | 0 | Previous generic async simulation gap removed |
+
+This plan covers the trade-executor changes needed to resolve or correctly
+classify the actionable rows. Protocol-specific transaction construction and
+receipt parsing remain in eth-defi.
+
+The ten `execution_failed` rows and the two non-bridge
+`transaction_reverted` rows have the following disposition:
+
+| Vault id | Vault | Current cause | Expected result after fixes | Owner |
+|---|---|---|---|---|
+| `1-0xd5d097f278a735d0a3c609deee71234cac14b47e` | cSigma USD | Generic synchronous redemption bypasses the manager capacity check | `redemption_capacity_limited` | trade-executor request routing |
+| `1-0x438982ea288763370946625fd76c2508ee1fb229` | cSuperior Quality Private Credit USDC | Withdrawal is modelled as an immediate synchronous redemption | An honest queued/request-only result or typed unavailability | eth-defi lifecycle |
+| `1-0x2b13311fd553e74b421d4ccc96e348f71e179dcf` | Ember Apollo ACRED | Redemption is below Ember's minimum | Typed `redemption_unavailable` with minimum/requested amounts | eth-defi failure contract |
+| `1-0x9be9294722f8aad37b11a9792be2c782182cafa2` | Ember Earn | `redeemShares` is not selected for settlement | `async_request_only` or settled success, depending simulation mode | trade-executor request identity; eth-defi ticket metadata |
+| `1-0x0b9342c15143e8f54a83f887c280a922f4c48771` | Ember Polymarket | `redeemShares` is not selected for settlement | `async_request_only` or settled success, depending simulation mode | trade-executor request identity; eth-defi ticket metadata |
+| `1-0xf3190a3ecc109f88e7947b849b281918c798a0c4` | Ember Third Eye | `redeemShares` is not selected for settlement | `async_request_only` or settled success, depending simulation mode | trade-executor request identity; eth-defi ticket metadata |
+| `1-0x373152feef81cc59502da2c8de877b3d5ae2e342` | Ember UDL | `redeemShares` is not selected for settlement | `async_request_only` or settled success, depending simulation mode | trade-executor request identity; eth-defi ticket metadata |
+| `8453-0xad20523a7dc37babc1cc74897e4977232b3d02e5` | Gains gTrade USDC | `makeWithdrawRequest` is not selected for settlement | `async_request_only` or settled success, depending simulation mode | trade-executor request identity; eth-defi ticket metadata |
+| `42161-0xd3443ee1e91af28e5fb858fbd0d72a63ba8046e0` | Gains gTrade USDC | `makeWithdrawRequest` is not selected for settlement | `async_request_only` or settled success, depending simulation mode | trade-executor request identity; eth-defi ticket metadata |
+| `42161-0x75288264fdfea8ce68e6d852696ab1ce2f3e5004` | D2 HYPE++ | Closed funding window reaches pricing as a plain exception | `deposit_closed` with next-open detail | trade-executor preflight; eth-defi structured reason |
+| `143-0x7cd231120a60f500887444a9baf5e1bd753a5e59` | Accountable Hyperithm Delta Neutral Vault | Deposit reverts with undecoded custom error `0x5945ea56` | Decoded `transaction_reverted` or typed preflight unavailability | eth-defi adapter |
+| `1-0x74ad2f789ed583dbd141bbdafc673fe1f033718b` | Upshift Sentora USD Earn | Generic ERC-4626 manager cannot deposit USDC into the multi-asset application flow | `adapter_unsupported` until the eth-defi USDC manager lands, then simulated success | trade-executor preflight; eth-defi P0 implementation |
+
+The three remaining transaction reverts are the Aerodrome USDC, Autopilot USDC
+Morpho and Pharaoh USDC cross-chain close-accounting regressions covered by work
+item 4. The two receipt-analysis rows are covered by work item 6.
+
+## In scope
+
+- `tradeexecutor/ethereum/vault/vault_routing.py`
+- `tradeexecutor/ethereum/swap.py`, only where a generic compatibility change is
+  unavoidable
+- `tradeexecutor/cli/vault_trade/runner.py`
+- `tradeexecutor/cli/vault_trade/state.py`
+- `tradeexecutor/cli/testtrade.py`
+- CCTP and portfolio accounting helpers used by the cross-chain test-trade path
+- focused unit, state lifecycle and fork tests
+- rerunning the same 129 explicit vault ids and publishing a comparable result
+  table
+
+## Out of scope
+
+- Implementing Upshift multi-asset USDC transactions in trade-executor
+- Adding protocol-specific receipt decoders in trade-executor
+- Treating a closed or allow-listed vault as a software failure
+- Automatically reducing a requested cSigma redemption to its current capacity
+- Forcing asynchronous settlement on live chains
+- Changing the semantics of the 29 deliberate `async_request_only` results
+
+## Dependency contract
+
+Trade-executor must consume the public eth-defi manager interfaces instead of
+reimplementing protocol rules:
+
+- `get_deposit_manager_capability()` describes whether deposit and redemption
+  lifecycles are implemented and whether each lifecycle is synchronous or
+  asynchronous.
+- `fetch_deposit_closed_reason()` returns a current, human-readable closure
+  reason when the adapter can determine one.
+- `create_deposit_request()` and `create_redemption_request()` own amount checks
+  and return the ordered protocol calls.
+- A request's `funcs` are the authoritative ordered lifecycle calls. A call
+  returned in `funcs` is always tagged and parsed as a request call, even if its
+  selector happens to be `approve`.
+- Any token allowance transaction which is not part of `funcs` is an executor
+  prerequisite with a separate `vault_approval` role. For a non-vault spender,
+  eth-defi must expose explicit approval requirements on the request; the
+  compatibility default for older request types remains the selected asset and
+  vault address. Trade-executor must not guess a spender from a selector.
+- `VaultFlowUnavailable` carries a typed direction, phase, requested amount and
+  available amount.
+- `DepositRequest.parse_deposit_transaction()` and
+  `RedemptionRequest.parse_redeem_transaction()` interpret the complete ordered
+  request transaction-hash list.
+- `analyse_deposit()` and `analyse_redemption()` return a valid
+  `DepositRedeemEventAnalysis` or a typed failure.
+
+Unknown capability metadata must retain the existing best-effort execution path
+for older adapters. An explicit unsupported capability must fail closed as
+`adapter_unsupported`.
+
+Upshift multi-asset vaults are a priority dependency: until eth-defi advertises
+and implements the selected USDC deposit lifecycle, trade-executor must report
+`adapter_unsupported` before pricing. Once eth-defi adds the USDC manager,
+trade-executor should route through it without an Upshift-specific branch.
+
+## Work item 1: use manager-owned request construction
+
+Refactor `VaultRoutingModel.make_direct_trade()` so both synchronous and
+asynchronous flows begin with the selected manager's request builder.
+
+1. Resolve the executable vault and its deposit manager once.
+2. Call `create_deposit_request(owner=..., raw_amount=...)` for buys and
+   `create_redemption_request(owner=..., raw_shares=...)` for sells.
+3. Sign the request's ordered `funcs` rather than recreating generic
+   `deposit()` or `redeem()` calls with `approve_and_deposit_4626()` and
+   `approve_and_redeem_4626()`.
+4. Build any separate allowance transaction from the request's explicit
+   approval requirement, falling back to the existing asset-to-vault allowance
+   only for legacy request types. Preserve existing guarded Safe/Lagoon wrapper
+   behaviour and do not assume every request call is sent directly to
+   `vault_address`.
+5. Keep synchronous settlement synchronous, but retain sufficient request
+   metadata for its manager analyser.
+6. Let typed `VaultFlowUnavailable` exceptions propagate to the vault runner.
+
+This makes the cSigma capacity-aware manager authoritative. A redemption above
+the available immediate capacity must become
+`redemption_capacity_limited`; trade-executor must not silently resize it.
+
+Unit tests must use a specialised synchronous manager whose request function and
+target differ from the generic ERC-4626 call. They must prove that the manager
+builder is invoked, calls retain their order and a typed capacity failure
+survives transaction building. Add asynchronous buy and sell cases proving both
+manager request builders are used and the legacy generic helpers are not.
+
+## Work item 2: make async receipt selection manager-aware
+
+Remove the dependency between asynchronous vault settlement and the global
+fixed-selector list in `is_swap_function()`.
+
+At construction time, tag every signed transaction with a durable
+`vault_approval` or `vault_request` role. Persist the request ordinal and its
+position within the trade's transaction list as identity; record a transaction
+hash as execution evidence only, never as the durable identity because retry
+signing can change it. Continue storing the raw amount, owner and direction
+required to reconstruct the eth-defi request.
+
+At settlement time:
+
+1. Detect `vault_async_flow` before calling `get_swap_transactions()`.
+2. Select all transactions tagged `vault_request`, ordered by their persisted
+   request ordinal. A separate prerequisite is excluded because its role is
+   `vault_approval`, not because its selector looks like an approval.
+3. Verify that every selected request transaction has a successful receipt.
+4. Pass the complete ordered hash list to
+   `parse_deposit_transaction()` or `parse_redeem_transaction()`.
+5. Use the final request receipt for the lifecycle timestamp unless the parsed
+   ticket exposes a more precise timestamp.
+6. Keep `get_swap_transactions()` for non-async swaps and synchronous
+   compatibility only.
+
+Do not add `redeemShares`, `makeWithdrawRequest` or future protocol names to the
+global selector set. The design must support a manager returning one or several
+arbitrarily named calls.
+
+Tests must cover:
+
+- approval plus one arbitrary request call;
+- a request containing multiple ordered protocol calls;
+- Ember-like `redeemShares` and Gains-like `makeWithdrawRequest` selectors;
+- serialise-and-reload before settlement;
+- a reverted or missing receipt in the selected request set; and
+- unrelated transactions attached to the same trade not being parsed as part
+  of the request.
+
+Persist these additions in optional `other_data` fields so existing state files
+deserialise without a schema migration. For a legacy pending async trade with no
+roles, use the existing `vault_request_tx_count` once to identify the final
+ordered request transactions, stamp the new roles, and persist the upgraded
+state before retrying. Test loading and settling a pre-change state fixture.
+
+## Work item 3: preflight the resolved executable vault
+
+Make capability, admission and closure checks operate on the same resolved vault
+adapter that pricing and routing will execute.
+
+1. Resolve the routed vault once during attempt preparation and store it on the
+   attempt.
+2. Read capability and deposit-window methods from that resolved object instead
+   of relying on optional methods on discovery metadata.
+3. Run adapter capability, allow-list and deposit-closure checks before
+   `pricing_model.can_deposit()` or any estimate call.
+4. Include the adapter's unsupported or closure reason and serialised capability
+   in `outcome_data`.
+5. Preserve best-effort fallback only when the adapter genuinely has no
+   capability API.
+
+Expected regressions:
+
+- D2's “Funding phase closed” condition is `deposit_closed`, with its opening
+  detail, rather than a pricing `RuntimeError`.
+- An unsupported Upshift multi-asset USDC flow is `adapter_unsupported` and does
+  not reach pricing or `get_deposit_manager()`.
+- A future supported Upshift USDC manager follows the normal routing path with
+  no trade-executor protocol special case.
+
+Unit tests must cover an explicitly unsupported capability, a closed deposit
+window, an admitted supported adapter, and an older adapter with no capability
+API. The older-adapter case must continue down the best-effort execution path
+instead of failing closed.
+
+## Work item 4: bridge exact satellite redemption proceeds
+
+Correct the cross-chain close path in `_make_cross_chain_test_trade()` and its
+close-only resume path. `TradingPosition.get_available_bridge_capital()` is an
+accounting value; it must not be the sole source for a CCTP burn amount when the
+wallet received less USDC than planned.
+
+1. Read the satellite denomination-token balance immediately before the
+   redemption request or synchronous close, write it to the attempt's
+   `other_data`, and durably sync the state store before signing or broadcasting
+   any redemption transaction.
+2. Do not create a bridge-back trade while an asynchronous redemption remains
+   pending.
+3. After successful settlement, calculate newly received USDC from the persisted
+   pre-redemption balance and current wallet balance, then compare it with the
+   close trade's `executed_reserve`. Never substitute a fresh post-settlement
+   balance for a missing baseline.
+4. Reconcile the bridge allocation with the actual settled proceeds. Retain the
+   smaller safe amount when RPC balance evidence and analysed event evidence
+   differ, and record the discrepancy for diagnostics.
+5. Build the CCTP close for only that reconciled amount, converted with
+   `TokenDetails.convert_to_raw()`. Leave fee and rounding dust on the
+   satellite chain rather than requesting an impossible transfer.
+6. Persist the measured balance baseline and reconciled bridge-back amount so a
+   resumed close is idempotent and does not measure the same proceeds twice.
+7. Before constructing a burn, find a persisted bridge-back trade for this
+   attempt. If it already has a signed or broadcast transaction, inspect and
+   resume that transaction or its CCTP attestation rather than creating a
+   second burn. Persist the trade id, transaction identity and lifecycle phase.
+8. Represent unbridged raw-unit dust as a residual quantity on the still-open
+   satellite bridge position, with the measured token balance recorded in
+   `other_data`. It may fund a later attempt on that chain. Do not write it off
+   or allow portfolio availability to exceed the on-chain balance; assert the
+   two agree within one raw token unit after reconciliation.
+9. Keep the general portfolio bridge accounting consistent: profit may make
+   allocated bridge capital negative, while a loss or fee must not leave a
+   phantom amount available to burn.
+
+Store the balance baseline, reconciled amount, residual and resume identity as
+optional versioned `other_data` fields. Missing fields in older bridge
+positions mean “not yet measured” only when no redemption transaction has been
+signed. If a legacy or inconsistent state has a signed or settled redemption but
+no baseline, derive the bridge-back amount solely from the manager's analysed
+redemption event evidence on the persisted transaction hashes. If neither a
+persisted baseline nor valid event analysis is available, raise a typed
+`bridge_proceeds_unavailable` outcome and do not construct a CCTP burn. No new
+required dataclass field may break loading an existing state file.
+
+Add unit tests for profit, loss, protocol fee, decimal dust, zero proceeds and a
+resumed asynchronous redemption. The resume test must include a crash after burn
+broadcast but before receipt or attestation processing, and prove that no second
+burn is signed. Add a forced legacy-state crash fixture with a settled redemption
+but no baseline: valid analysed event evidence must recover the amount, while
+missing analysis must produce `bridge_proceeds_unavailable` without signing a
+burn. The dust test must assert both the open residual state and its agreement
+with the wallet balance. Add focused fork regressions for at least one Base
+failure and the Avalanche Pharaoh failure. The three current regression vaults
+are Aerodrome USDC and Autopilot USDC Morpho on Base, and Pharaoh USDC on
+Avalanche.
+
+## Work item 5: scope failure evidence to the current operation
+
+Keep a status-zero transaction as the highest-priority classification, but only
+when that transaction belongs to the operation that raised the failure.
+
+1. Extend `VaultAttemptContext` with an operation evidence cursor captured
+   immediately before each preflight, build, execute or settlement operation.
+2. Capture only transactions and call context newer than that cursor when
+   recording the operation's failure.
+3. Preserve the current precedence within that evidence:
+   `transaction_reverted`, `broadcast_failed`, `gas_estimation_reverted`, then
+   typed or phase-derived failure.
+4. Persist the operation and phase with the evidence so reports remain
+   explainable after the Anvil fork is gone.
+
+Tests must prove:
+
+- a successful earlier CCTP bridge does not hide a later typed capacity result;
+- an unrelated earlier revert does not turn a later preflight failure into
+  `transaction_reverted`;
+- a status-zero transaction produced by the current operation overrides a
+  wrapped typed exception; and
+- a settlement failure sees request or claim transactions from that settlement
+  operation, but not unrelated transactions from another vault attempt.
+
+## Work item 6: rerun adapter-dependent receipt failures
+
+Do not add Yearn or YieldNest event parsing to trade-executor. After eth-defi
+returns valid `DepositRedeemEventAnalysis` values for Yearn Arche USD redemption
+and YieldNest RWA MAX deposit:
+
+1. add focused routing tests that exercise the manager analyser result;
+2. verify `VaultRoutingModel.settle_trade()` records executed shares, reserves
+   and price from that result; and
+3. rerun those explicit vault ids before the full matrix.
+
+If eth-defi still returns `DepositRedeemEventFailure` or raises during analysis,
+trade-executor must retain the typed `receipt_analysis_failed` outcome with the
+transaction hash and direction.
+
+## Test strategy
+
+Implement the smallest focused layers first:
+
+1. Unit-test manager request construction and persisted async request identity.
+2. Unit-test resolved-adapter preflight and operation-scoped classification.
+3. Unit-test bridge-back reconciliation and resume state.
+4. Run the existing CLI vault and settlement lifecycle modules.
+5. Run focused Base and Avalanche fork regressions.
+6. Run the same 129 explicit vault ids, using the same funding, block and async
+   settlement settings as the baseline.
+
+The final report must include counts by terminal result and a protocol-level
+table for every remaining actionable gap. Each row must state the vault id,
+chain, protocol, operation, result, short cause and owning repository.
+
+## Implementation order
+
+1. Introduce manager-owned request construction and request transaction roles.
+2. Update asynchronous parsing to consume those roles.
+3. Resolve and preflight the executable adapter.
+4. Add operation evidence cursors.
+5. Reconcile actual satellite redemption proceeds before CCTP bridge-back.
+6. Add adapter-dependent regression tests after the matching eth-defi changes.
+7. Run focused tests, then the unchanged 129-vault matrix.
+
+This order establishes the transaction and diagnostic contracts before changing
+cross-chain accounting, which makes later failures attributable to one
+operation.
+
+## Acceptance criteria
+
+- Specialised synchronous managers, including cSigma, own request validation and
+  transaction construction.
+- Capacity-limited cSigma redemptions are
+  `redemption_capacity_limited`, with requested and available raw shares.
+- Arbitrarily named asynchronous request functions settle without changes to
+  `is_swap_function()`.
+- D2 funding-window closures are `deposit_closed` before pricing.
+- Upshift multi-asset USDC is `adapter_unsupported` until eth-defi advertises a
+  supported USDC manager, then automatically uses that manager.
+- Satellite bridge-back never exceeds the USDC actually made available by the
+  completed redemption.
+- A missing pre-redemption baseline never falls back to a post-settlement wallet
+  read: valid manager event analysis recovers the amount, otherwise the attempt
+  stops as `bridge_proceeds_unavailable` without a burn.
+- The Aerodrome, Autopilot and Pharaoh bridge-back regressions no longer revert
+  with an insufficient token balance.
+- Only current-operation status-zero evidence takes precedence over typed
+  outcomes.
+- Yearn and YieldNest receipt results become successful when their eth-defi
+  analysers return valid event analysis; otherwise they remain explicit
+  `receipt_analysis_failed` rows.
+- Existing 20 `deposit_closed`, 14 `whitelisting-needed` and 29
+  `async_request_only` outcomes are not treated as acceptance failures.
+- Every vault in the twelve-row disposition table reaches its stated expected
+  outcome, or remains as an explicitly owned eth-defi dependency with the
+  transaction evidence needed to reproduce it.
+- The final matrix accounts for all 129 requested vault ids without an
+  unclassified exception.
+
+`whitelisting-needed` is an existing persisted public result literal, not an
+enum member or value introduced by this work. Renaming it is outside this plan
+because it would require a report-schema compatibility migration.
+
+## Verification commands
+
+Run tests from this worktree through the parent repository's Poetry environment,
+with the worktree and its eth-defi submodule first on `PYTHONPATH`:
+
+```shell
+source /home/mikko/code/trade-executor/.local-test.env
+cd /home/mikko/code/trade-executor
+poetry run bash -c 'cd "$1"; export PYTHONPATH="$PWD:$PWD/deps/web3-ethereum-defi:$PYTHONPATH"; exec pytest -n auto tests/cli/test_vault_trade_*.py' bash /home/mikko/code/trade-executor-pr1574-ethdefi-vault-support
+```
+
+```shell
+source /home/mikko/code/trade-executor/.local-test.env
+cd /home/mikko/code/trade-executor
+poetry run bash -c 'cd "$1"; export PYTHONPATH="$PWD:$PWD/deps/web3-ethereum-defi:$PYTHONPATH"; exec pytest -n auto tests/ethereum/vault/test_vault_settlement_*.py' bash /home/mikko/code/trade-executor-pr1574-ethdefi-vault-support
+```
+
+Run new focused test files individually with the same environment. Use
+`--log-cli-level=info` only while diagnosing a failure, not in committed test
+configuration. When invoking a multi-test command through the execution tool,
+set its timeout to at least 360 seconds; use at least 180 seconds for an
+individual test command.

--- a/tests/cli/test_vault_test_trade.py
+++ b/tests/cli/test_vault_test_trade.py
@@ -3,11 +3,14 @@
 import json
 import logging
 from collections import defaultdict, deque
+from decimal import Decimal
 from pathlib import Path
 from unittest.mock import MagicMock
 
 import pytest
 from eth_defi.vault.base import VaultSpec
+from eth_defi.vault.deposit_redeem import VaultFlowUnavailable
+from hexbytes import HexBytes
 from requests.exceptions import ReadTimeout
 from textual.app import App, ComposeResult
 from textual.widgets import DataTable, Input
@@ -53,11 +56,16 @@ from tradeexecutor.cli.vault_trade.simulation import (
 from tradeexecutor.cli.vault_trade.runner import (
     VaultAttemptContext,
     VaultTestBatchRunner,
+    get_adapter_unsupported_detail,
     get_bridge_conflict,
+    get_deposit_closed_detail,
     get_whitelisting_needed_detail,
+    normalise_vault_flow_failure,
     should_leave_deposit_open,
 )
 from tradeexecutor.ethereum import web3config as web3config_module
+from tradeexecutor.ethereum.vault import vault_routing
+from tradeexecutor.ethereum.vault.vault_routing import convert_vault_flow_analysis
 from tradeexecutor.ethereum.web3config import Web3Config
 from tradeexecutor.cli.log import setup_custom_log_levels
 from tradeexecutor.state.identifier import AssetIdentifier
@@ -421,6 +429,7 @@ def test_whitelisting_needed_status_round_trips_as_report_outcome() -> None:
         simulated=True,
         result="whitelisting-needed",
         detail="Vault requires whitelisting for executor Safe 0x1",
+        outcome_data={"executor_safe": "0x1"},
     )
 
     # 2. Serialise and reload the normal state JSON.
@@ -434,6 +443,50 @@ def test_whitelisting_needed_status_round_trips_as_report_outcome() -> None:
         [{"vault id": spec.as_string_id(), "status": "whitelisting-needed"}],
     )
     assert report["results"][0]["attempt"]["result"] == "whitelisting-needed"
+    assert report["results"][0]["attempt"]["outcome_data"] == {
+        "executor_safe": "0x1"
+    }
+
+
+def test_async_request_only_status_round_trips_as_report_outcome() -> None:
+    """A request-only simulation is distinct from unsupported settlement.
+
+    1. Record an async request-only simulated attempt.
+    2. Serialise and reload the normal state JSON.
+    3. Verify the raw result and display status remain distinct and readable.
+    """
+    # 1. Record an async request-only simulated attempt.
+    state = State()
+    reserve_asset = AssetIdentifier(
+        ChainId.base.value,
+        "0x0000000000000000000000000000000000000010",
+        "USDC",
+        6,
+    )
+    state.portfolio.initialise_reserves(reserve_asset, reserve_token_price=1.0)
+    spec = VaultSpec(
+        ChainId.arbitrum.value,
+        "0x0000000000000000000000000000000000000020",
+    )
+    position = record_attempt_result(
+        state,
+        create_vault_test_diagnostic_pair(spec, reserve_asset),
+        spec,
+        simulated=True,
+        result="async_request_only",
+        detail="Async deposit request completed; full lifecycle was not requested",
+    )
+
+    # 2. Serialise and reload the normal state JSON.
+    restored = State.from_json(state.to_json_safe())
+    restored_position = restored.portfolio.get_position_by_id(position.position_id)
+
+    # 3. Verify the raw result and display status remain distinct and readable.
+    assert get_vault_test_status(restored_position) == "async request only"
+    assert (
+        restored_position.other_data["vault_test_attempt"]["result"]
+        == "async_request_only"
+    )
 
 
 def test_vault_test_failure_persists_redacted_traceback_and_revert_evidence() -> None:
@@ -587,7 +640,7 @@ def test_vault_failure_classifier_uses_transaction_evidence() -> None:
     """Failure status is determined by lifecycle evidence rather than text.
 
     1. Classify a preflight exception with no transaction evidence.
-    2. Classify reverted, successful and broadcast receipts during execution.
+    2. Classify reverted and broadcast receipts during execution.
     3. Verify unsigned call context and no-evidence execution classifications.
     """
     # 1. Classify a preflight exception with no transaction evidence.
@@ -596,7 +649,7 @@ def test_vault_failure_classifier_uses_transaction_evidence() -> None:
         == "preflight_failed"
     )
 
-    # 2. Classify reverted and successful receipts during execution.
+    # 2. Classify reverted and broadcast receipts during execution.
     assert (
         classify_vault_test_failure(
             phase="execute",
@@ -609,7 +662,7 @@ def test_vault_failure_classifier_uses_transaction_evidence() -> None:
             phase="execute",
             error_data={"transactions": [{"status": True}]},
         )
-        == "receipt_analysis_failed"
+        == "execution_failed"
     )
     assert (
         classify_vault_test_failure(
@@ -1047,12 +1100,190 @@ def test_failure_attachment_ignores_positions_from_previous_attempts() -> None:
         result="preflight_failed",
         detail="RPC unavailable",
         error_data={},
+        outcome_data=None,
         previous=old_position,
     )
 
     # 3. Verify the earlier attempt's success metadata remains unchanged.
     assert attached_position_id is None
     assert old_position.other_data["vault_test_attempt"] == {"result": "success"}
+
+
+def test_vault_flow_failures_have_typed_report_outcomes() -> None:
+    """Typed eth-defi flow failures retain their protocol capacity context.
+
+    1. Create a redemption failure with a requested amount above available capacity.
+    2. Normalise the error through the vault-test reporting helper.
+    3. Verify the result and JSON-safe capacity evidence are explicit.
+    """
+    # 1. Create a redemption failure with a requested amount above available capacity.
+    error = VaultFlowUnavailable(
+        "Only part of the redemption is currently available at https://rpc.example/api-key",
+        protocol="csigma",
+        direction="redeem",
+        phase="preflight",
+        requested_raw_amount=200,
+        available_raw_amount=100,
+    )
+
+    # 2. Normalise the error through the vault-test reporting helper.
+    result, detail, outcome_data = normalise_vault_flow_failure(error)
+
+    # 3. Verify the result and JSON-safe capacity evidence are explicit.
+    assert result == "redemption_capacity_limited"
+    assert detail == "Only part of the redemption is currently available at <redacted-url>"
+    assert outcome_data == {
+        "protocol": "csigma",
+        "direction": "redeem",
+        "phase": "preflight",
+        "requested_raw_amount": "200",
+        "available_raw_amount": "100",
+    }
+
+
+def test_adapter_capability_gap_is_reported_before_execution() -> None:
+    """Unsupported eth-defi adapters become terminal diagnostics before routing.
+
+    1. Model a vault whose manager explicitly declines redemption support.
+    2. Check the batch preflight helper for a redemption operation.
+    3. Verify the result contains the directional capability record.
+    """
+    # 1. Model a vault whose manager explicitly declines redemption support.
+    capability = MagicMock()
+    capability.can_deposit = True
+    capability.can_redeem = False
+    capability.as_dict.return_value = {"can_deposit": True, "can_redeem": False}
+    vault = MagicMock()
+    vault.get_deposit_manager_capability.return_value = capability
+    attempt = MagicMock(vault=vault)
+
+    # 2. Check the batch preflight helper for a redemption operation.
+    detail, outcome_data = get_adapter_unsupported_detail(attempt, "redeem")
+
+    # 3. Verify the result contains the directional capability record.
+    assert detail == "eth-defi adapter does not support redeem for this vault"
+    assert outcome_data == {
+        "operation": "redeem",
+        "capability": {"can_deposit": True, "can_redeem": False},
+    }
+
+
+def test_unknown_adapter_capability_continues_to_execution() -> None:
+    """Unknown adapter support does not become an unsupported result.
+
+    1. Model a vault whose eth-defi adapter has no published capability.
+    2. Run the directional preflight helper for a deposit.
+    3. Verify the helper leaves the normal execution path available.
+    """
+    # 1. Model a vault whose eth-defi adapter has no published capability.
+    vault = MagicMock()
+    vault.get_deposit_manager_capability.return_value = None
+    attempt = MagicMock(vault=vault)
+
+    # 2. Run the directional preflight helper for a deposit.
+    result = get_adapter_unsupported_detail(attempt, "deposit")
+
+    # 3. Verify the helper leaves the normal execution path available.
+    assert result is None
+
+
+def test_adapter_without_capability_api_continues_to_execution() -> None:
+    """Adapters without the optional eth-defi capability API retain their flow.
+
+    1. Model a legacy vault adapter without capability metadata.
+    2. Run the directional preflight helper for a deposit.
+    3. Verify the helper leaves the normal execution path available.
+    """
+    # 1. Model a legacy vault adapter without capability metadata.
+    attempt = MagicMock(vault=object())
+
+    # 2. Run the directional preflight helper for a deposit.
+    result = get_adapter_unsupported_detail(attempt, "deposit")
+
+    # 3. Verify the helper leaves the normal execution path available.
+    assert result is None
+
+
+def test_adapter_without_deposit_closure_api_continues_to_execution() -> None:
+    """Legacy adapters without a closure probe continue to their normal flow.
+
+    1. Model a legacy vault adapter without deposit-closure metadata.
+    2. Read its closure detail through the batch preflight helper.
+    3. Verify the helper leaves the normal execution path available.
+    """
+    # 1. Model a legacy vault adapter without deposit-closure metadata.
+    attempt = MagicMock(vault=object())
+
+    # 2. Read its closure detail through the batch preflight helper.
+    result = get_deposit_closed_detail(attempt)
+
+    # 3. Verify the helper leaves the normal execution path available.
+    assert result is None
+
+
+def test_vault_flow_analysis_conversion_preserves_trade_signs() -> None:
+    """Shared receipt conversion uses the same signs for sync and async settlement.
+
+    1. Model a successful manager analysis with reserve and share quantities.
+    2. Convert it once as a deposit and once as a redemption.
+    3. Verify reserve, share sign and price follow the executor trade contract.
+    """
+    # 1. Model a successful manager analysis with reserve and share quantities.
+    analysis = MagicMock(
+        denomination_amount=Decimal("10"),
+        share_count=Decimal("8"),
+    )
+
+    # 2. Convert it once as a deposit and once as a redemption.
+    deposit = convert_vault_flow_analysis(analysis, direction="deposit")
+    redemption = convert_vault_flow_analysis(analysis, direction="redeem")
+
+    # 3. Verify reserve, share sign and price follow the executor trade contract.
+    assert deposit == (Decimal("10"), Decimal("8"), Decimal("1.25"))
+    assert redemption == (Decimal("10"), Decimal("-8"), Decimal("1.25"))
+
+
+def test_reverted_synchronous_vault_trade_skips_receipt_manager(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A status-zero receipt is reported before a manager tries event parsing.
+
+    1. Build a synchronous vault trade with a reverted receipt.
+    2. Settle it with a manager whose analyser would fail if called.
+    3. Verify normal trade failure reporting occurs without manager analysis.
+    """
+    # 1. Build a synchronous vault trade with a reverted receipt.
+    routing = vault_routing.VaultRouting(
+        "0x0000000000000000000000000000000000000001"
+    )
+    tx_hash = HexBytes("0x" + "01" * 32)
+    swap_transaction = MagicMock(tx_hash=tx_hash)
+    trade = MagicMock()
+    trade.other_data = {}
+    trade.is_buy.return_value = True
+    vault = MagicMock()
+    report_failure = MagicMock()
+    receipt = {"status": 0, "blockNumber": 123}
+
+    # 2. Settle it with a manager whose analyser would fail if called.
+    monkeypatch.setattr(vault_routing, "get_vault_for_pair", lambda *_, **__: vault)
+    monkeypatch.setattr(
+        vault_routing,
+        "get_swap_transactions",
+        lambda _: swap_transaction,
+    )
+    monkeypatch.setattr(vault_routing, "get_block_timestamp", lambda *_: None)
+    monkeypatch.setattr(vault_routing, "report_failure", report_failure)
+    routing.settle_trade(
+        MagicMock(),
+        MagicMock(),
+        trade,
+        {tx_hash: receipt},
+    )
+
+    # 3. Verify normal trade failure reporting occurs without manager analysis.
+    report_failure.assert_called_once()
+    vault.get_deposit_manager.assert_not_called()
 
 
 def test_vault_test_report_reads_the_latest_run_record() -> None:

--- a/tests/cli/test_vault_test_trade.py
+++ b/tests/cli/test_vault_test_trade.py
@@ -54,6 +54,7 @@ from tradeexecutor.cli.vault_trade.runner import (
     VaultAttemptContext,
     VaultTestBatchRunner,
     get_bridge_conflict,
+    get_whitelisting_needed_detail,
     should_leave_deposit_open,
 )
 from tradeexecutor.ethereum import web3config as web3config_module
@@ -358,6 +359,81 @@ def test_adapter_failure_can_be_recorded_as_a_normal_position() -> None:
         position.position_id
     )
     assert restored_position.simulated is False
+
+
+def test_whitelisted_vault_permission_gap_is_reported_before_execution() -> None:
+    """A known vault allow-list denial gets a dedicated report outcome.
+
+    1. Model an eth-defi vault adapter that requires a whitelisted depositor.
+    2. Resolve the executor Safe address through the pricing route.
+    3. Verify the report helper classifies only the denied account.
+    """
+    # 1. Model an eth-defi vault adapter that requires a whitelisted depositor.
+    vault = MagicMock()
+    vault.is_whitelisted_deposit.return_value = True
+    vault.is_account_whitelisted.return_value = False
+
+    # 2. Resolve the executor Safe address through the pricing route.
+    pair = MagicMock()
+    route = MagicMock()
+    route.get_vault.return_value = vault
+    route.get_owner_address.return_value = "0x0000000000000000000000000000000000000001"
+    pricing_model = MagicMock()
+    pricing_model.route.return_value = route
+    attempt = MagicMock(pair=pair, pricing_model=pricing_model)
+
+    # 3. Verify the report helper classifies only the denied account.
+    detail = get_whitelisting_needed_detail(attempt)
+    assert detail == (
+        "Vault requires whitelisting for executor Safe "
+        "0x0000000000000000000000000000000000000001"
+    )
+    vault.is_account_whitelisted.return_value = True
+    assert get_whitelisting_needed_detail(attempt) is None
+    vault.is_whitelisted_deposit.return_value = False
+    assert get_whitelisting_needed_detail(attempt) is None
+
+
+def test_whitelisting_needed_status_round_trips_as_report_outcome() -> None:
+    """The new whitelisting outcome remains stable in state and reports.
+
+    1. Record a whitelisting-needed diagnostic attempt.
+    2. Serialise and reload the normal state JSON.
+    3. Verify display status and report output preserve the exact condition.
+    """
+    # 1. Record a whitelisting-needed diagnostic attempt.
+    state = State()
+    reserve_asset = AssetIdentifier(
+        ChainId.base.value,
+        "0x0000000000000000000000000000000000000010",
+        "USDC",
+        6,
+    )
+    state.portfolio.initialise_reserves(reserve_asset, reserve_token_price=1.0)
+    spec = VaultSpec(
+        ChainId.arbitrum.value,
+        "0x0000000000000000000000000000000000000020",
+    )
+    position = record_attempt_result(
+        state,
+        create_vault_test_diagnostic_pair(spec, reserve_asset),
+        spec,
+        simulated=True,
+        result="whitelisting-needed",
+        detail="Vault requires whitelisting for executor Safe 0x1",
+    )
+
+    # 2. Serialise and reload the normal state JSON.
+    restored = State.from_json(state.to_json_safe())
+    restored_position = restored.portfolio.get_position_by_id(position.position_id)
+
+    # 3. Verify display status and report output preserve the exact condition.
+    assert get_vault_test_status(restored_position) == "whitelisting-needed"
+    report = export_vault_test_report(
+        restored,
+        [{"vault id": spec.as_string_id(), "status": "whitelisting-needed"}],
+    )
+    assert report["results"][0]["attempt"]["result"] == "whitelisting-needed"
 
 
 def test_vault_test_failure_persists_redacted_traceback_and_revert_evidence() -> None:

--- a/tests/cli/test_vault_test_trade.py
+++ b/tests/cli/test_vault_test_trade.py
@@ -394,7 +394,11 @@ def test_whitelisted_vault_permission_gap_is_reported_before_execution() -> None
     route.get_owner_address.return_value = "0x0000000000000000000000000000000000000001"
     pricing_model = MagicMock()
     pricing_model.route.return_value = route
-    attempt = MagicMock(pair=pair, pricing_model=pricing_model)
+    attempt = MagicMock(
+        pair=pair,
+        pricing_model=pricing_model,
+        executable_vault=vault,
+    )
 
     # 3. Verify the report helper classifies only the denied account.
     detail = get_whitelisting_needed_detail(attempt)
@@ -1184,7 +1188,7 @@ def test_adapter_capability_gap_is_reported_before_execution() -> None:
     capability.as_dict.return_value = {"can_deposit": True, "can_redeem": False}
     vault = MagicMock()
     vault.get_deposit_manager_capability.return_value = capability
-    attempt = MagicMock(vault=vault)
+    attempt = MagicMock(vault=vault, executable_vault=vault)
 
     # 2. Check the batch preflight helper for a redemption operation.
     detail, outcome_data = get_adapter_unsupported_detail(attempt, "redeem")
@@ -1207,7 +1211,7 @@ def test_unknown_adapter_capability_continues_to_execution() -> None:
     # 1. Model a vault whose eth-defi adapter has no published capability.
     vault = MagicMock()
     vault.get_deposit_manager_capability.return_value = None
-    attempt = MagicMock(vault=vault)
+    attempt = MagicMock(vault=vault, executable_vault=vault)
 
     # 2. Run the directional preflight helper for a deposit.
     result = get_adapter_unsupported_detail(attempt, "deposit")
@@ -1224,7 +1228,8 @@ def test_adapter_without_capability_api_continues_to_execution() -> None:
     3. Verify the helper leaves the normal execution path available.
     """
     # 1. Model a legacy vault adapter without capability metadata.
-    attempt = MagicMock(vault=object())
+    vault = object()
+    attempt = MagicMock(vault=vault, executable_vault=vault)
 
     # 2. Run the directional preflight helper for a deposit.
     result = get_adapter_unsupported_detail(attempt, "deposit")
@@ -1241,7 +1246,8 @@ def test_adapter_without_deposit_closure_api_continues_to_execution() -> None:
     3. Verify the helper leaves the normal execution path available.
     """
     # 1. Model a legacy vault adapter without deposit-closure metadata.
-    attempt = MagicMock(vault=object())
+    vault = object()
+    attempt = MagicMock(vault=vault, executable_vault=vault)
 
     # 2. Read its closure detail through the batch preflight helper.
     result = get_deposit_closed_detail(attempt)

--- a/tests/cli/test_vault_test_trade.py
+++ b/tests/cli/test_vault_test_trade.py
@@ -1,5 +1,6 @@
 """Unit tests for the standalone vault-test-trade command helpers."""
 
+import datetime
 import json
 import logging
 from collections import defaultdict, deque
@@ -63,9 +64,14 @@ from tradeexecutor.cli.vault_trade.runner import (
     normalise_vault_flow_failure,
     should_leave_deposit_open,
 )
+from tradeexecutor.cli.testtrade import BridgeProceedsUnavailable
 from tradeexecutor.ethereum import web3config as web3config_module
 from tradeexecutor.ethereum.vault import vault_routing
-from tradeexecutor.ethereum.vault.vault_routing import convert_vault_flow_analysis
+from tradeexecutor.ethereum.vault.vault_routing import (
+    convert_vault_flow_analysis,
+    get_async_vault_request_transactions,
+)
+from tradeexecutor.state.blockhain_transaction import BlockchainTransaction
 from tradeexecutor.ethereum.web3config import Web3Config
 from tradeexecutor.cli.log import setup_custom_log_levels
 from tradeexecutor.state.identifier import AssetIdentifier
@@ -1125,6 +1131,8 @@ def test_vault_flow_failures_have_typed_report_outcomes() -> None:
         requested_raw_amount=200,
         available_raw_amount=100,
     )
+    error.minimum_raw_amount = 10
+    error.next_open = datetime.datetime(2026, 7, 24, 12, 30)
 
     # 2. Normalise the error through the vault-test reporting helper.
     result, detail, outcome_data = normalise_vault_flow_failure(error)
@@ -1138,7 +1146,28 @@ def test_vault_flow_failures_have_typed_report_outcomes() -> None:
         "phase": "preflight",
         "requested_raw_amount": "200",
         "available_raw_amount": "100",
+        "minimum_raw_amount": "10",
+        "next_open": "2026-07-24T12:30:00",
     }
+
+
+def test_bridge_proceeds_failure_has_typed_report_outcome() -> None:
+    """Unavailable satellite redemption proceeds stay distinguishable in reports.
+
+    1. Create the bridge reconciliation failure.
+    2. Normalise it through the vault-test reporting helper.
+    3. Verify the report records the actionable bridge outcome.
+    """
+    # 1. Create the bridge reconciliation failure.
+    error = BridgeProceedsUnavailable("bridge_proceeds_unavailable: no new USDC")
+
+    # 2. Normalise it through the vault-test reporting helper.
+    result, detail, outcome_data = normalise_vault_flow_failure(error)
+
+    # 3. Verify the report records the actionable bridge outcome.
+    assert result == "bridge_proceeds_unavailable"
+    assert detail == "bridge_proceeds_unavailable: no new USDC"
+    assert outcome_data == {}
 
 
 def test_adapter_capability_gap_is_reported_before_execution() -> None:
@@ -1241,6 +1270,134 @@ def test_vault_flow_analysis_conversion_preserves_trade_signs() -> None:
     # 3. Verify reserve, share sign and price follow the executor trade contract.
     assert deposit == (Decimal("10"), Decimal("8"), Decimal("1.25"))
     assert redemption == (Decimal("10"), Decimal("-8"), Decimal("1.25"))
+
+
+def test_async_vault_request_transaction_roles_ignore_selectors() -> None:
+    """Async settlement selects persisted request roles instead of function names.
+
+    1. Create an approval and two arbitrarily named manager request transactions.
+    2. Select the manager request transaction set for settlement.
+    3. Verify approval exclusion and request ordering do not depend on selectors.
+    """
+    # 1. Create an approval and two arbitrarily named manager request transactions.
+    approval = BlockchainTransaction(function_selector="approve", other={
+        "vault_transaction_role": "vault_approval",
+    })
+    second_request = BlockchainTransaction(function_selector="makeWithdrawRequest", other={
+        "vault_transaction_role": "vault_request",
+        "vault_request_ordinal": 1,
+    })
+    first_request = BlockchainTransaction(function_selector="redeemShares", other={
+        "vault_transaction_role": "vault_request",
+        "vault_request_ordinal": 0,
+    })
+    trade = MagicMock(
+        blockchain_transactions=[approval, second_request, first_request],
+        other_data={},
+    )
+
+    # 2. Select the manager request transaction set for settlement.
+    selected = get_async_vault_request_transactions(
+        trade,
+        request_function_count=2,
+    )
+
+    # 3. Verify approval exclusion and request ordering do not depend on selectors.
+    assert selected == [first_request, second_request]
+
+
+def test_async_vault_request_transaction_legacy_upgrade() -> None:
+    """Legacy pending requests gain durable roles before their settlement retry.
+
+    1. Create a legacy approval plus manager request transaction set without roles.
+    2. Select the final manager calls using the rebuilt request function count.
+    3. Verify role metadata and durable transaction indices are persisted.
+    """
+    # 1. Create a legacy approval plus manager request transaction set without roles.
+    approval = BlockchainTransaction(function_selector="approve")
+    first_request = BlockchainTransaction(function_selector="redeemShares")
+    second_request = BlockchainTransaction(function_selector="makeWithdrawRequest")
+    trade = MagicMock(
+        trade_id=42,
+        blockchain_transactions=[approval, first_request, second_request],
+        other_data={},
+    )
+
+    # 2. Select the final manager calls using the rebuilt request function count.
+    selected = get_async_vault_request_transactions(
+        trade,
+        request_function_count=2,
+    )
+
+    # 3. Verify role metadata and durable transaction indices are persisted.
+    assert selected == [first_request, second_request]
+    assert trade.other_data["vault_request_transaction_indices"] == [1, 2]
+    assert first_request.other["vault_request_ordinal"] == 0
+    assert second_request.other["vault_request_ordinal"] == 1
+
+
+def test_async_settlement_parses_only_manager_request_transactions(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Async settlement gives manager parsing only persisted request calls.
+
+    1. Model an approval and an arbitrarily named async manager request.
+    2. Settle the trade with successful receipts for both transactions.
+    3. Verify the manager sees only the request hash and no global selector is used.
+    """
+    # 1. Model an approval and an arbitrarily named async manager request.
+    approval_hash = HexBytes("0x" + "01" * 32)
+    request_hash = HexBytes("0x" + "02" * 32)
+    approval = BlockchainTransaction(
+        tx_hash=approval_hash,
+        function_selector="approve",
+        other={"vault_transaction_role": "vault_approval"},
+    )
+    request = BlockchainTransaction(
+        tx_hash=request_hash,
+        function_selector="redeemShares",
+        other={
+            "vault_transaction_role": "vault_request",
+            "vault_request_ordinal": 0,
+        },
+    )
+    trade = MagicMock()
+    trade.trade_id = 12
+    trade.other_data = {
+        "vault_async_flow": True,
+        "vault_direction": "deposit",
+        "vault_owner_address": "0x0000000000000000000000000000000000000001",
+        "vault_raw_amount": "1000000",
+    }
+    trade.blockchain_transactions = [approval, request]
+    trade.is_buy.return_value = True
+    manager = MagicMock()
+    manager_request = MagicMock(funcs=[MagicMock()])
+    manager.create_deposit_request.return_value = manager_request
+    manager.serialize_deposit_ticket.return_value = {"ticket": "request"}
+    vault = MagicMock()
+    vault.get_deposit_manager.return_value = manager
+    routing = vault_routing.VaultRouting(
+        "0x0000000000000000000000000000000000000001"
+    )
+    state = MagicMock()
+
+    # 2. Settle the trade with successful receipts for both transactions.
+    monkeypatch.setattr(vault_routing, "get_vault_for_pair", lambda *_, **__: vault)
+    monkeypatch.setattr(vault_routing, "get_block_timestamp", lambda *_: None)
+    routing.settle_trade(
+        MagicMock(),
+        state,
+        trade,
+        {
+            approval_hash: {"status": 1, "blockNumber": 100},
+            request_hash: {"status": 1, "blockNumber": 101},
+        },
+    )
+
+    # 3. Verify the manager sees only the request hash and no global selector is used.
+    manager_request.parse_deposit_transaction.assert_called_once_with([request_hash])
+    state.mark_vault_settlement_pending.assert_called_once()
 
 
 def test_reverted_synchronous_vault_trade_skips_receipt_manager(

--- a/tests/units_tests/test_cross_chain_satellite_async_settlement.py
+++ b/tests/units_tests/test_cross_chain_satellite_async_settlement.py
@@ -374,7 +374,7 @@ def test_cross_chain_close_resumes_bridge_back_after_async_redemption_settles(mo
     """A later invocation finishes CCTP after an async redemption has settled.
 
     1. Model a closed satellite position and its still-open CCTP bridge position.
-    2. Make the position manager create a successful bridge-back trade.
+    2. Make the proceeds reconciler and position manager create a successful bridge-back trade.
     3. Run the close-only cross-chain flow as a later command invocation.
     4. Verify it skips a second vault redemption and closes only the bridge.
     """
@@ -394,12 +394,22 @@ def test_cross_chain_close_resumes_bridge_back_after_async_redemption_settles(mo
     state.portfolio.get_default_reserve_position.return_value.get_value.return_value = 4.9
     state.portfolio.get_all_trades.return_value = []
 
-    # 2. Make the position manager create a successful bridge-back trade.
+    # 2. Make the proceeds reconciler and position manager create a successful bridge-back trade.
     bridge_back_trade = _make_trade(TradeStatus.success)
     bridge_back_trade.is_success.return_value = True
     resumed_position_manager = MagicMock()
-    resumed_position_manager.close_position.return_value = [bridge_back_trade]
+    resumed_position_manager.close_cctp_bridge_position.return_value = [bridge_back_trade]
     monkeypatch.setattr(testtrade, "PositionManager", MagicMock(return_value=resumed_position_manager))
+    monkeypatch.setattr(
+        testtrade,
+        "_get_completed_satellite_redemption_trade",
+        MagicMock(),
+    )
+    monkeypatch.setattr(
+        testtrade,
+        "_get_satellite_bridge_back_amount",
+        MagicMock(return_value=Decimal("4.75")),
+    )
     execution_model = MagicMock()
     hot_wallet = MagicMock()
     hot_wallet.get_native_currency_balance.return_value = Decimal("1")
@@ -430,6 +440,103 @@ def test_cross_chain_close_resumes_bridge_back_after_async_redemption_settles(mo
 
     # 4. Verify it skips a second vault redemption and closes only the bridge.
     assert result is None
-    resumed_position_manager.close_position.assert_called_once()
-    assert resumed_position_manager.close_position.call_args.args[0] is bridge_position
+    resumed_position_manager.close_cctp_bridge_position.assert_called_once()
+    assert resumed_position_manager.close_cctp_bridge_position.call_args.args[0] is bridge_position
+    assert resumed_position_manager.close_cctp_bridge_position.call_args.kwargs["quantity"] == Decimal("4.75")
     execution_model.execute_trades.assert_called_once()
+
+
+def test_cross_chain_bridge_back_uses_actual_redemption_proceeds(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Bridge-back is capped by newly received satellite USDC, not accounting capital.
+
+    1. Record the custody balance before a vault redemption.
+    2. Model a smaller on-chain balance increase than analysed redemption proceeds.
+    3. Verify the bridge amount uses the smaller observed amount and persists it.
+    """
+    # 1. Record the custody balance before a vault redemption.
+    pair = MagicMock()
+    pair.chain_id = BASE_CHAIN_ID
+    pair.pool_address = "0x0000000000000000000000000000000000000abc"
+    pair.quote.address = "0x0000000000000000000000000000000000000def"
+    bridge_position = MagicMock()
+    bridge_position.other_data = {}
+    token = MagicMock()
+    token.fetch_balance_of.side_effect = [Decimal("3"), Decimal("3.8")]
+    monkeypatch.setattr(testtrade, "fetch_erc20_details", MagicMock(return_value=token))
+    monkeypatch.setattr(
+        testtrade,
+        "_get_cctp_custody_address",
+        MagicMock(return_value="0x0000000000000000000000000000000000000001"),
+    )
+    web3config = MagicMock()
+    testtrade._record_satellite_redemption_balance(
+        web3config=web3config,
+        routing_model=MagicMock(),
+        bridge_pair=MagicMock(),
+        bridge_position=bridge_position,
+        pair=pair,
+        fallback_address="0x0000000000000000000000000000000000000002",
+    )
+
+    # 2. Model a smaller on-chain balance increase than analysed redemption proceeds.
+    redemption_trade = MagicMock(executed_reserve=Decimal("1"), trade_id=99)
+    amount = testtrade._get_satellite_bridge_back_amount(
+        web3config=web3config,
+        routing_model=MagicMock(),
+        bridge_pair=MagicMock(),
+        bridge_position=bridge_position,
+        pair=pair,
+        redemption_trade=redemption_trade,
+        fallback_address="0x0000000000000000000000000000000000000002",
+    )
+
+    # 3. Verify the bridge amount uses the smaller observed amount and persists it.
+    assert amount == Decimal("0.8")
+    assert bridge_position.other_data["vault_test_satellite_redemption"]["bridge_back_amount"] == "0.8"
+    assert bridge_position.other_data["vault_test_satellite_redemption"]["residual"] == "3.0"
+
+
+def test_cross_chain_bridge_back_recovers_legacy_settled_redemption(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Legacy state uses persisted manager analysis when no balance baseline exists.
+
+    1. Model a settled redemption from a state version without a balance baseline.
+    2. Supply valid analysed proceeds and a sufficient current USDC wallet balance.
+    3. Verify the bridge amount is recovered without treating the current balance as new proceeds.
+    """
+    # 1. Model a settled redemption from a state version without a balance baseline.
+    pair = MagicMock()
+    pair.chain_id = BASE_CHAIN_ID
+    pair.pool_address = "0x0000000000000000000000000000000000000abc"
+    pair.quote.address = "0x0000000000000000000000000000000000000def"
+    bridge_position = MagicMock()
+    bridge_position.other_data = {}
+    token = MagicMock()
+    token.fetch_balance_of.return_value = Decimal("5")
+    monkeypatch.setattr(testtrade, "fetch_erc20_details", MagicMock(return_value=token))
+    monkeypatch.setattr(
+        testtrade,
+        "_get_cctp_custody_address",
+        MagicMock(return_value="0x0000000000000000000000000000000000000001"),
+    )
+
+    # 2. Supply valid analysed proceeds and a sufficient current USDC wallet balance.
+    redemption_trade = MagicMock(executed_reserve=Decimal("3"), trade_id=100)
+    amount = testtrade._get_satellite_bridge_back_amount(
+        web3config=MagicMock(),
+        routing_model=MagicMock(),
+        bridge_pair=MagicMock(),
+        bridge_position=bridge_position,
+        pair=pair,
+        redemption_trade=redemption_trade,
+        fallback_address="0x0000000000000000000000000000000000000002",
+    )
+
+    # 3. Verify the bridge amount is recovered without treating the current balance as new proceeds.
+    metadata = bridge_position.other_data["vault_test_satellite_redemption"]
+    assert amount == Decimal("3")
+    assert metadata["recovered_from_manager_analysis"] is True
+    assert metadata["wallet_proceeds"] is None

--- a/tradeexecutor/cli/commands/perform_test_trade.py
+++ b/tradeexecutor/cli/commands/perform_test_trade.py
@@ -270,6 +270,10 @@ def perform_test_trade(
 
     assert not (all_vaults and all_pairs), "Cannot specify both --all-vaults and --all-pairs"
 
+    # TODO: Cross-chain vault redemptions can record a balance baseline through
+    # ``sync_state_callback``, but this public command persists state only at
+    # command completion.  Deferred: thread the store callback through every
+    # ``make_test_trade()`` invocation before relying on crash-safe resume.
     try:
         if all_vaults:
             logger.info("Testing all vaults")

--- a/tradeexecutor/cli/testtrade.py
+++ b/tradeexecutor/cli/testtrade.py
@@ -34,6 +34,22 @@ from tradeexecutor.strategy.trading_strategy_universe import TradingStrategyUniv
 logger = logging.getLogger(__name__)
 
 
+def _update_test_trade_statistics(state: State, *, enabled: bool) -> None:
+    """Refresh statistics when a normal test trade needs persisted analytics."""
+
+    if not enabled:
+        return
+
+    long_short_metrics_latest = serialise_long_short_stats_as_json_table(state, None)
+    update_statistics(
+        native_datetime_utc_now(),
+        state.stats,
+        state.portfolio,
+        ExecutionMode.real_trading,
+        long_short_metrics_latest=long_short_metrics_latest,
+    )
+
+
 def _materialise_bridge_on_anvil(
     web3config,
     routing_model: RoutingModel,
@@ -113,6 +129,7 @@ def _make_cross_chain_test_trade(
     trade_flags: set[TradeFlag] | None = None,
     force_async_settlement_on_anvil: bool = True,
     anvil_time_skip_seconds: int = 24 * 3600,
+    update_statistics_after_trade: bool = True,
 ):
     """Cross-chain test trade: bridge in, open position, close position, bridge out.
 
@@ -310,9 +327,10 @@ def _make_cross_chain_test_trade(
         bridge_position = state.portfolio.get_bridge_position_for_chain(dest_chain_id)
         assert bridge_position is not None
 
-        long_short_metrics_latest = serialise_long_short_stats_as_json_table(state, None)
-        update_statistics(native_datetime_utc_now(), state.stats, state.portfolio,
-                          ExecutionMode.real_trading, long_short_metrics_latest=long_short_metrics_latest)
+        _update_test_trade_statistics(
+            state,
+            enabled=update_statistics_after_trade,
+        )
 
         if not buy_only:
             # Sell flow: close satellite, then bridge back
@@ -366,9 +384,10 @@ def _make_cross_chain_test_trade(
                     native_datetime_utc_now(), state, list(universe.reserve_assets),
                 )
 
-            long_short_metrics_latest = serialise_long_short_stats_as_json_table(state, None)
-            update_statistics(native_datetime_utc_now(), state.stats, state.portfolio,
-                              ExecutionMode.real_trading, long_short_metrics_latest=long_short_metrics_latest)
+            _update_test_trade_statistics(
+                state,
+                enabled=update_statistics_after_trade,
+            )
 
     # Final report
     gas_at_end = hot_wallet.get_native_currency_balance(web3)
@@ -634,6 +653,7 @@ def make_test_trade(
     web3config=None,
     trade_flags: set[TradeFlag] | None = None,
     force_async_settlement_on_anvil: bool = True,
+    update_statistics_after_trade: bool = True,
 ):
     """Perform a test trade.
 
@@ -831,6 +851,7 @@ def make_test_trade(
             trade_flags=trade_flags,
             force_async_settlement_on_anvil=force_async_settlement_on_anvil,
             anvil_time_skip_seconds=anvil_time_skip_seconds,
+            update_statistics_after_trade=update_statistics_after_trade,
         )
 
     # The message left on the test positions and trades
@@ -923,11 +944,10 @@ def make_test_trade(
             raise AssertionError("Test buy succeed, but the position was not opened\n"
                                  "Check for dust corrections.")
 
-        long_short_metrics_latest = serialise_long_short_stats_as_json_table(
-            state, None
+        _update_test_trade_statistics(
+            state,
+            enabled=update_statistics_after_trade,
         )
-        
-        update_statistics(native_datetime_utc_now(), state.stats, state.portfolio, ExecutionMode.real_trading, long_short_metrics_latest=long_short_metrics_latest)
     else:
         logger.info("Position %s is already open. No need to open it again.", position)
 
@@ -1003,11 +1023,10 @@ def make_test_trade(
             logger.error("Trade dump:\n%s", sell_trade.get_debug_dump())
             raise AssertionError("Test sell failed")
 
-        long_short_metrics_latest = serialise_long_short_stats_as_json_table(
-            state, None
+        _update_test_trade_statistics(
+            state,
+            enabled=update_statistics_after_trade,
         )
-        
-        update_statistics(native_datetime_utc_now(), state.stats, state.portfolio, ExecutionMode.real_trading, long_short_metrics_latest=long_short_metrics_latest)
 
     else:
         sell_trade = None
@@ -1078,11 +1097,10 @@ def make_test_trade(
                 raise AssertionError("Test buy succeed, but the position was not opened\n"
                                      "Check for dust corrections.")
 
-            long_short_metrics_latest = serialise_long_short_stats_as_json_table(
-                state, None
+            _update_test_trade_statistics(
+                state,
+                enabled=update_statistics_after_trade,
             )
-
-            update_statistics(native_datetime_utc_now(), state.stats, state.portfolio, ExecutionMode.real_trading, long_short_metrics_latest=long_short_metrics_latest)
 
         # Close the short
 
@@ -1142,11 +1160,10 @@ def make_test_trade(
             raise AssertionError("Short close succeed, but the position was not opened\n"
                                  "Check for dust corrections.")
 
-        long_short_metrics_latest = serialise_long_short_stats_as_json_table(
-            state, None
+        _update_test_trade_statistics(
+            state,
+            enabled=update_statistics_after_trade,
         )
-        
-        update_statistics(native_datetime_utc_now(), state.stats, state.portfolio, ExecutionMode.real_trading, long_short_metrics_latest=long_short_metrics_latest)
 
     gas_at_end = hot_wallet.get_native_currency_balance(web3)
     reserve_currency_at_end = state.portfolio.get_default_reserve_position().get_value()

--- a/tradeexecutor/cli/testtrade.py
+++ b/tradeexecutor/cli/testtrade.py
@@ -178,8 +178,8 @@ def _get_satellite_bridge_back_amount(
 
     The bridge accounting ledger can contain a planned amount which is larger
     than a lossy redemption's token balance.  Use the smaller of independently
-    observed wallet proceeds and the vault receipt analysis, and keep any dust
-    visible on the open bridge position for a later attempt.
+    observed wallet proceeds and the vault receipt analysis, retaining the
+    measured custody balance and any difference in diagnostic metadata.
     """
 
     expected_vault_id = f"{pair.chain_id}-{pair.pool_address}"
@@ -385,13 +385,14 @@ def _make_cross_chain_test_trade(
     if close_only:
         # Close-only: find existing positions and close them
         satellite_position = state.portfolio.get_position_by_trading_pair(pair)
-        closed_satellite_position = next(
+        closed_satellite_position = max(
             (
                 position
                 for position in state.portfolio.closed_positions.values()
                 if position.pair == pair
             ),
-            None,
+            key=lambda position: position.position_id,
+            default=None,
         )
         if satellite_position is None and closed_satellite_position is None:
             raise RuntimeError(

--- a/tradeexecutor/cli/testtrade.py
+++ b/tradeexecutor/cli/testtrade.py
@@ -139,7 +139,11 @@ def _record_satellite_redemption_balance(
     pair: TradingPairIdentifier,
     fallback_address: str,
 ) -> None:
-    """Persist the pre-redemption satellite USDC balance for bridge-back sizing."""
+    """Persist the pre-redemption satellite USDC balance for bridge-back sizing.
+
+    The caller synchronises the state before broadcasting the redemption in
+    real mode.  A later balance must never be repurposed as this baseline.
+    """
 
     chain_id = pair.chain_id
     custody_address = _get_cctp_custody_address(
@@ -385,6 +389,9 @@ def _make_cross_chain_test_trade(
     if close_only:
         # Close-only: find existing positions and close them
         satellite_position = state.portfolio.get_position_by_trading_pair(pair)
+        # A resumed async redemption has already moved its position to closed.
+        # Select the newest matching position: earlier test attempts can remain
+        # in the same state file and must not supply their redemption proceeds.
         closed_satellite_position = max(
             (
                 position
@@ -417,6 +424,7 @@ def _make_cross_chain_test_trade(
                 pair=pair,
                 fallback_address=hot_wallet.address,
             )
+            # Persist the observed balance before the close can move USDC.
             if sync_state_callback is not None:
                 sync_state_callback()
             ts = native_datetime_utc_now()
@@ -466,10 +474,13 @@ def _make_cross_chain_test_trade(
             notes=notes,
             flags=trade_flags,
         )
+        # A crash after CCTP broadcast must retain this trade identity so a
+        # later invocation does not create another burn.
         _record_planned_bridge_back(bridge_position, bridge_back_trades[0])
         if sync_state_callback is not None:
             sync_state_callback()
         execution_model.execute_trades(ts, state, bridge_back_trades, routing_model, routing_state)
+        # Store the signed/broadcast transaction evidence for retry handling.
         if sync_state_callback is not None:
             sync_state_callback()
         if bridge_back_trades[0].get_status() == TradeStatus.cctp_in_transit:
@@ -589,6 +600,7 @@ def _make_cross_chain_test_trade(
                 pair=pair,
                 fallback_address=hot_wallet.address,
             )
+            # Persist the observed balance before the close can move USDC.
             if sync_state_callback is not None:
                 sync_state_callback()
             ts = native_datetime_utc_now()
@@ -635,12 +647,15 @@ def _make_cross_chain_test_trade(
                 notes=notes,
                 flags=trade_flags,
             )
+            # A crash after CCTP broadcast must retain this trade identity so a
+            # later invocation does not create another burn.
             _record_planned_bridge_back(bridge_position, bridge_back_trades[0])
             if sync_state_callback is not None:
                 sync_state_callback()
             execution_model.execute_trades(
                 ts, state, bridge_back_trades, routing_model, routing_state,
             )
+            # Store the signed/broadcast transaction evidence for retry handling.
             if sync_state_callback is not None:
                 sync_state_callback()
             if bridge_back_trades[0].get_status() == TradeStatus.cctp_in_transit:

--- a/tradeexecutor/cli/testtrade.py
+++ b/tradeexecutor/cli/testtrade.py
@@ -2,6 +2,7 @@
 import logging
 import datetime
 from decimal import Decimal
+from typing import Callable
 
 from web3 import Web3
 
@@ -32,6 +33,10 @@ from tradeexecutor.strategy.routing import RoutingModel, RoutingState
 from tradeexecutor.strategy.trading_strategy_universe import TradingStrategyUniverse, translate_trading_pair
 
 logger = logging.getLogger(__name__)
+
+
+class BridgeProceedsUnavailable(RuntimeError):
+    """A satellite vault redemption cannot safely fund the CCTP return burn."""
 
 
 def _update_test_trade_statistics(state: State, *, enabled: bool) -> None:
@@ -105,6 +110,201 @@ def _materialise_bridge_on_anvil(
     fund_erc20_on_anvil(dest_web3, usdc_address, recipient, total_raw)
 
 
+def _get_cctp_custody_address(
+    routing_model: RoutingModel,
+    bridge_pair: TradingPairIdentifier,
+    chain_id: int,
+    fallback_address: str,
+) -> str:
+    """Resolve the address which actually holds bridged USDC on one chain."""
+
+    pair_config = routing_model.pair_configurator.get_config(
+        routing_model.pair_configurator.match_router(bridge_pair)
+    )
+    cctp_routing = pair_config.routing_model
+    if (
+        hasattr(cctp_routing, "custody_address_resolver")
+        and cctp_routing.custody_address_resolver
+    ):
+        return cctp_routing.custody_address_resolver(chain_id)
+    return fallback_address
+
+
+def _record_satellite_redemption_balance(
+    *,
+    web3config,
+    routing_model: RoutingModel,
+    bridge_pair: TradingPairIdentifier,
+    bridge_position,
+    pair: TradingPairIdentifier,
+    fallback_address: str,
+) -> None:
+    """Persist the pre-redemption satellite USDC balance for bridge-back sizing."""
+
+    chain_id = pair.chain_id
+    custody_address = _get_cctp_custody_address(
+        routing_model,
+        bridge_pair,
+        chain_id,
+        fallback_address,
+    )
+    token = fetch_erc20_details(
+        web3config.get_connection(ChainId(chain_id)),
+        pair.quote.address,
+        chain_id=chain_id,
+    )
+    balance = token.fetch_balance_of(custody_address)
+    bridge_position.other_data["vault_test_satellite_redemption"] = {
+        "schema_version": 1,
+        "vault_id": f"{pair.chain_id}-{pair.pool_address}",
+        "chain_id": chain_id,
+        "token_address": pair.quote.address,
+        "custody_address": custody_address,
+        "balance_before": str(balance),
+    }
+
+
+def _get_satellite_bridge_back_amount(
+    *,
+    web3config,
+    routing_model: RoutingModel,
+    bridge_pair: TradingPairIdentifier,
+    bridge_position,
+    pair: TradingPairIdentifier,
+    redemption_trade,
+    fallback_address: str,
+) -> Decimal:
+    """Reconcile CCTP burn size to the completed vault redemption proceeds.
+
+    The bridge accounting ledger can contain a planned amount which is larger
+    than a lossy redemption's token balance.  Use the smaller of independently
+    observed wallet proceeds and the vault receipt analysis, and keep any dust
+    visible on the open bridge position for a later attempt.
+    """
+
+    expected_vault_id = f"{pair.chain_id}-{pair.pool_address}"
+    chain_id = pair.chain_id
+    metadata = bridge_position.other_data.get("vault_test_satellite_redemption", {})
+    custody_address = metadata.get("custody_address") or _get_cctp_custody_address(
+        routing_model,
+        bridge_pair,
+        chain_id,
+        fallback_address,
+    )
+    token = fetch_erc20_details(
+        web3config.get_connection(ChainId(chain_id)),
+        pair.quote.address,
+        chain_id=chain_id,
+    )
+    analysed_proceeds = redemption_trade.executed_reserve
+    if analysed_proceeds is None or analysed_proceeds <= 0:
+        raise BridgeProceedsUnavailable(
+            "bridge_proceeds_unavailable: vault redemption has no executed USDC proceeds"
+        )
+
+    balance_after = token.fetch_balance_of(custody_address)
+    if (
+        metadata.get("vault_id") != expected_vault_id
+        or metadata.get("balance_before") is None
+    ):
+        # A state written before baseline persistence can still be resumed when
+        # the settled manager analysis has already established the exact
+        # proceeds.  Never replace this branch with a fresh balance baseline:
+        # it would turn pre-existing USDC into redemption proceeds.
+        bridge_amount = min(balance_after, analysed_proceeds)
+        if bridge_amount <= 0:
+            raise BridgeProceedsUnavailable(
+                "bridge_proceeds_unavailable: legacy redemption has no USDC available "
+                f"for {expected_vault_id}"
+            )
+        bridge_position.other_data["vault_test_satellite_redemption"] = {
+            "schema_version": 1,
+            "vault_id": expected_vault_id,
+            "chain_id": chain_id,
+            "token_address": pair.quote.address,
+            "custody_address": custody_address,
+            "balance_before": None,
+            "balance_after": str(balance_after),
+            "wallet_proceeds": None,
+            "analysed_proceeds": str(analysed_proceeds),
+            "bridge_back_amount": str(bridge_amount),
+            "residual": str(balance_after - bridge_amount),
+            "redemption_trade_id": redemption_trade.trade_id,
+            "recovered_from_manager_analysis": True,
+        }
+        return bridge_amount
+
+    balance_before = Decimal(metadata["balance_before"])
+    wallet_proceeds = max(balance_after - balance_before, Decimal(0))
+
+    bridge_amount = min(wallet_proceeds, analysed_proceeds)
+    if bridge_amount <= 0:
+        raise BridgeProceedsUnavailable(
+            "bridge_proceeds_unavailable: no newly available satellite USDC after redemption"
+        )
+
+    metadata.update(
+        {
+            "balance_after": str(balance_after),
+            "wallet_proceeds": str(wallet_proceeds),
+            "analysed_proceeds": str(analysed_proceeds),
+            "bridge_back_amount": str(bridge_amount),
+            "residual": str(balance_after - bridge_amount),
+            "redemption_trade_id": redemption_trade.trade_id,
+        }
+    )
+    bridge_position.other_data["vault_test_satellite_redemption"] = metadata
+    return bridge_amount
+
+
+def _record_planned_bridge_back(
+    bridge_position,
+    bridge_back_trade,
+) -> None:
+    """Persist the planned burn identity before it can be broadcast."""
+
+    metadata = bridge_position.other_data.setdefault(
+        "vault_test_satellite_redemption",
+        {},
+    )
+    metadata["bridge_back_trade_id"] = bridge_back_trade.trade_id
+
+
+def _get_completed_satellite_redemption_trade(position):
+    """Return the latest successful vault sell used to fund bridge-back."""
+
+    trade = max(
+        (
+            candidate
+            for candidate in position.trades.values()
+            if candidate.is_sell() and candidate.is_success()
+        ),
+        key=lambda candidate: candidate.trade_id,
+        default=None,
+    )
+    assert trade is not None, f"No completed satellite redemption on {position}"
+    return trade
+
+
+def _get_pending_bridge_back_trade(bridge_position):
+    """Return an already-started CCTP burn so a resume cannot duplicate it."""
+
+    return max(
+        (
+            trade
+            for trade in bridge_position.trades.values()
+            if trade.is_sell()
+            and trade.get_status() in {
+                TradeStatus.started,
+                TradeStatus.broadcasted,
+                TradeStatus.cctp_in_transit,
+            }
+        ),
+        key=lambda trade: trade.trade_id,
+        default=None,
+    )
+
+
 def _make_cross_chain_test_trade(
     web3: "Web3",
     web3config,
@@ -130,6 +330,7 @@ def _make_cross_chain_test_trade(
     force_async_settlement_on_anvil: bool = True,
     anvil_time_skip_seconds: int = 24 * 3600,
     update_statistics_after_trade: bool = True,
+    sync_state_callback: Callable[[], None] | None = None,
 ):
     """Cross-chain test trade: bridge in, open position, close position, bridge out.
 
@@ -207,6 +408,16 @@ def _make_cross_chain_test_trade(
         # has now settled and only its bridge-back leg remains.
         if satellite_position is not None:
             logger.info("Cross-chain close step 1: closing %s on %s", pair.get_ticker(), chain_name)
+            _record_satellite_redemption_balance(
+                web3config=web3config,
+                routing_model=routing_model,
+                bridge_pair=bridge_pair,
+                bridge_position=bridge_position,
+                pair=pair,
+                fallback_address=hot_wallet.address,
+            )
+            if sync_state_callback is not None:
+                sync_state_callback()
             ts = native_datetime_utc_now()
             position_manager = PositionManager(
                 ts, universe, state, pricing_model,
@@ -222,17 +433,44 @@ def _make_cross_chain_test_trade(
         else:
             logger.info("Cross-chain close step 1 already settled; continuing with bridge back")
 
-        # Step 2: Bridge back — sized by get_available_bridge_capital()
+        # Step 2: Bridge back only the USDC made available by redemption.
         logger.info("Cross-chain close step 2: bridging back from %s", chain_name)
+        pending_bridge_back = _get_pending_bridge_back_trade(bridge_position)
+        if pending_bridge_back is not None:
+            logger.info(
+                "Cross-chain close step 2 already has bridge-back trade #%d in %s; not creating a duplicate burn",
+                pending_bridge_back.trade_id,
+                pending_bridge_back.get_status(),
+            )
+            return
+        redemption_position = satellite_position or closed_satellite_position
+        redemption_trade = _get_completed_satellite_redemption_trade(redemption_position)
+        bridge_back_amount = _get_satellite_bridge_back_amount(
+            web3config=web3config,
+            routing_model=routing_model,
+            bridge_pair=bridge_pair,
+            bridge_position=bridge_position,
+            pair=pair,
+            redemption_trade=redemption_trade,
+            fallback_address=hot_wallet.address,
+        )
         ts = native_datetime_utc_now()
         position_manager = PositionManager(
             ts, universe, state, pricing_model,
             default_slippage_tolerance=max_slippage,
         )
-        bridge_back_trades = position_manager.close_position(
-            bridge_position, notes=notes, flags=trade_flags,
+        bridge_back_trades = position_manager.close_cctp_bridge_position(
+            bridge_position,
+            quantity=bridge_back_amount,
+            notes=notes,
+            flags=trade_flags,
         )
+        _record_planned_bridge_back(bridge_position, bridge_back_trades[0])
+        if sync_state_callback is not None:
+            sync_state_callback()
         execution_model.execute_trades(ts, state, bridge_back_trades, routing_model, routing_state)
+        if sync_state_callback is not None:
+            sync_state_callback()
         if bridge_back_trades[0].get_status() == TradeStatus.cctp_in_transit:
             return
         assert bridge_back_trades[0].is_success(), \
@@ -342,6 +580,16 @@ def _make_cross_chain_test_trade(
 
             # Step 3: Close satellite position
             logger.info("Cross-chain step 3: close %s on %s", pair.get_ticker(), chain_name)
+            _record_satellite_redemption_balance(
+                web3config=web3config,
+                routing_model=routing_model,
+                bridge_pair=bridge_pair,
+                bridge_position=bridge_position,
+                pair=pair,
+                fallback_address=hot_wallet.address,
+            )
+            if sync_state_callback is not None:
+                sync_state_callback()
             ts = native_datetime_utc_now()
             position_manager = PositionManager(
                 ts, universe, state, pricing_model,
@@ -356,19 +604,44 @@ def _make_cross_chain_test_trade(
             assert close_trades[0].is_success(), \
                 f"Satellite close failed: {close_trades[0].get_revert_reason()}"
 
-            # Step 4: Bridge back — sized by get_available_bridge_capital()
+            # Step 4: Bridge back only the USDC made available by redemption.
             logger.info("Cross-chain step 4: bridge back from %s", chain_name)
+            pending_bridge_back = _get_pending_bridge_back_trade(bridge_position)
+            if pending_bridge_back is not None:
+                logger.info(
+                    "Cross-chain step 4 already has bridge-back trade #%d in %s; not creating a duplicate burn",
+                    pending_bridge_back.trade_id,
+                    pending_bridge_back.get_status(),
+                )
+                return
+            bridge_back_amount = _get_satellite_bridge_back_amount(
+                web3config=web3config,
+                routing_model=routing_model,
+                bridge_pair=bridge_pair,
+                bridge_position=bridge_position,
+                pair=pair,
+                redemption_trade=close_trades[0],
+                fallback_address=hot_wallet.address,
+            )
             ts = native_datetime_utc_now()
             position_manager = PositionManager(
                 ts, universe, state, pricing_model,
                 default_slippage_tolerance=max_slippage,
             )
-            bridge_back_trades = position_manager.close_position(
-                bridge_position, notes=notes, flags=trade_flags,
+            bridge_back_trades = position_manager.close_cctp_bridge_position(
+                bridge_position,
+                quantity=bridge_back_amount,
+                notes=notes,
+                flags=trade_flags,
             )
+            _record_planned_bridge_back(bridge_position, bridge_back_trades[0])
+            if sync_state_callback is not None:
+                sync_state_callback()
             execution_model.execute_trades(
                 ts, state, bridge_back_trades, routing_model, routing_state,
             )
+            if sync_state_callback is not None:
+                sync_state_callback()
             if bridge_back_trades[0].get_status() == TradeStatus.cctp_in_transit:
                 return
             assert bridge_back_trades[0].is_success(), \
@@ -654,6 +927,7 @@ def make_test_trade(
     trade_flags: set[TradeFlag] | None = None,
     force_async_settlement_on_anvil: bool = True,
     update_statistics_after_trade: bool = True,
+    sync_state_callback: Callable[[], None] | None = None,
 ):
     """Perform a test trade.
 
@@ -852,6 +1126,7 @@ def make_test_trade(
             force_async_settlement_on_anvil=force_async_settlement_on_anvil,
             anvil_time_skip_seconds=anvil_time_skip_seconds,
             update_statistics_after_trade=update_statistics_after_trade,
+            sync_state_callback=sync_state_callback,
         )
 
     # The message left on the test positions and trades

--- a/tradeexecutor/cli/testtrade.py
+++ b/tradeexecutor/cli/testtrade.py
@@ -479,6 +479,9 @@ def _make_cross_chain_test_trade(
         _record_planned_bridge_back(bridge_position, bridge_back_trades[0])
         if sync_state_callback is not None:
             sync_state_callback()
+        # TODO: A process crash after broadcast and before this call returns
+        # leaves only the planned trade state.  Deferred: resume must inspect
+        # the persisted burn transaction before it can safely avoid a reburn.
         execution_model.execute_trades(ts, state, bridge_back_trades, routing_model, routing_state)
         # Store the signed/broadcast transaction evidence for retry handling.
         if sync_state_callback is not None:
@@ -652,6 +655,9 @@ def _make_cross_chain_test_trade(
             _record_planned_bridge_back(bridge_position, bridge_back_trades[0])
             if sync_state_callback is not None:
                 sync_state_callback()
+            # TODO: A process crash after broadcast and before this call
+            # returns needs transaction-aware CCTP resume handling to avoid a
+            # duplicate burn.  Deferred from this vault-test PR.
             execution_model.execute_trades(
                 ts, state, bridge_back_trades, routing_model, routing_state,
             )
@@ -669,7 +675,7 @@ def _make_cross_chain_test_trade(
                     web3config, routing_model, bridge_pair,
                     home_chain_id, hot_wallet.address, bridge_back_trades[0],
                 )
-                sync_model.sync_treasury(
+            sync_model.sync_treasury(
                     native_datetime_utc_now(), state, list(universe.reserve_assets),
                 )
 

--- a/tradeexecutor/cli/vault_trade/runner.py
+++ b/tradeexecutor/cli/vault_trade/runner.py
@@ -18,6 +18,7 @@ from typing import Any
 
 from eth_defi.compat import native_datetime_utc_now
 from eth_defi.vault.base import VaultSpec
+from eth_defi.vault.deposit_redeem import UnsupportedVaultSimulation, VaultFlowUnavailable
 from tradingstrategy.chain import ChainId
 
 from tradeexecutor.cli.bootstrap import (
@@ -52,6 +53,7 @@ from tradeexecutor.cli.vault_trade.simulation import (
 )
 from tradeexecutor.cli.vault_trade.tui import VaultTestAction
 from tradeexecutor.ethereum.routing_state import OutOfBalance
+from tradeexecutor.ethereum.vault.vault_routing import VaultReceiptAnalysisError
 from tradeexecutor.state.identifier import TradingPairIdentifier
 from tradeexecutor.state.position import TradingPosition
 from tradeexecutor.state.state import State
@@ -169,7 +171,7 @@ def get_whitelisting_needed_detail(attempt: "VaultAttempt") -> str | None:
     vault = get_vault(attempt.pair)
     try:
         whitelisted = vault.is_whitelisted_deposit()
-    except NotImplementedError:
+    except (AttributeError, NotImplementedError):
         return None
     if not whitelisted:
         return None
@@ -180,12 +182,111 @@ def get_whitelisting_needed_detail(attempt: "VaultAttempt") -> str | None:
 
     try:
         admitted = vault.is_account_whitelisted(owner_address)
-    except NotImplementedError:
+    except (AttributeError, NotImplementedError):
         return None
     if admitted:
         return None
 
     return f"Vault requires whitelisting for executor Safe {owner_address}"
+
+
+def get_adapter_unsupported_detail(
+    attempt: "VaultAttempt",
+    operation: str,
+) -> tuple[str, dict] | None:
+    """Return an explicit adapter limitation before a transaction is built."""
+
+    get_capability = getattr(attempt.vault, "get_deposit_manager_capability", None)
+    if get_capability is None:
+        # Some adapters have not adopted eth-defi's optional capability API.
+        # Preserve their existing execution path and diagnostics.
+        return None
+
+    capability = get_capability()
+    if capability is None:
+        return None
+
+    supported = capability.can_deposit if operation == "deposit" else capability.can_redeem
+    if supported:
+        return None
+
+    return (
+        f"eth-defi adapter does not support {operation} for this vault",
+        {"operation": operation, "capability": capability.as_dict()},
+    )
+
+
+def get_deposit_closed_detail(attempt: "VaultAttempt") -> str | None:
+    """Read a protocol-specific deposit closure before requesting a price."""
+
+    fetch_reason = getattr(attempt.vault, "fetch_deposit_closed_reason", None)
+    if fetch_reason is None:
+        return None
+
+    try:
+        return fetch_reason()
+    except NotImplementedError:
+        return None
+
+
+def normalise_vault_flow_failure(
+    error: BaseException,
+) -> tuple[str, str, dict] | None:
+    """Convert eth-defi typed flow failures into stable vault-test outcomes."""
+
+    current: BaseException | None = error
+    seen: set[int] = set()
+    while current is not None and id(current) not in seen:
+        seen.add(id(current))
+        if isinstance(current, VaultFlowUnavailable):
+            outcome_data = {
+                "protocol": current.protocol,
+                "direction": current.direction,
+                "phase": current.phase,
+                "requested_raw_amount": str(current.requested_raw_amount)
+                if current.requested_raw_amount is not None
+                else None,
+                "available_raw_amount": str(current.available_raw_amount)
+                if current.available_raw_amount is not None
+                else None,
+            }
+            if (
+                current.direction == "redeem"
+                and current.requested_raw_amount is not None
+                and current.available_raw_amount is not None
+                and current.requested_raw_amount > current.available_raw_amount
+            ):
+                return (
+                    "redemption_capacity_limited",
+                    redact_vault_test_error_text(current.reason),
+                    outcome_data,
+                )
+            if current.direction == "deposit":
+                return (
+                    "deposit_closed",
+                    redact_vault_test_error_text(current.reason),
+                    outcome_data,
+                )
+            if current.direction == "redeem":
+                return (
+                    "redemption_unavailable",
+                    redact_vault_test_error_text(current.reason),
+                    outcome_data,
+                )
+        if isinstance(current, UnsupportedVaultSimulation):
+            return (
+                "simulation_unsupported_async",
+                redact_vault_test_error_text(current),
+                {},
+            )
+        if isinstance(current, VaultReceiptAnalysisError):
+            return (
+                "receipt_analysis_failed",
+                redact_vault_test_error_text(current),
+                {},
+            )
+        current = current.__cause__ or current.__context__
+    return None
 
 
 def get_bridge_conflict(
@@ -512,6 +613,18 @@ class VaultTestBatchRunner:
         pair = attempt.pair
         spec = attempt.spec
 
+        adapter_unsupported = get_adapter_unsupported_detail(attempt, operation)
+        if adapter_unsupported is not None:
+            detail, outcome_data = adapter_unsupported
+            self._record_terminal_result(
+                attempt,
+                alarm,
+                result="adapter_unsupported",
+                detail=detail,
+                outcome_data=outcome_data,
+            )
+            return False
+
         # The default async simulation verifies requestDeposit only. The explicit
         # Anvil option invokes eth-defi's supported settlement helper instead.
         if (
@@ -543,6 +656,15 @@ class VaultTestBatchRunner:
                     alarm,
                     result="whitelisting-needed",
                     detail=whitelisting_detail,
+                )
+                return False
+            deposit_closed_detail = get_deposit_closed_detail(attempt)
+            if deposit_closed_detail is not None:
+                self._record_terminal_result(
+                    attempt,
+                    alarm,
+                    result="deposit_closed",
+                    detail=deposit_closed_detail,
                 )
                 return False
         if (
@@ -781,6 +903,7 @@ class VaultTestBatchRunner:
             close_only=operation == "redeem",
             web3config=self.runtime.web3config,
             test_short=False,
+            update_statistics_after_trade=False,
         )
 
         assert self.current_attempt is not None
@@ -848,6 +971,7 @@ class VaultTestBatchRunner:
                 trade_flags={TradeFlag.simulated},
                 test_short=False,
                 force_async_settlement_on_anvil=complete_async_lifecycle,
+                update_statistics_after_trade=False,
             )
         except Exception as error:
             # The outer handler records the result on the persistent state. Keep
@@ -881,7 +1005,7 @@ class VaultTestBatchRunner:
             vault_spec=attempt.spec,
             position_ids=created_position_ids,
             result=(
-                "simulation_unsupported_async"
+                "async_request_only"
                 if is_async and not complete_async_lifecycle
                 else "redemption_unavailable"
                 if not redemption_available
@@ -891,6 +1015,11 @@ class VaultTestBatchRunner:
                 "complete"
                 if not is_async or complete_async_lifecycle
                 else "deposit_requested"
+            ),
+            detail=(
+                "Async deposit request completed; full lifecycle was not requested"
+                if is_async and not complete_async_lifecycle
+                else None
             ),
             attempt_id=self.current_attempt.attempt_id
             if self.current_attempt
@@ -1160,16 +1289,28 @@ class VaultTestBatchRunner:
             web3config=self.runtime.web3config,
             phase=phase,
         )
-        result = classify_vault_test_failure(
-            phase=phase,
-            error_data=error_data,
+        has_reverted_transaction = any(
+            transaction.get("status") is False
+            for transaction in error_data.get("transactions", [])
         )
+        normalised_failure = (
+            None if has_reverted_transaction else normalise_vault_flow_failure(error)
+        )
+        if normalised_failure is None:
+            result = classify_vault_test_failure(
+                phase=phase,
+                error_data=error_data,
+            )
+            outcome_data = None
+        else:
+            result, detail, outcome_data = normalised_failure
         source_position_id = self._attach_failure_to_attempt_position(
             spec=spec,
             error_state=error_state,
             result=result,
             detail=detail,
             error_data=error_data,
+            outcome_data=outcome_data,
             previous=previous,
         )
         if source_position_id is not None:
@@ -1184,6 +1325,7 @@ class VaultTestBatchRunner:
             result=result,
             detail=detail,
             error=error_data,
+            outcome_data=outcome_data,
             source_position_id=previous.position_id if previous else None,
             attempt_id=self.current_attempt.attempt_id
             if self.current_attempt
@@ -1204,6 +1346,7 @@ class VaultTestBatchRunner:
         result: str,
         detail: str,
         error_data: dict,
+        outcome_data: dict | None,
         previous: TradingPosition | None,
     ) -> int | None:
         """Attach failure evidence to the actual target position when present."""
@@ -1227,6 +1370,8 @@ class VaultTestBatchRunner:
                 position_ids=position_ids,
                 result=result,
                 phase=self.current_attempt.phase,
+                detail=detail,
+                outcome_data=outcome_data,
                 attempt_id=self.current_attempt.attempt_id,
                 operation=self.current_attempt.operation,
                 provenance=self.current_attempt.provenance,
@@ -1265,6 +1410,7 @@ class VaultTestBatchRunner:
             phase=self.current_attempt.phase,
             result=result,
             detail=detail,
+            outcome_data=outcome_data,
             attempt_id=self.current_attempt.attempt_id,
             operation=self.current_attempt.operation,
             provenance=self.current_attempt.provenance,
@@ -1283,6 +1429,7 @@ class VaultTestBatchRunner:
         *,
         result: str,
         detail: str | None = None,
+        outcome_data: dict | None = None,
         source_position_id: int | None = None,
     ) -> None:
         """Persist a non-exception terminal diagnostic for one prepared vault."""
@@ -1295,6 +1442,7 @@ class VaultTestBatchRunner:
             simulated=self.auto_simulated,
             result=result,
             detail=detail,
+            outcome_data=outcome_data,
             source_position_id=source_position_id,
             attempt_id=self.current_attempt.attempt_id
             if self.current_attempt

--- a/tradeexecutor/cli/vault_trade/runner.py
+++ b/tradeexecutor/cli/vault_trade/runner.py
@@ -153,6 +153,41 @@ def should_leave_deposit_open(
     return operation == "deposit" and (manual or is_async or not redemption_available)
 
 
+def get_whitelisting_needed_detail(attempt: "VaultAttempt") -> str | None:
+    """Return a terminal report detail when the executor Safe lacks vault admission.
+
+    Unknown permission APIs deliberately return ``None`` so the normal adapter
+    path can still record its transaction or preflight diagnostics.
+    """
+
+    route = attempt.pricing_model.route(attempt.pair)
+    get_vault = getattr(route, "get_vault", None)
+    get_owner_address = getattr(route, "get_owner_address", None)
+    if get_vault is None or get_owner_address is None:
+        return None
+
+    vault = get_vault(attempt.pair)
+    try:
+        whitelisted = vault.is_whitelisted_deposit()
+    except NotImplementedError:
+        return None
+    if not whitelisted:
+        return None
+
+    owner_address = get_owner_address(attempt.pair)
+    if owner_address is None:
+        return "Vault requires whitelisting, but the executor Safe address could not be resolved"
+
+    try:
+        admitted = vault.is_account_whitelisted(owner_address)
+    except NotImplementedError:
+        return None
+    if admitted:
+        return None
+
+    return f"Vault requires whitelisting for executor Safe {owner_address}"
+
+
 def get_bridge_conflict(
     bridge_position: TradingPosition | None,
     vault_spec: VaultSpec,
@@ -500,6 +535,16 @@ class VaultTestBatchRunner:
 
         # Deposit/redemption window checks are diagnostic outcomes, not command
         # failures, and automatic mode continues with the next explicit id.
+        if operation == "deposit":
+            whitelisting_detail = get_whitelisting_needed_detail(attempt)
+            if whitelisting_detail is not None:
+                self._record_terminal_result(
+                    attempt,
+                    alarm,
+                    result="whitelisting-needed",
+                    detail=whitelisting_detail,
+                )
+                return False
         if (
             operation == "deposit"
             and attempt.pricing_model.can_deposit(native_datetime_utc_now(), pair)

--- a/tradeexecutor/cli/vault_trade/runner.py
+++ b/tradeexecutor/cli/vault_trade/runner.py
@@ -114,7 +114,12 @@ class VaultAttempt:
     """Prepared per-vault objects shared by action selection and execution."""
 
     spec: VaultSpec
+    # Discovery metadata is retained for stable report labels.  The route may
+    # resolve this to a richer eth-defi adapter, but that object must not leak
+    # into the persisted/reporting schema.
     vault: Any
+    # Capability, admission and deposit-window checks must use the same adapter
+    # as transaction routing, not the discovery record above.
     executable_vault: Any
     universe: Any
     pair: TradingPairIdentifier
@@ -164,6 +169,9 @@ def get_whitelisting_needed_detail(attempt: "VaultAttempt") -> str | None:
     path can still record its transaction or preflight diagnostics.
     """
 
+    # Ownership is routing-specific, while admission is adapter-specific.
+    # Keep those sources separate so a metadata record cannot bypass a live
+    # allow-list check.
     route = attempt.pricing_model.route(attempt.pair)
     get_owner_address = getattr(route, "get_owner_address", None)
     if get_owner_address is None:
@@ -595,7 +603,8 @@ class VaultTestBatchRunner:
         )
 
         # Keep discovery metadata for report rows while preflights use the
-        # executable route adapter.
+        # executable route adapter.  The two objects have different APIs and
+        # substituting one for the other loses report labels and protocol data.
         executable_vault = vault
         try:
             route = pricing_model.route(pair)

--- a/tradeexecutor/cli/vault_trade/runner.py
+++ b/tradeexecutor/cli/vault_trade/runner.py
@@ -115,6 +115,7 @@ class VaultAttempt:
 
     spec: VaultSpec
     vault: Any
+    executable_vault: Any
     universe: Any
     pair: TradingPairIdentifier
     routing_model: Any
@@ -164,12 +165,11 @@ def get_whitelisting_needed_detail(attempt: "VaultAttempt") -> str | None:
     """
 
     route = attempt.pricing_model.route(attempt.pair)
-    get_vault = getattr(route, "get_vault", None)
     get_owner_address = getattr(route, "get_owner_address", None)
-    if get_vault is None or get_owner_address is None:
+    if get_owner_address is None:
         return None
 
-    vault = get_vault(attempt.pair)
+    vault = attempt.executable_vault
     try:
         whitelisted = vault.is_whitelisted_deposit()
     except (AttributeError, NotImplementedError):
@@ -197,7 +197,11 @@ def get_adapter_unsupported_detail(
 ) -> tuple[str, dict] | None:
     """Return an explicit adapter limitation before a transaction is built."""
 
-    get_capability = getattr(attempt.vault, "get_deposit_manager_capability", None)
+    get_capability = getattr(
+        attempt.executable_vault,
+        "get_deposit_manager_capability",
+        None,
+    )
     if get_capability is None:
         # Some adapters have not adopted eth-defi's optional capability API.
         # Preserve their existing execution path and diagnostics.
@@ -220,7 +224,11 @@ def get_adapter_unsupported_detail(
 def get_deposit_closed_detail(attempt: "VaultAttempt") -> str | None:
     """Read a protocol-specific deposit closure before requesting a price."""
 
-    fetch_reason = getattr(attempt.vault, "fetch_deposit_closed_reason", None)
+    fetch_reason = getattr(
+        attempt.executable_vault,
+        "fetch_deposit_closed_reason",
+        None,
+    )
     if fetch_reason is None:
         return None
 
@@ -586,14 +594,15 @@ class VaultTestBatchRunner:
             self.runtime.execution_model.get_routing_state_details(),
         )
 
-        # Keep the executable adapter on the attempt. The vault universe entry
-        # remains a fallback only for older routes that cannot expose a vault.
+        # Keep discovery metadata for report rows while preflights use the
+        # executable route adapter.
+        executable_vault = vault
         try:
             route = pricing_model.route(pair)
             get_vault = getattr(route, "get_vault", None)
             resolved_vault = get_vault(pair) if get_vault is not None else None
             if resolved_vault is not None:
-                vault = resolved_vault
+                executable_vault = resolved_vault
         except (AttributeError, NotImplementedError):
             pass
 
@@ -609,6 +618,7 @@ class VaultTestBatchRunner:
         return VaultAttempt(
             spec=spec,
             vault=vault,
+            executable_vault=executable_vault,
             universe=universe,
             pair=pair,
             routing_model=routing_model,

--- a/tradeexecutor/cli/vault_trade/runner.py
+++ b/tradeexecutor/cli/vault_trade/runner.py
@@ -26,7 +26,7 @@ from tradeexecutor.cli.bootstrap import (
     check_universe_chains_have_rpc,
     check_universe_contracts_resolve,
 )
-from tradeexecutor.cli.testtrade import perform_test_trade
+from tradeexecutor.cli.testtrade import BridgeProceedsUnavailable, perform_test_trade
 from tradeexecutor.cli.vault_trade.core import build_vault_test_universe
 from tradeexecutor.cli.vault_trade.state import (
     close_simulated_positions,
@@ -136,6 +136,7 @@ class VaultAttemptContext:
     provenance: dict
     phase: str = "preflight"
     operation: str | None = None
+    operation_original_trade_ids: set[int] | None = None
 
 
 def should_leave_deposit_open(
@@ -250,6 +251,12 @@ def normalise_vault_flow_failure(
                 if current.available_raw_amount is not None
                 else None,
             }
+            minimum_raw_amount = getattr(current, "minimum_raw_amount", None)
+            if minimum_raw_amount is not None:
+                outcome_data["minimum_raw_amount"] = str(minimum_raw_amount)
+            next_open = getattr(current, "next_open", None)
+            if next_open is not None:
+                outcome_data["next_open"] = next_open.isoformat()
             if (
                 current.direction == "redeem"
                 and current.requested_raw_amount is not None
@@ -282,6 +289,12 @@ def normalise_vault_flow_failure(
         if isinstance(current, VaultReceiptAnalysisError):
             return (
                 "receipt_analysis_failed",
+                redact_vault_test_error_text(current),
+                {},
+            )
+        if isinstance(current, BridgeProceedsUnavailable):
+            return (
+                "bridge_proceeds_unavailable",
                 redact_vault_test_error_text(current),
                 {},
             )
@@ -573,6 +586,17 @@ class VaultTestBatchRunner:
             self.runtime.execution_model.get_routing_state_details(),
         )
 
+        # Keep the executable adapter on the attempt. The vault universe entry
+        # remains a fallback only for older routes that cannot expose a vault.
+        try:
+            route = pricing_model.route(pair)
+            get_vault = getattr(route, "get_vault", None)
+            resolved_vault = get_vault(pair) if get_vault is not None else None
+            if resolved_vault is not None:
+                vault = resolved_vault
+        except (AttributeError, NotImplementedError):
+            pass
+
         open_trade_position = get_vault_trade_position(
             self.state,
             spec,
@@ -609,6 +633,9 @@ class VaultTestBatchRunner:
 
         assert self.current_attempt is not None
         self.current_attempt.operation = operation
+        self.current_attempt.operation_original_trade_ids = {
+            trade.trade_id for trade in self.state.portfolio.get_all_trades()
+        }
 
         pair = attempt.pair
         spec = attempt.spec
@@ -904,6 +931,7 @@ class VaultTestBatchRunner:
             web3config=self.runtime.web3config,
             test_short=False,
             update_statistics_after_trade=False,
+            sync_state_callback=lambda: self.store.sync(self.state),
         )
 
         assert self.current_attempt is not None
@@ -1282,10 +1310,16 @@ class VaultTestBatchRunner:
         )
         detail = redact_vault_test_error_text(detail or error)
         error_state = getattr(error, "vault_test_failure_state", self.state)
+        evidence_trade_ids = (
+            self.current_attempt.operation_original_trade_ids
+            if self.current_attempt
+            and self.current_attempt.operation_original_trade_ids is not None
+            else original_trade_ids
+        )
         error_data = capture_vault_test_error(
             error,
             state=error_state,
-            original_trade_ids=original_trade_ids,
+            original_trade_ids=evidence_trade_ids,
             web3config=self.runtime.web3config,
             phase=phase,
         )

--- a/tradeexecutor/cli/vault_trade/state.py
+++ b/tradeexecutor/cli/vault_trade/state.py
@@ -50,6 +50,9 @@ VAULT_TEST_RESULTS = {
     "deposit_closed",
     "whitelisting-needed",
     "redemption_unavailable",
+    "redemption_capacity_limited",
+    "adapter_unsupported",
+    "async_request_only",
     "simulation_unsupported_async",
     # Version 1 diagnostic states used this generic value.  Keep presenting it
     # normally when an older state file is reopened, while new attempts use
@@ -262,9 +265,10 @@ def classify_vault_test_failure(
     transactions = error_data.get("transactions", [])
     if any(transaction.get("status") is False for transaction in transactions):
         return "transaction_reverted"
-    if any(transaction.get("status") is True for transaction in transactions):
-        return "receipt_analysis_failed"
-    if any(transaction.get("tx_hash") for transaction in transactions):
+    if any(
+        transaction.get("tx_hash") and transaction.get("status") is None
+        for transaction in transactions
+    ):
         return "broadcast_failed"
     if error_data.get("call_context"):
         return "gas_estimation_reverted"
@@ -479,6 +483,7 @@ def stamp_position_vault_test_attempt(
     phase: str | None = None,
     result: str | None = None,
     detail: str | None = None,
+    outcome_data: dict | None = None,
     attempt_id: str | None = None,
     operation: str | None = None,
     provenance: dict | None = None,
@@ -512,6 +517,8 @@ def stamp_position_vault_test_attempt(
         attempt["result"] = result
     if detail:
         attempt["detail"] = detail
+    if outcome_data:
+        attempt["outcome_data"] = outcome_data
 
 
 def record_attempt_result(
@@ -522,6 +529,7 @@ def record_attempt_result(
     simulated: bool,
     result: str,
     detail: str | None = None,
+    outcome_data: dict | None = None,
     error: dict | None = None,
     source_position_id: int | None = None,
     attempt_id: str | None = None,
@@ -556,6 +564,8 @@ def record_attempt_result(
     attempt["result"] = result
     if detail:
         attempt["detail"] = detail
+    if outcome_data:
+        attempt["outcome_data"] = outcome_data
     if error:
         attempt["error"] = error
     if source_position_id is not None:
@@ -627,6 +637,8 @@ def close_simulated_positions(
     position_ids: set[int],
     result: str | None = None,
     phase: str | None = None,
+    detail: str | None = None,
+    outcome_data: dict | None = None,
     attempt_id: str | None = None,
     operation: str | None = None,
     provenance: dict | None = None,
@@ -668,6 +680,10 @@ def close_simulated_positions(
                 attempt["provenance"] = provenance
             if result:
                 attempt["result"] = result
+            if detail:
+                attempt["detail"] = detail
+            if outcome_data:
+                attempt["outcome_data"] = outcome_data
         if position.is_open():
             state.portfolio.close_position(position, now)
 

--- a/tradeexecutor/cli/vault_trade/state.py
+++ b/tradeexecutor/cli/vault_trade/state.py
@@ -48,6 +48,7 @@ VAULT_TEST_RESULTS = {
     "execution_failed",
     "infrastructure_failed",
     "deposit_closed",
+    "whitelisting-needed",
     "redemption_unavailable",
     "simulation_unsupported_async",
     # Version 1 diagnostic states used this generic value.  Keep presenting it

--- a/tradeexecutor/cli/vault_trade/state.py
+++ b/tradeexecutor/cli/vault_trade/state.py
@@ -51,6 +51,7 @@ VAULT_TEST_RESULTS = {
     "whitelisting-needed",
     "redemption_unavailable",
     "redemption_capacity_limited",
+    "bridge_proceeds_unavailable",
     "adapter_unsupported",
     "async_request_only",
     "simulation_unsupported_async",

--- a/tradeexecutor/ethereum/vault/settlement_retry.py
+++ b/tradeexecutor/ethereum/vault/settlement_retry.py
@@ -29,7 +29,10 @@ from web3.contract.contract import ContractFunction
 
 from tradeexecutor.ethereum.tx import HotWalletTransactionBuilder, TransactionBuilder
 from tradeexecutor.ethereum.vault.settlement_estimate import refresh_vault_settlement_estimate
-from tradeexecutor.ethereum.vault.vault_routing import get_vault_for_pair
+from tradeexecutor.ethereum.vault.vault_routing import (
+    convert_vault_flow_analysis,
+    get_vault_for_pair,
+)
 from tradeexecutor.state.blockhain_transaction import BlockchainTransaction
 from tradeexecutor.state.state import State
 from tradeexecutor.state.trade import TradeExecution, TradeStatus
@@ -608,15 +611,12 @@ def _resolve_single_vault_trade(
             )
             return
 
+        executed_reserve, executed_amount, price = convert_vault_flow_analysis(
+            analysis,
+            direction=direction,
+        )
         if direction == "deposit":
-            executed_reserve = analysis.denomination_amount
-            executed_amount = analysis.share_count
-            price = float(executed_reserve / executed_amount) if executed_amount else 0
             _ensure_legacy_pending_deposit_capital_allocated(state, trade)
-        else:
-            executed_amount = -analysis.share_count
-            executed_reserve = analysis.denomination_amount
-            price = float(executed_reserve / analysis.share_count) if analysis.share_count else 0
 
         # Clear pending status before marking success
         trade.vault_settlement_pending_at = None
@@ -624,7 +624,7 @@ def _resolve_single_vault_trade(
         state.mark_trade_success(
             ts,
             trade,
-            executed_price=price,
+            executed_price=float(price),
             executed_amount=executed_amount,
             executed_reserve=executed_reserve,
             lp_fees=0,

--- a/tradeexecutor/ethereum/vault/settlement_retry.py
+++ b/tradeexecutor/ethereum/vault/settlement_retry.py
@@ -429,8 +429,14 @@ def _resolve_single_vault_trade(
     refresh_vault_settlement_estimate(trade, deposit_manager, ticket, direction)
 
     # STEP A: Check for existing post-request tx (idempotent handling)
-    request_tx_count = trade.other_data.get("vault_request_tx_count", 1)
-    has_existing_post_tx = len(trade.blockchain_transactions) > request_tx_count
+    # ``vault_request_tx_count`` now means manager request calls only, excluding
+    # a separately signed allowance.  Keep the old field as a fallback for
+    # state files created before ``vault_initial_tx_count`` was introduced.
+    initial_tx_count = trade.other_data.get(
+        "vault_initial_tx_count",
+        trade.other_data.get("vault_request_tx_count", 1),
+    )
+    has_existing_post_tx = len(trade.blockchain_transactions) > initial_tx_count
     tx_already_confirmed = False
     confirmed_receipt = None
     is_reclaim_tx = False

--- a/tradeexecutor/ethereum/vault/vault_routing.py
+++ b/tradeexecutor/ethereum/vault/vault_routing.py
@@ -12,10 +12,15 @@ from eth_defi.erc_4626.analysis import analyse_4626_flow_transaction
 from eth_defi.erc_4626.classification import create_vault_instance, create_vault_instance_autodetect
 from eth_defi.erc_4626.flow import approve_and_deposit_4626, approve_and_redeem_4626
 from eth_defi.erc_4626.profit_and_loss import estimate_4626_recent_profitability
+from eth_defi.erc_4626.deposit_redeem import ERC4626DepositManager
 from eth_defi.erc_4626.vault import ERC4626Vault
 from eth_defi.token import fetch_erc20_details, TokenDiskCache
 from eth_defi.trade import TradeSuccess
-from eth_defi.vault.deposit_redeem import VaultDepositManager
+from eth_defi.vault.deposit_redeem import (
+    DepositRedeemEventAnalysis,
+    DepositRedeemEventFailure,
+    VaultDepositManager,
+)
 
 from tradeexecutor.ethereum.swap import get_swap_transactions, report_failure
 from tradeexecutor.ethereum.token_cache import get_default_token_cache
@@ -39,6 +44,27 @@ from tradeexecutor.strategy.universe_model import StrategyExecutionUniverse
 
 
 logger = logging.getLogger(__name__)
+
+
+class VaultReceiptAnalysisError(RuntimeError):
+    """A mined vault transaction could not be decoded into executed amounts."""
+
+
+def convert_vault_flow_analysis(
+    analysis: DepositRedeemEventAnalysis,
+    *,
+    direction: str,
+) -> tuple[Decimal, Decimal, Decimal]:
+    """Convert a manager receipt analysis to executor trade quantities."""
+
+    executed_reserve = analysis.denomination_amount
+    if direction == "deposit":
+        executed_amount = analysis.share_count
+    else:
+        executed_amount = -analysis.share_count
+    price = executed_reserve / analysis.share_count
+    assert executed_reserve > 0 and executed_amount != 0 and price > 0
+    return executed_reserve, executed_amount, price
 
 
 class VaultRoutingState(RoutingState):
@@ -492,27 +518,60 @@ class VaultRouting(RoutingModel):
             return
 
         # Synchronous vault flow — analyse the deposit/redeem result
-        base_token_details = fetch_erc20_details(
-            web3,
-            trade.pair.base.checksum_address,
-            cache=self.token_cache,
-            chain_id=trade.pair.base.chain_id,
-        )
-        reserve = trade.reserve_currency
         direction = "deposit" if trade.is_buy() else "redeem"
 
-        try:
-            result = analyse_4626_flow_transaction(
-                vault=vault,
-                tx_hash=swap_tx.tx_hash,
-                tx_receipt=receipt,
-                direction=direction,
-                hot_wallet=False,
-            )
-        except Exception as e:
-            raise RuntimeError(f"Failed to analyse vault tx: {swap_tx.wrapped_function_selector}: {swap_tx.tx_hash} direction: {direction}, receipt: {receipt}, vault: {vault}") from e
+        if receipt["status"] == 0:
+            report_failure(ts, state, trade, stop_on_execution_failure)
+            return
+
+        deposit_manager = vault.get_deposit_manager()
+        manager_analyser = (
+            type(deposit_manager).analyse_deposit
+            if direction == "deposit"
+            else type(deposit_manager).analyse_redemption
+        )
+        generic_analyser = (
+            ERC4626DepositManager.analyse_deposit
+            if direction == "deposit"
+            else ERC4626DepositManager.analyse_redemption
+        )
+        if manager_analyser is generic_analyser:
+            # The generic manager requires a ticket to identify a GuardV0
+            # wrapper. Synchronous executor trades do not persist one yet.
+            # Keep its existing guarded-wrapper analyser until eth-defi exposes
+            # ticket-free support for this specific compatibility path.
+            try:
+                result = analyse_4626_flow_transaction(
+                    vault=vault,
+                    tx_hash=swap_tx.tx_hash,
+                    tx_receipt=receipt,
+                    direction=direction,
+                    hot_wallet=False,
+                )
+            except Exception as e:
+                raise VaultReceiptAnalysisError(
+                    f"Failed to analyse vault tx {swap_tx.tx_hash} ({direction})"
+                ) from e
+        else:
+            try:
+                if direction == "deposit":
+                    result = deposit_manager.analyse_deposit(swap_tx.tx_hash, None)
+                else:
+                    result = deposit_manager.analyse_redemption(swap_tx.tx_hash, None)
+            except Exception as e:
+                raise VaultReceiptAnalysisError(
+                    f"Failed to analyse vault tx {swap_tx.tx_hash} ({direction})"
+                ) from e
 
         if isinstance(result, TradeSuccess):
+
+            base_token_details = fetch_erc20_details(
+                web3,
+                trade.pair.base.checksum_address,
+                cache=self.token_cache,
+                chain_id=trade.pair.base.chain_id,
+            )
+            reserve = trade.reserve_currency
 
             path = result.path
 
@@ -554,6 +613,29 @@ class VaultRouting(RoutingModel):
             slippage = trade.get_slippage()
             logger.info(f"Executed: {executed_amount} {trade.pair.base.token_symbol}, {executed_reserve} {trade.pair.quote.token_symbol}, price: {trade.executed_price}, expected reserve: {trade.planned_reserve} {trade.pair.quote.token_symbol}, slippage {slippage:.2%}")
 
+        elif isinstance(result, DepositRedeemEventAnalysis):
+            executed_reserve, executed_amount, price = convert_vault_flow_analysis(
+                result,
+                direction=direction,
+            )
+            gas_used = receipt.get("gasUsed", 0)
+            gas_price = receipt.get("effectiveGasPrice", 0)
+
+            state.mark_trade_success(
+                ts,
+                trade,
+                executed_price=float(price),
+                executed_amount=executed_amount,
+                executed_reserve=executed_reserve,
+                lp_fees=0,
+                native_token_price=0,
+                cost_of_gas=float(Decimal(gas_used) * Decimal(gas_price) / Decimal(10**18)),
+            )
+        elif isinstance(result, DepositRedeemEventFailure):
+            raise VaultReceiptAnalysisError(
+                f"Vault manager could not analyse successful {direction} {swap_tx.tx_hash}: "
+                f"{result.revert_reason}"
+            )
         else:
             # Trade failed
             report_failure(ts, state, trade, stop_on_execution_failure)

--- a/tradeexecutor/ethereum/vault/vault_routing.py
+++ b/tradeexecutor/ethereum/vault/vault_routing.py
@@ -7,7 +7,6 @@ from typing import Dict, cast
 
 from eth_typing import HexAddress
 from hexbytes import HexBytes
-from web3.exceptions import Web3Exception
 
 from eth_defi.erc_4626.analysis import analyse_4626_flow_transaction
 from eth_defi.erc_4626.classification import create_vault_instance, create_vault_instance_autodetect
@@ -421,7 +420,7 @@ class VaultRouting(RoutingModel):
             trade.other_data["vault_deposit_amount"] = str(swap_amount)
             try:
                 settles_at = deposit_manager.get_deposit_delay_over(address)
-            except (NotImplementedError, ValueError, Web3Exception) as error:
+            except Exception as error:
                 logger.warning(
                     "Could not estimate vault deposit settlement time for %s: %s",
                     target_vault.vault_address,

--- a/tradeexecutor/ethereum/vault/vault_routing.py
+++ b/tradeexecutor/ethereum/vault/vault_routing.py
@@ -7,10 +7,10 @@ from typing import Dict, cast
 
 from eth_typing import HexAddress
 from hexbytes import HexBytes
+from web3.exceptions import Web3Exception
 
 from eth_defi.erc_4626.analysis import analyse_4626_flow_transaction
 from eth_defi.erc_4626.classification import create_vault_instance, create_vault_instance_autodetect
-from eth_defi.erc_4626.flow import approve_and_deposit_4626, approve_and_redeem_4626
 from eth_defi.erc_4626.profit_and_loss import estimate_4626_recent_profitability
 from eth_defi.erc_4626.deposit_redeem import ERC4626DepositManager
 from eth_defi.erc_4626.vault import ERC4626Vault
@@ -19,7 +19,6 @@ from eth_defi.trade import TradeSuccess
 from eth_defi.vault.deposit_redeem import (
     DepositRedeemEventAnalysis,
     DepositRedeemEventFailure,
-    VaultDepositManager,
 )
 
 from tradeexecutor.ethereum.swap import get_swap_transactions, report_failure
@@ -65,6 +64,93 @@ def convert_vault_flow_analysis(
     price = executed_reserve / analysis.share_count
     assert executed_reserve > 0 and executed_amount != 0 and price > 0
     return executed_reserve, executed_amount, price
+
+
+def _mark_vault_transaction(
+    transaction: BlockchainTransaction,
+    *,
+    role: str,
+    request_ordinal: int | None = None,
+) -> None:
+    """Persist the role of one transaction in a manager-owned vault flow.
+
+    Function selectors are protocol implementation details: an asynchronous
+    request may be called ``requestRedeem``, ``redeemShares`` or something not
+    yet known to the executor.  The role is therefore the durable settlement
+    identity, while a transaction hash remains execution evidence only.
+    """
+
+    if transaction.other is None:
+        transaction.other = {}
+    transaction.other["vault_transaction_role"] = role
+    if request_ordinal is not None:
+        transaction.other["vault_request_ordinal"] = request_ordinal
+
+
+def _get_contract_for_vault_function(
+    vault: ERC4626Vault,
+    function,
+):
+    """Get the contract object matching a manager-returned bound function.
+
+    Lagoon transaction construction validates that the supplied contract and
+    function target agree.  Managers are allowed to return calls directed at a
+    protocol helper rather than the vault itself, so retain known token/vault
+    contract objects and construct a minimal address wrapper for other targets.
+    """
+
+    address = function.address
+    if address.lower() == vault.vault_contract.address.lower():
+        return vault.vault_contract
+    if address.lower() == vault.denomination_token.contract.address.lower():
+        return vault.denomination_token.contract
+    if vault.share_token and address.lower() == vault.share_token.contract.address.lower():
+        return vault.share_token.contract
+    return vault.web3.eth.contract(address=address, abi=[])
+
+
+def get_async_vault_request_transactions(
+    trade: TradeExecution,
+    *,
+    request_function_count: int,
+) -> list[BlockchainTransaction]:
+    """Select ordered manager request transactions without selector matching.
+
+    New trades carry a role and ordinal on every signed transaction.  A legacy
+    pending trade has neither, so use the rebuilt manager request's function
+    count to select its final request calls, then upgrade the state in place.
+    """
+
+    request_transactions = [
+        tx
+        for tx in trade.blockchain_transactions
+        if (tx.other or {}).get("vault_transaction_role") == "vault_request"
+    ]
+    if request_transactions:
+        request_transactions.sort(
+            key=lambda tx: (tx.other or {}).get("vault_request_ordinal", 0)
+        )
+        return request_transactions
+
+    assert request_function_count > 0, "Manager request must contain at least one call"
+    assert len(trade.blockchain_transactions) >= request_function_count, (
+        f"Vault trade #{trade.trade_id} has fewer signed transactions than its "
+        f"rebuilt manager request: {len(trade.blockchain_transactions)} < {request_function_count}"
+    )
+    request_transactions = trade.blockchain_transactions[-request_function_count:]
+    for ordinal, transaction in enumerate(request_transactions):
+        _mark_vault_transaction(
+            transaction,
+            role="vault_request",
+            request_ordinal=ordinal,
+        )
+    trade.other_data["vault_request_transaction_indices"] = [
+        len(trade.blockchain_transactions) - request_function_count + offset
+        for offset in range(request_function_count)
+    ]
+    trade.other_data["vault_request_tx_count"] = request_function_count
+    trade.other_data.setdefault("vault_initial_tx_count", len(trade.blockchain_transactions))
+    return request_transactions
 
 
 class VaultRoutingState(RoutingState):
@@ -250,155 +336,105 @@ class VaultRouting(RoutingModel):
             trade.slippage_tolerance,
         )
 
-        asset_deltas = trade.calculate_asset_deltas()
-
         deposit_manager = target_vault.get_deposit_manager()
 
-        # Async vault flow (Ostium V1.5, ERC-7540 Lagoon)
-        if trade.is_buy() and not deposit_manager.has_synchronous_deposit():
-            return self._build_async_deposit_txs(
-                tx_builder, target_vault, deposit_manager, trade, address, swap_amount,
-            )
-        elif trade.is_sell() and not deposit_manager.has_synchronous_redemption():
-            return self._build_async_redeem_txs(
-                tx_builder, target_vault, deposit_manager, trade, address, swap_amount,
-            )
-
-        # Synchronous vault flow (standard ERC-4626)
+        # The manager owns protocol-specific amount checks and request calls for
+        # both synchronous and asynchronous flows.  In particular, this keeps
+        # cSigma's owner-specific immediate-redemption capacity check intact.
         if trade.is_buy():
-            approve_call, swap_call = approve_and_deposit_4626(
-                vault=target_vault,
-                from_=address,
+            request = deposit_manager.create_deposit_request(
+                owner=address,
                 amount=swap_amount,
                 check_enough_token=False,
             )
+            is_async = not deposit_manager.has_synchronous_deposit()
+            direction = "deposit"
         else:
-            approve_call, swap_call = approve_and_redeem_4626(
-                vault=target_vault,
-                from_=address,
-                amount=swap_amount
+            request = deposit_manager.create_redemption_request(
+                owner=address,
+                shares=swap_amount,
             )
+            is_async = not deposit_manager.has_synchronous_redemption()
+            direction = "redeem"
 
-        approve_gas_limit = 500_000
-        swap_gas_limit = self.vault_interaction_gas_limit
+        txs: list[BlockchainTransaction] = []
 
-        tx_1 = tx_builder.sign_transaction(
-            contract=target_vault.denomination_token.contract,
-            args_bound_func=approve_call,
-            gas_limit=approve_gas_limit,
-            asset_deltas=[],
-            notes=trade.notes,
-        )
+        # Current eth-defi request classes expose manager lifecycle calls in
+        # ``funcs`` and a manager-level approval target.  Preserve the selected
+        # asset's approval as a separate prerequisite; a request-provided
+        # approval call remains in ``funcs`` and is a request transaction.
+        if trade.is_buy():
+            get_approval_target = getattr(
+                deposit_manager,
+                "get_deposit_approval_target",
+                None,
+            )
+            approval_target = (
+                get_approval_target()
+                if get_approval_target is not None
+                else target_vault.vault_address
+            )
+            approve_call = target_vault.denomination_token.approve(
+                approval_target,
+                swap_amount,
+            )
+            approve_tx = tx_builder.sign_transaction(
+                contract=target_vault.denomination_token.contract,
+                args_bound_func=approve_call,
+                gas_limit=500_000,
+                asset_deltas=[],
+                notes=trade.notes,
+            )
+            _mark_vault_transaction(approve_tx, role="vault_approval")
+            txs.append(approve_tx)
 
-        tx_2 = tx_builder.sign_transaction(
-            contract=target_vault.vault_contract,
-            args_bound_func=swap_call,
-            gas_limit=swap_gas_limit,
-            asset_deltas=[],
-            notes=trade.notes,
-        )
-        return [tx_1, tx_2]
-
-    def _build_async_deposit_txs(
-        self,
-        tx_builder: TransactionBuilder,
-        target_vault: ERC4626Vault,
-        deposit_manager: VaultDepositManager,
-        trade: TradeExecution,
-        address: HexAddress,
-        swap_amount: Decimal,
-    ) -> list[BlockchainTransaction]:
-        """Build approve + requestDeposit transactions for async vault deposit."""
-
-        deposit_request = deposit_manager.create_deposit_request(
-            owner=address,
-            amount=swap_amount,
-        )
-        approve_call = target_vault.denomination_token.approve(
-            target_vault.vault_address,
-            swap_amount,
-        )
-
-        # Mark trade for async handling — store both raw and decimal amounts
-        # so we can reconstruct the request during settle_trade() parsing.
-        # Raw amounts are stored as strings: 18-decimal values exceed the
-        # JavaScript safe-integer limit enforced by the state file validator.
-        trade.other_data["vault_async_flow"] = True
-        trade.other_data["vault_raw_amount"] = str(deposit_request.raw_amount)
-        trade.other_data["vault_deposit_amount"] = str(swap_amount)
-        trade.other_data["vault_owner_address"] = address
-
-        # Estimate when this async deposit will settle, so the trade-ui can show
-        # an ETA while the request is in vault_settlement_pending. Ostium V1.5
-        # returns a real timestamp; operator-driven ERC-7540 vaults (Lagoon)
-        # return None (no deterministic on-chain schedule).
-        try:
-            settles_at = deposit_manager.get_deposit_delay_over(address)
-        except Exception as e:
-            logger.warning("Could not estimate vault deposit settlement time for %s: %s", target_vault.vault_address, e)
-            settles_at = None
-        trade.other_data["vault_settlement_estimated_at"] = settles_at.isoformat() if settles_at else None
-
-        # Sign approve tx first
-        txs = [tx_builder.sign_transaction(
-            contract=target_vault.denomination_token.contract,
-            args_bound_func=approve_call,
-            gas_limit=500_000,
-            asset_deltas=[],
-            notes=trade.notes,
-        )]
-
-        # Sign all request funcs (most adapters have 1, but support multiple)
-        for func in deposit_request.funcs:
-            txs.append(tx_builder.sign_transaction(
-                contract=target_vault.vault_contract,
-                args_bound_func=func,
+        for ordinal, function in enumerate(request.funcs):
+            request_tx = tx_builder.sign_transaction(
+                contract=_get_contract_for_vault_function(target_vault, function),
+                args_bound_func=function,
                 gas_limit=self.vault_interaction_gas_limit,
                 asset_deltas=[],
                 notes=trade.notes,
-            ))
+            )
+            _mark_vault_transaction(
+                request_tx,
+                role="vault_request",
+                request_ordinal=ordinal,
+            )
+            txs.append(request_tx)
 
-        trade.other_data["vault_request_tx_count"] = len(txs)
-        return txs
+        if not is_async:
+            return txs
 
-    def _build_async_redeem_txs(
-        self,
-        tx_builder: TransactionBuilder,
-        target_vault: ERC4626Vault,
-        deposit_manager: VaultDepositManager,
-        trade: TradeExecution,
-        address: HexAddress,
-        swap_amount: Decimal,
-    ) -> list[BlockchainTransaction]:
-        """Build requestWithdraw transaction for async vault redemption."""
-
-        redemption_request = deposit_manager.create_redemption_request(
-            owner=address,
-            shares=swap_amount,
-        )
-
-        # Mark trade for async handling — store both raw and decimal amounts.
-        # We store vault_redeem_shares (Decimal) for adapters like Lagoon that
-        # assert `not raw_shares` and require the decimal form for reconstruction.
-        # Raw amounts are stored as strings: 18-decimal share counts exceed the
-        # JavaScript safe-integer limit enforced by the state file validator.
+        # Persist request identity and reconstruction inputs.  The transaction
+        # indices and roles survive a re-sign; the hashes do not define identity.
         trade.other_data["vault_async_flow"] = True
-        trade.other_data["vault_raw_amount"] = str(redemption_request.raw_shares)
-        trade.other_data["vault_redeem_shares"] = str(swap_amount)
+        trade.other_data["vault_direction"] = direction
         trade.other_data["vault_owner_address"] = address
+        trade.other_data["vault_request_tx_count"] = len(request.funcs)
+        trade.other_data["vault_initial_tx_count"] = len(txs)
+        trade.other_data["vault_request_transaction_indices"] = list(
+            range(len(txs) - len(request.funcs), len(txs))
+        )
+        if direction == "deposit":
+            trade.other_data["vault_raw_amount"] = str(request.raw_amount)
+            trade.other_data["vault_deposit_amount"] = str(swap_amount)
+            try:
+                settles_at = deposit_manager.get_deposit_delay_over(address)
+            except (NotImplementedError, ValueError, Web3Exception) as error:
+                logger.warning(
+                    "Could not estimate vault deposit settlement time for %s: %s",
+                    target_vault.vault_address,
+                    error,
+                )
+                settles_at = None
+            trade.other_data["vault_settlement_estimated_at"] = (
+                settles_at.isoformat() if settles_at else None
+            )
+        else:
+            trade.other_data["vault_raw_amount"] = str(request.raw_shares)
+            trade.other_data["vault_redeem_shares"] = str(swap_amount)
 
-        # Sign all request funcs (most adapters have 1, but support multiple)
-        txs = []
-        for func in redemption_request.funcs:
-            txs.append(tx_builder.sign_transaction(
-                contract=target_vault.vault_contract,
-                args_bound_func=func,
-                gas_limit=self.vault_interaction_gas_limit,
-                asset_deltas=[],
-                notes=trade.notes,
-            ))
-
-        trade.other_data["vault_request_tx_count"] = len(txs)
         return txs
 
     def setup_trades(
@@ -444,25 +480,11 @@ class VaultRouting(RoutingModel):
         )
         logger.info(f"Settling vault trade: #{trade.trade_id} for {vault}")
 
-        swap_tx = get_swap_transactions(trade)
-
-        try:
-            receipt = receipts[HexBytes(swap_tx.tx_hash)]
-        except KeyError as e:
-            raise KeyError(f"Could not find hash: {swap_tx.tx_hash} in {receipts}") from e
-
-        ts = get_block_timestamp(web3, receipt["blockNumber"])
-
         # Async vault flow — parse request event and mark as pending settlement
         if trade.other_data.get("vault_async_flow"):
-            if receipt["status"] == 0:
-                report_failure(ts, state, trade, stop_on_execution_failure)
-                return
-
             deposit_manager = vault.get_deposit_manager()
             direction = trade.other_data.get("vault_direction", "deposit" if trade.is_buy() else "redeem")
             owner_address = HexAddress(trade.other_data["vault_owner_address"])
-            tx_hashes = [HexBytes(tx.tx_hash) for tx in trade.blockchain_transactions if tx.tx_hash]
 
             if direction == "deposit":
                 # Reconstruct deposit request using raw_amount (int) —
@@ -472,14 +494,11 @@ class VaultRouting(RoutingModel):
                     owner=owner_address,
                     raw_amount=int(trade.other_data["vault_raw_amount"]),
                 )
-                ticket = deposit_request.parse_deposit_transaction(tx_hashes)
-                ticket_data = deposit_manager.serialize_deposit_ticket(ticket)
-                refresh_vault_settlement_estimate(
+                request_transactions = get_async_vault_request_transactions(
                     trade,
-                    deposit_manager,
-                    ticket,
-                    direction,
+                    request_function_count=len(deposit_request.funcs),
                 )
+                parse_request = deposit_request.parse_deposit_transaction
             else:
                 # Reconstruct redemption request using shares (Decimal) —
                 # Lagoon asserts `not raw_shares` so we must pass the decimal form.
@@ -501,14 +520,42 @@ class VaultRouting(RoutingModel):
                         raw_shares=int(trade.other_data["vault_raw_amount"]),
                         check_enough_token=False,
                     )
-                ticket = redemption_request.parse_redeem_transaction(tx_hashes)
-                ticket_data = deposit_manager.serialize_redemption_ticket(ticket)
-                refresh_vault_settlement_estimate(
+                request_transactions = get_async_vault_request_transactions(
                     trade,
-                    deposit_manager,
-                    ticket,
-                    direction,
+                    request_function_count=len(redemption_request.funcs),
                 )
+                parse_request = redemption_request.parse_redeem_transaction
+
+            request_receipts: list[dict] = []
+            for request_transaction in request_transactions:
+                try:
+                    request_receipt = receipts[HexBytes(request_transaction.tx_hash)]
+                except KeyError as e:
+                    raise KeyError(
+                        f"Could not find request hash: {request_transaction.tx_hash} in {receipts}"
+                    ) from e
+                request_receipts.append(request_receipt)
+                if request_receipt["status"] == 0:
+                    ts = get_block_timestamp(web3, request_receipt["blockNumber"])
+                    report_failure(ts, state, trade, stop_on_execution_failure)
+                    return
+
+            # The final manager request call is the lifecycle timestamp. Do not
+            # include a preceding token approval or infer the request by name.
+            receipt = request_receipts[-1]
+            ts = get_block_timestamp(web3, receipt["blockNumber"])
+            tx_hashes = [HexBytes(tx.tx_hash) for tx in request_transactions]
+            ticket = parse_request(tx_hashes)
+            if direction == "deposit":
+                ticket_data = deposit_manager.serialize_deposit_ticket(ticket)
+            else:
+                ticket_data = deposit_manager.serialize_redemption_ticket(ticket)
+            refresh_vault_settlement_estimate(
+                trade,
+                deposit_manager,
+                ticket,
+                direction,
+            )
 
             state.mark_vault_settlement_pending(ts, trade, ticket_data)
             logger.info(
@@ -516,6 +563,24 @@ class VaultRouting(RoutingModel):
                 trade.trade_id, direction, ticket_data,
             )
             return
+
+        # New manager-owned requests have an explicit role even for a
+        # synchronous flow.  This allows a specialised manager to use a
+        # non-standard function name without teaching the global swap selector
+        # list about its protocol.  Keep selector discovery for legacy trades.
+        request_transactions = [
+            tx
+            for tx in trade.blockchain_transactions
+            if (tx.other or {}).get("vault_transaction_role") == "vault_request"
+        ]
+        swap_tx = request_transactions[-1] if request_transactions else get_swap_transactions(trade)
+
+        try:
+            receipt = receipts[HexBytes(swap_tx.tx_hash)]
+        except KeyError as e:
+            raise KeyError(f"Could not find hash: {swap_tx.tx_hash} in {receipts}") from e
+
+        ts = get_block_timestamp(web3, receipt["blockNumber"])
 
         # Synchronous vault flow — analyse the deposit/redeem result
         direction = "deposit" if trade.is_buy() else "redeem"


### PR DESCRIPTION
## Why

The 129-vault cross-chain simulation conflated adapter support, live vault restrictions, transaction reverts and receipt decoding failures. This update preserves manager-owned lifecycle outcomes so the vault test reports each condition accurately.

## Lessons learnt

A vault adapter must own protocol-specific request and receipt semantics, while trade-executor must preserve structured outcomes without treating an earlier successful lifecycle transaction as proof that receipt analysis failed. Bridge-back burns must be sized from completed redemption proceeds, not planned bridge capital.

## Summary

- route synchronous and asynchronous requests through deposit managers and persist role-based request identity
- retain typed availability context, including capacity, minimum amount and next-open time
- reconcile satellite redemption proceeds before creating a CCTP return burn
- add lifecycle and bridge-resume regression coverage, plus the remaining-fixes plan

## Related issues and PRs

Depends on [web3-ethereum-defi PR #1365](https://github.com/tradingstrategy-ai/web3-ethereum-defi/pull/1365), which supplies the adapter and ABI changes. Continues this PR’s simulated-vault report follow-up.