### PR TITLE
fix: cap HyperCore withdrawal drift safely

### DIFF
--- a/tests/hyperliquid/test_hypercore_activation_cost.py
+++ b/tests/hyperliquid/test_hypercore_activation_cost.py
@@ -16,6 +16,7 @@ from eth_defi.compat import native_datetime_utc_now
 from eth_defi.hyperliquid.api import UserVaultEquity
 
 from tradeexecutor.ethereum.vault.hypercore_routing import (
+    HypercoreWithdrawalPreflightError,
     compute_spot_to_evm_withdrawal_amount,
     usdc_to_raw,
 )
@@ -416,8 +417,6 @@ def test_live_withdrawal_preflight_blocks_active_lockup():
     2. Mock Hyperliquid to report an active user lock-up for the Safe.
     3. Verify the preflight raises before any withdrawal can be broadcast.
     """
-    from tradeexecutor.ethereum.vault.hypercore_routing import HypercoreWithdrawalPreflightError
-
     routing = _make_routing(simulate=False)
     trade = _make_trade(planned_reserve=Decimal("25.0"), is_buy=False)
 
@@ -477,36 +476,67 @@ def test_live_withdrawal_preflight_blocks_requests_above_max_withdrawable():
     assert "exceeds current max_withdrawable" in str(exc_info.value)
 
 
-def test_live_withdrawal_preflight_caps_tiny_max_withdrawable_drift():
-    """Live withdrawal preflight caps dust-sized max-withdrawable drift instead of crashing.
+def test_live_withdrawal_preflight_caps_normal_max_withdrawable_drift_with_safety_margin():
+    """Live withdrawal preflight caps normal NAV drift below the fresh live limit.
 
-    1. Create one live Hypercore sell trade whose request is only tiny raw units above max_withdrawable.
-    2. Mock Hyperliquid to report an expired lock-up and the slightly lower live max_withdrawable.
-    3. Verify the preflight returns the live max_withdrawable and stores it for settlement.
+    1. Create the 2026-07-28 HyperAI sell whose planning snapshot was 0.642134 USDC above the execution-time cap.
+    2. Mock Hyperliquid to report an expired lock-up and the lower fresh max_withdrawable.
+    3. Verify preflight leaves the full-close safety margin and stores that exact amount for settlement.
     """
     routing = _make_routing(simulate=False)
-    trade = _make_trade(planned_reserve=Decimal("13.104554"), is_buy=False)
+    trade = _make_trade(planned_reserve=Decimal("3473.748012"), is_buy=False)
 
     unlocked_equity = UserVaultEquity(
         vault_address="0xVAULT",
-        equity=Decimal("13.104323"),
+        equity=Decimal("3475.062534"),
         locked_until=native_datetime_utc_now() - datetime.timedelta(days=1),
     )
 
-    # 1. Create one live Hypercore sell trade whose request is only tiny raw units above max_withdrawable.
-    # 2. Mock Hyperliquid to report an expired lock-up and the slightly lower live max_withdrawable.
-    # 3. Verify the preflight returns the live max_withdrawable and stores it for settlement.
-    with patch("tradeexecutor.ethereum.vault.hypercore_routing.HyperliquidVault.fetch_info", return_value=SimpleNamespace(max_withdrawable=Decimal("13.104323"))):
+    # 1. Create the 2026-07-28 HyperAI sell whose planning snapshot was 0.642134 USDC above the execution-time cap.
+    # 2. Mock Hyperliquid to report an expired lock-up and the lower fresh max_withdrawable.
+    # 3. Verify preflight leaves the full-close safety margin and stores that exact amount for settlement.
+    with patch("tradeexecutor.ethereum.vault.hypercore_routing.HyperliquidVault.fetch_info", return_value=SimpleNamespace(max_withdrawable=Decimal("3473.105878"))):
         with patch("tradeexecutor.ethereum.vault.hypercore_routing.fetch_user_vault_equity", return_value=unlocked_equity):
             with patch.object(routing, "_get_session", return_value=routing._session):
                 effective_raw = routing._check_live_withdrawal_preconditions(
                     trade=trade,
-                    requested_raw=13_104_554,
+                    requested_raw=3_473_748_012,
                     vault_address="0xVAULT",
                 )
 
