### PR TITLE
fix: use manager-owned vault simulation settlement

### DIFF
--- a/.claude/plans/trade-executor-eth-defi-master-vault-fixes.md
+++ b/.claude/plans/trade-executor-eth-defi-master-vault-fixes.md
@@ -1,0 +1,310 @@
+# Trade-executor eth-defi master vault fixes
+
+## Objective
+
+Finish the trade-executor work needed to consume the vault support currently
+available on eth-defi master, with particular focus on full asynchronous
+simulation.
+
+The implementation must:
+
+- use an async vault manager's persisted request ticket when forcing settlement
+  on Anvil;
+- call the manager-owned `force_settle()` implementation only when the manager
+  explicitly advertises that capability;
+- retain the existing Ostium V1.5 test helper as a compatibility path until
+  eth-defi exposes an equivalent manager implementation;
+- return `simulation_unsupported_async` for other async managers instead of
+  making a signer-less RPC call or falling through to a generic assertion; and
+- retain the state-inference, cSigma, and revert-evidence fixes already present
+  on this branch.
+
+## Corrected baseline
+
+The report in `docs/reports/cross-chain-vault-test-trade-executor.md` cannot be
+used as direct evidence for this branch's current behaviour. Although its prose
+names trade-executor commit `248e1e20`, every persisted attempt records
+trade-executor commit `42781eea`, and all 1,163 traceback paths point to the
+parent checkout rather than this worktree.
+
+The editable Poetry installation placed the parent checkout ahead of the
+worktree. Future verification must run from this worktree with both source
+roots explicitly first:
+
+```shell
+source .local-test.env && \
+PYTHONPATH="$(pwd):$(pwd)/deps/web3-ethereum-defi:$PYTHONPATH" \
+poetry --project /path/to/parent/trade-executor run pytest ...
+```
+
+Before accepting a matrix rerun, verify `tradeexecutor.__file__`,
+`eth_defi.__file__`, and the report's `trade_executor_commit` provenance all
+refer to this worktree and its current commit.
+
+## Existing behaviour to preserve
+
+These requested fixes are already implemented at `248e1e20` and should receive
+regression coverage or verification, not a second implementation:
+
+1. `VaultTestBatchRunner` calls `perform_test_trade()` with
+   `update_statistics_after_trade=False`, preventing diagnostic positions with
+   no trades from reaching long/short statistics.
+2. Real execution changes the attempt phase to `state_inference` only after
+   `perform_test_trade()` returns. Simulated execution records
+   `state_inference_failed` if no target position/trade was created.
+3. `VaultRouting.deposit_or_redeem()` uses the selected manager's
+   `create_deposit_request()` / `create_redemption_request()` calls. cSigma's
+   `VaultFlowUnavailable` therefore reaches
+   `normalise_vault_flow_failure()` and maps to
+   `redemption_capacity_limited` with requested and available raw amounts.
+4. Failure capture retains transaction status, hash, chain, target/wrapped
+   target, function selectors, revert reason, stack trace, and unsigned call
+   context. A status-0 Accountable transaction remains
+   `transaction_reverted`; decoding selector `0x5945ea56` remains an eth-defi
+   responsibility.
+
+Do not weaken `TradingPosition.is_long()` or `is_short()`, add a second cSigma
+capacity API, or decode Accountable protocol errors in trade-executor.
+
+## Work item 1: reconstruct the manager ticket for forced settlement
+
+Refactor `_force_vault_settlement_and_resolve()` in
+`tradeexecutor/cli/testtrade.py`.
+
+The eth-defi `VaultDepositManager` abstraction deliberately owns both deposit
+and redemption requests, tickets, claims, and forced settlement. There is no
+separate redemption-manager lookup: direction chooses methods on the same
+manager instance.
+
+The exact API was verified in the pinned eth-defi master worktree before
+writing this plan:
+
+- `VaultBase.get_deposit_manager_capability()`;
+- `VaultDepositManagerCapability.supports_anvil_settlement`;
+- `VaultDepositManager.reconstruct_deposit_ticket()`;
+- `VaultDepositManager.reconstruct_redemption_ticket()`; and
+- `VaultDepositManager.force_settle(ticket)`.
+
+Implementation steps:
+
+1. Resolve the vault and its single bidirectional deposit/redemption manager
+   using the vault-chain Web3 connection already passed to the function.
+2. Read `vault_direction` from `trade.other_data`.
+3. Reconstruct the exact persisted request ticket with
+   `reconstruct_deposit_ticket(trade.other_data)` or
+   `reconstruct_redemption_ticket(trade.other_data)`.
+4. Read `vault.get_deposit_manager_capability()` and inspect
+   `supports_anvil_settlement`.
+5. When the capability is `True`, call `deposit_manager.force_settle(ticket)`.
+   Do not pass the executor owner as a settlement caller. Lagoon's manager
+   implementation is responsible for impersonating its deployed valuation
+   manager and Safe and for validating that the selected ticket becomes
+   claimable.
+6. Persist a compact JSON-safe summary of the forced settlement result in
+   `trade.other_data`, including whether settlement was required, the
+   before/after status values, and transaction hashes. This is diagnostic
+   evidence, not durable transaction identity for the subsequent claim. Store
+   enum statuses through their string `.value` and transaction hashes as
+   `0x`-prefixed hex strings; do not persist enum or `HexBytes` objects.
+7. Call `check_and_resolve_vault_settlements()` after the manager has made the
+   ticket claimable. Continue passing `web3config` so a satellite claim uses
+   the vault chain's transaction builder.
+
+Do not append the manager's force-settlement transactions to
+`trade.blockchain_transactions`: the retry module currently interprets
+post-request transactions as claim/reclaim attempts. Store them in
+`trade.other_data` unless that retry ownership model is deliberately refactored
+with corresponding migration tests.
+
+## Work item 2: preserve the Ostium compatibility path and fail closed elsewhere
+
+The eth-defi master baseline only implements manager-owned `force_settle()` for
+Lagoon. Ostium V1.5 is already supported by
+`force_ostium_v15_settlement()` in trade-executor and must not regress.
+
+1. If `supports_anvil_settlement is True`, always use the generic manager path.
+2. Otherwise, if the selected vault is Ostium V1.5, retain the existing
+   permissionless settlement loop using an Anvil-unlocked development account.
+   Then run the shared claim resolver.
+3. Treat an absent capability method, a `None` capability, or a capability
+   whose `supports_anvil_settlement` is missing, `None`, or `False` as not
+   advertising generic forced settlement. Only the explicit Ostium V1.5
+   compatibility branch may proceed from that state.
+4. For every other asynchronous manager, raise
+   `UnsupportedVaultSimulation` before issuing a settlement transaction.
+   Include the manager class, vault address, direction, and advertised
+   capability in the message.
+5. Let the vault-test runner's existing `UnsupportedVaultSimulation` branch in
+   `normalise_vault_flow_failure()` convert the exception to
+   `simulation_unsupported_async`. Retain a focused test for this existing
+   mapping so the forced-settlement change cannot bypass it.
+
+This removes the direct Lagoon `force_lagoon_settle(vault, owner)` branch that
+caused `No Signer available`, while keeping a bounded compatibility exception
+for Ostium.
+
+## Work item 3: strengthen failure and regression tests
+
+Add focused tests without network access.
+
+1. In the home-chain async settlement test module, model a pending trade with a
+   serialised ticket and a vault whose capability advertises
+   `supports_anvil_settlement=True`.
+2. Verify `_force_vault_settlement_and_resolve()` reconstructs the correct
+   direction-specific ticket, calls `manager.force_settle(ticket)`, persists a
+   JSON-safe result summary, and invokes the shared claim resolver.
+3. Add the redemption-direction sibling within the same test where practical,
+   using parametrisation only if it keeps the ordered test steps readable.
+4. Model an async manager without forced settlement support and verify
+   `UnsupportedVaultSimulation` is raised before any settlement or claim call.
+5. Model an Ostium V1.5 vault whose capability does not advertise manager-owned
+   Anvil settlement. Verify the compatibility loop calls
+   `force_ostium_v15_settlement()` with an Anvil-unlocked development account,
+   calls the shared claim resolver afterwards, and does not call
+   `manager.force_settle()`.
+6. Retain or adapt the existing control-flow tests proving home-chain and
+   satellite resolvers use the correct Web3 connection.
+7. Add a runner normalisation assertion showing the unsupported exception maps
+   to `simulation_unsupported_async`.
+8. Keep the existing cSigma capacity and transaction-evidence classifier tests
+   green.
+
+If the mocking needed for `_force_vault_settlement_and_resolve()` becomes
+excessive, extract one small helper to reconstruct the ticket and perform
+manager settlement. Do not introduce protocol abstractions owned by eth-defi.
+
+## Work item 4: retain the failing inner vault operation
+
+The corrected 129-vault run exposed a reporting ownership issue: an automatic
+`deposit` attempt normally performs both a deposit and a redemption, but a
+failure in the latter half still inherits the outer `operation=deposit` label.
+
+1. When recording an exception, inspect only trades created after the attempt's
+   original trade-id snapshot.
+2. Select the newest vault trade, excluding CCTP bridge and unrelated trades.
+3. Derive `deposit` from a buy trade and `redeem` from a sell trade.
+4. Use the derived value for the attempt failure record. If no new vault trade
+   exists, retain the outer operation because the failure happened before vault
+   request construction.
+5. Add a focused test with an old vault trade, a new deposit, a new redemption,
+   and a later non-vault bridge trade. The helper must report `redeem`.
+
+This is reporting-only and must not affect execution, transaction
+classification, or resume ownership.
+
+## Work item 5: reconcile redemption share shortfalls correctly
+
+The corrected matrix exposed status-0 share transfers for the Base Aerodrome
+USDC and Avalanche Pharaoh USDC 40acres vaults. The executor requested its
+planned share quantity even though the wallet held slightly fewer shares.
+
+`VaultRouting.deposit_or_redeem()` intends to round a small shortfall down to
+the onchain balance, but its condition is
+`onchain_balance + swap_amount < 0`. Both values are positive during redemption,
+so this condition can never be true and the epsilon branch is dead.
+
+1. Extract or implement an explicit redemption reconciliation that accepts a
+   positive planned raw/decimal share amount, positive onchain balance, and the
+   configured relative epsilon.
+2. When the balance is equal to or greater than the plan, retain the planned
+   amount; do not redeem unrelated surplus shares.
+3. When the balance is below the plan within epsilon, use the onchain balance.
+4. When the balance shortfall exceeds epsilon, retain the current accounting
+   assertion.
+5. Add one focused test covering exact/surplus balance, an epsilon-sized
+   shortfall, and an excessive shortfall.
+
+This must use the existing token conversion/request path and must not hide a
+material accounting mismatch.
+
+## Work item 6: recognise manager-declared asynchronous directions
+
+The corrected matrix leaves four Ember and two Gains redemptions as
+`redemption pending`, even with `--settle-async-on-anvil`. Their static pair
+kind is synchronous, while their eth-defi manager capabilities correctly
+declare a synchronous deposit and asynchronous redemption. The batch runner
+currently uses only `pair.is_async_vault()` to decide whether to request a full
+forced lifecycle, so it never asks the shared settlement path to resolve or
+reject these redemption tickets.
+
+The concrete capability attributes were verified against pinned eth-defi
+master: `VaultDepositManagerCapability.deposit_flow` and
+`VaultDepositManagerCapability.redemption_flow`, each typed as
+`VaultDepositFlow | None`. The matrix's human-readable `redemption pending`
+status is derived from a trade whose internal status is
+`TradeStatus.vault_settlement_pending`.
+
+1. Add a small runner helper that treats a vault lifecycle as asynchronous when
+   either the pair kind is async or its manager capability declares an
+   asynchronous deposit or redemption flow. The pinned eth-defi API defines
+   `VaultDepositFlow` as the string literal
+   `Literal["synchronous", "asynchronous"]`; compare these fields directly to
+   that verified API.
+2. Treat an absent capability API, `None` capability, or missing flow fields as
+   no additional async evidence; retain the pair-kind fallback.
+3. Use this combined result for `complete_async_lifecycle` in simulated batch
+   execution so a mixed synchronous-deposit/asynchronous-redemption vault is
+   allowed to perform the round trip. Do not change live/manual execution
+   semantics. This flag permits the lifecycle and enables forced settlement,
+   but `_resolve_home_chain_async_settlement()` and
+   `_resolve_satellite_async_settlement()` call the manager settlement path
+   only when the individual direction's trade status is
+   `vault_settlement_pending`. A successful synchronous deposit therefore
+   bypasses forced settlement; only the pending asynchronous redemption reaches
+   the direction-specific ticket path.
+4. With `--settle-async-on-anvil`, allow the existing manager settlement path
+   to resolve managers that advertise support and raise
+   `UnsupportedVaultSimulation` for Ember/Gains managers that do not. This
+   converts misleading durable `redemption pending` rows to the actionable
+   `simulation_unsupported_async` result.
+5. Add focused tests for a synchronous pair whose capability declares an
+   asynchronous redemption, a synchronous-only capability, missing capability,
+   and an intrinsically async pair. Retain coverage that the settlement resolver
+   is a no-op for a direction whose trade is already successful, so mixed-flow
+   detection cannot force-settle the synchronous half.
+
+This is lifecycle detection only. Do not invent settlement support for a
+manager that does not advertise it.
+
+## Verification
+
+Run the focused tests individually with the worktree-first environment:
+
+```shell
+source .local-test.env && \
+PYTHONPATH="$(pwd):$(pwd)/deps/web3-ethereum-defi:$PYTHONPATH" \
+poetry --project /path/to/parent/trade-executor run pytest \
+  tests/units_tests/test_home_chain_async_settlement.py
+
+source .local-test.env && \
+PYTHONPATH="$(pwd):$(pwd)/deps/web3-ethereum-defi:$PYTHONPATH" \
+poetry --project /path/to/parent/trade-executor run pytest \
+  tests/units_tests/test_cross_chain_satellite_async_settlement.py
+
+source .local-test.env && \
+PYTHONPATH="$(pwd):$(pwd)/deps/web3-ethereum-defi:$PYTHONPATH" \
+poetry --project /path/to/parent/trade-executor run pytest \
+  tests/cli/test_vault_test_trade.py
+```
+
+Then run a Lagoon full-lifecycle fork test, if its required RPC environment is
+available, before repeating the 129-vault matrix.
+
+For the matrix rerun, first print the imported module paths in the same shell.
+Accept the output only when:
+
+- `trade_executor_commit` is this branch's current commit;
+- traceback paths, if any, point into this worktree;
+- Lagoon no longer reports `No Signer available`;
+- unsupported async managers end as `simulation_unsupported_async`;
+- cSigma over-capacity redemption ends as
+  `redemption_capacity_limited`; and
+- successful receipt analysis cannot be overwritten by long/short statistics.
+
+## Non-goals
+
+- Implementing new eth-defi protocol adapters or error decoders.
+- Claiming all ERC-7540 managers can be force-settled.
+- Changing live-chain asynchronous settlement.
+- Treating protocol closures or unsupported simulation as successful trades.
+- Editing global position long/short invariants.

