### PR TITLE
feat: clean small HyperCore vault positions

### DIFF
--- a/.claude/docs/hypercore-vault.md
+++ b/.claude/docs/hypercore-vault.md
@@ -335,6 +335,43 @@ the phase-1 performance-fee shortfall. The constants and inline comments in
 references); the `CHANGELOG.md` and git history record each fix. Read those
 comments before changing settlement logic.
 
+## Small-position cleanup
+
+`correct-accounts` cleans tracked **HyperCore-native** vault positions below
+the strategy's minimum allocation by default, plus positions already marked as
+awaiting a previous cleanup redemption.  This is implemented in
+`tradeexecutor/ethereum/vault/hypercore_small_position_cleanup.py`; it does
+not apply to ERC-4626, ERC-7540, or Ostium vault positions.  It currently runs
+through a Lagoon strategy vault's HyperCore execution route, but it cleans
+HyperCore positions, not Lagoon vault shares.  Use
+`--no-cleanup-hypercore-small-positions` to opt out for one run.
+
+The cleaner uses `individual_rebalance_min_threshold_usd` (or the legacy
+`minimum_rebalance_trade_threshold`) as the strategy allocation floor.  It
+revalues the existing HyperCore position first, then plans a full-close trade
+through the normal HyperCore router so the verified vault → perp → spot → EVM
+withdrawal sequence credits actual USDC to the strategy reserve.
+
+HyperCore silently rejects withdrawals below 5 USDC and full withdrawals that
+are marginally above live equity.  Before each pass the cleaner refreshes live
+equity.  If needed, it tops up enough to leave the 5 USDC withdrawal floor even
+for the largest 10 USDC retry margin (at least 5 USDC; e.g. a 3.45 USDC
+position receives an 11.55 USDC top-up).  It skips the position if reserves do
+not cover that temporary capital.  The top-up is an isolated trade: HyperCore
+locks the whole vault position after every deposit, so the cleaner records a
+pending-redemption marker and waits for a later `correct-accounts` run after
+the live lock-up has expired.  It never attempts a same-run top-up and redeem.
+
+Once unlocked, the normal redeem path retries a phase-1 silent no-op with
+progressively larger 3, 5, and 10 USDC safety margins.  A retry that leaves
+more than the 2 USDC state-close epsilon remains tracked for a later cleanup
+run, where it can be topped up again if necessary.  A still-open residual
+confirmed at or below 2 USDC is locally closed with a zero-quantity repair.
+On a successful cleanup the top-up is temporary capital and actual withdrawn
+proceeds return to reserves.  If a routed cleanup trade fails, its state is
+saved and it is left for the normal failed-trade repair flow rather than being
+silently written off.
+
 ## Testing
 
 HyperCore execution cannot be exercised against a normal EVM testnet — the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 0.2
 
+- Add default-on `correct-accounts` cleanup for undersized HyperCore vault positions, with isolated top-up/redemption passes and increasingly tolerant withdrawal retries (2026-07-29)
 
 - Extend `vault-test-trade` simulations to validate typed closed deposits through GuardV0 without broadcasting, and distinguish vault JSON statuses that incorrectly report deposits open or closed (2026-07-28)
 