-    assert effective_raw == 13_104_323
-    assert trade.other_data["hypercore_capped_withdrawal_raw"] == 13_104_323
+    assert effective_raw == 3_471_605_878
+    assert trade.other_data["hypercore_capped_withdrawal_raw"] == 3_471_605_878
+
+
+def test_live_withdrawal_preflight_blocks_cap_below_safety_margin():
+    """Live withdrawal preflight must not persist a zero or negative safe cap.
+
+    1. Create a sell that is within the normal live-drift tolerance above a small live cap.
+    2. Mock Hyperliquid to report an expired lock-up and a cap below the withdrawal safety margin.
+    3. Verify preflight aborts instead of building an invalid zero or negative withdrawal.
+    """
+    routing = _make_routing(simulate=False)
+    trade = _make_trade(planned_reserve=Decimal("1.6"), is_buy=False)
+    unlocked_equity = UserVaultEquity(
+        vault_address="0xVAULT",
+        equity=Decimal("1.0"),
+        locked_until=native_datetime_utc_now() - datetime.timedelta(days=1),
+    )
+
+    # 1. Create a sell that is within the normal live-drift tolerance above a small live cap.
+    # 2. Mock Hyperliquid to report an expired lock-up and a cap below the withdrawal safety margin.
+    # 3. Verify preflight aborts instead of building an invalid zero or negative withdrawal.
+    with patch("tradeexecutor.ethereum.vault.hypercore_routing.HyperliquidVault.fetch_info", return_value=SimpleNamespace(max_withdrawable=Decimal("1.0"))):
+        with patch("tradeexecutor.ethereum.vault.hypercore_routing.fetch_user_vault_equity", return_value=unlocked_equity):
+            with patch.object(routing, "_get_session", return_value=routing._session):
+                with pytest.raises(HypercoreWithdrawalPreflightError) as exc_info:
+                    routing._check_live_withdrawal_preconditions(
+                        trade=trade,
+                        requested_raw=1_600_000,
+                        vault_address="0xVAULT",
+                    )
+
+    assert "too small after" in str(exc_info.value)
 
 
 @patch("tradeexecutor.ethereum.vault.hypercore_routing.report_failure")

--- a/tradeexecutor/ethereum/vault/hypercore_routing.py
+++ b/tradeexecutor/ethereum/vault/hypercore_routing.py
@@ -169,21 +169,21 @@ HYPERCORE_LIKELY_CLOSE_TOLERANCE = 0.975
 #: accounting later.
 HYPERCORE_WITHDRAWAL_SAFETY_MARGIN_RAW = 1_500_000
 
-#: Tiny live preflight cap tolerance (raw USDC, 6 decimals).
+#: Normal live preflight cap drift tolerance (raw USDC, 6 decimals).
 #:
 #: Incident reference:
 #:
 #: - HyperAI crashed on 2026-04-15 during trade #336, Jay Pennie.
-#: - Planned withdrawal was 13.104554 USDC.
-#: - Live HyperCore ``max_withdrawable`` had drifted to 13.104323 USDC.
-#: - The difference was only 231 raw USDC (0.000231 USDC).
-#: - Treating that dust-sized drift as fatal stopped the whole 21-trade
-#:   sequential rebalance and left the executor down.
+#: - The requested withdrawal can be based on a live planning snapshot a few
+#:   seconds older than the preflight snapshot.
+#: - Active vault NAV can move enough in that interval to change the reported
+#:   cap by dollars, not merely by a few raw units.
 #:
-#: Keep this tolerance deliberately small. It is only for raw-unit/API/NAV
-#: drift between decision making and live execution, not for real liquidity
-#: shortages.
-HYPERCORE_WITHDRAWAL_PREFLIGHT_CAP_TOLERANCE_RAW = 500_000
+#: This is deliberately separate from the execution safety margin below: it
+#: controls the maximum planning-to-execution drift we accept, not the amount
+#: left behind once the action is queued. Larger gaps still indicate a material
+#: liquidity change that must not silently alter same-cycle cash planning.
+HYPERCORE_WITHDRAWAL_PREFLIGHT_CAP_TOLERANCE_RAW = 1_500_000
 
 #: Number of phase-1 retry attempts after HyperCore silently no-ops a
 #: ``vaultTransfer`` withdrawal.