--- a/docs/reports/cross-chain-vault-test-eth-defi.md
+++ b/docs/reports/cross-chain-vault-test-eth-defi.md
@@ -1,26 +1,188 @@
 # Eth-defi cross-chain vault test report
 
-## Run
+## Evidence and scope
 
-The complete 129-vault cross-chain simulated matrix was run on 2026-07-24
-against `web3-ethereum-defi` master `b5803bdc5`.
+The corrected 129-vault matrix ran on 2026-07-24 against eth-defi master
+`b5803bdc52606190969ca44af878b25cde8e3dec`. Both import paths were verified
+before the run. The invalid earlier matrix, whose tracebacks imported a
+different trade-executor checkout, is not evidence for eth-defi behaviour.
 
-The raw terminal classification is dominated by a trade-executor post-trade
-state-inference failure. It is therefore not valid to count its 92
-`receipt_analysis_failed` rows as eth-defi decoder failures. The actionable
-eth-defi findings are below.
+The corrected run completed 43 full deposit/redemption simulations. Another 65
+vaults were currently closed or required whitelisting. The actionable
+protocol-level gaps are detailed below. The separate trade-executor report
+covers executor fixes already implemented for settlement ownership,
+failure-operation attribution, share rounding and async lifecycle detection.
 
-| Protocol | Vaults | Required eth-defi work |
-|---|---:|---|
-| Upshift | 1 | Implement a dedicated multi-asset deposit manager for Sentora USD Earn, including accepted-asset conversion, request construction and event analysis. |
-| cSigma Finance | 2 | Expose owner- and amount-aware `maxRedeem` capacity through the manager and return a structured unavailable/capacity outcome before redemption construction. |
-| D2 Finance | 1 | Make closed funding windows and zero `previewDeposit()` pricing a structured preflight result, including the next-open time when available. |
-| Accountable | 1 | Decode custom error `0x5945ea56` and publish the caller/admission condition for the Monad satellite vault. |
-| Lagoon/ERC-7540 | 28 | Provide a protocol-specific Anvil request/settle/claim simulation path, or explicitly advertise that it is unsupported without invoking a signer-less settlement call. |
+## Eth-defi work required
 
-## Evidence to recheck after executor fixes
+### Lagoon Finance
 
