### PR TITLE
fix: redeem HyperCore dust without top-ups

### DIFF
--- a/.claude/docs/cli-command.md
+++ b/.claude/docs/cli-command.md
@@ -96,6 +96,14 @@ Representative code:
 - `tradeexecutor/cli/commands/close_position.py`
 - `tradeexecutor/cli/commands/start.py`
 
+`correct-accounts --dry-run` is the read-only variant for live reconciliation.
+It loads the existing state through `SimulateStore`, reads current balances,
+reports HyperCore small-position redemptions and generic accounting
+corrections, and returns before transaction builders or correction execution.
+It does not create a backup, broadcast, or persist state. Do not substitute
+`--skip-save`: that option skips the final state write but does not prevent
+earlier transaction broadcasts.
+
 ### Hybrid commands
 
 Some commands are mostly local-state commands but still construct strategy plumbing or universe data.

--- a/.claude/docs/hypercore-vault.md
+++ b/.claude/docs/hypercore-vault.md
@@ -43,11 +43,12 @@ Key properties that shape our execution:
   redemption returns can therefore be materially smaller than the gross amount
   requested. The rate is carried per vault on the trading pair
   (`other_data["vault_performance_fee"]`), not assumed as a constant.
-- **Lock-ups and minimums (per vault).** Deposits lock for a period that also
-  differs per vault — 1 day for leader vaults, 4 days for protocol/HLP vaults;
-  withdrawals below a ~5 USDC floor are silently rejected; `vaultTransfer` has
-  no "withdraw all" mode and silently no-ops if you ask for more than current
-  equity.
+- **Lock-ups and deposit minimums (per vault).** Deposits lock for a period
+  that also differs per vault — 1 day for leader vaults, 4 days for
+  protocol/HLP vaults. The client-side `MINIMUM_VAULT_DEPOSIT` check applies
+  only to the deposit encoder; the withdrawal encoder has no equivalent check.
+  `vaultTransfer` has no "withdraw all" mode and silently no-ops if a
+  redemption asks for more than current equity.
 - **Silent failures.** Bridge and transfer actions can have a successful EVM
   receipt while HyperCore moves nothing. Every phase must therefore be
   *verified* against HyperCore state, not trusted on receipt status.
@@ -73,7 +74,7 @@ The driver lives in `tradeexecutor/ethereum/vault/hypercore_routing.py`.
 | `HypercoreVaultRouting(RoutingModel)` | Builds, signs, broadcasts and verifies all phases. Holds the HyperEVM `web3`, the `LagoonVault` (whose Safe is the on-chain account), the deployer `HotWallet`, and the reserve token address. |
 | `HypercoreVaultRoutingState(RoutingState)` | Per-cycle routing state. |
 | `HypercoreWithdrawalVerificationError` | A phase did not reach the expected HyperCore balance within the timeout. |
-| `HypercoreWithdrawalPreflightError` | Live preconditions (lock-up, equity, minimum) failed before broadcasting. |
+| `HypercoreWithdrawalPreflightError` | Live preconditions (lock-up, positive amount, equity or liquidity) failed before broadcasting. |
 | `SettlementBroadcastError` | A settlement transaction failed to broadcast/confirm; carries the partial `BlockchainTransaction`. |
 
 From eth_defi (`eth_defi.hyperliquid`): `HyperliquidSession` (Info API client),
@@ -352,25 +353,37 @@ revalues the existing HyperCore position first, then plans a full-close trade
 through the normal HyperCore router so the verified vault → perp → spot → EVM
 withdrawal sequence credits actual USDC to the strategy reserve.
 
-HyperCore silently rejects withdrawals below 5 USDC and full withdrawals that
-are marginally above live equity.  Before each pass the cleaner refreshes live
-equity.  If needed, it tops up enough to leave the 5 USDC withdrawal floor even
-for the largest 10 USDC retry margin (at least 5 USDC; e.g. a 3.45 USDC
-position receives an 11.55 USDC top-up).  It skips the position if reserves do
-not cover that temporary capital.  The top-up is an isolated trade: HyperCore
-locks the whole vault position after every deposit, so the cleaner records a
-pending-redemption marker and waits for a later `correct-accounts` run after
-the live lock-up has expired.  It never attempts a same-run top-up and redeem.
+Full withdrawals that are marginally above live equity silently no-op. Before
+each pass the cleaner refreshes live equity and checks the existing lock-up.
+Once unlocked, it directly attempts a full-close redemption at any amount
+that is large enough to verify every withdrawal phase after the
+live-equity safety margin. It never tops up a position: the client-side 5 USDC
+check belongs to the **deposit encoder**, not the withdrawal encoder, and
+depositing would unnecessarily create a new lock-up. No backend redemption
+minimum has been confirmed; every attempted redemption is verified for actual
+balance movement.
 
-Once unlocked, the normal redeem path retries a phase-1 silent no-op with
-progressively larger 3, 5, and 10 USDC safety margins.  A retry that leaves
-more than the 2 USDC state-close epsilon remains tracked for a later cleanup
-run, where it can be topped up again if necessary.  A still-open residual
-confirmed at or below 2 USDC is locally closed with a zero-quantity repair.
-On a successful cleanup the top-up is temporary capital and actual withdrawn
-proceeds return to reserves.  If a routed cleanup trade fails, its state is
-saved and it is left for the normal failed-trade repair flow rather than being
-silently written off.
+Cleanup uses an adaptive initial margin of at most 0.10 USDC instead of the
+normal 1.50 USDC full-close margin, because withholding 1.50 USDC would strand
+a material share of a 3–5 USDC position. The redeem path retries a phase-1
+silent no-op with progressively larger 0.25, 0.50, and 1.00 USDC safety
+margins, but only while the resulting redemption remains above the 0.20 USDC
+follow-up phase verification tolerance. The deposit constant is deliberately
+not reused in the withdrawal path; normal settlement verification detects a
+backend no-op. A position with
+0.30 USDC or less cannot produce enough balance movement to verify every
+follow-up phase after the initial margin, so it is locally closed as protocol
+dust without broadcasting. A still-open residual above 0.30 USDC remains
+tracked for another direct redemption pass; a residual at or below 0.30 USDC
+is locally closed with a zero-quantity repair. If a routed cleanup trade
+fails, its state is saved and it is left for the normal failed-trade repair
+flow rather than being silently written off.
+
+Use `correct-accounts --dry-run` to refresh live balances and report eligible
+HyperCore redemptions and accounting corrections without persisting trades,
+broadcasting transactions, backing up, or saving state. `--skip-save` is not a
+dry-run flag: it can still broadcast transactions before skipping the final
+state write.
 
 ## Testing
 
@@ -452,7 +465,8 @@ environment, never hardcoded):
 - `scripts/audit-hypercore-redemption-state.py` (→ `audit-redemption-state.py`) —
   audit a state file for stranded USDC / unfinished redemptions.
 - `trade-executor repair-hypercore-dust` (`tradeexecutor/cli/commands/repair_hypercore_dust.py`) —
-  clean up sub-minimum vault dust left after capped withdrawals.
+  clean up untracked vault dust left after capped withdrawals. Its withdrawal
+  path does not reuse the deposit encoder's 5 USDC check.
 - `check-hypercore-user.py` — referenced by the failure diagnostics
   (`hypercore_stranded_usdc` recovery note) to inspect a Safe's live HyperCore
   perp/spot/vault balances before manually completing a `spotSend` or deposit.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 0.2
 
-- Add default-on `correct-accounts` cleanup for undersized HyperCore vault positions, with isolated top-up/redemption passes and increasingly tolerant withdrawal retries (2026-07-29)
+- Fix default-on `correct-accounts` cleanup for undersized HyperCore vault positions to redeem directly without deposits or new lock-ups, keep verifiable residuals tracked, and provide a read-only `--dry-run` preview (2026-07-30)
 
 - Extend `vault-test-trade` simulations to validate typed closed deposits through GuardV0 without broadcasting, and distinguish vault JSON statuses that incorrectly report deposits open or closed (2026-07-28)
 

--- a/docs/plans/hypercore-vault-dust-close.md
+++ b/docs/plans/hypercore-vault-dust-close.md
@@ -1,5 +1,13 @@
 # Fix plan: Hypercore vault dust pollutes closed positions
 
+> **Historical note:** This plan's original conclusion that small residuals
+> were inherently unredeemable was not established. `MINIMUM_VAULT_DEPOSIT`
+> is enforced by the deposit encoder; the withdrawal encoder has no equivalent
+> client-side check. No backend redemption minimum has been confirmed. Current
+> `correct-accounts` cleanup attempts sufficiently large residual redemptions
+> and verifies settlement. The write-off behaviour described below remains
+> relevant for amounts too small to verify safely.
+
 ## Problem
 
 The hyper-ai strategy (Lagoon vault-of-vaults on Hyperliquid, chain 999) shows
@@ -48,7 +56,8 @@ off and `continue`** — instead of creating + immediately closing a phantom
 position. This mirrors how leftover spot dust is treated.
 
 - The genuine exit already closes the real position, so nothing economic is lost.
-- The residual is < $2 per vault and genuinely un-withdrawable.
+- The residual is < $2 per vault and was treated as accounting dust by this
+  historical fix.
 - `_build_hypercore_vault_account_checks()` only checks open/frozen positions,
   and the docstring confirms Hypercore vaults "never enter the generic asset-map
   based correction path", so the written-off residual will not trigger a
@@ -93,7 +102,8 @@ USD-equity vs epsilon comparison is sound. Two minor suggestions applied:
 
 - The 27 unfilled-rebalance empty positions (planned buy never executed) are a
   separate issue.
-- Lowering `HYPERCORE_WITHDRAWAL_SAFETY_MARGIN_RAW` would reduce stranded dust
-  but cannot eliminate it (protocol refuses exact full exits). Not pursued here.
+- The normal withdrawal safety margin cannot eliminate final NAV-drift dust.
+  Later cleanup work added a smaller adaptive margin and verified retries for
+  tracked small positions.
 - Existing dust positions already in production state are not retro-cleaned by
   this change; `repair_hypercore_dust` / `correct-accounts` history remains.

--- a/strategies/hyper-ai.py
+++ b/strategies/hyper-ai.py
@@ -175,7 +175,9 @@ class Parameters:
     #: Keep it because the alpha model uses it when cleaning up tiny residual positions.
     min_portfolio_weight_pct = 0.005
 
-    #: Hyperliquid has a hard 5 USD minimum deposit.
+    #: Client-side minimum enforced by the HyperCore deposit encoder. The same
+    #: value is reused below as a strategy sell-materiality policy, not as a
+    #: HyperCore withdrawal requirement.
     absolute_min_vault_deposit_usd = 5.0
     #: Preserve the old 50 USD buy threshold at 100k initial cash.
     individual_rebalance_min_threshold_of_initial_cash_pct = 0.0005
@@ -200,12 +202,13 @@ class Parameters:
     backtest_end = datetime.datetime(2026, 3, 11)
     #: Low-value treasury bankroll for small-cap forward-testing validation.
     initial_cash = 1000
-    #: Derived at class creation time from the configured initial cash and the 5 USD hard floor.
+    #: Buy sizing must respect the deposit encoder's 5 USD minimum.
     individual_rebalance_min_threshold_usd = max(
         absolute_min_vault_deposit_usd,
         initial_cash * individual_rebalance_min_threshold_of_initial_cash_pct,
     )