@@ -842,19 +842,22 @@ class HypercoreVaultRouting(RoutingModel):
             # snapshots taken slightly earlier.
             overshoot_raw = requested_raw - max_withdrawable_raw
             if overshoot_raw <= HYPERCORE_WITHDRAWAL_PREFLIGHT_CAP_TOLERANCE_RAW:
-                # 2026-04-15 HyperAI incident:
-                # - Trade #336 requested 13.104554 USDC.
-                # - Live max_withdrawable was 13.104323 USDC.
-                # - Overshoot was 231 raw units, i.e. 0.000231 USDC.
-                #
-                # A strict abort here is worse than a tiny live cap because
-                # sequential execution stops at the first exception. The
-                # earlier trades may already have executed, while the remaining
-                # planned trades are stranded and the executor exits.
+                # A strict abort here is worse than a normal live-NAV cap
+                # because sequential execution stops at the first exception.
+                # Do not request the exact fresh cap: it may move again before
+                # HyperCore processes the queued vaultTransfer and then silently
+                # no-op. Leave the same safety margin used by full closes.
+                safe_max_withdrawable_raw = max_withdrawable_raw - HYPERCORE_WITHDRAWAL_SAFETY_MARGIN_RAW
+                if safe_max_withdrawable_raw <= 0:
+                    raise HypercoreWithdrawalPreflightError(
+                        f"Hypercore withdrawal blocked for Safe {self.safe_address} in vault {vault_address}: "
+                        f"current max_withdrawable {vault_info.max_withdrawable} USDC is too small after "
+                        f"the {raw_to_usdc(HYPERCORE_WITHDRAWAL_SAFETY_MARGIN_RAW)} USDC safety margin."
+                    )
                 logger.warning(
                     "Hypercore withdrawal request for Safe %s in vault %s is %d raw USDC "
                     "(%s USDC) above current max_withdrawable %s USDC; capping withdrawal "
-                    "from %d raw (%s USDC) to %d raw (%s USDC)",
+                    "from %d raw (%s USDC) to %d raw (%s USDC), leaving %d raw (%s USDC) safety margin",
                     self.safe_address,
                     vault_address,
                     overshoot_raw,
@@ -862,14 +865,12 @@ class HypercoreVaultRouting(RoutingModel):
                     vault_info.max_withdrawable,
                     requested_raw,
                     raw_to_usdc(requested_raw),
-                    max_withdrawable_raw,
-                    raw_to_usdc(max_withdrawable_raw),
+                    safe_max_withdrawable_raw,
+                    raw_to_usdc(safe_max_withdrawable_raw),
+                    HYPERCORE_WITHDRAWAL_SAFETY_MARGIN_RAW,
+                    raw_to_usdc(HYPERCORE_WITHDRAWAL_SAFETY_MARGIN_RAW),
                 )
-                # Use the live cap for the phase-1 vaultTransfer call. This is
-                # the amount HyperCore says can be withdrawn now, so it avoids
-                # the silent no-op behaviour seen when vaultTransfer is asked
-                # for even a tiny amount above the live cap.
-                effective_requested_raw = max_withdrawable_raw
+                effective_requested_raw = safe_max_withdrawable_raw
                 # Settlement phases 2-3 must use exactly the same amount that
                 # phase 1 was built with. Reuse the existing key used by
                 # full-close live-equity caps so downstream code remains on a


### PR DESCRIPTION
## Why

HyperCore vault NAV can change between the live planning snapshot and phase-1 execution. A normal $0.642134 reduction in `max_withdrawable` exceeded the former $0.50 dust allowance and crashed the sequential trading loop.

## Lessons learnt

The fresh HyperCore withdrawal limit is a moving execution constraint. A small accepted cap drift must be adjusted below the fresh limit, not submitted at the exact limit, because a further NAV move can cause a silent `vaultTransfer` no-op.

## Summary

- Accept up to $1.50 of normal planning-to-execution withdrawal-cap drift.
- Build phase 1 at the fresh cap less the existing $1.50 execution safety margin and persist that amount for settlement.
- Cover the production drift values and the non-positive safe-cap guard with focused tests.