### PR TITLE
fix: pin the GMX reader deployment used by the valuation fork tests

### DIFF
--- a/tests/exchange_account/test_gmx_valuation_integration.py
+++ b/tests/exchange_account/test_gmx_valuation_integration.py
@@ -57,7 +57,6 @@ from decimal import Decimal
 
 import pytest
 from web3 import HTTPProvider, Web3
-
 from web3.contract import Contract
 
 from eth_defi.abi import get_deployed_contract
@@ -99,21 +98,23 @@ FORK_BLOCK = 401_729_535
 #: Arbitrum mainnet chain ID
 ARBITRUM_CHAIN_ID = 42161
 
-#: GMX SyntheticsReader deployment that is live at :py:data:`FORK_BLOCK`.
+#: GMX SyntheticsReader used by these fork tests.
 #:
 #: The reader must be pinned alongside the fork block.
 #: :py:func:`eth_defi.gmx.contracts.get_contract_addresses` resolves the reader
-#: from GMX's published ``contracts.json`` at call time, preferring their
-#: ``updates`` branch, so it always returns the *current* deployment. GMX
-#: redeploys the reader periodically: the deployment it currently advertises
+#: from GMX's published ``contracts.json`` at call time and tries their
+#: ``updates`` branch first, so it returns the *current* deployment. GMX
+#: redeploys the reader periodically: the deployment currently advertised there
 #: (``0xfA26cBb46e2614609406de08CA1Dc7f70a684184``) was created at Arbitrum
-#: block 483,924,493, which is roughly 82 million blocks *after* this fork
-#: block. Calling it here hits an address with no code, and web3 reports the
-#: empty return as ``BadFunctionCallOutput: ... is contract deployed correctly
-#: and chain synced?``, which hides the real cause.
+#: block 483,924,493, roughly 82 million blocks *after* :py:data:`FORK_BLOCK`.
+#: Calling it here hits an address with no code, and web3 reports the empty
+#: return as ``BadFunctionCallOutput: ... is contract deployed correctly and
+#: chain synced?``, which hides the real cause.
 #:
-#: This address is the reader listed on GMX's stable ``main`` branch. It has
-#: code at the fork block and returns the position sets these tests assert on.
+#: This address is the reader listed on GMX's stable ``main`` branch. It was
+#: chosen because it is verified to have code at :py:data:`FORK_BLOCK` and to
+#: return the position sets these tests assert on; it is not necessarily the
+#: deployment GMX advertised at that block.
 GMX_READER_AT_FORK_BLOCK = "0x470fbC46bcC0f16532691Df360A07d8Bf5ee0789"
 
 