--- a/tests/hyperliquid/test_hypercore_small_position_cleanup.py
+++ b/tests/hyperliquid/test_hypercore_small_position_cleanup.py
@@ -1,0 +1,323 @@
+"""Test cleanup planning for undersized HyperCore-native vault positions."""
+
+import datetime
+from decimal import Decimal
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+from tradingstrategy.chain import ChainId
+
+from tradeexecutor.ethereum.vault.hypercore_routing import (
+    HYPERCORE_SMALL_POSITION_CLEANUP_RETRY_SAFETY_MARGINS_RAW,
+    HYPERCORE_WITHDRAWAL_SAFETY_MARGIN_RAW,
+    HypercoreWithdrawalPreflightError,
+    HypercoreVaultRouting,
+)
+from tradeexecutor.ethereum.vault.hypercore_small_position_cleanup import (
+    HypercoreSmallPositionCandidate,
+    discover_hypercore_small_positions,
+    get_hypercore_minimum_allocation,
+    get_hypercore_small_position_top_up_reserve,
+    plan_hypercore_small_position_cleanup,
+    run_hypercore_small_position_cleanup,
+)
+from tradeexecutor.ethereum.vault.hypercore_vault import create_hypercore_vault_pair
+from tradeexecutor.state.identifier import AssetIdentifier
+from tradeexecutor.state.position import TradingPosition
+from tradeexecutor.state.state import State
+from tradeexecutor.state.trade import TradeType
+
+
+NOW = datetime.datetime(2026, 7, 28, 12, 0, 0)
+
+
+def _make_position(live_equity: Decimal) -> tuple[State, TradingPosition]:
+    """Create an open HyperCore position with a chosen current USD value."""
+
+    reserve_asset = AssetIdentifier(
+        chain_id=ChainId.hyperliquid.value,
+        address="0x2000000000000000000000000000000000000000",
+        token_symbol="USDC",
+        decimals=6,
+    )
+    pair = create_hypercore_vault_pair(
+        quote=reserve_asset,
+        vault_address="0x1111111111111111111111111111111111111111",
+    )
+    state = State()
+    state.portfolio.initialise_reserves(reserve_asset, reserve_token_price=1.0)
+    state.portfolio.adjust_reserves(reserve_asset, Decimal("100"), "Initial reserve")
+    position, opening_trade, _created = state.create_trade(
+        strategy_cycle_at=NOW,
+        pair=pair,
+        quantity=None,
+        reserve=Decimal("10"),
+        assumed_price=1.0,
+        trade_type=TradeType.rebalance,
+        reserve_currency=reserve_asset,
+        reserve_currency_price=1.0,
+    )
+    state.mark_trade_success(
+        executed_at=NOW,
+        trade=opening_trade,
+        executed_price=1.0,
+        executed_amount=Decimal("10"),
+        executed_reserve=Decimal("10"),
+        lp_fees=0,
+        native_token_price=0.0,
+        force=True,
+    )
+    position.revalue_base_asset(NOW, float(live_equity / Decimal("10")))
+    return state, position
+
+
+def test_cleanup_plans_top_up_for_sub_floor_hypercore_position():
+    """A sub-floor HyperCore position schedules a temporary top-up before a later redemption.
+
+    1. Create a 3.45 USDC HyperCore position below the strategy's 50 USDC allocation floor.
+    2. Discover it and plan the cleanup.
+    3. Verify the plan tops up enough for every retry without creating a lock-up-blocked close.
+    """
+
+    # 1. Create a 3.45 USDC HyperCore position below the strategy's 50 USDC allocation floor.
+    state, position = _make_position(Decimal("3.45"))
+
+    # 2. Discover it and plan the cleanup.
+    candidates = discover_hypercore_small_positions(state, Decimal("50"))
+    assert len(candidates) == 1
+    assert candidates[0].top_up_reserve == Decimal("11.55")
+    trades = plan_hypercore_small_position_cleanup(state, candidates[0], NOW)
+
+    # 3. Verify the plan tops up enough for every retry without creating a lock-up-blocked close.
+    assert len(trades) == 1
+    assert trades[0].is_buy()
+    assert trades[0].planned_reserve == Decimal("11.55")
+    assert position.get_quantity(planned=True) > position.get_quantity()
+    assert trades[0].other_data["hypercore_small_position_cleanup"] is True
+    assert get_hypercore_small_position_top_up_reserve(Decimal("2")) == Decimal("13")
+
+
+def test_cleanup_uses_strategy_minimum_allocation_and_avoids_unneeded_top_up():
+    """A redeemable position is selected from strategy parameters without a top-up.
+
+    1. Read HyperAI's minimum-allocation style parameter and verify an explicit zero disables cleanup.
+    2. Create a 25 USDC HyperCore position below that allocation but above the redeemable floor.
+    3. Verify cleanup plans one full-close trade and does not add temporary capital.
+    """
+
+    # 1. Read HyperAI's minimum-allocation style parameter and verify an explicit zero disables cleanup.
+    minimum_allocation = get_hypercore_minimum_allocation(
+        {"individual_rebalance_min_threshold_usd": 50}
+    )
+    assert minimum_allocation == Decimal("50")
+    assert get_hypercore_minimum_allocation(
+        {
+            "individual_rebalance_min_threshold_usd": 0,
+            "minimum_rebalance_trade_threshold": 50,
+        }
+    ) is None
+
+    # 2. Create a 25 USDC HyperCore position below that allocation but above the redeemable floor.
+    state, position = _make_position(Decimal("25"))
+    candidates = discover_hypercore_small_positions(state, minimum_allocation)
+    assert len(candidates) == 1
+    assert candidates[0].top_up_reserve is None
+    trades = plan_hypercore_small_position_cleanup(state, candidates[0], NOW)
+
+    # 3. Verify cleanup plans one full-close trade and does not add temporary capital.
+    assert len(trades) == 1
+    assert trades[0].is_sell()
+    assert trades[0].planned_quantity == -position.get_quantity()
+    assert trades[0].other_data["hypercore_small_position_cleanup"] is True
+    position.other_data["hypercore_small_position_cleanup_pending_redeem"] = True
+    pending_candidates = discover_hypercore_small_positions(state, Decimal("5"))
+    assert pending_candidates[0].is_pending_cleanup is True
+
+
+def test_cleanup_uses_progressively_larger_silent_noop_retry_margins():
+    """A cleanup close receives an adaptive retry margin ladder.
+
+    1. Create the normal and cleanup trade markers used by the HyperCore router.
+    2. Ask the routing helper for their silent-no-op retry margins.
+    3. Verify only cleanup closes receive the progressively larger retry ladder.
+    """
+
+    # 1. Create the normal and cleanup trade markers used by the HyperCore router.
+    routing = object.__new__(HypercoreVaultRouting)
+    normal_trade = SimpleNamespace(other_data={})
+    cleanup_trade = SimpleNamespace(other_data={"hypercore_small_position_cleanup": True})
+
+    # 2. Ask the routing helper for their silent-no-op retry margins.
+    normal_margins = routing._get_phase1_noop_retry_safety_margins(normal_trade)
+    cleanup_margins = routing._get_phase1_noop_retry_safety_margins(cleanup_trade)
+
+    # 3. Verify only cleanup closes receive the progressively larger retry ladder.
+    assert normal_margins == (HYPERCORE_WITHDRAWAL_SAFETY_MARGIN_RAW,)
+    assert cleanup_margins == HYPERCORE_SMALL_POSITION_CLEANUP_RETRY_SAFETY_MARGINS_RAW
+
+
+def test_cleanup_retry_keeps_material_residual_tracked_for_another_pass():
+    """A high-margin retry does not write off a material HyperCore residual.
+
+    1. Create normal and cleanup retry trades for a HyperCore vault pair.
+    2. Ask the router whether their residual must remain tracked.
+    3. Verify only the 3 USDC cleanup retry requires a later redemption run.
+    """
+
+    # 1. Create normal and cleanup retry trades for a HyperCore vault pair.
+    _state, position = _make_position(Decimal("25"))
+    routing = object.__new__(HypercoreVaultRouting)
+    normal_trade = SimpleNamespace(other_data={}, pair=position.pair)
+    cleanup_trade = SimpleNamespace(
+        other_data={
+            "hypercore_small_position_cleanup": True,
+            "hypercore_phase1_retry_safety_margin_raw": 3_000_000,
+        },
+        pair=position.pair,
+    )
+
+    # 2. Ask the router whether their residual must remain tracked.
+    normal_has_residual = routing._cleanup_retry_leaves_material_residual(normal_trade)
+    cleanup_has_residual = routing._cleanup_retry_leaves_material_residual(cleanup_trade)
+
+    # 3. Verify only the 3 USDC cleanup retry requires a later redemption run.
+    assert normal_has_residual is False
+    assert cleanup_has_residual is True
+
+
+def test_cleanup_top_up_waits_for_vault_lock_up_before_redeeming():
+    """A cleanup top-up is persisted and a locked position is deferred.
+
+    1. Arrange an unlocked small candidate that needs a top-up and a locked pending candidate.
+    2. Run the cleaner with mocks because this unit test must not broadcast to HyperCore.
+    3. Verify only the top-up executes and the pending-redeem marker is persisted.
+    """
+
+    # 1. Arrange an unlocked small candidate that needs a top-up and a locked pending candidate.
+    # Mocks isolate pass orchestration from transaction broadcasts and live HyperCore reads.
+    top_up_candidate = HypercoreSmallPositionCandidate(
+        position_id=57,
+        vault_name="Crypto Plaza",
+        vault_address="0x1111111111111111111111111111111111111111",
+        live_equity=Decimal("3.45"),
+        minimum_allocation=Decimal("5"),
+        top_up_reserve=Decimal("11.55"),
+        is_pending_cleanup=False,
+    )
+    locked_candidate = HypercoreSmallPositionCandidate(
+        position_id=58,
+        vault_name="Crypto Plaza",
+        vault_address="0x2222222222222222222222222222222222222222",
+        live_equity=Decimal("15"),
+        minimum_allocation=Decimal("5"),
+        top_up_reserve=None,
+        is_pending_cleanup=True,
+    )
+    state = MagicMock()
+    state.portfolio.get_default_reserve_position.return_value.quantity = Decimal("100")
+    top_up_position = MagicMock()
+    top_up_position.other_data = {}
+    state.portfolio.open_positions = {57: top_up_position}
+    top_up_trade = MagicMock()
+    top_up_trade.is_success.return_value = True
+    store = MagicMock()
+
+    # 2. Run the cleaner with mocks because this unit test must not broadcast to HyperCore.
+    with (
+        patch(
+            "tradeexecutor.ethereum.vault.hypercore_small_position_cleanup.plan_hypercore_small_position_cleanup",
+            return_value=[top_up_trade],
+        ),
+        patch(
+            "tradeexecutor.ethereum.vault.hypercore_small_position_cleanup.fetch_user_vault_equity",
+            side_effect=[
+                SimpleNamespace(
+                    equity=Decimal("3.45"),
+                    is_lockup_expired=True,
+                    locked_until=NOW,
+                ),
+                SimpleNamespace(
+                    equity=Decimal("15"),
+                    is_lockup_expired=False,
+                    locked_until=NOW + datetime.timedelta(days=1),
+                ),
+            ],
+        ),
+    ):
+        report = run_hypercore_small_position_cleanup(
+            state=state,
+            timestamp=NOW,
+            candidates=[top_up_candidate, locked_candidate],
+            execution_model=MagicMock(),
+            routing_model=MagicMock(),
+            routing_state=MagicMock(),
+            session=MagicMock(),
+            safe_address="0xSafe",
+            store=store,
+        )
+
+    # 3. Verify only the top-up executes and the pending-redeem marker is persisted.
+    assert report.executed_trades == [top_up_trade]
+    assert report.closed_position_ids == []
+    assert top_up_position.other_data["hypercore_small_position_cleanup_pending_redeem"] is True
+    assert store.sync.call_count == 2
+
+
+def test_cleanup_saves_preflight_failure_as_a_repairable_failed_trade():
+    """A withdrawal preflight failure is persisted without aborting account correction.
+
+    1. Arrange a redeemable candidate whose close preflight raises the standard exception.
+    2. Run the cleaner with mocked execution because this unit test must not broadcast to HyperCore.
+    3. Verify the attempted trade and failure state are saved, with no false local close.
+    """
+
+    # 1. Arrange a redeemable candidate whose close preflight raises the standard exception.
+    candidate = HypercoreSmallPositionCandidate(
+        position_id=57,
+        vault_name="Crypto Plaza",
+        vault_address="0x1111111111111111111111111111111111111111",
+        live_equity=Decimal("25"),
+        minimum_allocation=Decimal("50"),
+        top_up_reserve=None,
+        is_pending_cleanup=False,
+    )
+    failed_close_trade = MagicMock()
+    store = MagicMock()
+    execution_model = MagicMock()
+    execution_model.execute_trades.side_effect = HypercoreWithdrawalPreflightError("lock-up changed")
+    state = MagicMock()
+    state.portfolio.get_default_reserve_position.return_value.quantity = Decimal("100")
+    failed_close_trade.is_started.return_value = True
+
+    # 2. Run the cleaner with mocked execution because this unit test must not broadcast to HyperCore.
+    with patch(
+        "tradeexecutor.ethereum.vault.hypercore_small_position_cleanup.plan_hypercore_small_position_cleanup",
+        return_value=[failed_close_trade],
+    ), patch(
+        "tradeexecutor.ethereum.vault.hypercore_small_position_cleanup.fetch_user_vault_equity",
+        return_value=SimpleNamespace(
+            equity=Decimal("25"),
+            is_lockup_expired=True,
+            locked_until=NOW,
+        ),
+    ), patch(
+        "tradeexecutor.ethereum.vault.hypercore_small_position_cleanup.freeze_position_on_failed_trade",
+    ) as freeze_position:
+        report = run_hypercore_small_position_cleanup(
+            state=state,
+            timestamp=NOW,
+            candidates=[candidate],
+            execution_model=execution_model,
+            routing_model=MagicMock(),
+            routing_state=MagicMock(),
+            session=MagicMock(),
+            safe_address="0xSafe",
+            store=store,
+        )
+
+    # 3. Verify the attempted trade and failure state are saved, with no false local close.
+    assert report.executed_trades == [failed_close_trade]
+    assert report.closed_position_ids == []
+    state.mark_trade_failed.assert_called_once_with(NOW, failed_close_trade)
+    freeze_position.assert_called_once_with(NOW, state, [failed_close_trade])
+    assert store.sync.call_count == 1