-    #: Derived at class creation time from the configured initial cash and the 5 USD hard floor.
+    #: Sell sizing uses a strategy materiality threshold. The withdrawal
+    #: encoder has no equivalent 5 USD check.
     sell_rebalance_min_threshold_usd = max(
         absolute_min_vault_deposit_usd,
         initial_cash * sell_rebalance_min_threshold_of_initial_cash_pct,
@@ -838,5 +841,5 @@ survivor-first selection and age-ramp weighting.
 - 98% allocation target
 - 12% maximum concentration per asset
 - 20% per-position cap of pool TVL
-- 5 USD minimum vault deposit (Hyperliquid hard floor)
+- 5 USD client-side minimum vault deposit
 """

--- a/tests/hyperliquid/test_claim_hypercore_vault_dust.py
+++ b/tests/hyperliquid/test_claim_hypercore_vault_dust.py
@@ -10,14 +10,17 @@ import pytest
 from eth_defi.hyperliquid.api import UserVaultEquity
 from hexbytes import HexBytes
 from tradingstrategy.chain import ChainId
+from typer.main import get_command
 from typer.testing import CliRunner
 from web3 import Web3
 
+from tradeexecutor.cli import main
 from tradeexecutor.ethereum.vault import hypercore_dust_claim
 from tradeexecutor.ethereum.vault.hypercore_dust_claim import (
     HYPERCORE_DUST_CLAIM_NOTE,
 )
 from tradeexecutor.ethereum.vault.hypercore_routing import (
+    HYPERCORE_FOLLOW_UP_PHASE_TOLERANCE_RAW,
     HYPERCORE_WITHDRAWAL_SAFETY_MARGIN_RAW,
     raw_to_usdc,
 )
@@ -241,13 +244,14 @@ def _patch_execution(
 
 
 def test_claim_hypercore_vault_dust_persists_actual_delta_before_later_failure(
-    monkeypatch,
-):
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
     """Claim Hypercore dust and persist state before a later claim fails.
 
     1. Create two live claimable vault equities and a reserve-only state.
     2. Run the mocked claim flow, forcing the second vault to fail.
-    3. Verify the first vault went through all phases and saved actual reserve delta accounting.
+    3. Verify the first vault went through all phases, saved actual reserve delta accounting, and emitted only captured operator output.
     """
     # 1. Create two live claimable vault equities and a reserve-only state.
     state = _make_state()
@@ -304,7 +308,7 @@ def test_claim_hypercore_vault_dust_persists_actual_delta_before_later_failure(
             unit_testing=True,
         )
 
-    # 3. Verify the first vault went through all phases and saved actual reserve delta accounting.
+    # 3. Verify the first vault went through all phases, saved actual reserve delta accounting, and emitted only captured operator output.
     reserve = state.portfolio.get_default_reserve_position()
     event = next(iter(reserve.balance_updates.values()))
     assert broadcast_order == ["vault_to_perp", "perp_to_spot", "spot_to_evm"]
@@ -316,16 +320,19 @@ def test_claim_hypercore_vault_dust_persists_actual_delta_before_later_failure(
         state.sync.accounting.balance_update_refs[-1].balance_event_id
         == event.balance_update_id
     )
+    captured = capsys.readouterr()
+    assert "Hypercore vault dust candidates" in captured.out
 
 
 def test_claim_hypercore_vault_dust_safety_guards_and_cli_registration(
-    monkeypatch,
-):
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
     """Verify Hypercore dust claim safety guards and command registration.
 
     1. Verify active perp positions abort the command before broadcasting.
-    2. Verify open-state, above-cap, below-floor, and re-read stale-state candidates are not executed.
-    3. Verify the CLI command is exported and the Typer app can build the command tree.
+    2. Verify open-state, above-cap, sub-5 redemption, bridge-threshold, and re-read stale-state handling.
+    3. Verify the CLI command is exported, Typer builds the command tree, and operator output is captured.
     """
     # 1. Verify active perp positions abort the command before broadcasting.
     active_state = _make_state()
@@ -357,7 +364,7 @@ def test_claim_hypercore_vault_dust_safety_guards_and_cli_registration(
         active_context.hot_wallet.transact_and_broadcast_with_contract.call_count == 0
     )
 
-    # 2. Verify open-state, above-cap, below-floor, and re-read stale-state candidates are not executed.
+    # 2. Verify open-state, above-cap, sub-5 redemption, and re-read stale-state handling.
     reserve_asset = _make_reserve_asset()
 
     open_state = _make_state()
@@ -424,29 +431,68 @@ def test_claim_hypercore_vault_dust_safety_guards_and_cli_registration(
         == 0
     )
 
-    below_floor_state = _make_state()
-    below_floor_balances = {
+    sub_five_state = _make_state()
+    sub_five_balances = {
         "evm_usdc": Decimal("1"),
         "spot_total": Decimal("0"),
         "spot_free": Decimal("0"),
         "perp_withdrawable": Decimal("0"),
         "perp_position_count": 0,
     }
-    below_floor_context = _make_context(below_floor_state, below_floor_balances)
-    below_floor_equity = raw_to_usdc(HYPERCORE_WITHDRAWAL_SAFETY_MARGIN_RAW) + Decimal(
+    sub_five_context = _make_context(sub_five_state, sub_five_balances)
+    sub_five_equity = raw_to_usdc(HYPERCORE_WITHDRAWAL_SAFETY_MARGIN_RAW) + Decimal(
         "4.99"
     )
     _patch_live_reads(
         monkeypatch,
-        below_floor_balances,
-        [_make_equity(equity=below_floor_equity)],
-        max_withdrawable=below_floor_equity,
+        sub_five_balances,
+        [_make_equity(equity=sub_five_equity)],
+        max_withdrawable=sub_five_equity,
     )
-    below_floor_candidate = hypercore_dust_claim.discover_hypercore_dust_candidates(
-        below_floor_context, Decimal("25")
+    sub_five_candidate = hypercore_dust_claim.discover_hypercore_dust_candidates(
+        sub_five_context, Decimal("25")
     )[0]
-    assert below_floor_candidate.status == "below_floor"
-    assert below_floor_candidate.safe_raw_claim_amount < 5_000_000
+    assert sub_five_candidate.status == "claimable"
+    assert sub_five_candidate.safe_raw_claim_amount == 4_990_000
+
+    bridge_threshold_state = _make_state()
+    bridge_threshold_context = _make_context(
+        bridge_threshold_state,
+        sub_five_balances,
+    )
+    bridge_threshold_equity = raw_to_usdc(
+        HYPERCORE_WITHDRAWAL_SAFETY_MARGIN_RAW
+        + HYPERCORE_FOLLOW_UP_PHASE_TOLERANCE_RAW
+    )
+    _patch_live_reads(
+        monkeypatch,
+        sub_five_balances,
+        [_make_equity(equity=bridge_threshold_equity)],
+        max_withdrawable=bridge_threshold_equity,
+    )
+    bridge_threshold_candidate = (
+        hypercore_dust_claim.discover_hypercore_dust_candidates(
+            bridge_threshold_context,
+            Decimal("25"),
+        )[0]
+    )
+    assert bridge_threshold_candidate.status == "below_bridge_threshold"
+    assert not bridge_threshold_candidate.is_claimable
+
+    assert (
+        hypercore_dust_claim._get_phase1_noop_retry_raw(
+            current_vault_equity=Decimal("3.45"),
+            previous_raw=2_000_000,
+        )
+        == 1_950_000
+    )
+    assert (
+        hypercore_dust_claim._get_phase1_noop_retry_raw(
+            current_vault_equity=Decimal("1.65"),
+            previous_raw=200_000,
+        )
+        is None
+    )
 
     reread_state = _make_state()
     reread_balances = {
@@ -496,16 +542,12 @@ def test_claim_hypercore_vault_dust_safety_guards_and_cli_registration(
         reread_context.hot_wallet.transact_and_broadcast_with_contract.call_count == 0
     )
 
-    # 3. Verify the CLI command is exported and the Typer app can build the command tree.
-    from tradeexecutor.cli import main
-
+    # 3. Verify the CLI command is exported, Typer builds the command tree, and operator output is captured.
     assert main.claim_hypercore_vault_dust in set(main.__all__)
     runner = CliRunner()
     assert runner.invoke(main.app, ["version"]).exit_code == 0
     claim_help = runner.invoke(main.app, ["claim-hypercore-vault-dust", "--help"])
     assert claim_help.exit_code == 0
-
-    from typer.main import get_command
 
     click_command = get_command(main.app).commands["claim-hypercore-vault-dust"]
     max_claim_params = [
@@ -514,3 +556,5 @@ def test_claim_hypercore_vault_dust_safety_guards_and_cli_registration(
     assert len(max_claim_params) == 1
     assert max_claim_params[0].opts == ["--max-claim-usdc"]
     assert str(max_claim_params[0].type) == "STRING"
+    captured = capsys.readouterr()
+    assert "Hypercore vault dust candidates" in captured.out

--- a/tests/hyperliquid/test_hypercore_small_position_cleanup.py
+++ b/tests/hyperliquid/test_hypercore_small_position_cleanup.py
@@ -5,19 +5,22 @@ from decimal import Decimal
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
+import pytest
 from tradingstrategy.chain import ChainId
 
 from tradeexecutor.ethereum.vault.hypercore_routing import (
+    HYPERCORE_SMALL_POSITION_CLEANUP_INITIAL_SAFETY_MARGIN_RAW,
     HYPERCORE_SMALL_POSITION_CLEANUP_RETRY_SAFETY_MARGINS_RAW,
     HYPERCORE_WITHDRAWAL_SAFETY_MARGIN_RAW,
     HypercoreWithdrawalPreflightError,
     HypercoreVaultRouting,
 )
 from tradeexecutor.ethereum.vault.hypercore_small_position_cleanup import (
+    HYPERCORE_SMALL_POSITION_MINIMUM_REDEEMABLE_EQUITY,
     HypercoreSmallPositionCandidate,
+    _close_confirmed_hypercore_residual,
     discover_hypercore_small_positions,
     get_hypercore_minimum_allocation,
-    get_hypercore_small_position_top_up_reserve,
     plan_hypercore_small_position_cleanup,
     run_hypercore_small_position_cleanup,
 )
@@ -26,6 +29,9 @@ from tradeexecutor.state.identifier import AssetIdentifier
 from tradeexecutor.state.position import TradingPosition
 from tradeexecutor.state.state import State
 from tradeexecutor.state.trade import TradeType
+from tradeexecutor.strategy.dust import (
+    HYPERCORE_SMALL_POSITION_CLEANUP_PENDING_REDEEM,
+)
 
 
 NOW = datetime.datetime(2026, 7, 28, 12, 0, 0)
@@ -71,12 +77,12 @@ def _make_position(live_equity: Decimal) -> tuple[State, TradingPosition]:
     return state, position
 
 
-def test_cleanup_plans_top_up_for_sub_floor_hypercore_position():
-    """A sub-floor HyperCore position schedules a temporary top-up before a later redemption.
+def test_cleanup_plans_direct_redemption_below_deposit_minimum():
+    """A sub-5 USDC HyperCore position is redeemed without a temporary top-up.
 
     1. Create a 3.45 USDC HyperCore position below the strategy's 50 USDC allocation floor.
     2. Discover it and plan the cleanup.
-    3. Verify the plan tops up enough for every retry without creating a lock-up-blocked close.
+    3. Verify the plan is a full close and does not add capital or extend the lock-up.
     """
 
     # 1. Create a 3.45 USDC HyperCore position below the strategy's 50 USDC allocation floor.
@@ -85,24 +91,22 @@ def test_cleanup_plans_top_up_for_sub_floor_hypercore_position():
     # 2. Discover it and plan the cleanup.
     candidates = discover_hypercore_small_positions(state, Decimal("50"))
     assert len(candidates) == 1
-    assert candidates[0].top_up_reserve == Decimal("11.55")
     trades = plan_hypercore_small_position_cleanup(state, candidates[0], NOW)
 
-    # 3. Verify the plan tops up enough for every retry without creating a lock-up-blocked close.
+    # 3. Verify the plan is a full close and does not add capital or extend the lock-up.
     assert len(trades) == 1
-    assert trades[0].is_buy()
-    assert trades[0].planned_reserve == Decimal("11.55")
-    assert position.get_quantity(planned=True) > position.get_quantity()
+    assert trades[0].is_sell()
+    assert trades[0].planned_quantity == -position.get_quantity()
+    assert trades[0].planned_reserve == pytest.approx(Decimal("3.45"))
     assert trades[0].other_data["hypercore_small_position_cleanup"] is True
-    assert get_hypercore_small_position_top_up_reserve(Decimal("2")) == Decimal("13")
 
 
-def test_cleanup_uses_strategy_minimum_allocation_and_avoids_unneeded_top_up():
-    """A redeemable position is selected from strategy parameters without a top-up.
+def test_cleanup_uses_strategy_minimum_allocation_and_pending_marker():
+    """A redeemable position is selected from strategy parameters and pending state.
 
     1. Read HyperAI's minimum-allocation style parameter and verify an explicit zero disables cleanup.
-    2. Create a 25 USDC HyperCore position below that allocation but above the redeemable floor.
-    3. Verify cleanup plans one full-close trade and does not add temporary capital.
+    2. Create a 25 USDC HyperCore position below that allocation.
+    3. Verify cleanup plans one full-close trade and preserves pending-cleanup discovery.
     """
 
     # 1. Read HyperAI's minimum-allocation style parameter and verify an explicit zero disables cleanup.
@@ -117,29 +121,29 @@ def test_cleanup_uses_strategy_minimum_allocation_and_avoids_unneeded_top_up():
         }
     ) is None
 
-    # 2. Create a 25 USDC HyperCore position below that allocation but above the redeemable floor.
+    # 2. Create a 25 USDC HyperCore position below that allocation.
     state, position = _make_position(Decimal("25"))
     candidates = discover_hypercore_small_positions(state, minimum_allocation)
     assert len(candidates) == 1
-    assert candidates[0].top_up_reserve is None
     trades = plan_hypercore_small_position_cleanup(state, candidates[0], NOW)
 
-    # 3. Verify cleanup plans one full-close trade and does not add temporary capital.
+    # 3. Verify cleanup plans one full-close trade and preserves pending-cleanup discovery.
     assert len(trades) == 1
     assert trades[0].is_sell()
     assert trades[0].planned_quantity == -position.get_quantity()
     assert trades[0].other_data["hypercore_small_position_cleanup"] is True
-    position.other_data["hypercore_small_position_cleanup_pending_redeem"] = True
+    position.other_data[HYPERCORE_SMALL_POSITION_CLEANUP_PENDING_REDEEM] = True
     pending_candidates = discover_hypercore_small_positions(state, Decimal("5"))
     assert pending_candidates[0].is_pending_cleanup is True
 
 
 def test_cleanup_uses_progressively_larger_silent_noop_retry_margins():
-    """A cleanup close receives an adaptive retry margin ladder.
+    """A cleanup close receives an adaptive retry ladder without a deposit floor.
 
     1. Create the normal and cleanup trade markers used by the HyperCore router.
     2. Ask the routing helper for their silent-no-op retry margins.
-    3. Verify only cleanup closes receive the progressively larger retry ladder.
+    3. Verify cleanup starts with a small adaptive margin and accepts a positive sub-5 retry.
+    4. Verify only cleanup closes receive the progressively larger retry ladder.
     """
 
     # 1. Create the normal and cleanup trade markers used by the HyperCore router.
@@ -151,57 +155,133 @@ def test_cleanup_uses_progressively_larger_silent_noop_retry_margins():
     normal_margins = routing._get_phase1_noop_retry_safety_margins(normal_trade)
     cleanup_margins = routing._get_phase1_noop_retry_safety_margins(cleanup_trade)
 
-    # 3. Verify only cleanup closes receive the progressively larger retry ladder.
+    # 3. Verify cleanup starts with a small adaptive margin and accepts a positive sub-5 retry.
+    assert routing._get_full_close_safety_margin_raw(
+        cleanup_trade,
+        3_450_000,
+    ) == HYPERCORE_SMALL_POSITION_CLEANUP_INITIAL_SAFETY_MARGIN_RAW
+    with pytest.raises(
+        HypercoreWithdrawalPreflightError,
+        match="required to verify every withdrawal phase",
+    ):
+        routing._get_full_close_safety_margin_raw(
+            cleanup_trade,
+            50_000,
+        )
+    assert routing._get_full_close_safety_margin_raw(
+        normal_trade,
+        3_450_000,
+    ) == HYPERCORE_WITHDRAWAL_SAFETY_MARGIN_RAW
+    retry_raw = routing._get_phase1_noop_retry_raw(
+        current_vault_equity=Decimal("3.45"),
+        previous_raw=3_350_000,
+        safety_margin_raw=250_000,
+    )
+    assert retry_raw == 3_200_000
+    assert routing._get_phase1_noop_retry_raw(
+        current_vault_equity=Decimal("3.45"),
+        previous_raw=3_350_000,
+        safety_margin_raw=1_000_000,
+    ) == 2_450_000
+    assert routing._get_phase1_noop_retry_raw(
+        current_vault_equity=Decimal("1.15"),
+        previous_raw=1_050_000,
+        safety_margin_raw=1_000_000,
+    ) is None
+
+    # 4. Verify only cleanup closes receive the progressively larger retry ladder.
     assert normal_margins == (HYPERCORE_WITHDRAWAL_SAFETY_MARGIN_RAW,)
     assert cleanup_margins == HYPERCORE_SMALL_POSITION_CLEANUP_RETRY_SAFETY_MARGINS_RAW
 
 
-def test_cleanup_retry_keeps_material_residual_tracked_for_another_pass():
-    """A high-margin retry does not write off a material HyperCore residual.
+def test_cleanup_keeps_verifiable_residual_and_closes_protocol_dust():
+    """Retain a verifiable HyperCore residual and write off only protocol dust.
 
-    1. Create normal and cleanup retry trades for a HyperCore vault pair.
-    2. Ask the router whether their residual must remain tracked.
-    3. Verify only the 3 USDC cleanup retry requires a later redemption run.
+    1. Create two tracked HyperCore positions after successful cleanup withdrawals.
+    2. Re-read residuals above and at the minimum verifiable equity.
+    3. Verify the larger residual stays pending while protocol dust closes locally.
     """
 
-    # 1. Create normal and cleanup retry trades for a HyperCore vault pair.
-    _state, position = _make_position(Decimal("25"))
-    routing = object.__new__(HypercoreVaultRouting)
-    normal_trade = SimpleNamespace(other_data={}, pair=position.pair)
-    cleanup_trade = SimpleNamespace(
-        other_data={
-            "hypercore_small_position_cleanup": True,
-            "hypercore_phase1_retry_safety_margin_raw": 3_000_000,
-        },
-        pair=position.pair,
+    # 1. Create two tracked HyperCore positions after successful cleanup withdrawals.
+    pending_state, pending_position = _make_position(Decimal("0.31"))
+    dust_state, dust_position = _make_position(
+        HYPERCORE_SMALL_POSITION_MINIMUM_REDEEMABLE_EQUITY
+    )
+    pending_position.get_first_trade().executed_quantity = Decimal("0.31")
+    dust_position.get_first_trade().executed_quantity = (
+        HYPERCORE_SMALL_POSITION_MINIMUM_REDEEMABLE_EQUITY
+    )
+    assert pending_position.can_be_closed() is True
+    pending_candidate = HypercoreSmallPositionCandidate(
+        position_id=pending_position.position_id,
+        vault_name="Pending Fund",
+        vault_address=pending_position.pair.pool_address,
+        live_equity=Decimal("0.31"),
+        minimum_allocation=Decimal("5"),
+        is_pending_cleanup=False,
+    )
+    dust_candidate = HypercoreSmallPositionCandidate(
+        position_id=dust_position.position_id,
+        vault_name="Dust Fund",
+        vault_address=dust_position.pair.pool_address,
+        live_equity=HYPERCORE_SMALL_POSITION_MINIMUM_REDEEMABLE_EQUITY,
+        minimum_allocation=Decimal("5"),
+        is_pending_cleanup=False,
     )
 
-    # 2. Ask the router whether their residual must remain tracked.
-    normal_has_residual = routing._cleanup_retry_leaves_material_residual(normal_trade)
-    cleanup_has_residual = routing._cleanup_retry_leaves_material_residual(cleanup_trade)
+    # 2. Re-read residuals above and at the minimum verifiable equity.
+    with patch(
+        "tradeexecutor.ethereum.vault.hypercore_small_position_cleanup.fetch_user_vault_equity",
+        side_effect=[
+            SimpleNamespace(equity=Decimal("0.31")),
+            SimpleNamespace(
+                equity=HYPERCORE_SMALL_POSITION_MINIMUM_REDEEMABLE_EQUITY
+            ),
+        ],
+    ):
+        pending_residual = _close_confirmed_hypercore_residual(
+            state=pending_state,
+            candidate=pending_candidate,
+            session=MagicMock(),
+            safe_address="0xSafe",
+        )
+        dust_residual = _close_confirmed_hypercore_residual(
+            state=dust_state,
+            candidate=dust_candidate,
+            session=MagicMock(),
+            safe_address="0xSafe",
+        )
 
-    # 3. Verify only the 3 USDC cleanup retry requires a later redemption run.
-    assert normal_has_residual is False
-    assert cleanup_has_residual is True
+    # 3. Verify the larger residual stays pending while protocol dust closes locally.
+    assert pending_residual == Decimal("0.31")
+    assert (
+        pending_position.other_data[
+            HYPERCORE_SMALL_POSITION_CLEANUP_PENDING_REDEEM
+        ]
+        is True
+    )
+    assert pending_position.can_be_closed() is False
+    assert pending_position.position_id in pending_state.portfolio.open_positions
+    assert dust_residual is None
+    assert dust_position.position_id in dust_state.portfolio.closed_positions
 
 
-def test_cleanup_top_up_waits_for_vault_lock_up_before_redeeming():
-    """A cleanup top-up is persisted and a locked position is deferred.
+def test_cleanup_directly_redeems_dust_and_defers_locked_position():
+    """Redeem viable dust, close protocol dust locally, and defer locked positions.
 
-    1. Arrange an unlocked small candidate that needs a top-up and a locked pending candidate.
+    1. Arrange unlocked redeemable and protocol-dust candidates plus a locked candidate.
     2. Run the cleaner with mocks because this unit test must not broadcast to HyperCore.
-    3. Verify only the top-up executes and the pending-redeem marker is persisted.
+    3. Verify only the viable redemption executes and the protocol dust closes locally.
     """
 
-    # 1. Arrange an unlocked small candidate that needs a top-up and a locked pending candidate.
+    # 1. Arrange unlocked redeemable and protocol-dust candidates plus a locked candidate.
     # Mocks isolate pass orchestration from transaction broadcasts and live HyperCore reads.
-    top_up_candidate = HypercoreSmallPositionCandidate(
+    dust_candidate = HypercoreSmallPositionCandidate(
         position_id=57,
         vault_name="Crypto Plaza",
         vault_address="0x1111111111111111111111111111111111111111",
         live_equity=Decimal("3.45"),
         minimum_allocation=Decimal("5"),
-        top_up_reserve=Decimal("11.55"),
         is_pending_cleanup=False,
     )
     locked_candidate = HypercoreSmallPositionCandidate(
@@ -210,23 +290,29 @@ def test_cleanup_top_up_waits_for_vault_lock_up_before_redeeming():
         vault_address="0x2222222222222222222222222222222222222222",
         live_equity=Decimal("15"),
         minimum_allocation=Decimal("5"),
-        top_up_reserve=None,
         is_pending_cleanup=True,
     )
+    protocol_dust_candidate = HypercoreSmallPositionCandidate(
+        position_id=59,
+        vault_name="Tiny Fund",
+        vault_address="0x3333333333333333333333333333333333333333",
+        live_equity=HYPERCORE_SMALL_POSITION_MINIMUM_REDEEMABLE_EQUITY,
+        minimum_allocation=Decimal("5"),
+        is_pending_cleanup=False,
+    )
     state = MagicMock()
-    state.portfolio.get_default_reserve_position.return_value.quantity = Decimal("100")
-    top_up_position = MagicMock()
-    top_up_position.other_data = {}
-    state.portfolio.open_positions = {57: top_up_position}
-    top_up_trade = MagicMock()
-    top_up_trade.is_success.return_value = True
+    protocol_dust_position = MagicMock()
+    state.portfolio.open_positions.get.return_value = protocol_dust_position
+    close_trade = MagicMock()
+    close_trade.is_success.return_value = True
     store = MagicMock()
+    execution_model = MagicMock()
 
     # 2. Run the cleaner with mocks because this unit test must not broadcast to HyperCore.
     with (
         patch(
             "tradeexecutor.ethereum.vault.hypercore_small_position_cleanup.plan_hypercore_small_position_cleanup",
-            return_value=[top_up_trade],
+            return_value=[close_trade],
         ),
         patch(
             "tradeexecutor.ethereum.vault.hypercore_small_position_cleanup.fetch_user_vault_equity",
@@ -241,72 +327,29 @@ def test_cleanup_top_up_waits_for_vault_lock_up_before_redeeming():
                     is_lockup_expired=False,
                     locked_until=NOW + datetime.timedelta(days=1),
                 ),
+                SimpleNamespace(
+                    equity=HYPERCORE_SMALL_POSITION_MINIMUM_REDEEMABLE_EQUITY,
+                    is_lockup_expired=True,
+                    locked_until=NOW,
+                ),
             ],
         ),
+        patch(
+            "tradeexecutor.ethereum.vault.hypercore_small_position_cleanup._close_confirmed_hypercore_residual",
+            return_value=None,
+        ),
+        patch(
+            "tradeexecutor.ethereum.vault.hypercore_small_position_cleanup.close_position_with_empty_trade",
+        ) as close_locally,
     ):
         report = run_hypercore_small_position_cleanup(
             state=state,
             timestamp=NOW,
-            candidates=[top_up_candidate, locked_candidate],
-            execution_model=MagicMock(),
-            routing_model=MagicMock(),
-            routing_state=MagicMock(),
-            session=MagicMock(),
-            safe_address="0xSafe",
-            store=store,
-        )
-
-    # 3. Verify only the top-up executes and the pending-redeem marker is persisted.
-    assert report.executed_trades == [top_up_trade]
-    assert report.closed_position_ids == []
-    assert top_up_position.other_data["hypercore_small_position_cleanup_pending_redeem"] is True
-    assert store.sync.call_count == 2
-
-
-def test_cleanup_saves_preflight_failure_as_a_repairable_failed_trade():
-    """A withdrawal preflight failure is persisted without aborting account correction.
-
-    1. Arrange a redeemable candidate whose close preflight raises the standard exception.
-    2. Run the cleaner with mocked execution because this unit test must not broadcast to HyperCore.
-    3. Verify the attempted trade and failure state are saved, with no false local close.
-    """
-
-    # 1. Arrange a redeemable candidate whose close preflight raises the standard exception.
-    candidate = HypercoreSmallPositionCandidate(
-        position_id=57,
-        vault_name="Crypto Plaza",
-        vault_address="0x1111111111111111111111111111111111111111",
-        live_equity=Decimal("25"),
-        minimum_allocation=Decimal("50"),
-        top_up_reserve=None,
-        is_pending_cleanup=False,
-    )
-    failed_close_trade = MagicMock()
-    store = MagicMock()
-    execution_model = MagicMock()
-    execution_model.execute_trades.side_effect = HypercoreWithdrawalPreflightError("lock-up changed")
-    state = MagicMock()
-    state.portfolio.get_default_reserve_position.return_value.quantity = Decimal("100")
-    failed_close_trade.is_started.return_value = True
-
-    # 2. Run the cleaner with mocked execution because this unit test must not broadcast to HyperCore.
-    with patch(
-        "tradeexecutor.ethereum.vault.hypercore_small_position_cleanup.plan_hypercore_small_position_cleanup",
-        return_value=[failed_close_trade],
-    ), patch(
-        "tradeexecutor.ethereum.vault.hypercore_small_position_cleanup.fetch_user_vault_equity",
-        return_value=SimpleNamespace(
-            equity=Decimal("25"),
-            is_lockup_expired=True,
-            locked_until=NOW,
-        ),
-    ), patch(
-        "tradeexecutor.ethereum.vault.hypercore_small_position_cleanup.freeze_position_on_failed_trade",
-    ) as freeze_position:
-        report = run_hypercore_small_position_cleanup(
-            state=state,
-            timestamp=NOW,
-            candidates=[candidate],
+            candidates=[
+                dust_candidate,
+                locked_candidate,
+                protocol_dust_candidate,
+            ],
             execution_model=execution_model,
             routing_model=MagicMock(),
             routing_state=MagicMock(),
@@ -315,9 +358,167 @@ def test_cleanup_saves_preflight_failure_as_a_repairable_failed_trade():
             store=store,
         )
 