-Ember (5), IPOR Fusion (17), Morpho (11), Yearn (43), Euler (4), 40acres
-(3), Gains Network (2), Plutus (2) and YieldNest (1) are currently masked by
-the executor's post-trade state-inference failure. Re-run those rows after the
-trade-executor fixes above before changing their adapters or decoders.
+Affected vaults:
+
+- Moon Digital AM USDC,
+  `1-0xa00f63e85b3d242568a9edecb48f5e2cf879b07b`;
+- Syntropia USDC,
+  `1-0xd17049ed25d8f99fe3bfd10cef2263da9995cfd8`;
+- Angmar Capital,
+  `42161-0x1723cb57af58efb35a013870c90fcc3d60174a4e`;
+- For Yield v2,
+  `8453-0x2bff679b1a9fbcc202316c1402172747ba2fbf56`;
+- RB Capital Yield,
+  `8453-0x63b04d3ce2c14f6d308657ab73ac92fc1a0b1075`;
+  and
+- TruMarket,
+  `8453-0xbe7db44f4ce20dac83b578b94fd35087f66e9754`.
+
+The first three reach `LagoonDepositManager.force_settle()`, but their
+redemption ticket stays `pending -> pending`. Add version-aware settlement
+diagnostics: record the valuation-manager and Safe calls made, inspect the
+settlement receipt/events, and determine whether these deployed versions need
+another settlement method, epoch advance or role. If the fork cannot make the
+ticket claimable, raise `UnsupportedVaultSimulation` with that concrete
+version/role reason.
+
+The three Base vaults revert inside `settleDeposit(_newTotalAssets=...)` because
+the vault calls USDC `transferFrom()` from the impersonated asset holder without
+sufficient allowance. The Anvil driver must reproduce the deployed protocol's
+real approval path before settlement, or explicitly mark that deployment
+unsupported. Catch and translate the settlement transaction failure at the
+manager boundary; do not leak a raw `TransactionAssertionError`, because the
+caller then cannot distinguish a failed settlement driver from a failed user
+request. Return settlement hashes only after checking every receipt.
+
+Add focused fork tests for one successful Lagoon deposit/redemption lifecycle,
+one `pending -> pending` deployment and one allowance-requiring deployment.
+
+### Ember
+
+Affected vaults:
+
+- Ember Earn, `1-0x9be9294722f8aad37b11a9792be2c782182cafa2`;
+- Ember Polymarket, `1-0x0b9342c15143e8f54a83f887c280a922f4c48771`;
+- Ember Third Eye, `1-0xf3190a3ecc109f88e7947b849b281918c798a0c4`;
+- Ember UDL, `1-0x373152feef81cc59502da2c8de877b3d5ae2e342`;
+  and
+- Ember Apollo ACRED,
+  `1-0x2b13311fd553e74b421d4ccc96e348f71e179dcf`.
+
+The first four correctly create asynchronous redemption tickets, but eth-defi
+does not advertise or implement an Anvil settlement driver. If the operator
+processing call can be reproduced on a fork, implement
+`EmberDepositManager.force_settle(ticket)`, impersonate the documented operator,
+advance any required time, verify the matching `RequestProcessed` event and
+publish `supports_anvil_settlement=True`. Otherwise leave the capability false
+and provide a precise unsupported reason.
+
+Apollo ACRED rejects the small test redemption because 904 raw shares are below
+`minWithdrawableShares() == 9,170,000`. Replace the generic `ValueError` with a
+typed `VaultFlowUnavailable` carrying protocol, vault, direction, requested raw
+shares and minimum raw shares. This lets consumers classify it as a current
+redemption constraint rather than an adapter execution failure.
+
+### Gains Network
+
+Affected vaults:
+
+- Base gTrade USDC,
+  `8453-0xad20523a7dc37babc1cc74897e4977232b3d02e5`;
+  and
+- Arbitrum gTrade USDC,
+  `42161-0xd3443ee1e91af28e5fb858fbd0d72a63ba8046e0`.
+
+Deposits succeed and epoch redemptions become pending. Implement a
+ticket-specific Anvil settlement driver that advances the epoch and invokes the
+keeper/manager processing path required by the deployed version. It must verify
+the exact redemption ticket becomes claimable before advertising
+`supports_anvil_settlement=True`. If protocol state cannot be safely advanced,
+return a typed unsupported-simulation result with the epoch and timing
+requirement.
+
+### cSigma Finance
+
+Affected vaults:
+
+- cSigma USD, `1-0xd5d097f278a735d0a3c609deee71234cac14b47e`;
+  and
+- cSuperior Quality Private Credit USDC,
+  `1-0x438982ea288763370946625fd76c2508ee1fb229`.
+
+The capacity-aware `CsigmaDepositManager` is selected only for the one hardcoded
+V2 address. cSigma USD therefore falls back to the generic ERC-4626 manager and
+asserts because `maxRedeem(owner)` is only 45,379 raw shares while the request
+is 907,575. Detect supported cSigma deployments by contract version or
+capability rather than one address, and return `VaultFlowUnavailable` with
+requested and available capacity before constructing the request.
+
+cSuperior deposits successfully, but `redeem()` reverts with
+`Withdrawal pending`. This is evidence that the deployment is not an immediate
+synchronous ERC-4626 redemption. Model its FIFO/queued withdrawal as an
+asynchronous redemption request and ticket, including request-event parsing,
+status probing, claim construction and an Anvil settlement driver if the queue
+can be advanced. Do not treat `Withdrawal pending` as a generic synchronous
+revert.
+
+### YieldNest
+
+YieldNest RWA MAX,
+`1-0x01ba69727e2860b37bc1a2bd56999c1afb4c15d8`, accepts the deposit but its
+`redeem()` reverts with custom error `0xb8b8b59c` and encoded owner/requested
+amount data. Add the deployed ABI error, decode the selector and determine
+whether it represents capacity, cooldown, queueing or access policy. Expose the
+corresponding preflight or asynchronous manager flow and raise a typed
+`VaultFlowUnavailable` when the condition is current-state admission rather
+than an implementation error.
+
+### Accountable
+
+Hyperithm Delta Neutral Vault,
+`143-0x7cd231120a60f500887444a9baf5e1bd753a5e59`, reverts its Monad `deposit()`
+with custom error `0x5945ea56`. Add the deployed contract error ABI or selector
+mapping, identify whether the executor module needs a role/allow-list entry or
+whether deposits are paused/capped, and surface that condition through
+`is_account_whitelisted()`, deposit-capability preflight or a typed
+`VaultFlowUnavailable`. Preserve the selector and decoded arguments in the
+failure.
+
+### Upshift
+
+Sentora USD Earn,
+`1-0x74ad2f789ed583dbd141bbdafc673fe1f033718b`, is correctly reported as
+adapter-unsupported because it accepts multiple assets and the generic manager
+cannot choose or convert the input asset. Implement a dedicated manager that:
+
+1. discovers accepted assets and their per-asset limits;
+2. selects the requested denomination asset or performs the required conversion;
+3. builds approval and deposit/request calls for that asset;
+4. parses shares and denomination amounts from the deployed events; and
+5. advertises support only for directions with a complete request/claim
+   lifecycle.
+
+### Plutus
+
+Plutus Hedge Token,
+`42161-0x58bfc95a864e18e8f3041d2fcd3418f48393fe6a`, reports
+`redemption_unavailable` after a successful deposit. Confirm whether this is a
+live protocol state (cooldown, window or capacity) or missing adapter support.
+If it is live state, populate a typed reason and next eligible time where
+available. If a public request/claim flow exists, implement it and advertise
+the correct synchronous/asynchronous capability.
+
+## Not eth-defi defects
+
+The two 40acres balance reverts were caused by trade-executor requesting its
+planned share quantity instead of a slightly smaller actual module balance; the
+executor reconciliation is fixed. The 51 deposit-closed rows and 14
+whitelist-gated rows reflect current on-chain admission and should remain
+structured non-success results.
+
+## Acceptance criteria
+
+For each protocol change:
+
+1. add a focused manager-level test using the affected deployment/version;
+2. publish capability metadata only for complete deposit and redemption paths;
+3. use typed flow or unsupported-simulation exceptions instead of generic
+   `ValueError`, `AssertionError` or raw settlement transaction errors;
+4. persist enough ticket data to reconstruct a claim after restart; and
+5. verify a successful forced settlement changes the selected ticket from
+   pending to claimable before returning.

--- a/docs/reports/cross-chain-vault-test-eth-defi.md
+++ b/docs/reports/cross-chain-vault-test-eth-defi.md
@@ -1,0 +1,26 @@
+# Eth-defi cross-chain vault test report
+
+## Run
+
+The complete 129-vault cross-chain simulated matrix was run on 2026-07-24
+against `web3-ethereum-defi` master `b5803bdc5`.
+
+The raw terminal classification is dominated by a trade-executor post-trade
+state-inference failure. It is therefore not valid to count its 92
+`receipt_analysis_failed` rows as eth-defi decoder failures. The actionable
+eth-defi findings are below.
+
+| Protocol | Vaults | Required eth-defi work |
+|---|---:|---|
+| Upshift | 1 | Implement a dedicated multi-asset deposit manager for Sentora USD Earn, including accepted-asset conversion, request construction and event analysis. |
+| cSigma Finance | 2 | Expose owner- and amount-aware `maxRedeem` capacity through the manager and return a structured unavailable/capacity outcome before redemption construction. |
+| D2 Finance | 1 | Make closed funding windows and zero `previewDeposit()` pricing a structured preflight result, including the next-open time when available. |
+| Accountable | 1 | Decode custom error `0x5945ea56` and publish the caller/admission condition for the Monad satellite vault. |
+| Lagoon/ERC-7540 | 28 | Provide a protocol-specific Anvil request/settle/claim simulation path, or explicitly advertise that it is unsupported without invoking a signer-less settlement call. |
+
+## Evidence to recheck after executor fixes
+
+Ember (5), IPOR Fusion (17), Morpho (11), Yearn (43), Euler (4), 40acres
+(3), Gains Network (2), Plutus (2) and YieldNest (1) are currently masked by
+the executor's post-trade state-inference failure. Re-run those rows after the
+trade-executor fixes above before changing their adapters or decoders.

--- a/docs/reports/cross-chain-vault-test-trade-executor.md
+++ b/docs/reports/cross-chain-vault-test-trade-executor.md
@@ -1,0 +1,41 @@
+# Trade-executor cross-chain vault test report
+
+## Run
+
+The complete 129-vault cross-chain simulated matrix was run on 2026-07-24
+with `trade-executor` at `248e1e20` and `web3-ethereum-defi` master at
+`b5803bdc5`. The invocation used `--auto-simulated --settle-async-on-anvil`.
+
+| Result | Vaults |
+|---|---:|
+| Deposit closed | 34 |
+| Receipt analysis failed | 92 |
+| Transaction reverted | 2 |
+| Execution failed | 1 |
+
+The only execution-admission gap is Upshift Sentora USD Earn
+(`1-0x74ad2f789ed583dbd141bbdafc673fe1f033718b`), whose multi-asset deposit
+is explicitly unsupported by the generic ERC-4626 manager.
+
+## Trade-executor fixes needed
+
+1. Preserve a completed deposit and its decoded receipt as success when the
+   post-trade long/short classification cannot be inferred. This accounting
+   assertion currently turns 92 completed lifecycle attempts into
+   `receipt_analysis_failed` across otherwise unrelated protocols.
+2. Classify the result as `state_inference_failed` (or a dedicated position
+   classification outcome), rather than `receipt_analysis_failed`, when
+   transaction and manager analysis succeeded but portfolio inspection fails.
+   Preserve the transaction evidence and decoded amounts in either case.
+3. Do not run simulated Lagoon/ERC-7540 settlement through a signer-less
+   provider. The 28 Lagoon rows return JSON-RPC `No Signer available`; the
+   runner should classify this as infrastructure or explicitly unsupported
+   settlement before attempting the request.
+4. Treat cSigma's `maxRedeem` constraint as an amount-aware redemption-capacity
+   result, not a receipt-analysis error after a successful deposit.
+5. Keep the Accountable Monad satellite revert (`0x5945ea56`) as a structured
+   transaction-reverted result with decoded custom-error context.
+
+These are executor-side reporting and lifecycle issues. They obscure protocol
+coverage and should be addressed before using this matrix as an adapter-success
+metric.

--- a/docs/reports/cross-chain-vault-test-trade-executor.md
+++ b/docs/reports/cross-chain-vault-test-trade-executor.md
@@ -1,41 +1,142 @@
 # Trade-executor cross-chain vault test report
 
-## Run
+## Evidence and scope
 
-The complete 129-vault cross-chain simulated matrix was run on 2026-07-24
-with `trade-executor` at `248e1e20` and `web3-ethereum-defi` master at
-`b5803bdc5`. The invocation used `--auto-simulated --settle-async-on-anvil`.
+The earlier report was invalid for this branch: its persisted provenance named
+trade-executor commit `42781eea`, and its tracebacks imported the parent
+checkout, despite the report prose claiming `248e1e20`. It must not be used as
+an adapter baseline.
 