--- a/tradeexecutor/cli/commands/correct_accounts.py
+++ b/tradeexecutor/cli/commands/correct_accounts.py
@@ -15,6 +15,11 @@ from typer import Option
 
 from eth_defi.compat import native_datetime_utc_now
 from eth_defi.hotwallet import HotWallet
+from eth_defi.hyperliquid.session import (
+    HYPERLIQUID_API_URL,
+    HYPERLIQUID_TESTNET_API_URL,
+    create_hyperliquid_session,
+)
 from eth_defi.provider.broken_provider import get_almost_latest_block_number
 
 from tradeexecutor.exchange_account.derive import DeriveNetwork
@@ -29,6 +34,11 @@ from ...ethereum.enzyme.vault import EnzymeVaultSyncModel
 from ...ethereum.hot_wallet_sync_model import HotWalletSyncModel
 from ...ethereum.lagoon.vault import LagoonVaultSyncModel
 from ...ethereum.tx import HotWalletTransactionBuilder
+from ...ethereum.vault.hypercore_small_position_cleanup import (
+    discover_hypercore_small_positions,
+    get_hypercore_minimum_allocation,
+    run_hypercore_small_position_cleanup,
+)
 from ...state.repair import close_hypercore_dust_positions
 from ...state.state import UncleanState
 from ...state.trade import TradeType