-    # 3. Verify the attempted trade and failure state are saved, with no false local close.
-    assert report.executed_trades == [failed_close_trade]
+    # 3. Verify only the viable redemption executes and the protocol dust closes locally.
+    assert report.executed_trades == [close_trade]
+    assert report.closed_position_ids == [57, 59]
+    execution_model.execute_trades.assert_called_once()
+    close_locally.assert_called_once_with(state.portfolio, protocol_dust_position)
+    assert store.sync.call_count == 3
+
+
+def test_cleanup_dry_run_does_not_create_trades_or_write_state():
+    """Dry-run reports redeemable and locally closable positions without changing anything.
+
+    1. Arrange unlocked redeemable, bridge-threshold, and zero-equity cleanup candidates.
+    2. Run the cleaner in dry-run mode with all live balances mocked.
+    3. Verify no trade is planned or executed and the state store is untouched.
+    """
+
+    # 1. Arrange unlocked redeemable, bridge-threshold, and zero-equity cleanup candidates.
+    positive_candidate = HypercoreSmallPositionCandidate(
+        position_id=57,
+        vault_name="Crypto Plaza",
+        vault_address="0x1111111111111111111111111111111111111111",
+        live_equity=Decimal("3.45"),
+        minimum_allocation=Decimal("5"),
+        is_pending_cleanup=False,
+    )
+    zero_candidate = HypercoreSmallPositionCandidate(
+        position_id=58,
+        vault_name="Loop Fund",
+        vault_address="0x2222222222222222222222222222222222222222",
+        live_equity=Decimal(0),
+        minimum_allocation=Decimal("5"),
+        is_pending_cleanup=False,
+    )
+    bridge_threshold_candidate = HypercoreSmallPositionCandidate(
+        position_id=59,
+        vault_name="Tiny Fund",
+        vault_address="0x3333333333333333333333333333333333333333",
+        live_equity=HYPERCORE_SMALL_POSITION_MINIMUM_REDEEMABLE_EQUITY,
+        minimum_allocation=Decimal("5"),
+        is_pending_cleanup=False,
+    )
+    execution_model = MagicMock()
+    store = MagicMock()
+
+    # 2. Run the cleaner in dry-run mode with all live balances mocked.
+    with patch(
+        "tradeexecutor.ethereum.vault.hypercore_small_position_cleanup.fetch_user_vault_equity",
+        side_effect=[
+            SimpleNamespace(
+                equity=Decimal("3.45"),
+                is_lockup_expired=True,
+                locked_until=NOW,
+            ),
+            None,
+            SimpleNamespace(
+                equity=HYPERCORE_SMALL_POSITION_MINIMUM_REDEEMABLE_EQUITY,
+                is_lockup_expired=True,
+                locked_until=NOW,
+            ),
+        ],
+    ), patch(
+        "tradeexecutor.ethereum.vault.hypercore_small_position_cleanup.plan_hypercore_small_position_cleanup",
+    ) as plan_cleanup:
+        report = run_hypercore_small_position_cleanup(
+            state=MagicMock(),
+            timestamp=NOW,
+            candidates=[
+                positive_candidate,
+                zero_candidate,
+                bridge_threshold_candidate,
+            ],
+            execution_model=execution_model,
+            routing_model=MagicMock(),
+            routing_state=MagicMock(),
+            session=MagicMock(),
+            safe_address="0xSafe",
+            store=store,
+            dry_run=True,
+        )
+
+    # 3. Verify no trade is planned or executed and the state store is untouched.
+    assert report.executed_trades == []
+    assert report.closed_position_ids == []
+    plan_cleanup.assert_not_called()
+    execution_model.execute_trades.assert_not_called()
+    store.sync.assert_not_called()
+
+
+def test_cleanup_saves_preflight_failure_without_leaving_a_planned_trade():
+    """Persist started failures and expire preflight failures before broadcast.
+
+    1. Arrange two redeemable candidates whose close preflight raises before and after trade start.
+    2. Run the cleaner with mocked execution because this unit test must not broadcast to HyperCore.
+    3. Verify the started trade is repairable and the planned trade expires for rediscovery.
+    """
+
+    # 1. Arrange two redeemable candidates whose close preflight raises before and after trade start.
+    started_candidate = HypercoreSmallPositionCandidate(
+        position_id=57,
+        vault_name="Crypto Plaza",
+        vault_address="0x1111111111111111111111111111111111111111",
+        live_equity=Decimal("25"),
+        minimum_allocation=Decimal("50"),
+        is_pending_cleanup=False,
+    )
+    planned_candidate = HypercoreSmallPositionCandidate(
+        position_id=58,
+        vault_name="Loop Fund",
+        vault_address="0x2222222222222222222222222222222222222222",
+        live_equity=Decimal("25"),
+        minimum_allocation=Decimal("50"),
+        is_pending_cleanup=False,
+    )
+    failed_close_trade = MagicMock()
+    planned_close_trade = MagicMock()
+    store = MagicMock()
+    execution_model = MagicMock()
+    execution_model.execute_trades.side_effect = HypercoreWithdrawalPreflightError("lock-up changed")
+    state = MagicMock()
+    state.portfolio.get_default_reserve_position.return_value.quantity = Decimal("100")
+    failed_close_trade.is_started.return_value = True
+    planned_close_trade.is_started.return_value = False
+    planned_close_trade.is_planned.return_value = True
+
+    # 2. Run the cleaner with mocked execution because this unit test must not broadcast to HyperCore.
+    with patch(
+        "tradeexecutor.ethereum.vault.hypercore_small_position_cleanup.plan_hypercore_small_position_cleanup",
+        side_effect=[[failed_close_trade], [planned_close_trade]],
+    ), patch(
+        "tradeexecutor.ethereum.vault.hypercore_small_position_cleanup.fetch_user_vault_equity",
+        side_effect=[
+            SimpleNamespace(
+                equity=Decimal("25"),
+                is_lockup_expired=True,
+                locked_until=NOW,
+            ),
+            SimpleNamespace(
+                equity=Decimal("25"),
+                is_lockup_expired=True,
+                locked_until=NOW,
+            ),
+        ],
+    ), patch(
+        "tradeexecutor.ethereum.vault.hypercore_small_position_cleanup.freeze_position_on_failed_trade",
+    ) as freeze_position:
+        report = run_hypercore_small_position_cleanup(
+            state=state,
+            timestamp=NOW,
+            candidates=[started_candidate, planned_candidate],
+            execution_model=execution_model,
+            routing_model=MagicMock(),
+            routing_state=MagicMock(),
+            session=MagicMock(),
+            safe_address="0xSafe",
+            store=store,
+        )
+
+    # 3. Verify the started trade is repairable and the planned trade expires for rediscovery.
+    assert report.executed_trades == [failed_close_trade, planned_close_trade]
     assert report.closed_position_ids == []
     state.mark_trade_failed.assert_called_once_with(NOW, failed_close_trade)
     freeze_position.assert_called_once_with(NOW, state, [failed_close_trade])