-| Result | Vaults |
+The corrected 129-vault matrix ran on 2026-07-24 from this worktree with:
+
+- trade-executor HEAD `2479c991`;
+- eth-defi master `b5803bdc52606190969ca44af878b25cde8e3dec`;
+- worktree-first imports for both `tradeexecutor` and the eth-defi submodule;
+  and
+- `--auto-simulated --settle-async-on-anvil`.
+
+The report's trade-executor commit field records HEAD rather than dirty source
+state. Traceback paths and explicit import checks confirm that the run used the
+worktree implementation, including manager-owned Lagoon settlement. The final
+operation-attribution, share-reconciliation and capability-based async
+detection patches described below were added after this matrix snapshot and
+have focused test coverage.
+
+## Corrected matrix output
+
+| Status | Vaults | Interpretation |
+|---|---:|---|
+| Success (simulated) | 43 | Deposit and redemption lifecycle completed |
+| Redemption pending | 6 | Four Ember and two Gains redemptions were not recognised as async from manager metadata |
+| Deposit closed | 51 | Current on-chain admission state, principally Yearn `maxDeposit=0` |
+| Whitelisting needed | 14 | The simulated executor Safe is not admitted |
+| Adapter unsupported | 1 | Upshift multi-asset deposit is not implemented |
+| Simulation unsupported async | 3 | Lagoon settlement ran but left the redemption ticket pending |
+| Broadcast failed | 3 | Lagoon forced deposit settlement reverted for insufficient allowance |
+| Transaction reverted | 5 | Two 40acres closes, cSigma redemption, YieldNest redemption and Accountable deposit |
+| Execution failed | 2 | cSigma capacity assertion and Ember minimum-withdrawal error |
+| Redemption unavailable | 1 | Plutus Hedge Token accepted the deposit but did not offer redemption |
+
+The 51 closed and 14 whitelist-gated rows are useful admission results, not
+adapter regressions. The 21 rows below are incomplete or unsupported lifecycle
+coverage in this snapshot.
+
+| Protocol | Vaults with gaps | Matrix result |
+|---|---:|---|
+| 40acres | 2 | Redemption transferred slightly more shares than the satellite module held |
+| Accountable | 1 | Monad deposit reverted with undecoded custom error `0x5945ea56` |
+| cSigma Finance | 2 | One `maxRedeem` capacity assertion; one `Withdrawal pending` redemption revert |
+| Ember | 5 | Four asynchronous redemptions pending; Apollo ACRED below protocol minimum |
+| Gains Network | 2 | Asynchronous redemptions pending |
+| Lagoon Finance | 6 | Three tickets remained pending; three `settleDeposit()` allowance reverts |
+| Plutus | 1 | Redemption currently unavailable |
+| Upshift | 1 | Multi-asset deposit adapter unsupported |
+| YieldNest | 1 | Redemption reverted with custom error `0xb8b8b59c` |
+
+## Implemented trade-executor fixes
+
+### Manager-owned forced settlement
+
+`_force_vault_settlement_and_resolve()` now:
+
+1. resolves the eth-defi manager and its capability;
+2. reconstructs the persisted deposit or redemption ticket for the actual
+   direction;
+3. calls `manager.force_settle(ticket)` only when
+   `supports_anvil_settlement is True`;
+4. stores JSON-safe before/after statuses and settlement transaction hashes in
+   `trade.other_data`;
+5. retains the existing Ostium V1.5 permissionless Anvil compatibility path;
+   and
+6. raises `UnsupportedVaultSimulation` before broadcasting for every other
+   manager.
+
+This removes the signer-less Lagoon call. The corrected matrix contains no
+`No Signer available`, `receipt_analysis_failed`, or
+`state_inference_failed` rows. A focused Lagoon lifecycle completed both
+deposit and redemption and persisted manager settlement evidence.
+
+### Failure operation attribution
+
+Automatic deposit attempts perform a deposit and, where possible, a
+redemption. Failure capture now examines only new vault trades and labels the
+attempt from the newest one. A failed sell is therefore reported as `redeem`
+instead of inheriting the outer `deposit` label; later bridge trades cannot
+overwrite it.
+
+### Redemption share reconciliation
+
+The old epsilon branch tested
+`onchain_balance + planned_redemption < 0`. Both operands are positive, so it
+was unreachable. The routing path now:
+
+- retains the planned amount when the balance covers it;
+- caps to the actual on-chain balance for a shortfall within the configured
+  epsilon; and
+- preserves the accounting assertion for a material shortfall.
+
+This addresses the two 40acres `transfer amount exceeds balance` rows. A
+post-fix live rerun could not start because two fresh ephemeral Lagoon
+deployments reverted during guard configuration, before either target vault
+was executed; the deterministic reconciliation cases pass.
+
+### Manager-declared async lifecycle detection
+
+The batch runner now combines the pair kind with
+`VaultDepositManagerCapability.deposit_flow` and `redemption_flow`. This
+recognises mixed synchronous-deposit/asynchronous-redemption managers such as
+Ember and Gains. With forced simulation enabled, their pending redemption now
+reaches the existing direction-specific resolver and becomes
+`simulation_unsupported_async` unless eth-defi advertises a settlement driver.
+A successful synchronous deposit never enters forced settlement because the
+resolver is gated by `TradeStatus.vault_settlement_pending`.
+
+## Remaining trade-executor work
+
+No protocol-specific settlement logic should be added to trade-executor.
+Remaining executor work is verification and report provenance:
+
+1. Repeat the full matrix after the ephemeral Lagoon deployment issue is
+   resolved. Confirm the two 40acres rows close successfully, the six
+   Ember/Gains rows become explicit unsupported-simulation results, and all
+   redemption failures carry `operation=redeem`.
+2. Record the imported eth-defi commit and dirty-worktree state in report
+   provenance. The corrected JSON reports `eth_defi_commit=null`, and HEAD alone
+   cannot identify uncommitted executor code.
+3. Continue mapping typed eth-defi `UnsupportedVaultSimulation` and
+   `VaultFlowUnavailable` exceptions to stable terminal results. Do not infer
+   protocol policy from generic RPC assertion text.
+
+The protocol-specific work required for completed simulations is listed in the
+separate eth-defi report.
+
+## Verification
+
+Focused checks after implementation:
+
+| Test | Result |
 |---|---:|
-| Deposit closed | 34 |
-| Receipt analysis failed | 92 |
-| Transaction reverted | 2 |
-| Execution failed | 1 |
-
-The only execution-admission gap is Upshift Sentora USD Earn
-(`1-0x74ad2f789ed583dbd141bbdafc673fe1f033718b`), whose multi-asset deposit
-is explicitly unsupported by the generic ERC-4626 manager.
-
-## Trade-executor fixes needed
-
-1. Preserve a completed deposit and its decoded receipt as success when the
-   post-trade long/short classification cannot be inferred. This accounting
-   assertion currently turns 92 completed lifecycle attempts into
-   `receipt_analysis_failed` across otherwise unrelated protocols.
-2. Classify the result as `state_inference_failed` (or a dedicated position
-   classification outcome), rather than `receipt_analysis_failed`, when
-   transaction and manager analysis succeeded but portfolio inspection fails.
-   Preserve the transaction evidence and decoded amounts in either case.
-3. Do not run simulated Lagoon/ERC-7540 settlement through a signer-less
-   provider. The 28 Lagoon rows return JSON-RPC `No Signer available`; the
-   runner should classify this as infrastructure or explicitly unsupported
-   settlement before attempting the request.
-4. Treat cSigma's `maxRedeem` constraint as an amount-aware redemption-capacity
-   result, not a receipt-analysis error after a successful deposit.
-5. Keep the Accountable Monad satellite revert (`0x5945ea56`) as a structured
-   transaction-reverted result with decoded custom-error context.
-
-These are executor-side reporting and lifecycle issues. They obscure protocol
-coverage and should be addressed before using this matrix as an adapter-success
-metric.
+| `tests/cli/test_vault_test_trade.py` | 44 passed |
+| `tests/units_tests/test_home_chain_async_settlement.py` | 9 passed |
+| `tests/units_tests/test_cross_chain_satellite_async_settlement.py` | 9 passed |
+| `deps/web3-ethereum-defi/tests/lagoon/test_erc_7540_deposit_redeem.py` | 2 passed |

--- a/docs/reports/cross-chain-vault-test-trade-executor.md
+++ b/docs/reports/cross-chain-vault-test-trade-executor.md
@@ -15,12 +15,14 @@ The corrected 129-vault matrix ran on 2026-07-24 from this worktree with:
   and
 - `--auto-simulated --settle-async-on-anvil`.
 
-The report's trade-executor commit field records HEAD rather than dirty source
-state. Traceback paths and explicit import checks confirm that the run used the
-worktree implementation, including manager-owned Lagoon settlement. The final
-operation-attribution, share-reconciliation and capability-based async
-detection patches described below were added after this matrix snapshot and
-have focused test coverage.
+The run used uncommitted manager-owned settlement changes that were later
+included in `9220345b`, but its JSON provenance records only the then-current
+HEAD `2479c991`. Traceback paths and explicit import checks confirm the
+worktree source was imported, but the exact dirty source state cannot be
+reconstructed from the JSON. Treat the counts as observed behavioural evidence,
+not as a commit-reproducible run. Operation attribution, share reconciliation
+and capability-based async detection were added after this matrix snapshot and
+have focused test coverage only.
 
 ## Corrected matrix output
 
@@ -93,7 +95,7 @@ was unreachable. The routing path now:
 - retains the planned amount when the balance covers it;
 - caps to the actual on-chain balance for a shortfall within the configured
   epsilon; and
-- preserves the accounting assertion for a material shortfall.
+- raises the accounting assertion before broadcasting for a material shortfall.
 
 This addresses the two 40acres `transfer amount exceeds balance` rows. A
 post-fix live rerun could not start because two fresh ephemeral Lagoon

--- a/tests/cli/test_vault_test_trade.py
+++ b/tests/cli/test_vault_test_trade.py
@@ -1428,7 +1428,7 @@ def test_vault_redemption_amount_reconciles_only_small_share_shortfalls() -> Non
     assert small_shortfall == Decimal("0.99")
 
     # 3. Verify a material accounting shortfall remains an error.