@@ -81,11 +91,6 @@ def _sync_hypercore_vault_positions(
     safe_address = sync_model.get_token_storage_address()
     chain_id = web3.eth.chain_id
 
-    from eth_defi.hyperliquid.session import (
-        HYPERLIQUID_API_URL,
-        HYPERLIQUID_TESTNET_API_URL,
-        create_hyperliquid_session,
-    )
     from tradeexecutor.ethereum.vault.hypercore_vault import create_hypercore_vault_value_func
     from tradeexecutor.strategy.account_correction import create_missing_vault_positions
     from tradeexecutor.state.valuation import ValuationUpdate
@@ -390,6 +395,7 @@ def correct_accounts(
     transfer_away: bool = Option(False, "--transfer-away", envvar="TRANSFER_AWAY", help="For tokens without assigned position, scoop them to the hot wallet instead of trying to construct a new position"),
     raise_on_unclean: bool = typer.Option(False, is_flag=True, envvar="RAISE_ON_UNCLEAN", help="Raise an exception if unclean. Unit test option."),
     skip_hypercore_transit_recovery: bool = Option(False, "--skip-hypercore-transit-recovery", envvar="SKIP_HYPERCORE_TRANSIT_RECOVERY", help="Skip automatic Safe-level HyperCore spot/perp USDC recovery before account correction."),
+    cleanup_hypercore_small_positions: bool = Option(True, "--cleanup-hypercore-small-positions/--no-cleanup-hypercore-small-positions", envvar="CLEANUP_HYPERCORE_SMALL_POSITIONS", help="Redeem open HyperCore vault positions below the strategy minimum allocation before correcting accounts."),
 
     # Derive exchange account options
     derive_owner_private_key: Optional[str] = Option(None, envvar="DERIVE_OWNER_PRIVATE_KEY", help="Derive owner wallet private key"),
@@ -703,6 +709,52 @@ def correct_accounts(
         web3=web3,
         state=state,
     )
+
+    if cleanup_hypercore_small_positions and asset_management_mode.is_vault():
+        minimum_allocation = get_hypercore_minimum_allocation(mod.parameters)
+        if minimum_allocation is None:
+            logger.info(
+                "HyperCore small-position cleanup skipped: strategy does not define a minimum allocation parameter"
+            )
+        elif not isinstance(sync_model, LagoonVaultSyncModel):
+            logger.info(
+                "HyperCore small-position cleanup skipped: it is only implemented for Lagoon vault strategies"
+            )
+        else:
+            cleanup_candidates = discover_hypercore_small_positions(
+                state,
+                minimum_allocation,
+            )
+            if not cleanup_candidates:
+                logger.info("HyperCore small-position cleanup found no eligible positions")
+            else:
+                ensure_routing_setup()
+                if routing_state is None:
+                    logger.warning(
+                        "HyperCore small-position cleanup skipped: routing is unavailable for this strategy"
+                    )
+                else:
+                    is_testnet = web3.eth.chain_id == 998
+                    api_url = HYPERLIQUID_TESTNET_API_URL if is_testnet else HYPERLIQUID_API_URL
+                    session = create_hyperliquid_session(api_url=api_url)
+                    cleanup_report = run_hypercore_small_position_cleanup(
+                        state=state,
+                        timestamp=native_datetime_utc_now(),
+                        candidates=cleanup_candidates,
+                        execution_model=execution_model,
+                        routing_model=runner.routing_model,
+                        routing_state=routing_state,
+                        session=session,
+                        safe_address=sync_model.get_token_storage_address(),
+                        store=store,
+                    )
+                    logger.info(
+                        "HyperCore small-position cleanup processed %d trade(s) across %d candidate(s); "
+                        "%d position(s) were closed",
+                        len(cleanup_report.executed_trades),
+                        len(cleanup_report.candidates),
+                        len(cleanup_report.closed_position_ids),
+                    )
 
     closed_dust_trades = close_hypercore_dust_positions(state.portfolio)
     if closed_dust_trades:

--- a/tradeexecutor/ethereum/vault/hypercore_routing.py
+++ b/tradeexecutor/ethereum/vault/hypercore_routing.py
@@ -169,6 +169,16 @@ HYPERCORE_LIKELY_CLOSE_TOLERANCE = 0.975
 #: accounting later.
 HYPERCORE_WITHDRAWAL_SAFETY_MARGIN_RAW = 1_500_000
 
+#: A HyperCore small-position cleanup retries a silent phase-1 no-op with
+#: increasingly conservative safety margins.  This is deliberately scoped to
+#: the correct-accounts clean-up marker: normal strategy rebalances retain
+#: their single 1.50 USDC retry margin and fail loudly after a repeat no-op.
+HYPERCORE_SMALL_POSITION_CLEANUP_RETRY_SAFETY_MARGINS_RAW = (
+    3_000_000,
+    5_000_000,
+    10_000_000,
+)
+
 #: Normal live preflight cap drift tolerance (raw USDC, 6 decimals).
 #:
 #: Incident reference:
@@ -1247,6 +1257,7 @@ class HypercoreVaultRouting(RoutingModel):
         self,
         current_vault_equity: Decimal,
         previous_raw: int,
+        safety_margin_raw: int = HYPERCORE_WITHDRAWAL_SAFETY_MARGIN_RAW,
     ) -> int | None:
         """Return a smaller phase-1 retry amount after a suspected silent no-op.
 
@@ -1271,7 +1282,7 @@ class HypercoreVaultRouting(RoutingModel):
         # Subtract the normal full-close safety margin from the fresh equity so
         # the second queued action has room for another small NAV move before
         # HyperCore processes it.
-        retry_raw = current_raw - HYPERCORE_WITHDRAWAL_SAFETY_MARGIN_RAW
+        retry_raw = current_raw - safety_margin_raw
 
         # Hyperliquid silently rejects vault transfers below the same 5 USDC
         # floor used for deposits.  If the retry amount is below the floor, the
@@ -1289,6 +1300,34 @@ class HypercoreVaultRouting(RoutingModel):
             return None
 
         return retry_raw
+
+    def _get_phase1_noop_retry_safety_margins(
+        self,
+        trade: TradeExecution,
+    ) -> tuple[int, ...]:
+        """Get phase-1 retry margins for a normal or cleanup withdrawal."""
+
+        if trade.other_data.get("hypercore_small_position_cleanup"):
+            return HYPERCORE_SMALL_POSITION_CLEANUP_RETRY_SAFETY_MARGINS_RAW
+        return (HYPERCORE_WITHDRAWAL_SAFETY_MARGIN_RAW,) * HYPERCORE_WITHDRAWAL_PHASE1_RETRY_ATTEMPTS
+
+    def _cleanup_retry_leaves_material_residual(self, trade: TradeExecution) -> bool:
+        """Whether a cleanup retry must retain its residual in state.
+
+        A higher retry safety margin protects against a HyperCore no-op, but
+        it also leaves that amount in the vault.  Retain it for another
+        top-up-and-redeem pass instead of treating it as normal close dust.
+        """
+
+        safety_margin_raw = trade.other_data.get(
+            "hypercore_phase1_retry_safety_margin_raw"
+        )
+        return (
+            bool(trade.other_data.get("hypercore_small_position_cleanup"))
+            and safety_margin_raw is not None
+            and raw_to_usdc(int(safety_margin_raw))
+            > Decimal(str(get_close_epsilon_for_pair(trade.pair)))
+        )
 
     def _wait_for_spot_free_usdc_balance(
         self,
@@ -2634,40 +2673,36 @@ class HypercoreVaultRouting(RoutingModel):
                         perp_balance,
                     )
                 else:
-                    retry_raw = None
-                    if current_vault_equity is not None:
+                    retry_margins = self._get_phase1_noop_retry_safety_margins(trade)
+                    retry_succeeded = False
+                    last_retry_wait_error: HypercoreWithdrawalVerificationError | None = None
+                    for retry_number, retry_safety_margin_raw in enumerate(retry_margins, start=1):
+                        if current_vault_equity is None:
+                            break
+
                         retry_raw = self._get_phase1_noop_retry_raw(
                             current_vault_equity=current_vault_equity,
                             previous_raw=expected_raw,
+                            safety_margin_raw=retry_safety_margin_raw,
                         )
+                        if retry_raw is None:
+                            break
 
-                    if retry_raw is not None and HYPERCORE_WITHDRAWAL_PHASE1_RETRY_ATTEMPTS > 0:
-                        # 2026-04-15 DOEZOE incident:
-                        #
-                        # The first phase-1 tx had EVM status=1, but perp
-                        # withdrawable stayed flat for 30 seconds. The fresh
-                        # vault-equity snapshot was slightly below the amount
-                        # we had asked HyperCore to withdraw, which is the
-                        # known silent no-op pattern for ``vaultTransfer``.
-                        #
-                        # Retry once using the latest equity minus the same
-                        # safety margin used for full closes. This salvages the
-                        # trade and keeps the sequential rebalance moving,
-                        # while still leaving meaningful repeated failures for
-                        # operator recovery.
                         logger.warning(
                             "Withdrawal phase 1 for trade %s appears to have silently no-opped: %s. "
                             "Fresh vault equity is %s USDC, previous phase-1 amount was %d raw "
-                            "(%s USDC). Retrying phase 1 (%d/%d) with %d raw (%s USDC).",
+                            "(%s USDC). Retrying phase 1 (%d/%d) with %d raw (%s USDC), "
+                            "using a %s raw safety margin.",
                             trade.trade_id,
                             e,
                             current_vault_equity,
                             expected_raw,
                             raw_to_usdc(expected_raw),
-                            1,
-                            HYPERCORE_WITHDRAWAL_PHASE1_RETRY_ATTEMPTS,
+                            retry_number,
+                            len(retry_margins),
                             retry_raw,
                             raw_to_usdc(retry_raw),
+                            retry_safety_margin_raw,
                         )
 
                         self.deployer.sync_nonce(web3)
@@ -2703,14 +2738,12 @@ class HypercoreVaultRouting(RoutingModel):
 
                         expected_raw = retry_raw
                         phase1_requested_reserve = raw_to_usdc(expected_raw)
-                        # Recompute the fee tolerance for the smaller retry amount.
-                        # Reusing the original (larger) tolerance would let the
-                        # retry wait accept little or no perp increase.
                         phase1_performance_fee_tolerance = estimate_max_withdrawal_commission(
                             phase1_requested_reserve,
                             performance_fee_rate,
                         )
                         trade.other_data["hypercore_capped_withdrawal_raw"] = retry_raw
+                        trade.other_data["hypercore_phase1_retry_safety_margin_raw"] = retry_safety_margin_raw
                         vault_equity_before_phase1_snapshot = current_vault_equity
                         has_pre_phase1_vault_equity_snapshot = True
 
@@ -2723,20 +2756,52 @@ class HypercoreVaultRouting(RoutingModel):
                                 timeout=30.0,
                                 poll_interval=2.0,
                             )
-                        except HypercoreWithdrawalVerificationError as retry_wait_error:
-                            logger.error(
-                                "Withdrawal phase 1 retry verification failed for trade %s: %s",
+                            retry_succeeded = True
+                            break
+                        except HypercoreWithdrawalVerificationError as retry_error:
+                            last_retry_wait_error = retry_error
+                            logger.warning(
+                                "Withdrawal phase 1 retry %d/%d verification failed for trade %s: %s",
+                                retry_number,
+                                len(retry_margins),
                                 trade.trade_id,
-                                retry_wait_error,
+                                retry_error,
                             )
+                            try:
+                                refreshed_equity = fetch_user_vault_equity(
+                                    session,
+                                    user=self.safe_address,
+                                    vault_address=vault_address,
+                                    bypass_cache=True,
+                                )
+                                current_vault_equity = (
+                                    refreshed_equity.equity
+                                    if refreshed_equity is not None
+                                    else None
+                                )
+                            except Exception as refresh_error:
+                                logger.warning(
+                                    "Could not refresh vault equity before retrying trade %s: %s",
+                                    trade.trade_id,
+                                    refresh_error,
+                                )
+                                current_vault_equity = None
+
+                    if not retry_succeeded:
+                        if (
+                            not trade.other_data.get("hypercore_small_position_cleanup")
+                            and last_retry_wait_error is not None
+                        ):
                             self._mark_stranded_usdc(trade, expected_raw, "hypercore_perp")
                             self.diagnose_hyperliquid_vault_redemption_failure(
-                                trade, vault_address, "phase1_retry_perp_wait",
-                                str(retry_wait_error),
+                                trade,
+                                vault_address,
+                                "phase1_retry_perp_wait",
+                                str(last_retry_wait_error),
                             )
                             report_failure(ts, state, trade, stop_on_execution_failure)
                             return
-                    else:
+
                         logger.error(
                             "Withdrawal phase 1 verification failed for trade %s: %s",
                             trade.trade_id, e,
@@ -2759,8 +2824,10 @@ class HypercoreVaultRouting(RoutingModel):
                         else:
                             self._mark_stranded_usdc(trade, expected_raw, "hypercore_perp")
                         self.diagnose_hyperliquid_vault_redemption_failure(
-                            trade, vault_address, "phase1_perp_wait",
-                            str(e),
+                            trade,
+                            vault_address,
+                            "phase1_retry_perp_wait" if last_retry_wait_error else "phase1_perp_wait",
+                            str(last_retry_wait_error or e),
                         )
                         report_failure(ts, state, trade, stop_on_execution_failure)
                         return
@@ -3080,6 +3147,14 @@ class HypercoreVaultRouting(RoutingModel):
             (trade.closing or TradeFlag.close in trade.flags or closes_position_quantity)
             and not close_materially_short
         )
+
+        # A cleanup retry may deliberately use a safety margin larger than
+        # HyperCore's normal close epsilon.  Do not discard that material
+        # residual from state: the small-position cleaner will top it up and
+        # redeem it in a follow-up pass.  Normal full closes retain their
+        # established close behaviour and may write off the <= 2 USDC margin.
+        if self._cleanup_retry_leaves_material_residual(trade):
+            should_close_full_quantity = False
 
         if should_close_full_quantity:
             executed_amount = trade.planned_quantity

--- a/tradeexecutor/ethereum/vault/hypercore_small_position_cleanup.py
+++ b/tradeexecutor/ethereum/vault/hypercore_small_position_cleanup.py
@@ -1,0 +1,436 @@
+"""Clean undersized tracked HyperCore vault positions.
+
+This module is deliberately limited to **HyperCore native vault** positions.
+It must not be used for ERC-4626, ERC-7540, or Ostium vault positions: those
+protocols have different redemption and settlement semantics.  The current
+caller uses Lagoon's HyperCore execution route, but this module never handles
+Lagoon vault shares.
+
+HyperCore ``vaultTransfer`` has no withdraw-all operation and rejects an
+amount that is even slightly above live equity.  A small position is therefore
+redeemed through the normal HyperCore router, with a full-close flag and a
+larger retry margin if the first vaultTransfer silently no-ops.  When the
+position is too small to leave the protocol's 5 USDC withdrawal floor after
+the safety margin, the cleaner first tops it up by enough to make every retry
+withdrawable from fresh live equity.  The subsequent full close returns the
+usable capital to reserves.  A deposit locks the whole vault position, so the
+top-up and the later redemption deliberately happen in separate runs.
+Any retry residual above the close epsilon remains state-tracked and is
+redeemed on a later run; only final protocol dust is written off in state.
+If a routed trade fails, the updated state is saved and the normal failed-trade
+repair flow takes over.
+"""
+
+import datetime
+import logging
+from dataclasses import dataclass, replace
+from decimal import Decimal
+
+from eth_defi.hyperliquid.api import fetch_user_vault_equity
+from eth_defi.hyperliquid.core_writer import MINIMUM_VAULT_DEPOSIT
+
+from tradeexecutor.ethereum.vault.hypercore_routing import (
+    HYPERCORE_SMALL_POSITION_CLEANUP_RETRY_SAFETY_MARGINS_RAW,
+    HypercoreWithdrawalPreflightError,
+    raw_to_usdc,
+    usdc_to_raw,
+)
+from tradeexecutor.state.freeze import freeze_position_on_failed_trade
+from tradeexecutor.state.repair import close_position_with_empty_trade
+from tradeexecutor.state.trade import TradeExecution, TradeType
+from tradeexecutor.strategy.dust import HYPERLIQUID_VAULT_CLOSE_EPSILON
+from tradeexecutor.strategy.execution_model import ExecutionHaltableIssue
+
+
+logger = logging.getLogger(__name__)
+
+USDC_QUANTUM = Decimal("0.000001")
+
+
+#: Strategy parameters that express the lowest useful allocation.  HyperAI
+#: uses the first name; the second preserves compatibility with older strategy
+#: modules using the generic alpha-model setting.
+MINIMUM_ALLOCATION_PARAMETER_NAMES = (
+    "individual_rebalance_min_threshold_usd",
+    "minimum_rebalance_trade_threshold",
+)
+
+
+@dataclass(slots=True)
+class HypercoreSmallPositionCandidate:
+    """One tracked HyperCore position eligible for small-position cleanup."""
+
+    position_id: int
+    vault_name: str
+    vault_address: str
+    live_equity: Decimal
+    minimum_allocation: Decimal
+    top_up_reserve: Decimal | None
+    is_pending_cleanup: bool
+
+
+@dataclass(slots=True)
+class HypercoreSmallPositionCleanupReport:
+    """Outcome of one small-position cleanup pass."""
+
+    candidates: list[HypercoreSmallPositionCandidate]
+    executed_trades: list[TradeExecution]
+    closed_position_ids: list[int]
+
+
+def get_hypercore_minimum_allocation(parameters) -> Decimal | None:
+    """Read the strategy's minimum useful allocation for HyperCore cleanup.
+
+    Strategies without either parameter opt out safely.  This keeps the
+    correct-accounts default-on option from inventing an allocation threshold.
+    """
+
+    if parameters is None:
+        return None
+
+    for name in MINIMUM_ALLOCATION_PARAMETER_NAMES:
+        value = parameters.get(name)
+        if value is not None:
+            minimum_allocation = Decimal(str(value))
+            return minimum_allocation if minimum_allocation > 0 else None
+
+    return None
+
+
+def get_hypercore_small_position_top_up_reserve(
+    live_equity: Decimal,
+) -> Decimal | None:
+    """Get the temporary top-up that makes every cleanup retry withdrawable now."""
+
+    live_equity = raw_to_usdc(usdc_to_raw(live_equity))
+    minimum_deposit = raw_to_usdc(MINIMUM_VAULT_DEPOSIT)
+    largest_retry_margin = raw_to_usdc(
+        max(HYPERCORE_SMALL_POSITION_CLEANUP_RETRY_SAFETY_MARGINS_RAW)
+    )
+    minimum_equity_for_retry_ladder = minimum_deposit + largest_retry_margin
+    if live_equity >= minimum_equity_for_retry_ladder:
+        return None
+    return max(minimum_deposit, minimum_equity_for_retry_ladder - live_equity)
+
+
+def discover_hypercore_small_positions(
+    state,
+    minimum_allocation: Decimal,
+) -> list[HypercoreSmallPositionCandidate]:
+    """Find live tracked HyperCore positions below the strategy allocation floor.
+
+    ``correct-accounts`` revalues HyperCore positions from the Hyperliquid API
+    immediately before calling this function, so ``position.get_value()`` is a
+    live-equity value rather than the stale quantity held in state.
+    """
+
+    candidates: list[HypercoreSmallPositionCandidate] = []
+
+    for position in state.portfolio.get_open_positions():
+        if not position.pair.is_hyperliquid_vault():
+            continue
+        if position.has_unexecuted_trades():
+            logger.warning(
+                "Skipping HyperCore small-position cleanup for position %d: "
+                "it has unfinished trades",
+                position.position_id,
+            )
+            continue
+
+        live_equity = Decimal(str(position.get_value(include_interest=False))).quantize(USDC_QUANTUM)
+        is_pending_cleanup = (
+            position.other_data.get("hypercore_small_position_cleanup_pending_redeem") is True
+        )
+        if live_equity <= 0 or (
+            not is_pending_cleanup and live_equity >= minimum_allocation
+        ):
+            continue
+
+        vault_address = position.pair.pool_address or position.pair.base.address
+        candidates.append(
+            HypercoreSmallPositionCandidate(
+                position_id=position.position_id,
+                vault_name=position.pair.get_vault_name() or position.pair.get_ticker(),
+                vault_address=vault_address,
+                live_equity=live_equity,
+                minimum_allocation=minimum_allocation,
+                top_up_reserve=get_hypercore_small_position_top_up_reserve(live_equity),
+                is_pending_cleanup=is_pending_cleanup,
+            )
+        )
+
+    return candidates
+
+
+def plan_hypercore_small_position_cleanup(
+    state,
+    candidate: HypercoreSmallPositionCandidate,
+    timestamp: datetime.datetime,
+) -> list[TradeExecution]:
+    """Create one top-up or full-close trade for a cleanup candidate.
+
+    A HyperCore deposit locks the whole vault position, so a top-up must be
+    persisted and allowed to unlock before its later redemption.
+    """
+
+    position = state.portfolio.open_positions[candidate.position_id]
+    assert position.pair.is_hyperliquid_vault()
+    assert position.last_token_price > 0, (
+        f"HyperCore cleanup position {position.position_id} has no usable price"
+    )
+
+    reserve_asset = state.portfolio.get_default_reserve_position().asset
+    if candidate.is_pending_cleanup:
+        cleanup_reason = "a prior small-position cleanup is awaiting redemption"
+    else:
+        cleanup_reason = (
+            f"live equity {candidate.live_equity:.6f} USDC is below strategy minimum "
+            f"allocation {candidate.minimum_allocation:.6f} USDC"
+        )
+    note_prefix = f"correct-accounts HyperCore small-position cleanup: {cleanup_reason}."
+
+    if candidate.top_up_reserve is not None:
+        _position, top_up_trade, _created = state.portfolio.create_trade(
+            strategy_cycle_at=timestamp,
+            pair=position.pair,
+            quantity=None,
+            reserve=candidate.top_up_reserve,
+            assumed_price=position.last_token_price,
+            trade_type=TradeType.rebalance,
+            reserve_currency=reserve_asset,
+            reserve_currency_price=1.0,
+            position=position,
+            notes=(
+                f"{note_prefix} Topping up {candidate.top_up_reserve:.6f} USDC so every "
+                "HyperCore retry can meet the withdrawal floor."
+            ),
+        )
+        top_up_trade.other_data["hypercore_small_position_cleanup"] = True
+        return [top_up_trade]
+
+    close_quantity = -position.get_quantity(planned=True)
+    assert close_quantity < 0, (
+        f"HyperCore cleanup position {position.position_id} has no positive quantity to close"
+    )
+    _position, close_trade, _created = state.portfolio.create_trade(
+        strategy_cycle_at=timestamp,
+        pair=position.pair,
+        quantity=close_quantity,
+        reserve=None,
+        assumed_price=position.last_token_price,
+        trade_type=TradeType.rebalance,
+        reserve_currency=reserve_asset,
+        reserve_currency_price=1.0,
+        position=position,
+        closing=True,
+        notes=(
+            f"{note_prefix} Redeeming the full planned quantity with the "
+            "HyperCore small-position retry margin."
+        ),
+    )
+    close_trade.other_data["hypercore_small_position_cleanup"] = True
+    return [close_trade]
+
+
+def _close_confirmed_hypercore_residual(
+    *,
+    state,
+    candidate: HypercoreSmallPositionCandidate,
+    session,
+    safe_address: str,
+) -> Decimal | None:
+    """Close safety-margin dust, or return a material residual to redeem again."""
+
+    position = state.portfolio.open_positions.get(candidate.position_id)
+    if position is None:
+        return None
+
+    live_equity = fetch_user_vault_equity(
+        session,
+        user=safe_address,
+        vault_address=candidate.vault_address,
+        bypass_cache=True,
+    )
+    residual_equity = Decimal(0) if live_equity is None else live_equity.equity
+    if residual_equity > HYPERLIQUID_VAULT_CLOSE_EPSILON:
+        position.other_data["hypercore_small_position_cleanup_pending_redeem"] = True
+        logger.warning(
+            "HyperCore cleanup left %.6f USDC in position %d, above the %.2f "
+            "dust write-off threshold; leaving it open for a later cleanup run",
+            residual_equity,
+            position.position_id,
+            HYPERLIQUID_VAULT_CLOSE_EPSILON,
+        )
+        return residual_equity
+
+    repair_trade = close_position_with_empty_trade(state.portfolio, position)
+    position.add_notes_message(
+        "correct-accounts closed the final HyperCore safety-margin residual "
+        f"({residual_equity:.6f} USDC) after small-position redemption"
+    )
+    logger.info(
+        "Closed HyperCore cleanup residual for position %d with repair trade %d",
+        candidate.position_id,
+        repair_trade.trade_id,
+    )
+    return None
+
+
+def run_hypercore_small_position_cleanup(
+    *,
+    state,
+    timestamp: datetime.datetime,
+    candidates: list[HypercoreSmallPositionCandidate],
+    execution_model,
+    routing_model,
+    routing_state,
+    session,
+    safe_address: str,
+    store,
+) -> HypercoreSmallPositionCleanupReport:
+    """Redeem tracked small HyperCore positions and return proceeds to reserves.
+
+    Trades use the normal HyperCore execution router, so all three withdrawal
+    phases are verified and an actual successful sell credits the portfolio
+    reserve.  A top-up is persisted by itself because it locks the whole vault
+    position until HyperCore's lock-up expires.
+    """
+
+    executed_trades: list[TradeExecution] = []
+    closed_position_ids: list[int] = []
+
+    for candidate in candidates:
+        try:
+            live_equity_result = fetch_user_vault_equity(
+                session,
+                user=safe_address,
+                vault_address=candidate.vault_address,
+                bypass_cache=True,
+            )
+        except Exception as e:
+            logger.warning(
+                "HyperCore small-position cleanup skipped position %d: could not refresh "
+                "live vault equity: %s",
+                candidate.position_id,
+                e,
+            )
+            continue
+
+        live_equity = Decimal(0) if live_equity_result is None else live_equity_result.equity
+        if live_equity <= 0:
+            position = state.portfolio.open_positions.get(candidate.position_id)
+            if position is not None:
+                close_position_with_empty_trade(state.portfolio, position)
+                store.sync(state)
+                closed_position_ids.append(candidate.position_id)
+            continue
+        if live_equity >= candidate.minimum_allocation and not candidate.is_pending_cleanup:
+            logger.info(
+                "HyperCore small-position cleanup skipped position %d: live equity %.6f USDC "
+                "now meets the %.6f USDC allocation minimum",
+                candidate.position_id,
+                live_equity,
+                candidate.minimum_allocation,
+            )
+            continue
+        if not live_equity_result.is_lockup_expired:
+            logger.info(
+                "HyperCore small-position cleanup deferred for position %d: vault lock-up "
+                "remains until %s",
+                candidate.position_id,
+                live_equity_result.locked_until,
+            )
+            continue
+
+        current_candidate = replace(
+            candidate,
+            live_equity=live_equity,
+            top_up_reserve=get_hypercore_small_position_top_up_reserve(live_equity),
+        )
+        is_top_up = current_candidate.top_up_reserve is not None
+        if is_top_up:
+            reserve_quantity = state.portfolio.get_default_reserve_position().quantity
+            if reserve_quantity < current_candidate.top_up_reserve:
+                logger.warning(
+                    "HyperCore small-position cleanup skipped position %d: needs %.6f USDC "
+                    "temporary top-up but only %.6f USDC is in reserves",
+                    current_candidate.position_id,
+                    current_candidate.top_up_reserve,
+                    reserve_quantity,
+                )
+                continue
+
+        trades = plan_hypercore_small_position_cleanup(state, current_candidate, timestamp)
+        logger.info(
+            "Cleaning HyperCore small position %d (%s): equity %.6f USDC, minimum "
+            "allocation %.6f USDC, action=%s",
+            current_candidate.position_id,
+            current_candidate.vault_name,
+            current_candidate.live_equity,
+            current_candidate.minimum_allocation,
+            "top_up" if is_top_up else "redeem",
+        )
+        try:
+            execution_model.execute_trades(
+                timestamp,
+                state,
+                trades,
+                routing_model,
+                routing_state,
+                check_balances=False,
+            )
+        except (ExecutionHaltableIssue, HypercoreWithdrawalPreflightError) as e:
+            trade = trades[0]
+            if isinstance(e, HypercoreWithdrawalPreflightError) and trade.is_started():
+                state.mark_trade_failed(timestamp, trade)
+                freeze_position_on_failed_trade(timestamp, state, [trade])
+            logger.error(
+                "HyperCore small-position cleanup failed for position %d: %s. "
+                "The updated state has been saved; repair the failed trade before retrying.",
+                current_candidate.position_id,
+                e,
+            )
+            executed_trades.extend(trades)
+            continue
+        else:
+            executed_trades.extend(trades)
+        finally:
+            store.sync(state)
+
+        trade = trades[0]
+        if not trade.is_success():
+            continue
+        if is_top_up:
+            position = state.portfolio.open_positions.get(current_candidate.position_id)
+            if position is None:
+                logger.error(
+                    "HyperCore small-position cleanup top-up trade %d succeeded but position %d "
+                    "is no longer open",
+                    trade.trade_id,
+                    current_candidate.position_id,
+                )
+                continue
+            position.other_data["hypercore_small_position_cleanup_pending_redeem"] = True
+            store.sync(state)
+            logger.info(
+                "HyperCore small-position cleanup topped up position %d; redemption will run "
+                "after the vault lock-up expires",
+                current_candidate.position_id,
+            )
+            continue
+
+        residual_equity = _close_confirmed_hypercore_residual(
+            state=state,
+            candidate=current_candidate,
+            session=session,
+            safe_address=safe_address,
+        )
+        store.sync(state)
+        if residual_equity is None:
+            closed_position_ids.append(candidate.position_id)
+
+    return HypercoreSmallPositionCleanupReport(
+        candidates=candidates,
+        executed_trades=executed_trades,
+        closed_position_ids=closed_position_ids,
+    )


### PR DESCRIPTION
## Why

A previously meaningful HyperCore allocation can fall below both the strategy trade threshold and HyperCore withdrawal floor, leaving a dust position open indefinitely.

## Lessons learnt

HyperCore deposits lock the whole vault position, so dust recovery must persist a top-up and redeem only in a later unlocked correction run. Repeated withdrawal tolerances must retain material residuals in state.

## Summary

- Add default-on `correct-accounts` cleanup for undersized HyperCore-native vault positions.
- Top up safely when required, defer through lock-up, then redeem with a 3/5/10 USDC retry ladder.
- Add documentation and focused regression coverage.