-    assert store.sync.call_count == 1
+    planned_close_trade.mark_expired.assert_called_once_with(NOW)
+    assert store.sync.call_count == 2

--- a/tradeexecutor/cli/commands/correct_accounts.py
+++ b/tradeexecutor/cli/commands/correct_accounts.py
@@ -26,7 +26,7 @@ from tradeexecutor.exchange_account.derive import DeriveNetwork
 from tradeexecutor.exchange_account.utils import create_exchange_account_value_func
 from tradeexecutor.strategy.account_correction import correct_accounts as _correct_accounts, check_accounts, UnknownTokenPositionFix, check_state_internal_coherence
 from .app import app
-from ..bootstrap import prepare_executor_id, create_web3_config, create_sync_model, create_client, backup_state, create_execution_and_sync_model, resolve_deployment_file, configure_default_chain
+from ..bootstrap import prepare_executor_id, create_web3_config, create_sync_model, create_client, backup_state, create_execution_and_sync_model, resolve_deployment_file, configure_default_chain, create_state_store
 from ..double_position import check_double_position
 from ..log import setup_logging
 from ...ethereum.enzyme.tx import EnzymeTransactionBuilder
@@ -396,6 +396,7 @@ def correct_accounts(
     raise_on_unclean: bool = typer.Option(False, is_flag=True, envvar="RAISE_ON_UNCLEAN", help="Raise an exception if unclean. Unit test option."),
     skip_hypercore_transit_recovery: bool = Option(False, "--skip-hypercore-transit-recovery", envvar="SKIP_HYPERCORE_TRANSIT_RECOVERY", help="Skip automatic Safe-level HyperCore spot/perp USDC recovery before account correction."),
     cleanup_hypercore_small_positions: bool = Option(True, "--cleanup-hypercore-small-positions/--no-cleanup-hypercore-small-positions", envvar="CLEANUP_HYPERCORE_SMALL_POSITIONS", help="Redeem open HyperCore vault positions below the strategy minimum allocation before correcting accounts."),
+    dry_run: bool = Option(False, "--dry-run", envvar="DRY_RUN", help="Read live balances and report corrections and HyperCore small-position redemptions without persisting trades, broadcasting transactions, backing up, or saving state."),
 
     # Derive exchange account options
     derive_owner_private_key: Optional[str] = Option(None, envvar="DERIVE_OWNER_PRIVATE_KEY", help="Derive owner wallet private key"),
@@ -421,6 +422,8 @@ def correct_accounts(
     positions cannot carry over with the current event based tracking logic.
 
     This command is interactive and you need to confirm any changes applied to the state.
+    Use ``--dry-run`` for a read-only report. Dry-run never broadcasts
+    transactions and does not write or back up the state file.
 
     An old state file is automatically backed up.
     """
@@ -482,7 +485,13 @@ def correct_accounts(
     if not state_file:
         state_file = f"state/{id}.json"
 
-    store, state = backup_state(state_file, unit_testing=unit_testing)
+    if dry_run:
+        store = create_state_store(Path(state_file), simulate=True)
+        assert not store.is_pristine(), f"State file does not exist: {state_file}"
+        state = store.load()
+        logger.warning("Dry run enabled: no transactions will be broadcast and no state will be written")
+    else:
+        store, state = backup_state(state_file, unit_testing=unit_testing)
 
     slippage_tolerance = 0.013
     if mod:
@@ -728,32 +737,39 @@ def correct_accounts(
             if not cleanup_candidates:
                 logger.info("HyperCore small-position cleanup found no eligible positions")
             else:
+                is_testnet = web3.eth.chain_id == 998
+                api_url = HYPERLIQUID_TESTNET_API_URL if is_testnet else HYPERLIQUID_API_URL
+                session = create_hyperliquid_session(api_url=api_url)
                 ensure_routing_setup()
-                if routing_state is None:
-                    logger.warning(
-                        "HyperCore small-position cleanup skipped: routing is unavailable for this strategy"
-                    )
-                else:
-                    is_testnet = web3.eth.chain_id == 998
-                    api_url = HYPERLIQUID_TESTNET_API_URL if is_testnet else HYPERLIQUID_API_URL
-                    session = create_hyperliquid_session(api_url=api_url)
+                if dry_run or routing_state is not None:
                     cleanup_report = run_hypercore_small_position_cleanup(
                         state=state,
                         timestamp=native_datetime_utc_now(),
                         candidates=cleanup_candidates,
-                        execution_model=execution_model,
-                        routing_model=runner.routing_model,
-                        routing_state=routing_state,
+                        execution_model=None if dry_run else execution_model,
+                        routing_model=None if dry_run else runner.routing_model,
+                        routing_state=None if dry_run else routing_state,
                         session=session,
                         safe_address=sync_model.get_token_storage_address(),
                         store=store,
+                        dry_run=dry_run,
                     )
-                    logger.info(
-                        "HyperCore small-position cleanup processed %d trade(s) across %d candidate(s); "
-                        "%d position(s) were closed",
-                        len(cleanup_report.executed_trades),
-                        len(cleanup_report.candidates),
-                        len(cleanup_report.closed_position_ids),
+                    if dry_run:
+                        logger.info(
+                            "Dry run: HyperCore small-position cleanup found %d candidate(s)",
+                            len(cleanup_report.candidates),
+                        )
+                    else:
+                        logger.info(
+                            "HyperCore small-position cleanup processed %d trade(s) across %d candidate(s); "
+                            "%d position(s) were closed",
+                            len(cleanup_report.executed_trades),
+                            len(cleanup_report.candidates),
+                            len(cleanup_report.closed_position_ids),
+                        )
+                else:
+                    logger.warning(
+                        "HyperCore small-position cleanup skipped: routing is unavailable for this strategy"
                     )
 
     closed_dust_trades = close_hypercore_dust_positions(state.portfolio)
@@ -763,14 +779,15 @@ def correct_accounts(
             len(closed_dust_trades),
         )
 
-    _recover_hypercore_transit_balances(
-        asset_management_mode=asset_management_mode,
-        sync_model=sync_model,
-        web3=web3,
-        hot_wallet=hot_wallet,
-        state=state,
-        skip_hypercore_transit_recovery=skip_hypercore_transit_recovery,
-    )
+    if not dry_run:
+        _recover_hypercore_transit_balances(
+            asset_management_mode=asset_management_mode,
+            sync_model=sync_model,
+            web3=web3,
+            hot_wallet=hot_wallet,
+            state=state,
+            skip_hypercore_transit_recovery=skip_hypercore_transit_recovery,
+        )
 
     block_number = get_almost_latest_block_number(web3)
     logger.info(f"Correcting accounts at block {block_number:,}")
@@ -806,6 +823,14 @@ def correct_accounts(
         logger.info("No account corrections found")
 
     check_state_internal_coherence(state)
+
+    if dry_run:
+        logger.info("Dry run found %d accounting correction(s)", len(corrections))
+        for correction in corrections:
+            logger.info("  Would apply: %s", correction)
+        logger.info("Dry run complete: no transactions broadcast and no state written")
+        web3config.close()
+        return
 
     tx_builder = sync_model.create_transaction_builder()
 

--- a/tradeexecutor/ethereum/vault/README-vault-position-manual.md
+++ b/tradeexecutor/ethereum/vault/README-vault-position-manual.md
@@ -194,6 +194,37 @@ store.sync(state)
 
 ## Closing a position
 
+### HyperCore deposit and redemption thresholds
+
+HyperCore native vault deposits and redemptions use different client-side
+validation:
+
+- The client **deposit** path requires at least 5 USDC. The
+  `MINIMUM_VAULT_DEPOSIT` constant and deposit encoder enforce this.
+- The `vaultTransfer` withdrawal encoder has no equivalent check. No backend
+  redemption minimum has been confirmed, so the client permits redemptions
+  below 5 USDC and relies on settlement verification to detect a no-op.
+- A redemption must still be positive, within live `max_withdrawable`, and
+  below fresh vault equity after the safety margin. It must also wait for the
+  depositor lock-up to expire.
+
+`correct-accounts` uses these rules to redeem undersized HyperCore positions
+directly. It never tops up a position being closed, because a deposit would
+extend the lock-up. Cleanup uses an adaptive safety margin of at most 0.10 USDC
+instead of the normal 1.50 USDC full-close margin, then falls back to 0.25,
+0.50, and 1.00 USDC verified retry margins if HyperCore silently no-ops.
+Positions at or below 0.30 USDC are closed locally because they cannot produce
+enough balance movement to verify every withdrawal phase safely. Larger
+residuals remain tracked for another direct redemption pass. Preview the live
+actions without changing persisted state or broadcasting transactions:
+
+```shell
+poetry run trade-executor correct-accounts --dry-run
+```
+
+Do not use `--skip-save` as a dry-run substitute: it only skips the final state
+write and may still broadcast transactions.
+
 ### Close single position (for single-pair strategies)
 
 ```python

--- a/tradeexecutor/ethereum/vault/hypercore_dust_claim.py
+++ b/tradeexecutor/ethereum/vault/hypercore_dust_claim.py
@@ -1,4 +1,9 @@
-"""Claim untracked Hypercore vault dust back to Lagoon reserves."""
+"""Claim untracked Hypercore vault dust back to Lagoon reserves.
+
+``MINIMUM_VAULT_DEPOSIT`` is enforced by the deposit encoder. The withdrawal
+encoder has no equivalent client-side check, so this command attempts amounts
+that remain large enough to verify every settlement phase.
+"""
 
 import datetime
 import logging
@@ -17,7 +22,6 @@ from eth_defi.hyperliquid.api import (
     fetch_user_vault_equity,
 )
 from eth_defi.hyperliquid.core_writer import (
-    MINIMUM_VAULT_DEPOSIT,
     build_hypercore_send_asset_to_evm_call,
     build_hypercore_transfer_usd_class_call,
     build_hypercore_withdraw_from_vault_call,
@@ -291,7 +295,7 @@ def _classify_candidate(
         context.reserve_token.convert_to_raw(requested_amount)
         - HYPERCORE_WITHDRAWAL_SAFETY_MARGIN_RAW
     )
-    if safe_raw_claim_amount < MINIMUM_VAULT_DEPOSIT:
+    if safe_raw_claim_amount <= 0:
         return HypercoreDustCandidate(
             vault_address=vault_address,
             vault_name=vault_name,
@@ -300,10 +304,26 @@ def _classify_candidate(
             locked_until=equity.locked_until,
             safe_raw_claim_amount=max(safe_raw_claim_amount, 0),
             estimated_reserve_increase=Decimal(0),
-            status="below_floor",
+            status="consumed_by_safety_margin",
             reason=(
-                f"Safe claim amount after withdrawal safety margin is below "
-                f"Hyperliquid floor {raw_to_usdc(MINIMUM_VAULT_DEPOSIT)} USDC"
+                "No positive claim amount remains after applying the "
+                "withdrawal safety margin"
+            ),
+        )
+
+    if safe_raw_claim_amount <= HYPERCORE_FOLLOW_UP_PHASE_TOLERANCE_RAW:
+        return HypercoreDustCandidate(
+            vault_address=vault_address,
+            vault_name=vault_name,
+            equity=equity.equity,
+            max_withdrawable=max_withdrawable,
+            locked_until=equity.locked_until,
+            safe_raw_claim_amount=safe_raw_claim_amount,
+            estimated_reserve_increase=Decimal(0),
+            status="below_bridge_threshold",
+            reason=(
+                "Claim amount is too small to verify the perp-to-spot and "
+                "spot-to-EVM phases safely"
             ),
         )
 
@@ -502,11 +522,15 @@ def _get_phase1_noop_retry_raw(
     current_vault_equity: Decimal,
     previous_raw: int,
 ) -> int | None:
-    """Return a smaller phase-1 retry amount after a suspected silent no-op."""
+    """Return a smaller phase-1 retry amount after a suspected silent no-op.
+
+    ``MINIMUM_VAULT_DEPOSIT`` is deliberately irrelevant because the
+    withdrawal encoder does not apply it.
+    """
     retry_raw = (
         usdc_to_raw(current_vault_equity) - HYPERCORE_WITHDRAWAL_SAFETY_MARGIN_RAW
     )
-    if retry_raw < MINIMUM_VAULT_DEPOSIT:
+    if retry_raw <= HYPERCORE_FOLLOW_UP_PHASE_TOLERANCE_RAW:
         return None
     if retry_raw >= previous_raw:
         return None

--- a/tradeexecutor/ethereum/vault/hypercore_routing.py
+++ b/tradeexecutor/ethereum/vault/hypercore_routing.py
@@ -125,7 +125,11 @@ from eth_defi.compat import native_datetime_utc_now
 
 from tradeexecutor.ethereum.tx import TransactionBuilder
 from tradeexecutor.state.identifier import TradingPairIdentifier, AssetIdentifier
-from tradeexecutor.strategy.dust import get_close_epsilon_for_pair
+from tradeexecutor.strategy.dust import (
+    HYPERCORE_SMALL_POSITION_CLEANUP_CLOSE_EPSILON,
+    HYPERCORE_SMALL_POSITION_CLEANUP_PENDING_REDEEM,
+    get_close_epsilon_for_pair,
+)
 from tradingstrategy.pair import PandasPairUniverse
 
 if TYPE_CHECKING:
@@ -164,19 +168,26 @@ HYPERCORE_LIKELY_CLOSE_TOLERANCE = 0.975
 #: proved insufficient for some live withdrawals when vault share price moved
 #: between the API read and HyperCore processing the queued action.
 #:
-#: This will leave up to ~$1.50 unclaimable dust in the vault (below the $5
-#: minimum vault withdrawal threshold) that must be cleaned up in
-#: accounting later.
+#: This may leave up to ~$1.50 in the vault. The withdrawal encoder does not
+#: apply ``MINIMUM_VAULT_DEPOSIT``, so a later cleanup pass may attempt the
+#: remaining positive amount. Final residual dust is handled in accounting.
 HYPERCORE_WITHDRAWAL_SAFETY_MARGIN_RAW = 1_500_000
+
+#: Initial full-close margin used only by ``correct-accounts`` small-position
+#: cleanup. Withholding the normal 1.50 USDC margin from a 3–5 USDC position
+#: would strand a material share of the capital. Cleanup starts with 0.10 USDC
+#: and falls back to its larger silent-no-op retry ladder if live NAV moves by
+#: more than this before HyperCore processes the action.
+HYPERCORE_SMALL_POSITION_CLEANUP_INITIAL_SAFETY_MARGIN_RAW = 100_000
 
 #: A HyperCore small-position cleanup retries a silent phase-1 no-op with
 #: increasingly conservative safety margins.  This is deliberately scoped to
 #: the correct-accounts clean-up marker: normal strategy rebalances retain
 #: their single 1.50 USDC retry margin and fail loudly after a repeat no-op.
 HYPERCORE_SMALL_POSITION_CLEANUP_RETRY_SAFETY_MARGINS_RAW = (
-    3_000_000,
-    5_000_000,
-    10_000_000,
+    250_000,
+    500_000,
+    1_000_000,
 )
 
 #: Normal live preflight cap drift tolerance (raw USDC, 6 decimals).
@@ -216,6 +227,14 @@ HYPERCORE_WITHDRAWAL_PHASE1_RETRY_ATTEMPTS = 1
 # Proper fix: carry the actually observed amount from one phase to the next.
 # Remove this extra slack once settlement becomes amount-adaptive across phases.
 HYPERCORE_FOLLOW_UP_PHASE_TOLERANCE_RAW = 200_000
+
+#: Cleanup withdrawals must remain large enough for every balance verifier to
+#: require observable movement. The initial 0.10 USDC NAV margin is withheld
+#: before the 0.20 USDC follow-up phase tolerance is applied.
+HYPERCORE_SMALL_POSITION_CLEANUP_MIN_REDEMPTION_RAW = (
+    HYPERCORE_SMALL_POSITION_CLEANUP_INITIAL_SAFETY_MARGIN_RAW
+    + HYPERCORE_FOLLOW_UP_PHASE_TOLERANCE_RAW
+)
 
 # Relative tolerance for live HyperCore balance waits.
 #
@@ -760,12 +779,15 @@ class HypercoreVaultRouting(RoutingModel):
         #    actual equity — even by 1 raw USDC.  The vault NAV fluctuates
         #    due to fees, PnL, and mark-to-market during the ~2-5 s between
         #    reading the API and HyperCore processing the queued action.
-        #    This leaves ~$1.50 unclaimable dust in the vault that must be
-        #    cleaned up in accounting later.
-        safe_raw = live_raw - HYPERCORE_WITHDRAWAL_SAFETY_MARGIN_RAW
+        #    Small-position cleanup uses a smaller adaptive margin so the
+        #    generic 1.50 USDC margin does not strand a material share of a
+        #    3–5 USDC position. Its settlement path has larger automatic
+        #    retries if the first attempt silently no-ops.
+        safety_margin_raw = self._get_full_close_safety_margin_raw(trade, live_raw)
+        safe_raw = live_raw - safety_margin_raw
         assert safe_raw > 0, (
             f"Live vault equity {live_raw} raw ({equity.equity} USDC) is too small to "
-            f"withdraw after subtracting safety margin {HYPERCORE_WITHDRAWAL_SAFETY_MARGIN_RAW} raw"
+            f"withdraw after subtracting safety margin {safety_margin_raw} raw"
         )
 
         logger.info(
@@ -773,7 +795,7 @@ class HypercoreVaultRouting(RoutingModel):
             "safety margin %d raw, withdrawal amount %d raw (%s USDC), "
             "planned %s USDC (%d raw) for Safe %s, vault %s",
             equity.equity, live_raw,
-            HYPERCORE_WITHDRAWAL_SAFETY_MARGIN_RAW, safe_raw, raw_to_usdc(safe_raw),
+            safety_margin_raw, safe_raw, raw_to_usdc(safe_raw),
             raw_to_usdc(planned_raw), planned_raw,
             self.safe_address, vault_address,
         )
@@ -784,6 +806,29 @@ class HypercoreVaultRouting(RoutingModel):
         trade.other_data["hypercore_capped_withdrawal_raw"] = safe_raw
 
         return safe_raw
+
+    def _get_full_close_safety_margin_raw(
+        self,
+        trade: TradeExecution,
+        available_raw: int,
+    ) -> int:
+        """Return the NAV-drift margin for a full-close redemption.
+
+        Normal strategy withdrawals retain the proven 1.50 USDC margin.
+        ``correct-accounts`` cleanup uses a fixed 0.10 USDC margin and rejects
+        amounts that cannot produce verifiable movement in every later phase.
+        ``MINIMUM_VAULT_DEPOSIT`` is deliberately irrelevant because the
+        withdrawal encoder does not apply it.
+        """
+        if trade.other_data.get("hypercore_small_position_cleanup"):
+            if available_raw <= HYPERCORE_SMALL_POSITION_CLEANUP_MIN_REDEMPTION_RAW:
+                raise HypercoreWithdrawalPreflightError(
+                    f"HyperCore cleanup has only {raw_to_usdc(available_raw)} USDC available; "
+                    f"more than {raw_to_usdc(HYPERCORE_SMALL_POSITION_CLEANUP_MIN_REDEMPTION_RAW)} "
+                    "USDC is required to verify every withdrawal phase"
+                )
+            return HYPERCORE_SMALL_POSITION_CLEANUP_INITIAL_SAFETY_MARGIN_RAW
+        return HYPERCORE_WITHDRAWAL_SAFETY_MARGIN_RAW
 
     def _check_live_withdrawal_preconditions(
         self,
@@ -856,13 +901,17 @@ class HypercoreVaultRouting(RoutingModel):
                 # because sequential execution stops at the first exception.
                 # Do not request the exact fresh cap: it may move again before
                 # HyperCore processes the queued vaultTransfer and then silently
-                # no-op. Leave the same safety margin used by full closes.
-                safe_max_withdrawable_raw = max_withdrawable_raw - HYPERCORE_WITHDRAWAL_SAFETY_MARGIN_RAW
+                # no-op. Leave the same safety margin used by this full close.
+                safety_margin_raw = self._get_full_close_safety_margin_raw(
+                    trade,
+                    max_withdrawable_raw,
+                )
+                safe_max_withdrawable_raw = max_withdrawable_raw - safety_margin_raw
                 if safe_max_withdrawable_raw <= 0:
                     raise HypercoreWithdrawalPreflightError(
                         f"Hypercore withdrawal blocked for Safe {self.safe_address} in vault {vault_address}: "
                         f"current max_withdrawable {vault_info.max_withdrawable} USDC is too small after "
-                        f"the {raw_to_usdc(HYPERCORE_WITHDRAWAL_SAFETY_MARGIN_RAW)} USDC safety margin."
+                        f"the {raw_to_usdc(safety_margin_raw)} USDC safety margin."
                     )
                 logger.warning(
                     "Hypercore withdrawal request for Safe %s in vault %s is %d raw USDC "
@@ -877,8 +926,8 @@ class HypercoreVaultRouting(RoutingModel):
                     raw_to_usdc(requested_raw),
                     safe_max_withdrawable_raw,
                     raw_to_usdc(safe_max_withdrawable_raw),
-                    HYPERCORE_WITHDRAWAL_SAFETY_MARGIN_RAW,
-                    raw_to_usdc(HYPERCORE_WITHDRAWAL_SAFETY_MARGIN_RAW),
+                    safety_margin_raw,
+                    raw_to_usdc(safety_margin_raw),
                 )
                 effective_requested_raw = safe_max_withdrawable_raw
                 # Settlement phases 2-3 must use exactly the same amount that
@@ -1284,11 +1333,11 @@ class HypercoreVaultRouting(RoutingModel):
         # HyperCore processes it.
         retry_raw = current_raw - safety_margin_raw
 
-        # Hyperliquid silently rejects vault transfers below the same 5 USDC
-        # floor used for deposits.  If the retry amount is below the floor, the
-        # right answer is to leave the position as dust for accounting cleanup,
-        # not to spend another tx that we already know will no-op.
-        if retry_raw < MINIMUM_VAULT_DEPOSIT:
+        # MINIMUM_VAULT_DEPOSIT is deliberately not checked here. The deposit
+        # encoder enforces it, while encode_vault_withdraw() has no equivalent
+        # check. A retry becomes invalid when its expected movement is no
+        # longer larger than the follow-up phase verification tolerance.
+        if retry_raw <= HYPERCORE_FOLLOW_UP_PHASE_TOLERANCE_RAW:
             return None
 
         # Only retry when the fresh-equity-based amount is actually smaller
@@ -1310,24 +1359,6 @@ class HypercoreVaultRouting(RoutingModel):
         if trade.other_data.get("hypercore_small_position_cleanup"):
             return HYPERCORE_SMALL_POSITION_CLEANUP_RETRY_SAFETY_MARGINS_RAW
         return (HYPERCORE_WITHDRAWAL_SAFETY_MARGIN_RAW,) * HYPERCORE_WITHDRAWAL_PHASE1_RETRY_ATTEMPTS
-
-    def _cleanup_retry_leaves_material_residual(self, trade: TradeExecution) -> bool:
-        """Whether a cleanup retry must retain its residual in state.
-
-        A higher retry safety margin protects against a HyperCore no-op, but
-        it also leaves that amount in the vault.  Retain it for another
-        top-up-and-redeem pass instead of treating it as normal close dust.
-        """
-
-        safety_margin_raw = trade.other_data.get(
-            "hypercore_phase1_retry_safety_margin_raw"
-        )
-        return (
-            bool(trade.other_data.get("hypercore_small_position_cleanup"))
-            and safety_margin_raw is not None
-            and raw_to_usdc(int(safety_margin_raw))
-            > Decimal(str(get_close_epsilon_for_pair(trade.pair)))
-        )
 
     def _wait_for_spot_free_usdc_balance(
         self,
@@ -1715,12 +1746,9 @@ class HypercoreVaultRouting(RoutingModel):
                         trade.trade_id,
                     )
 
-        # Enforce Hyperliquid minimum vault deposit/withdrawal amounts.
-        # Hyperliquid silently rejects vault transfers below the minimum
-        # threshold — no error, no event, the USDC just stays in the
-        # escrow. The minimum is 5 USDC (MINIMUM_VAULT_DEPOSIT = 5_000_000
-        # raw, 6 decimals), determined by reverse-engineering the
-        # Hyperliquid web UI. See eth_defi.hyperliquid.core_writer.
+        # Enforce the deposit encoder's 5 USDC minimum
+        # (MINIMUM_VAULT_DEPOSIT = 5_000_000 raw, 6 decimals). The withdrawal
+        # encoder has no equivalent check. See eth_defi.hyperliquid.core_writer.
         if trade.is_buy():
             activation_hint = (
                 f" Note: {activation_cost_raw / 1e6:.0f} USDC was deducted for "
@@ -2488,9 +2516,9 @@ class HypercoreVaultRouting(RoutingModel):
                 capped_raw = trade.other_data["hypercore_capped_withdrawal_raw"]
                 logger.info(
                     "Using live equity withdrawal amount for settlement: %d raw USDC (%s USDC) "
-                    "(planned was %d raw USDC, safety margin was %d raw)",
+                    "(planned was %d raw USDC)",
                     capped_raw, raw_to_usdc(capped_raw),
-                    expected_raw, HYPERCORE_WITHDRAWAL_SAFETY_MARGIN_RAW,
+                    expected_raw,
                 )
                 expected_raw = capped_raw
 
@@ -2595,6 +2623,9 @@ class HypercoreVaultRouting(RoutingModel):
             Decimal(str(trade.slippage_tolerance or 0)),
         )
         phase1_requested_reserve = raw_to_usdc(expected_raw)
+        remaining_equity_after_withdrawal: Decimal | None = (
+            Decimal(0) if self.simulate else None
+        )
 
         if self.simulate:
             # Simulate mode: mock CoreWriter does not bridge USDC,
@@ -3083,6 +3114,7 @@ class HypercoreVaultRouting(RoutingModel):
                     bypass_cache=True,
                 )
                 remaining_equity = eq_after.equity if eq_after else Decimal(0)
+                remaining_equity_after_withdrawal = remaining_equity
 
                 if vault_equity_before_phase1_snapshot is not None:
                     equity_decrease = (
@@ -3148,13 +3180,22 @@ class HypercoreVaultRouting(RoutingModel):
             and not close_materially_short
         )
 
-        # A cleanup retry may deliberately use a safety margin larger than
-        # HyperCore's normal close epsilon.  Do not discard that material
-        # residual from state: the small-position cleaner will top it up and
-        # redeem it in a follow-up pass.  Normal full closes retain their
-        # established close behaviour and may write off the <= 2 USDC margin.
-        if self._cleanup_retry_leaves_material_residual(trade):
-            should_close_full_quantity = False
+        if trade.other_data.get("hypercore_small_position_cleanup") and position is not None:
+            retain_cleanup_residual = (
+                remaining_equity_after_withdrawal is None
+                or remaining_equity_after_withdrawal
+                > HYPERCORE_SMALL_POSITION_CLEANUP_CLOSE_EPSILON
+            )
+            if retain_cleanup_residual:
+                position.other_data[
+                    HYPERCORE_SMALL_POSITION_CLEANUP_PENDING_REDEEM
+                ] = True
+                should_close_full_quantity = False
+            else:
+                position.other_data.pop(
+                    HYPERCORE_SMALL_POSITION_CLEANUP_PENDING_REDEEM,
+                    None,
+                )
 
         if should_close_full_quantity:
             executed_amount = trade.planned_quantity

--- a/tradeexecutor/ethereum/vault/hypercore_small_position_cleanup.py
+++ b/tradeexecutor/ethereum/vault/hypercore_small_position_cleanup.py
@@ -6,19 +6,18 @@ protocols have different redemption and settlement semantics.  The current
 caller uses Lagoon's HyperCore execution route, but this module never handles
 Lagoon vault shares.
 
-HyperCore ``vaultTransfer`` has no withdraw-all operation and rejects an
-amount that is even slightly above live equity.  A small position is therefore
-redeemed through the normal HyperCore router, with a full-close flag and a
-larger retry margin if the first vaultTransfer silently no-ops.  When the
-position is too small to leave the protocol's 5 USDC withdrawal floor after
-the safety margin, the cleaner first tops it up by enough to make every retry
-withdrawable from fresh live equity.  The subsequent full close returns the
-usable capital to reserves.  A deposit locks the whole vault position, so the
-top-up and the later redemption deliberately happen in separate runs.
-Any retry residual above the close epsilon remains state-tracked and is
-redeemed on a later run; only final protocol dust is written off in state.
-If a routed trade fails, the updated state is saved and the normal failed-trade
-repair flow takes over.
+HyperCore ``vaultTransfer`` has no withdraw-all operation and silently no-ops
+for an amount that is even slightly above live equity. A small position is
+therefore redeemed through the normal HyperCore router, with a full-close flag
+and progressively larger retry margins if the first ``vaultTransfer`` silently
+no-ops. ``MINIMUM_VAULT_DEPOSIT`` is enforced by the deposit encoder; the
+withdrawal encoder has no equivalent client-side check. The cleaner therefore
+never tops up a position it is trying to close. Settlement checks detect a
+backend no-op. Cleanup uses an adaptive 0.10 USDC initial margin instead of the
+normal 1.50 USDC close margin, so almost all of a small position is recovered.
+If too little remains to verify all withdrawal phases, the position is closed
+locally as protocol dust. If a routed trade fails, the updated state is saved
+and the normal failed-trade repair flow takes over.
 """
 
 import datetime
@@ -27,24 +26,30 @@ from dataclasses import dataclass, replace
 from decimal import Decimal
 
 from eth_defi.hyperliquid.api import fetch_user_vault_equity
-from eth_defi.hyperliquid.core_writer import MINIMUM_VAULT_DEPOSIT
-
 from tradeexecutor.ethereum.vault.hypercore_routing import (
-    HYPERCORE_SMALL_POSITION_CLEANUP_RETRY_SAFETY_MARGINS_RAW,
+    HYPERCORE_SMALL_POSITION_CLEANUP_MIN_REDEMPTION_RAW,
     HypercoreWithdrawalPreflightError,
     raw_to_usdc,
-    usdc_to_raw,
 )
 from tradeexecutor.state.freeze import freeze_position_on_failed_trade
 from tradeexecutor.state.repair import close_position_with_empty_trade
 from tradeexecutor.state.trade import TradeExecution, TradeType
-from tradeexecutor.strategy.dust import HYPERLIQUID_VAULT_CLOSE_EPSILON
+from tradeexecutor.strategy.dust import (
+    HYPERCORE_SMALL_POSITION_CLEANUP_CLOSE_EPSILON,
+    HYPERCORE_SMALL_POSITION_CLEANUP_PENDING_REDEEM,
+)
 from tradeexecutor.strategy.execution_model import ExecutionHaltableIssue
 
 
 logger = logging.getLogger(__name__)
 
 USDC_QUANTUM = Decimal("0.000001")
+HYPERCORE_SMALL_POSITION_MINIMUM_REDEEMABLE_EQUITY = (
+    HYPERCORE_SMALL_POSITION_CLEANUP_CLOSE_EPSILON
+)
+assert HYPERCORE_SMALL_POSITION_MINIMUM_REDEEMABLE_EQUITY == raw_to_usdc(
+    HYPERCORE_SMALL_POSITION_CLEANUP_MIN_REDEMPTION_RAW
+)
 
 
 #: Strategy parameters that express the lowest useful allocation.  HyperAI
@@ -65,7 +70,6 @@ class HypercoreSmallPositionCandidate:
     vault_address: str
     live_equity: Decimal
     minimum_allocation: Decimal
-    top_up_reserve: Decimal | None
     is_pending_cleanup: bool
 
 
@@ -97,22 +101,6 @@ def get_hypercore_minimum_allocation(parameters) -> Decimal | None:
     return None
 
 
-def get_hypercore_small_position_top_up_reserve(
-    live_equity: Decimal,
-) -> Decimal | None:
-    """Get the temporary top-up that makes every cleanup retry withdrawable now."""
-
-    live_equity = raw_to_usdc(usdc_to_raw(live_equity))
-    minimum_deposit = raw_to_usdc(MINIMUM_VAULT_DEPOSIT)
-    largest_retry_margin = raw_to_usdc(
-        max(HYPERCORE_SMALL_POSITION_CLEANUP_RETRY_SAFETY_MARGINS_RAW)
-    )
-    minimum_equity_for_retry_ladder = minimum_deposit + largest_retry_margin
-    if live_equity >= minimum_equity_for_retry_ladder:
-        return None
-    return max(minimum_deposit, minimum_equity_for_retry_ladder - live_equity)
-
-
 def discover_hypercore_small_positions(
     state,
     minimum_allocation: Decimal,
@@ -139,7 +127,10 @@ def discover_hypercore_small_positions(
 
         live_equity = Decimal(str(position.get_value(include_interest=False))).quantize(USDC_QUANTUM)
         is_pending_cleanup = (
-            position.other_data.get("hypercore_small_position_cleanup_pending_redeem") is True
+            position.other_data.get(
+                HYPERCORE_SMALL_POSITION_CLEANUP_PENDING_REDEEM
+            )
+            is True
         )
         if live_equity <= 0 or (
             not is_pending_cleanup and live_equity >= minimum_allocation
@@ -154,7 +145,6 @@ def discover_hypercore_small_positions(
                 vault_address=vault_address,
                 live_equity=live_equity,
                 minimum_allocation=minimum_allocation,
-                top_up_reserve=get_hypercore_small_position_top_up_reserve(live_equity),
                 is_pending_cleanup=is_pending_cleanup,
             )
         )
@@ -167,10 +157,11 @@ def plan_hypercore_small_position_cleanup(
     candidate: HypercoreSmallPositionCandidate,
     timestamp: datetime.datetime,
 ) -> list[TradeExecution]:
-    """Create one top-up or full-close trade for a cleanup candidate.
+    """Create a full-close trade for a cleanup candidate with redeemable equity.
 
-    A HyperCore deposit locks the whole vault position, so a top-up must be
-    persisted and allowed to unlock before its later redemption.
+    ``MINIMUM_VAULT_DEPOSIT`` is deliberately irrelevant here because the
+    withdrawal encoder does not apply that client-side deposit check. Dust
+    cleanup must not add capital or extend the vault lock-up.
     """
 
     position = state.portfolio.open_positions[candidate.position_id]
@@ -188,25 +179,6 @@ def plan_hypercore_small_position_cleanup(
             f"allocation {candidate.minimum_allocation:.6f} USDC"
         )
     note_prefix = f"correct-accounts HyperCore small-position cleanup: {cleanup_reason}."
-
-    if candidate.top_up_reserve is not None:
-        _position, top_up_trade, _created = state.portfolio.create_trade(
-            strategy_cycle_at=timestamp,
-            pair=position.pair,
-            quantity=None,
-            reserve=candidate.top_up_reserve,
-            assumed_price=position.last_token_price,
-            trade_type=TradeType.rebalance,
-            reserve_currency=reserve_asset,
-            reserve_currency_price=1.0,
-            position=position,
-            notes=(
-                f"{note_prefix} Topping up {candidate.top_up_reserve:.6f} USDC so every "
-                "HyperCore retry can meet the withdrawal floor."
-            ),
-        )
-        top_up_trade.other_data["hypercore_small_position_cleanup"] = True
-        return [top_up_trade]
 
     close_quantity = -position.get_quantity(planned=True)
     assert close_quantity < 0, (
@@ -252,14 +224,14 @@ def _close_confirmed_hypercore_residual(
         bypass_cache=True,
     )
     residual_equity = Decimal(0) if live_equity is None else live_equity.equity
-    if residual_equity > HYPERLIQUID_VAULT_CLOSE_EPSILON:
-        position.other_data["hypercore_small_position_cleanup_pending_redeem"] = True
+    if residual_equity > HYPERCORE_SMALL_POSITION_MINIMUM_REDEEMABLE_EQUITY:
+        position.other_data[HYPERCORE_SMALL_POSITION_CLEANUP_PENDING_REDEEM] = True
         logger.warning(
             "HyperCore cleanup left %.6f USDC in position %d, above the %.2f "
             "dust write-off threshold; leaving it open for a later cleanup run",
             residual_equity,
             position.position_id,
-            HYPERLIQUID_VAULT_CLOSE_EPSILON,
+            HYPERCORE_SMALL_POSITION_MINIMUM_REDEEMABLE_EQUITY,
         )
         return residual_equity
 
@@ -287,13 +259,20 @@ def run_hypercore_small_position_cleanup(
     session,
     safe_address: str,
     store,
+    dry_run: bool = False,
 ) -> HypercoreSmallPositionCleanupReport:
     """Redeem tracked small HyperCore positions and return proceeds to reserves.
 
     Trades use the normal HyperCore execution router, so all three withdrawal
     phases are verified and an actual successful sell credits the portfolio
-    reserve.  A top-up is persisted by itself because it locks the whole vault
-    position until HyperCore's lock-up expires.
+    reserve. The cleaner never tops up a position because the local 5 USDC
+    check belongs to deposits and a deposit would create a new lock-up.
+    Positions too small for meaningful phase verification are closed locally
+    without broadcasting.
+
+    :param dry_run:
+        Refresh and report eligible positions without creating trades,
+        broadcasting transactions, or saving state.
     """
 
     executed_trades: list[TradeExecution] = []
@@ -318,6 +297,13 @@ def run_hypercore_small_position_cleanup(
 
         live_equity = Decimal(0) if live_equity_result is None else live_equity_result.equity
         if live_equity <= 0:
+            if dry_run:
+                logger.info(
+                    "Dry run: would close zero-equity HyperCore position %d (%s)",
+                    candidate.position_id,
+                    candidate.vault_name,
+                )
+                continue
             position = state.portfolio.open_positions.get(candidate.position_id)
             if position is not None:
                 close_position_with_empty_trade(state.portfolio, position)
@@ -342,33 +328,48 @@ def run_hypercore_small_position_cleanup(
             )
             continue
 
-        current_candidate = replace(
-            candidate,
-            live_equity=live_equity,
-            top_up_reserve=get_hypercore_small_position_top_up_reserve(live_equity),
-        )
-        is_top_up = current_candidate.top_up_reserve is not None
-        if is_top_up:
-            reserve_quantity = state.portfolio.get_default_reserve_position().quantity
-            if reserve_quantity < current_candidate.top_up_reserve:
-                logger.warning(
-                    "HyperCore small-position cleanup skipped position %d: needs %.6f USDC "
-                    "temporary top-up but only %.6f USDC is in reserves",
-                    current_candidate.position_id,
-                    current_candidate.top_up_reserve,
-                    reserve_quantity,
+        current_candidate = replace(candidate, live_equity=live_equity)
+
+        if live_equity <= HYPERCORE_SMALL_POSITION_MINIMUM_REDEEMABLE_EQUITY:
+            if dry_run:
+                logger.info(
+                    "Dry run: would close HyperCore position %d (%s) locally because "
+                    "%.6f USDC is not enough to verify all withdrawal phases",
+                    candidate.position_id,
+                    candidate.vault_name,
+                    live_equity,
                 )
                 continue
+            position = state.portfolio.open_positions.get(candidate.position_id)
+            if position is not None:
+                close_position_with_empty_trade(state.portfolio, position)
+                position.add_notes_message(
+                    "correct-accounts closed the HyperCore position locally because "
+                    f"{live_equity:.6f} USDC was not enough to verify all withdrawal phases"
+                )
+                store.sync(state)
+                closed_position_ids.append(candidate.position_id)
+            continue
+
+        if dry_run:
+            logger.info(
+                "Dry run: would redeem HyperCore small position %d (%s), "
+                "live equity %.6f USDC, strategy minimum allocation %.6f USDC",
+                current_candidate.position_id,
+                current_candidate.vault_name,
+                current_candidate.live_equity,
+                current_candidate.minimum_allocation,
+            )
+            continue
 
         trades = plan_hypercore_small_position_cleanup(state, current_candidate, timestamp)
         logger.info(
-            "Cleaning HyperCore small position %d (%s): equity %.6f USDC, minimum "
-            "allocation %.6f USDC, action=%s",
+            "Cleaning HyperCore small position %d (%s): equity %.6f USDC, "
+            "minimum allocation %.6f USDC, action=redeem",
             current_candidate.position_id,
             current_candidate.vault_name,
             current_candidate.live_equity,
             current_candidate.minimum_allocation,
-            "top_up" if is_top_up else "redeem",
         )
         try:
             execution_model.execute_trades(
@@ -384,6 +385,8 @@ def run_hypercore_small_position_cleanup(
             if isinstance(e, HypercoreWithdrawalPreflightError) and trade.is_started():
                 state.mark_trade_failed(timestamp, trade)
                 freeze_position_on_failed_trade(timestamp, state, [trade])
+            elif isinstance(e, HypercoreWithdrawalPreflightError) and trade.is_planned():
+                trade.mark_expired(timestamp)
             logger.error(
                 "HyperCore small-position cleanup failed for position %d: %s. "
                 "The updated state has been saved; repair the failed trade before retrying.",
@@ -399,24 +402,6 @@ def run_hypercore_small_position_cleanup(
 
         trade = trades[0]
         if not trade.is_success():
-            continue
-        if is_top_up:
-            position = state.portfolio.open_positions.get(current_candidate.position_id)
-            if position is None:
-                logger.error(
-                    "HyperCore small-position cleanup top-up trade %d succeeded but position %d "
-                    "is no longer open",
-                    trade.trade_id,
-                    current_candidate.position_id,
-                )
-                continue
-            position.other_data["hypercore_small_position_cleanup_pending_redeem"] = True
-            store.sync(state)
-            logger.info(
-                "HyperCore small-position cleanup topped up position %d; redemption will run "
-                "after the vault lock-up expires",
-                current_candidate.position_id,
-            )
             continue
 
         residual_equity = _close_confirmed_hypercore_residual(

--- a/tradeexecutor/state/position.py
+++ b/tradeexecutor/state/position.py
@@ -28,7 +28,11 @@ from tradeexecutor.state.trade import TradeExecution, TradeStatus
 from tradeexecutor.state.trigger import Trigger
 from tradeexecutor.state.types import USDollarAmount, BPS, USDollarPrice, Percent, LeverageMultiplier, LegacyDataException
 from tradeexecutor.state.valuation import ValuationUpdate
-from tradeexecutor.strategy.dust import get_dust_epsilon_for_pair, get_close_epsilon_for_pair
+from tradeexecutor.strategy.dust import (
+    HYPERCORE_SMALL_POSITION_CLEANUP_PENDING_REDEEM,
+    get_close_epsilon_for_pair,
+    get_dust_epsilon_for_pair,
+)
 from tradeexecutor.strategy.execution_context import ExecutionMode
 from tradeexecutor.strategy.lending_protocol_leverage import create_short_loan, update_short_loan, create_credit_supply_loan, update_credit_supply_loan
 from tradeexecutor.strategy.pnl import calculate_pnl
@@ -1411,6 +1415,15 @@ class TradingPosition(GenericPosition):
         if self.is_spot() or self.is_credit_supply():
             if quantity <= 0:
                 return True
+
+        if (
+            self.pair.is_hyperliquid_vault()
+            and self.other_data.get(HYPERCORE_SMALL_POSITION_CLEANUP_PENDING_REDEEM)
+        ):
+            # A cleanup withdrawal can deliberately leave 0.30–1.00 USDC for
+            # another verified pass. Do not let the normal 2 USDC HyperCore
+            # close epsilon discard that still-redeemable position.
+            return quantity <= 0
 
         if self.pair.is_cctp_bridge():
             available_bridge_capital = self.get_available_bridge_capital()

--- a/tradeexecutor/state/repair.py
+++ b/tradeexecutor/state/repair.py
@@ -572,8 +572,8 @@ def close_hypercore_dust_positions(
 
         trade = close_position_with_empty_trade(portfolio, position)
         position.add_notes_message(
-            "Auto-closed Hypercore dust position because Hypercore vault "
-            f"withdrawals cannot fully redeem the final residual balance ({now.isoformat()})"
+            "Auto-closed Hypercore dust position after the safety-margin "
+            f"redemption left a final residual balance ({now.isoformat()})"
         )
         logger.info(
             "Auto-closed Hypercore dust position %s with repair trade %s",

--- a/tradeexecutor/strategy/dust.py
+++ b/tradeexecutor/strategy/dust.py
@@ -54,6 +54,16 @@ DEFAULT_VAULT_EPSILON = Decimal(10 ** -6)
 #: residual as dust and the runner can auto-close it before account checks.
 HYPERLIQUID_VAULT_CLOSE_EPSILON = Decimal("2.00")
 
+#: A HyperCore small-position cleanup residual above this amount can still
+#: produce verifiable movement through every withdrawal phase.
+HYPERCORE_SMALL_POSITION_CLEANUP_CLOSE_EPSILON = Decimal("0.30")
+
+#: Position marker that keeps a verifiable cleanup residual open despite the
+#: normal 2 USDC HyperCore close epsilon.
+HYPERCORE_SMALL_POSITION_CLEANUP_PENDING_REDEEM = (
+    "hypercore_small_position_cleanup_pending_redeem"
+)
+
 #: Hypercore vault equities fluctuate every block due to active trading
 #: inside the vault, and live cycles can spend a long time in sequential
 #: settlement before the final accounting read happens.


### PR DESCRIPTION
## Why

Yesterday's HyperCore small-position cleanup treated the 5 USDC deposit encoder minimum as a withdrawal minimum and topped up positions before closing them. That unnecessarily deposited new capital, restarted the vault lock-up, and did not reflect what the withdrawal encoder actually validates.

Tracked positions #57 and #493 are now unlocked and have live equity below the HyperAI allocation floor. `correct-accounts` should redeem them directly while preserving strict settlement verification and without claiming that the HyperCore backend accepts any particular minimum redemption amount.

## Lessons learnt

- `MINIMUM_VAULT_DEPOSIT` is a confirmed client-side deposit rule, not evidence of a backend withdrawal floor.
- Every HyperCore withdrawal phase needs observable balance movement; a merely positive amount is not enough for safe verification.
- Cleanup residuals above 0.30 USDC must remain tracked despite the normal 2 USDC HyperCore close epsilon.
- A dry run needs both a no-op state store and an early return before any transaction-building or correction path.

## Summary

- Replace the cleanup top-up flow with direct full-close HyperCore redemption.
- Use a 0.10 USDC initial safety margin and 0.25, 0.50, and 1.00 USDC retry margins.
- Reject or locally close amounts too small for verifiable multi-phase settlement, and keep larger residuals marked for another pass.
- Remove the deposit minimum from withdrawal retry and standalone dust-claim checks while retaining live lock-up, liquidity, equity, operator-cap, and settlement guards.
- Add `correct-accounts --dry-run` for a non-broadcasting, non-persistent live preview.
- Correct related strategy comments, docstrings, operator documentation, historical notes, and changelog wording.