-    with pytest.raises(AssertionError, match="large relative difference"):
+    with pytest.raises(AssertionError, match="large relative shortfall"):
         reconcile_vault_redemption_amount(
             Decimal("1"),
             Decimal("0.9"),

--- a/tests/cli/test_vault_test_trade.py
+++ b/tests/cli/test_vault_test_trade.py
@@ -10,7 +10,11 @@ from unittest.mock import MagicMock
 
 import pytest
 from eth_defi.vault.base import VaultSpec
-from eth_defi.vault.deposit_redeem import VaultFlowUnavailable
+from eth_defi.vault.deposit_redeem import (
+    UnsupportedVaultSimulation,
+    VaultDepositManagerCapability,
+    VaultFlowUnavailable,
+)
 from hexbytes import HexBytes
 from requests.exceptions import ReadTimeout
 from textual.app import App, ComposeResult
@@ -60,6 +64,8 @@ from tradeexecutor.cli.vault_trade.runner import (
     get_adapter_unsupported_detail,
     get_bridge_conflict,
     get_deposit_closed_detail,
+    has_async_vault_lifecycle,
+    get_latest_attempt_vault_operation,
     get_whitelisting_needed_detail,
     normalise_vault_flow_failure,
     should_leave_deposit_open,
@@ -70,6 +76,7 @@ from tradeexecutor.ethereum.vault import vault_routing
 from tradeexecutor.ethereum.vault.vault_routing import (
     convert_vault_flow_analysis,
     get_async_vault_request_transactions,
+    reconcile_vault_redemption_amount,
 )
 from tradeexecutor.state.blockhain_transaction import BlockchainTransaction
 from tradeexecutor.ethereum.web3config import Web3Config
@@ -284,6 +291,61 @@ def test_deposit_round_trip_gating() -> None:
             operation="redeem", is_async=True, redemption_available=False, manual=True
         )
         is False
+    )
+
+
+def test_async_vault_lifecycle_uses_manager_capability_metadata() -> None:
+    """Manager flow metadata supplements static pair-kind async detection.
+
+    1. Model real string capabilities for mixed and synchronous-only lifecycles.
+    2. Model absent capability metadata and an intrinsically asynchronous pair.
+    3. Verify every async source is recognised without changing safe fallbacks.
+
+    Mocks cover metadata combinations without constructing chain-backed adapters.
+    """
+    # 1. Model real string capabilities for mixed and synchronous-only lifecycles.
+    synchronous_pair = MagicMock()
+    synchronous_pair.is_async_vault.return_value = False
+    mixed_vault = MagicMock()
+    mixed_vault.get_deposit_manager_capability.return_value = (
+        VaultDepositManagerCapability(
+            can_deposit=True,
+            can_redeem=True,
+            deposit_flow="synchronous",
+            redemption_flow="asynchronous",
+        )
+    )
+    synchronous_vault = MagicMock()
+    synchronous_vault.get_deposit_manager_capability.return_value = (
+        VaultDepositManagerCapability(
+            can_deposit=True,
+            can_redeem=True,
+            deposit_flow="synchronous",
+            redemption_flow="synchronous",
+        )
+    )
+
+    # 2. Model absent capability metadata and an intrinsically asynchronous pair.
+    missing_capability_vault = object()
+    null_capability_vault = MagicMock()
+    null_capability_vault.get_deposit_manager_capability.return_value = None
+    asynchronous_pair = MagicMock()
+    asynchronous_pair.is_async_vault.return_value = True
+
+    # 3. Verify every async source is recognised without changing safe fallbacks.
+    assert has_async_vault_lifecycle(synchronous_pair, mixed_vault) is True
+    assert has_async_vault_lifecycle(synchronous_pair, synchronous_vault) is False
+    assert (
+        has_async_vault_lifecycle(synchronous_pair, missing_capability_vault)
+        is False
+    )
+    assert (
+        has_async_vault_lifecycle(synchronous_pair, null_capability_vault)
+        is False
+    )
+    assert (
+        has_async_vault_lifecycle(asynchronous_pair, missing_capability_vault)
+        is True
     )
 
 
@@ -1155,6 +1217,64 @@ def test_vault_flow_failures_have_typed_report_outcomes() -> None:
     }
 
 