@@ -127,6 +128,9 @@ def pinned_gmx_reader(monkeypatch: pytest.MonkeyPatch) -> None:
     """
 
     def get_pinned_reader_contract(web3: Web3, chain: str) -> Contract:
+        # ``chain`` is accepted to match get_reader_contract() and ignored
+        # because the pinned address already identifies the deployment.
+        del chain
         return get_deployed_contract(
             web3,
             "gmx/Reader.json",

--- a/tests/exchange_account/test_gmx_valuation_integration.py
+++ b/tests/exchange_account/test_gmx_valuation_integration.py
@@ -58,9 +58,13 @@ from decimal import Decimal
 import pytest
 from web3 import HTTPProvider, Web3
 
+from web3.contract import Contract
+
+from eth_defi.abi import get_deployed_contract
 from eth_defi.chain import install_chain_middleware
 from eth_defi.compat import native_datetime_utc_now
 from eth_defi.gas import node_default_gas_price_strategy
+from eth_defi.gmx import valuation as gmx_valuation
 from eth_defi.gmx.valuation import fetch_gmx_total_equity
 from eth_defi.provider.anvil import fork_network_anvil
 from eth_defi.token import fetch_erc20_details
@@ -94,6 +98,46 @@ FORK_BLOCK = 401_729_535
 
 #: Arbitrum mainnet chain ID
 ARBITRUM_CHAIN_ID = 42161
+
+#: GMX SyntheticsReader deployment that is live at :py:data:`FORK_BLOCK`.
+#:
+#: The reader must be pinned alongside the fork block.
+#: :py:func:`eth_defi.gmx.contracts.get_contract_addresses` resolves the reader
+#: from GMX's published ``contracts.json`` at call time, preferring their
+#: ``updates`` branch, so it always returns the *current* deployment. GMX
+#: redeploys the reader periodically: the deployment it currently advertises
+#: (``0xfA26cBb46e2614609406de08CA1Dc7f70a684184``) was created at Arbitrum
+#: block 483,924,493, which is roughly 82 million blocks *after* this fork
+#: block. Calling it here hits an address with no code, and web3 reports the
+#: empty return as ``BadFunctionCallOutput: ... is contract deployed correctly
+#: and chain synced?``, which hides the real cause.
+#:
+#: This address is the reader listed on GMX's stable ``main`` branch. It has
+#: code at the fork block and returns the position sets these tests assert on.
+GMX_READER_AT_FORK_BLOCK = "0x470fbC46bcC0f16532691Df360A07d8Bf5ee0789"
+
+
+@pytest.fixture(autouse=True)
+def pinned_gmx_reader(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Pin the GMX reader to the deployment live at the fork block.
+
+    Without this, the reader address is resolved live from GMX and drifts ahead
+    of the pinned fork block whenever GMX redeploys, breaking these tests for
+    reasons unrelated to the code under test.
+    """
+
+    def get_pinned_reader_contract(web3: Web3, chain: str) -> Contract:
+        return get_deployed_contract(
+            web3,
+            "gmx/Reader.json",
+            Web3.to_checksum_address(GMX_READER_AT_FORK_BLOCK),
+        )
+
+    monkeypatch.setattr(
+        gmx_valuation,
+        "get_reader_contract",
+        get_pinned_reader_contract,
+    )
 
 
 @pytest.fixture()


### PR DESCRIPTION
## Why

Both GMX valuation integration tests have been failing on `master`:

```
FAILED tests/exchange_account/test_gmx_valuation_integration.py::test_gmx_valuation_pipeline_usdc_positions
FAILED tests/exchange_account/test_gmx_valuation_integration.py::test_gmx_valuation_pipeline_eth_short
web3.exceptions.BadFunctionCallOutput: Could not transact with/call contract function, is contract deployed correctly and chain synced?
```

The error is misleading. Nothing is out of sync — the GMX SyntheticsReader
simply did not exist yet at the block the tests fork from.

`eth_defi.gmx.contracts.get_contract_addresses()` resolves the reader from
GMX's published `contracts.json` at call time, preferring their `updates`
branch, so it always returns the **current** deployment. GMX redeployed the
reader to `0xfA26cBb46e2614609406de08CA1Dc7f70a684184` at Arbitrum block
**483,924,493** — roughly 82 million blocks *after* this test's pinned
`FORK_BLOCK` of **401,729,535**. The call therefore hit an address with no code,
and web3 turned the empty return into the generic "is the contract deployed"
message.

This is unrelated to the vault work merged in #1578; the same two tests fail on
the preceding commit `0e84f313`.

## Lessons learnt

A pinned fork block needs a pinned contract deployment. When a dependency
resolves an address from a live source, a fixed-block fork test inherits that
source's drift and will break at an unrelated time for an unrelated reason.
`BadFunctionCallOutput` should be read as "no code at this address at this
block" before it is read as an RPC or sync problem — checking `eth_getCode` at
the fork block distinguishes the two immediately.

## Summary

- pin the GMX reader used by these tests to
  `0x470fbC46bcC0f16532691Df360A07d8Bf5ee0789`, the deployment listed on GMX's
  stable `main` branch, which has code at `FORK_BLOCK` and returns the position
  sets the tests assert on (ETH short account: 1 position, USDC account: 9
  positions)
- document why the reader must be pinned alongside the block, including the
  deployment block that caused the break, so the next drift is diagnosable
