### PR TITLE
fix: continue Lagoon settlement after partial receipt visibility

### DIFF
--- a/tradeexecutor/ethereum/lagoon/vault.py
+++ b/tradeexecutor/ethereum/lagoon/vault.py
@@ -603,9 +603,16 @@ class LagoonVaultSyncModel(AddressSyncModel):
             )
             settle_tx_hash = signed_tx_2.hash
 
-        # Wait for all read RPCs to see the settlement receipt and let state
-        # propagate before reading on-chain analysis data
-        wait_for_transaction_receipt_robust(web3, settle_tx_hash, confirmation_block_count=2, extra_sleep=2.0)
+        # Let all read RPCs see the settlement receipt and state propagate before
+        # analysis. The preceding broadcast helper already confirmed the transaction,
+        # so a permanently unhealthy secondary reader may fall back after the timeout.
+        wait_for_transaction_receipt_robust(
+            web3,
+            settle_tx_hash,
+            confirmation_block_count=2,
+            extra_sleep=2.0,
+            allow_partial_visibility_after_timeout=True,
+        )
 
         analysis = analyse_vault_flow_in_settlement(
             vault,


### PR DESCRIPTION
## Why

A confirmed Lagoon settlement should complete its local analysis and accounting when a secondary RPC is unhealthy, rather than stopping the live executor.

## Lessons learnt

On 2026-07-23, a Hyperliquid settlement succeeded on-chain while dRPC returned HTTP 400 for receipt reads. The executor treated the secondary reader outage as a failed scheduled task and exited before recording the settlement.

## Summary

- Pin web3-ethereum-defi with resilient receipt-visibility handling
- Explicitly enable the timeout fallback for Lagoon post-settlement analysis
- Preserve the all-reader propagation wait before falling back