+def test_unsupported_vault_simulation_has_typed_report_outcome() -> None:
+    """Unsupported manager settlement becomes an actionable terminal result.
+
+    1. Create the typed eth-defi simulation capability failure.
+    2. Normalise it through the vault-test reporting helper.
+    3. Verify the report result remains distinct from execution failures.
+    """
+    # 1. Create the typed eth-defi simulation capability failure.
+    error = UnsupportedVaultSimulation(
+        "AccountableDepositManager does not advertise Anvil settlement"
+    )
+
+    # 2. Normalise it through the vault-test reporting helper.
+    result, detail, outcome_data = normalise_vault_flow_failure(error)
+
+    # 3. Verify the report result remains distinct from execution failures.
+    assert result == "simulation_unsupported_async"
+    assert (
+        detail
+        == "AccountableDepositManager does not advertise Anvil settlement"
+    )
+    assert outcome_data == {}
+
+
+def test_failure_operation_uses_latest_attempt_vault_trade() -> None:
+    """A redemption failure is not labelled as the outer deposit attempt.
+
+    1. Model an old vault trade and new deposit/redemption trades.
+    2. Add a newer non-vault bridge trade that must not own the operation.
+    3. Verify the latest new vault trade identifies the redemption phase.
+
+    Mocks isolate trade ordering from portfolio serialisation.
+    """
+    # 1. Model an old vault trade and new deposit/redemption trades.
+    old_trade = MagicMock(trade_id=1)
+    old_trade.is_vault.return_value = True
+    deposit_trade = MagicMock(trade_id=2)
+    deposit_trade.is_vault.return_value = True
+    deposit_trade.is_buy.return_value = True
+    redemption_trade = MagicMock(trade_id=3)
+    redemption_trade.is_vault.return_value = True
+    redemption_trade.is_buy.return_value = False
+
+    # 2. Add a newer non-vault bridge trade that must not own the operation.
+    bridge_trade = MagicMock(trade_id=4)
+    bridge_trade.is_vault.return_value = False
+    state = MagicMock()
+    state.portfolio.get_all_trades.return_value = [
+        old_trade,
+        deposit_trade,
+        redemption_trade,
+        bridge_trade,
+    ]
+
+    # 3. Verify the latest new vault trade identifies the redemption phase.
+    assert get_latest_attempt_vault_operation(state, {1}) == "redeem"
+
+
 def test_bridge_proceeds_failure_has_typed_report_outcome() -> None:
     """Unavailable satellite redemption proceeds stay distinguishable in reports.
 
@@ -1276,6 +1396,44 @@ def test_vault_flow_analysis_conversion_preserves_trade_signs() -> None:
     # 3. Verify reserve, share sign and price follow the executor trade contract.
     assert deposit == (Decimal("10"), Decimal("8"), Decimal("1.25"))
     assert redemption == (Decimal("10"), Decimal("-8"), Decimal("1.25"))
+
+
+def test_vault_redemption_amount_reconciles_only_small_share_shortfalls() -> None:
+    """Vault redemption uses the available balance only for tolerable shortfalls.
+
+    1. Reconcile exact, surplus and small-shortfall on-chain share balances.
+    2. Verify a small shortfall caps the redemption while other balances retain the plan.
+    3. Verify a material accounting shortfall remains an error.
+    """
+    # 1. Reconcile exact, surplus and small-shortfall on-chain share balances.
+    exact = reconcile_vault_redemption_amount(
+        Decimal("1"),
+        Decimal("1"),
+        epsilon=0.025,
+    )
+    surplus = reconcile_vault_redemption_amount(
+        Decimal("1"),
+        Decimal("1.01"),
+        epsilon=0.025,
+    )
+    small_shortfall = reconcile_vault_redemption_amount(
+        Decimal("1"),
+        Decimal("0.99"),
+        epsilon=0.025,
+    )
+
+    # 2. Verify a small shortfall caps the redemption while other balances retain the plan.
+    assert exact == Decimal("1")
+    assert surplus == Decimal("1")
+    assert small_shortfall == Decimal("0.99")
+
+    # 3. Verify a material accounting shortfall remains an error.
+    with pytest.raises(AssertionError, match="large relative difference"):
+        reconcile_vault_redemption_amount(
+            Decimal("1"),
+            Decimal("0.9"),
+            epsilon=0.025,
+        )
 
 
 def test_async_vault_request_transaction_roles_ignore_selectors() -> None:

--- a/tests/units_tests/test_home_chain_async_settlement.py
+++ b/tests/units_tests/test_home_chain_async_settlement.py
@@ -28,9 +28,19 @@ from decimal import Decimal
 from unittest.mock import MagicMock
 
 import pytest
+from eth_defi.erc_4626.vault_protocol.gains.vault import OstiumVault, OstiumVersion
+from eth_defi.vault.deposit_redeem import (
+    AsyncVaultRequestStatus,
+    UnsupportedVaultSimulation,
+    VaultForcedSettlementResult,
+)
+from hexbytes import HexBytes
 
 from tradeexecutor.cli import testtrade
-from tradeexecutor.cli.testtrade import _resolve_home_chain_async_settlement
+from tradeexecutor.cli.testtrade import (
+    _force_vault_settlement_and_resolve,
+    _resolve_home_chain_async_settlement,
+)
 from tradeexecutor.state.identifier import TradingPairIdentifier
 from tradeexecutor.state.trade import TradeStatus
 from tradeexecutor.strategy.sync_model import SyncModel
@@ -165,6 +175,206 @@ def test_pending_home_trade_on_anvil_force_settles(monkeypatch) -> None:
     assert captured["state"] is state
     assert captured["trade"] is trade
     assert captured["execution_model"] is execution_model
+
+
+@pytest.mark.parametrize(
+    ("direction", "reconstruct_method"),
+    [
+        ("deposit", "reconstruct_deposit_ticket"),
+        ("redeem", "reconstruct_redemption_ticket"),
+    ],
+)
+def test_forced_anvil_settlement_uses_manager_ticket(
+    monkeypatch: pytest.MonkeyPatch,
+    direction: str,
+    reconstruct_method: str,
+) -> None:
+    """A capable async manager owns ticket reconstruction and Anvil settlement.
+
+    1. Model a pending async trade and manager with explicit Anvil capability.
+    2. Force settlement through the trade-executor helper.
+    3. Verify the direction-specific ticket and manager driver were used.
+    4. Verify JSON-safe evidence was saved before the shared claim resolver ran.
+
+    Mocks isolate settlement orchestration from chain-backed manager execution.
+    """
+    # 1. Model a pending async trade and manager with explicit Anvil capability.
+    trade = _make_trade(TradeStatus.vault_settlement_pending)
+    trade.pair = MagicMock()
+    trade.other_data = {"vault_direction": direction, "ticket": "serialised"}
+    ticket = object()
+    manager = MagicMock()
+    getattr(manager, reconstruct_method).return_value = ticket
+    manager.force_settle.return_value = VaultForcedSettlementResult(
+        ticket=ticket,
+        settlement_required=True,
+        status_before=AsyncVaultRequestStatus.pending,
+        status_after=AsyncVaultRequestStatus.claimable,
+        transaction_hashes=(HexBytes("0x" + "01" * 32),),
+    )
+    capability = MagicMock(supports_anvil_settlement=True)
+    vault = MagicMock()
+    vault.address = "0x0000000000000000000000000000000000000001"
+    vault.get_deposit_manager.return_value = manager
+    vault.get_deposit_manager_capability.return_value = capability
+    monkeypatch.setattr(testtrade, "is_anvil", lambda _: True)
+    monkeypatch.setattr(testtrade, "get_vault_for_pair", lambda *_: vault)
+    resolve = MagicMock(return_value=[trade])
+    monkeypatch.setattr(
+        testtrade,
+        "check_and_resolve_vault_settlements",
+        resolve,
+    )
+
+    # 2. Force settlement through the trade-executor helper.
+    state = MagicMock()
+    execution_model = MagicMock()
+    web3config = MagicMock()
+    _force_vault_settlement_and_resolve(
+        MagicMock(),
+        state,
+        trade,
+        execution_model,
+        web3config=web3config,
+    )
+
+    # 3. Verify the direction-specific ticket and manager driver were used.
+    getattr(manager, reconstruct_method).assert_called_once_with(trade.other_data)
+    other_reconstruct_method = (
+        "reconstruct_redemption_ticket"
+        if direction == "deposit"
+        else "reconstruct_deposit_ticket"
+    )
+    getattr(manager, other_reconstruct_method).assert_not_called()
+    manager.force_settle.assert_called_once_with(ticket)
+
+    # 4. Verify JSON-safe evidence was saved before the shared claim resolver ran.
+    assert trade.other_data["vault_forced_settlement"] == {
+        "manager": manager.__class__.__name__,
+        "direction": direction,
+        "settlement_required": True,
+        "status_before": "pending",
+        "status_after": "claimable",
+        "transaction_hashes": ["0x" + "01" * 32],
+    }
+    resolve.assert_called_once_with(
+        state=state,
+        execution_model=execution_model,
+        web3config=web3config,
+    )
+
+
+def test_forced_anvil_settlement_fails_closed_for_unknown_manager(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An async manager without capability fails before settlement or claiming.
+
+    1. Model a pending async trade whose manager has no forced-settlement support.
+    2. Request forced Anvil settlement.
+    3. Verify a typed unsupported result is raised before manager or claim calls.
+
+    Mocks verify fail-closed control flow without issuing an RPC transaction.
+    """
+    # 1. Model a pending async trade whose manager has no forced-settlement support.
+    trade = _make_trade(TradeStatus.vault_settlement_pending)
+    trade.pair = MagicMock()
+    trade.other_data = {"vault_direction": "deposit"}
+    manager = MagicMock()
+    capability = MagicMock(supports_anvil_settlement=None)
+    capability.as_dict.return_value = {
+        "can_deposit": True,
+        "deposit_flow": "asynchronous",
+    }
+    vault = MagicMock()
+    vault.address = "0x0000000000000000000000000000000000000001"
+    vault.get_deposit_manager.return_value = manager
+    vault.get_deposit_manager_capability.return_value = capability
+    monkeypatch.setattr(testtrade, "is_anvil", lambda _: True)
+    monkeypatch.setattr(testtrade, "get_vault_for_pair", lambda *_: vault)
+    resolve = MagicMock()
+    monkeypatch.setattr(
+        testtrade,
+        "check_and_resolve_vault_settlements",
+        resolve,
+    )
+
+    # 2. Request forced Anvil settlement.
+    with pytest.raises(
+        UnsupportedVaultSimulation,
+        match="does not advertise Anvil settlement",
+    ):
+        _force_vault_settlement_and_resolve(
+            MagicMock(),
+            MagicMock(),
+            trade,
+            MagicMock(),
+        )
+
+    # 3. Verify a typed unsupported result is raised before manager or claim calls.
+    manager.reconstruct_deposit_ticket.assert_not_called()
+    manager.force_settle.assert_not_called()
+    resolve.assert_not_called()
+
+
+def test_forced_anvil_settlement_preserves_ostium_compatibility(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Ostium V1.5 keeps its permissionless settlement compatibility path.
+
+    1. Model an Ostium V1.5 pending trade without manager-owned settlement support.
+    2. Force settlement using an Anvil-unlocked development account.
+    3. Verify the Ostium helper and shared claim resolver ran.
+    4. Verify the generic manager driver was not called.
+
+    Mocks isolate the compatibility branch from live Ostium settlement.
+    """
+    # 1. Model an Ostium V1.5 pending trade without manager-owned settlement support.
+    trade = _make_trade(TradeStatus.vault_settlement_pending)
+    trade.pair = MagicMock()
+    trade.other_data = {"vault_direction": "deposit"}
+    manager = MagicMock()
+    capability = MagicMock(supports_anvil_settlement=None)
+    vault = MagicMock(spec=OstiumVault)
+    vault.version = OstiumVersion.v1_5
+    vault.get_deposit_manager.return_value = manager
+    vault.get_deposit_manager_capability.return_value = capability
+    monkeypatch.setattr(testtrade, "is_anvil", lambda _: True)
+    monkeypatch.setattr(testtrade, "get_vault_for_pair", lambda *_: vault)
+    force_ostium = MagicMock()
+    monkeypatch.setattr(
+        testtrade,
+        "force_ostium_v15_settlement",
+        force_ostium,
+    )
+    resolve = MagicMock(return_value=[trade])
+    monkeypatch.setattr(
+        testtrade,
+        "check_and_resolve_vault_settlements",
+        resolve,
+    )
+
+    # 2. Force settlement using an Anvil-unlocked development account.
+    web3 = MagicMock()
+    web3.eth.accounts = ["0x0000000000000000000000000000000000000002"]
+    state = MagicMock()
+    execution_model = MagicMock()
+    _force_vault_settlement_and_resolve(
+        web3,
+        state,
+        trade,
+        execution_model,
+    )
+
+    # 3. Verify the Ostium helper and shared claim resolver ran.
+    force_ostium.assert_called_once_with(vault, web3.eth.accounts[0])
+    resolve.assert_called_once_with(
+        state=state,
+        execution_model=execution_model,
+        web3config=None,
+    )
+
+    # 4. Verify the generic manager driver was not called.
+    manager.force_settle.assert_not_called()
 
 
 def test_pending_home_trade_on_anvil_unresolved_raises(monkeypatch) -> None:

--- a/tradeexecutor/cli/testtrade.py
+++ b/tradeexecutor/cli/testtrade.py
@@ -1,22 +1,33 @@
 """Perform a test trade on a universe."""
 import logging
-import datetime
 from decimal import Decimal
 from typing import Callable
 
 from web3 import Web3
 
 from eth_defi.compat import native_datetime_utc_now
+from eth_defi.erc_4626.vault_protocol.gains.testing import force_ostium_v15_settlement
+from eth_defi.erc_4626.vault_protocol.gains.vault import OstiumVault, OstiumVersion
 from eth_defi.provider.anvil import fund_erc20_on_anvil, is_anvil, mine
 from eth_defi.token import USDC_NATIVE_TOKEN, fetch_erc20_details
-from tradeexecutor.state.identifier import TradingPairIdentifier, TradingPairKind
+from eth_defi.vault.deposit_redeem import (
+    AsyncVaultRequestStatus,
+    UnsupportedVaultSimulation,
+    VaultDepositManager,
+    VaultForcedSettlementResult,
+)
+from tradeexecutor.state.identifier import TradingPairIdentifier
 from tradingstrategy.chain import ChainId
 from tradingstrategy.lending import LendingReserveDescription
 from tradingstrategy.universe import Universe
 from tradingstrategy.pair import HumanReadableTradingPairDescription
 from tradingstrategy.exchange import ExchangeUniverse
 
+from tradeexecutor.ethereum.cctp.planner import _find_bridge_pair
 from tradeexecutor.ethereum.enzyme.vault import EnzymeVaultSyncModel
+from tradeexecutor.ethereum.vault.settlement_retry import check_and_resolve_vault_settlements
+from tradeexecutor.ethereum.vault.vault_routing import get_vault_for_pair
+from tradeexecutor.ethereum.web3config import TEST_CHAIN_IDS
 from tradeexecutor.state.trade import TradeFlag, TradeStatus
 from tradeexecutor.state.types import Percent
 from tradeexecutor.statistics.core import update_statistics
@@ -53,6 +64,32 @@ def _update_test_trade_statistics(state: State, *, enabled: bool) -> None:
         ExecutionMode.real_trading,
         long_short_metrics_latest=long_short_metrics_latest,
     )
+
+
+def _serialise_forced_vault_settlement(
+    deposit_manager: VaultDepositManager,
+    direction: str,
+    settlement: VaultForcedSettlementResult,
+) -> dict:
+    """Convert manager-owned Anvil settlement evidence to JSON-safe values."""
+
+    def serialise_status(status: AsyncVaultRequestStatus | None) -> str | None:
+        return status.value if status is not None else None
+
+    def serialise_hash(tx_hash) -> str:
+        value = tx_hash.hex()
+        return value if value.startswith("0x") else f"0x{value}"
+
+    return {
+        "manager": deposit_manager.__class__.__name__,
+        "direction": direction,
+        "settlement_required": settlement.settlement_required,
+        "status_before": serialise_status(settlement.status_before),
+        "status_after": serialise_status(settlement.status_after),
+        "transaction_hashes": [
+            serialise_hash(tx_hash) for tx_hash in settlement.transaction_hashes
+        ],
+    }
 
 
 def _materialise_bridge_on_anvil(
@@ -698,8 +735,9 @@ def _make_cross_chain_test_trade(
 def _force_vault_settlement_and_resolve(web3, state, trade, execution_model, web3config=None):
     """Force settlement on Anvil for an async vault test trade and resolve it.
 
-    Uses protocol-specific settlement forcing (e.g. tryNewSettlement for Ostium V1.5,
-    force_lagoon_settle for ERC-7540) then runs the generic settlement retry.
+    Uses the selected eth-defi manager's ticket-aware settlement driver. Ostium
+    V1.5 retains its earlier permissionless compatibility path until its manager
+    exposes the same capability.
 
     :param web3:
         Web3 connection for the chain the vault lives on. For cross-chain
@@ -714,11 +752,6 @@ def _force_vault_settlement_and_resolve(web3, state, trade, execution_model, web
         it the resolver falls back to the execution model's default connection,
         which is only correct for home-chain vaults.
     """
-    from eth_defi.erc_4626.vault_protocol.gains.vault import OstiumVault, OstiumVersion
-    from eth_defi.erc_4626.vault_protocol.gains.testing import force_ostium_v15_settlement
-    from tradeexecutor.ethereum.vault.vault_routing import get_vault_for_pair
-    from tradeexecutor.ethereum.vault.settlement_retry import check_and_resolve_vault_settlements
-
     # This function impersonates the vault operator and only makes sense against
     # an Anvil fork — on a real chain nobody can force a settlement. Enforce the
     # test-only invariant here rather than relying on every caller's is_anvil()
@@ -726,25 +759,48 @@ def _force_vault_settlement_and_resolve(web3, state, trade, execution_model, web
     assert is_anvil(web3), "_force_vault_settlement_and_resolve() is Anvil-only (forces operator settlement)"
 
     vault = get_vault_for_pair(web3, trade.pair)
-    owner = trade.other_data.get("vault_owner_address")
+    deposit_manager = vault.get_deposit_manager()
+    direction = trade.other_data.get(
+        "vault_direction",
+        "deposit" if trade.is_buy() else "redeem",
+    )
+    if direction not in {"deposit", "redeem"}:
+        raise UnsupportedVaultSimulation(
+            f"Unknown vault settlement direction {direction!r} for {vault.address}"
+        )
 
-    # Ostium's tryNewSettlement() is permissionless and is broadcast with
-    # node-side signing (eth_sendTransaction {"from": ...}), so its gas payer must
-    # be an account the node can sign for. The vault owner is the executor's hot
-    # wallet — a random key whose local signer middleware lives only on the
-    # executor's own web3, not on the Anvil node — so paying from it fails with
-    # "No Signer available". On Anvil we therefore pay tryNewSettlement() gas from
-    # a node-unlocked dev account instead. (The Lagoon branch below keeps `owner`:
-    # its settlement is permissioned and must come from the actual asset manager.)
-    settlement_caller = owner
-    dev_accounts = web3.eth.accounts
-    if dev_accounts:
+    get_capability = getattr(vault, "get_deposit_manager_capability", None)
+    capability = get_capability() if get_capability is not None else None
+    supports_manager_settlement = (
+        getattr(capability, "supports_anvil_settlement", None) is True
+    )
+
+    if supports_manager_settlement:
+        if direction == "deposit":
+            ticket = deposit_manager.reconstruct_deposit_ticket(trade.other_data)
+        else:
+            ticket = deposit_manager.reconstruct_redemption_ticket(trade.other_data)
+
+        settlement = deposit_manager.force_settle(ticket)
+        trade.other_data["vault_forced_settlement"] = (
+            _serialise_forced_vault_settlement(
+                deposit_manager,
+                direction,
+                settlement,
+            )
+        )
+    elif isinstance(vault, OstiumVault) and vault.version == OstiumVersion.v1_5:
+        # Ostium's tryNewSettlement() is permissionless and uses node-side
+        # signing, so pay gas from an Anvil-unlocked account rather than the
+        # executor hot wallet whose local signer is unknown to the node.
+        dev_accounts = web3.eth.accounts
+        if not dev_accounts:
+            raise UnsupportedVaultSimulation(
+                "Ostium V1.5 settlement requires an Anvil-unlocked gas payer"
+            )
         settlement_caller = dev_accounts[0]
 
-    # Protocol-specific settlement forcing
-    if isinstance(vault, OstiumVault) and vault.version == OstiumVersion.v1_5:
         # May need multiple settlements for withdrawal
-        direction = trade.other_data.get("vault_direction", "deposit")
         settlements_needed = 1
         if direction == "redeem":
             withdraw_target = vault.vault_contract.functions.targetSettlementId(False).call()
@@ -753,13 +809,16 @@ def _force_vault_settlement_and_resolve(web3, state, trade, execution_model, web
         for _ in range(settlements_needed):
             force_ostium_v15_settlement(vault, settlement_caller)
     else:
-        # ERC-7540 (Lagoon) — use force_lagoon_settle if available. Lagoon
-        # settlement is permissioned, so it must be sent from the vault manager
-        # (the owner for test trades), not the dev account used for Ostium above.
-        from eth_defi.erc_4626.vault_protocol.lagoon.vault import LagoonVault
-        if isinstance(vault, LagoonVault):
-            from eth_defi.erc_4626.vault_protocol.lagoon.testing import force_lagoon_settle
-            force_lagoon_settle(vault, owner)
+        capability_data = (
+            capability.as_dict()
+            if capability is not None and hasattr(capability, "as_dict")
+            else None
+        )
+        raise UnsupportedVaultSimulation(
+            f"{deposit_manager.__class__.__name__} does not advertise Anvil "
+            f"settlement for vault {vault.address}, direction={direction}, "
+            f"capability={capability_data}"
+        )
 
     # Now run the generic settlement retry. Pass web3config so the claim is
     # broadcast on the vault's own chain for cross-chain satellite vaults.
@@ -974,8 +1033,8 @@ def make_test_trade(
 
     assert isinstance(sync_model, SyncModel)
     assert isinstance(universe, TradingStrategyUniverse)
-    assert type(max_slippage) == float
-    assert max_slippage > 0, f"max_slippage not set"
+    assert isinstance(max_slippage, float)
+    assert max_slippage > 0, "max_slippage not set"
 
     ts = native_datetime_utc_now()
 
@@ -1015,7 +1074,6 @@ def make_test_trade(
         # (callers managing bridging themselves pass web3config=None).
         # Also skip when the default chain is a test chain (Anvil fork)
         # because the fork chain_id won't match real pair chain_ids.
-        from tradeexecutor.ethereum.web3config import TEST_CHAIN_IDS
         is_cross_chain = False
         if web3config is not None and web3config.default_chain_id not in TEST_CHAIN_IDS:
             home_chain_id = web3config.default_chain_id.value
@@ -1113,8 +1171,6 @@ def make_test_trade(
     # Cross-chain dispatch: if the target pair is on a satellite chain,
     # delegate to the cross-chain helper that handles bridge in/out
     if is_cross_chain:
-        from tradeexecutor.ethereum.cctp.planner import _find_bridge_pair
-
         all_pairs = list(universe.iterate_pairs())
         bridge_pair = _find_bridge_pair(all_pairs, pair.chain_id)
         if bridge_pair is None:

--- a/tradeexecutor/cli/vault_trade/runner.py
+++ b/tradeexecutor/cli/vault_trade/runner.py
@@ -162,6 +162,28 @@ def should_leave_deposit_open(
     return operation == "deposit" and (manual or is_async or not redemption_available)
 
 
+def has_async_vault_lifecycle(
+    pair: TradingPairIdentifier,
+    vault: Any,
+) -> bool:
+    """Detect async directions declared by either routing or manager metadata."""
+
+    if pair.is_async_vault():
+        return True
+
+    get_capability = getattr(vault, "get_deposit_manager_capability", None)
+    if get_capability is None:
+        return False
+    capability = get_capability()
+    if capability is None:
+        return False
+
+    return "asynchronous" in (
+        getattr(capability, "deposit_flow", None),
+        getattr(capability, "redemption_flow", None),
+    )
+
+
 def get_whitelisting_needed_detail(attempt: "VaultAttempt") -> str | None:
     """Return a terminal report detail when the executor Safe lacks vault admission.
 
@@ -316,6 +338,26 @@ def normalise_vault_flow_failure(
             )
         current = current.__cause__ or current.__context__
     return None
+
+
+def get_latest_attempt_vault_operation(
+    state: State,
+    original_trade_ids: set[int],
+) -> str | None:
+    """Infer the failing inner operation from vault trades created by an attempt."""
+
+    latest_vault_trade = max(
+        (
+            trade
+            for trade in state.portfolio.get_all_trades()
+            if trade.trade_id not in original_trade_ids and trade.is_vault()
+        ),
+        key=lambda trade: trade.trade_id,
+        default=None,
+    )
+    if latest_vault_trade is None:
+        return None
+    return "deposit" if latest_vault_trade.is_buy() else "redeem"
 
 
 def get_bridge_conflict(
@@ -992,7 +1034,10 @@ class VaultTestBatchRunner:
         # RPC effects are reverted after the attempt.  A deep-copied state keeps
         # simulated balances, valuations and settlement changes equally isolated.
         fork_state = deepcopy(self.state)
-        is_async = attempt.pair.is_async_vault()
+        is_async = has_async_vault_lifecycle(
+            attempt.pair,
+            attempt.executable_vault,
+        )
         complete_async_lifecycle = is_async and self.settle_async_on_anvil
         try:
             perform_test_trade(
@@ -1335,6 +1380,12 @@ class VaultTestBatchRunner:
             and self.current_attempt.operation_original_trade_ids is not None
             else original_trade_ids
         )
+        failure_operation = get_latest_attempt_vault_operation(
+            error_state,
+            evidence_trade_ids,
+        )
+        if failure_operation is not None and self.current_attempt is not None:
+            self.current_attempt.operation = failure_operation
         error_data = capture_vault_test_error(
             error,
             state=error_state,

--- a/tradeexecutor/ethereum/vault/vault_routing.py
+++ b/tradeexecutor/ethereum/vault/vault_routing.py
@@ -63,8 +63,9 @@ def reconcile_vault_redemption_amount(
     relative_shortfall = (planned_amount - onchain_balance) / planned_amount
     if relative_shortfall > Decimal(str(epsilon)):
         raise AssertionError(
-            "Vault share token has a large relative difference in onchain balance "
-            "when trying to redeem the share token"
+            f"Vault share token balance has a large relative shortfall: "
+            f"planned {planned_amount}, on-chain {onchain_balance}, "
+            f"relative shortfall {relative_shortfall}, epsilon {epsilon}"
         )
 
     return onchain_balance
@@ -280,7 +281,8 @@ class VaultRouting(RoutingModel):
         else:
             token_in = trade.pair.base
             token_out = reserve_asset
-            # Swap amount is negative
+            # Sells have a negative planned quantity, but redemption requests
+            # take a positive share amount.
             swap_amount = -trade.planned_quantity
 
             share_token = target_vault.share_token
@@ -297,26 +299,11 @@ class VaultRouting(RoutingModel):
                 onchain_balance,
                 position.get_quantity(planned=True),
             )
-            try:
-                reconciled_amount = reconcile_vault_redemption_amount(
-                    swap_amount,
-                    onchain_balance,
-                    epsilon=self.redeem_epsilon,
-                )
-            except AssertionError:
-                relative_shortfall = (swap_amount - onchain_balance) / swap_amount
-                logger.error(
-                    "Vault trade %s, position %s, share token %s, has a large relative difference in onchain balance: %f, planned quantity: %s, onchain balance: %s, epsilon is %f",
-                    trade.trade_id,
-                    position,
-                    share_token,
-                    relative_shortfall,
-                    trade.planned_quantity,
-                    onchain_balance,
-                    self.redeem_epsilon,
-                )
-                raise
-
+            reconciled_amount = reconcile_vault_redemption_amount(
+                swap_amount,
+                onchain_balance,
+                epsilon=self.redeem_epsilon,
+            )
             if reconciled_amount < swap_amount:
                 relative_shortfall = (swap_amount - onchain_balance) / swap_amount
                 logger.warning(

--- a/tradeexecutor/ethereum/vault/vault_routing.py
+++ b/tradeexecutor/ethereum/vault/vault_routing.py
@@ -2,15 +2,13 @@
 
 import logging
 from decimal import Decimal
-import datetime
-from typing import Dict, cast
+from typing import cast
 
 from eth_typing import HexAddress
 from hexbytes import HexBytes
 
 from eth_defi.erc_4626.analysis import analyse_4626_flow_transaction
 from eth_defi.erc_4626.classification import create_vault_instance, create_vault_instance_autodetect
-from eth_defi.erc_4626.profit_and_loss import estimate_4626_recent_profitability
 from eth_defi.erc_4626.deposit_redeem import ERC4626DepositManager
 from eth_defi.erc_4626.vault import ERC4626Vault
 from eth_defi.token import fetch_erc20_details, TokenDiskCache
@@ -46,6 +44,30 @@ logger = logging.getLogger(__name__)
 
 class VaultReceiptAnalysisError(RuntimeError):
     """A mined vault transaction could not be decoded into executed amounts."""
+
+
+def reconcile_vault_redemption_amount(
+    planned_amount: Decimal,
+    onchain_balance: Decimal,
+    *,
+    epsilon: float,
+) -> Decimal:
+    """Cap a redemption to a tolerably smaller on-chain share balance."""
+
+    assert planned_amount > 0, f"Planned redemption must be positive, got {planned_amount}"
+    assert onchain_balance >= 0, f"On-chain share balance cannot be negative, got {onchain_balance}"
+
+    if onchain_balance >= planned_amount:
+        return planned_amount
+
+    relative_shortfall = (planned_amount - onchain_balance) / planned_amount
+    if relative_shortfall > Decimal(str(epsilon)):
+        raise AssertionError(
+            "Vault share token has a large relative difference in onchain balance "
+            "when trying to redeem the share token"
+        )
+
+    return onchain_balance
 
 
 def convert_vault_flow_analysis(
@@ -181,7 +203,6 @@ class VaultRouting(RoutingModel):
     def __init__(
         self,
         reserve_token_address: JSONHexAddress,
-        profitability_estimation_lookback_window=datetime.timedelta(days=7),
         epsilon=Decimal(1e-6),
         redeem_epsilon=0.025,
     ):
@@ -189,7 +210,6 @@ class VaultRouting(RoutingModel):
             allowed_intermediary_pairs={},
             reserve_token_address=reserve_token_address,
         )
-        self.profitability_estimation_lookback_window = profitability_estimation_lookback_window
         self.epsilon = epsilon
 
         # 3M gas was not enough to withdraw from IPOR, but Base has a per-tx gas cap 16,777,216
@@ -257,22 +277,6 @@ class VaultRouting(RoutingModel):
             token_in = reserve_asset
             token_out = trade.pair.base
             swap_amount = trade.get_planned_reserve()
-
-            try:
-                profitability_estimation = estimate_4626_recent_profitability(
-                    vault=target_vault,
-                    lookback_window=self.profitability_estimation_lookback_window,
-                )
-                profitability_estimation_error = None
-            except Exception as e:
-                # Ok to fail, data used only for diagnostics and UI
-                profitability_estimation = None
-                profitability_estimation_error = str(e)
-                logger.error(
-                    "Vault trade %s profitability estimation failed: %s",
-                    trade,
-                    e,
-                )
         else:
             token_in = trade.pair.base
             token_out = reserve_asset
@@ -293,38 +297,45 @@ class VaultRouting(RoutingModel):
                 onchain_balance,
                 position.get_quantity(planned=True),
             )
-            rel_diff = abs((onchain_balance - swap_amount) / swap_amount)
-            if rel_diff != 0 and onchain_balance + swap_amount < 0:
-                if rel_diff > self.redeem_epsilon:
-                    # Accounting broken
+            try:
+                reconciled_amount = reconcile_vault_redemption_amount(
+                    swap_amount,
+                    onchain_balance,
+                    epsilon=self.redeem_epsilon,
+                )
+            except AssertionError:
+                relative_shortfall = (swap_amount - onchain_balance) / swap_amount
+                logger.error(
+                    "Vault trade %s, position %s, share token %s, has a large relative difference in onchain balance: %f, planned quantity: %s, onchain balance: %s, epsilon is %f",
+                    trade.trade_id,
+                    position,
+                    share_token,
+                    relative_shortfall,
+                    trade.planned_quantity,
+                    onchain_balance,
+                    self.redeem_epsilon,
+                )
+                raise
 
-                    logger.error(
-                        "Vault trade %s, position %s, share token %s, has a large relative difference in onchain balance: %f, planned quantity: %s, onchain balance: %s, epsilon is %f",
-                        trade.trade_id,
-                        position,
-                        share_token,
-                        rel_diff,
-                        trade.planned_quantity,
-                        onchain_balance,
-                        self.redeem_epsilon,
-                    )
-                    raise AssertionError("Vault share token has a large relative difference in onchain balance when trying to redeem the share token")
-                else:
-                    # Epsilon rounding
-                    logger.warning(
-                        "Vault trade %s, position %s, share token %s, has a small relative difference in onchain balance: %f, planned quantity: %s, onchain balance: %s, automatically rounding, epsilon is %f",
-                        trade.trade_id,
-                        position,
-                        share_token,
-                        rel_diff,
-                        trade.planned_quantity,
-                        onchain_balance,
-                        self.redeem_epsilon,
-                    )
-                    swap_amount = onchain_balance
+            if reconciled_amount < swap_amount:
+                relative_shortfall = (swap_amount - onchain_balance) / swap_amount
+                logger.warning(
+                    "Vault trade %s, position %s, share token %s, has a small relative difference in onchain balance: %f, planned quantity: %s, onchain balance: %s, automatically rounding, epsilon is %f",
+                    trade.trade_id,
+                    position,
+                    share_token,
+                    relative_shortfall,
+                    trade.planned_quantity,
+                    onchain_balance,
+                    self.redeem_epsilon,
+                )
+                swap_amount = reconciled_amount
             else:
-                # Exact match
-                logger.info("Onchain balance and accounting has exact match for shares to redeem: %s", swap_amount)
+                logger.info(
+                    "Onchain balance covers the planned shares to redeem: planned %s, onchain %s",
+                    swap_amount,
+                    onchain_balance,
+                )
 
         logger.info(
             "Preparing vault flow %s -> %s, amount %s (%s), slippage tolerance %f",
@@ -468,7 +479,7 @@ class VaultRouting(RoutingModel):
         web3: Web3,
         state: State,
         trade: TradeExecution,
-        receipts: Dict[str, dict],
+        receipts: dict[str, dict],
         stop_on_execution_failure=False,
     ):
 


### PR DESCRIPTION
## Why

Cross-chain vault simulation must use the lifecycle owned by each eth-defi deposit manager. The previous generic Lagoon settlement call used the executor owner as a signer, could fail with `No Signer available`, and could not distinguish an unsupported simulation from a user transaction failure.

The earlier 129-vault report also came from the parent checkout instead of this worktree. A verified rerun was needed before assigning gaps to trade-executor or eth-defi.

## Lessons learnt

- Worktree tests must put both the trade-executor worktree and its eth-defi submodule first on `PYTHONPATH`; otherwise the editable Poetry installation can silently import the parent checkout.
- Async lifecycle ownership is directional. A vault may have a synchronous deposit and asynchronous redemption even when its static pair kind is synchronous.
- Forced settlement must reconstruct the persisted manager ticket and run only when the manager explicitly advertises Anvil support.
- A planned vault redemption and the on-chain share balance are both positive quantities. Reconciliation must compare their shortfall directly; adding them made the previous epsilon branch unreachable.
- Automatic round-trip failures must be labelled from the newest vault trade, not from the outer deposit attempt or a later bridge trade.

## Summary

- use eth-defi master `b5803bdc5`
- reconstruct deposit and redemption tickets through the selected manager
- invoke manager-owned Anvil settlement and persist JSON-safe settlement evidence
- retain the Ostium V1.5 compatibility path and fail closed for unsupported managers
- recognise async directions from manager capability metadata
- reconcile small redemption share shortfalls while preserving material accounting assertions
- attribute failures to the actual deposit or redemption operation
- add focused settlement, reporting and reconciliation tests
- replace the invalid baseline with verified trade-executor and eth-defi gap reports containing actionable repository-specific work

Continues #1576.
