### PR TITLE
fix: consume typed vault JSON deposit status

### DIFF
--- a/docs/plans/trade-executor-vault-test-remaining-fixes.md
+++ b/docs/plans/trade-executor-vault-test-remaining-fixes.md
@@ -20,7 +20,12 @@ request-only asynchronous results remain valid terminal outcomes.
 
 ## Evidence and scope
 
-The latest run covered 129 vaults and produced:
+This is a historical implementation plan. Its result counts are the original
+129-vault baseline that motivated the work, not the latest published matrix.
+For the later rerun, see
+[`cross-chain-vault-test-2026-07-25-rerun-results.md`](../reports/cross-chain-vault-test-2026-07-25-rerun-results.md).
+
+The baseline run covered 129 vaults and produced:
 
 | Result | Count | Interpretation |
 |---|---:|---|
@@ -377,7 +382,7 @@ operation.
 - Yearn and YieldNest receipt results become successful when their eth-defi
   analysers return valid event analysis; otherwise they remain explicit
   `receipt_analysis_failed` rows.
-- Existing 20 `deposit_closed`, 14 `whitelisting-needed` and 29
+- The baseline's 20 `deposit_closed`, 14 `whitelisting-needed` and 29
   `async_request_only` outcomes are not treated as acceptance failures.
 - Every vault in the twelve-row disposition table reaches its stated expected
   outcome, or remains as an explicitly owned eth-defi dependency with the

--- a/tests/cli/test_vault_test_trade.py
+++ b/tests/cli/test_vault_test_trade.py
@@ -24,6 +24,7 @@ from requests.exceptions import ReadTimeout
 from textual.app import App, ComposeResult
 from textual.widgets import DataTable, Input
 from tradingstrategy.chain import ChainId
+from tradingstrategy.vault import VaultDepositStatus
 from web3.exceptions import BadFunctionCallOutput
 
 from tradeexecutor.cli.commands.lagoon_deploy_vault import (
@@ -72,6 +73,7 @@ from tradeexecutor.cli.vault_trade.runner import (
     get_adapter_unsupported_detail,
     get_bridge_conflict,
     get_deposit_closed_detail,
+    get_incorrect_deposit_status_reporting,
     get_incorrect_whitelisting_detail,
     get_redemption_unavailable_detail,
     has_async_vault_lifecycle,
@@ -1498,6 +1500,44 @@ def test_simulated_vault_records_incorrect_json_whitelist_status() -> None:
     }
 
 
+def test_simulated_vault_uses_explicit_json_deposit_status() -> None:
+    """Only an explicit recognised JSON deposit status creates mismatch evidence.
+
+    1. Compare explicit open JSON status with a closed onchain observation.
+    2. Verify status provenance and the legacy reason are retained in the report.
+    3. Confirm missing, unknown and future JSON values remain non-blocking.
+    """
+    # 1. Compare explicit open JSON status with a closed onchain observation.
+    observed_at = datetime.datetime(2026, 7, 30, 7, 0)
+    attempt = SimpleNamespace(
+        vault=SimpleNamespace(
+            metadata=SimpleNamespace(
+                deposit_status=VaultDepositStatus.open,
+                deposit_closed_reason=None,
+                deposit_status_source="eth-defi",
+                deposit_status_observed_at=observed_at,
+                deposit_status_observed_block=23_456_789,
+            ),
+        ),
+    )
+    mismatch = get_incorrect_deposit_status_reporting(attempt, "closed")
+
+    # 2. Verify status provenance and the legacy reason are retained in the report.
+    assert mismatch == {
+        "vault_json_deposit_status": "open",
+        "vault_json_deposit_closed_reason": None,
+        "onchain_deposit_status": "closed",
+        "vault_json_deposit_status_source": "eth-defi",
+        "vault_json_deposit_status_observed_at": "2026-07-30T07:00:00",
+        "vault_json_deposit_status_observed_block": 23_456_789,
+    }
+
+    # 3. Confirm missing, unknown and future JSON values remain non-blocking.
+    for status in (None, VaultDepositStatus.unknown, "maintenance"):
+        attempt.vault.metadata.deposit_status = status
+        assert get_incorrect_deposit_status_reporting(attempt, "closed") is None
+
+
 def test_simulated_closed_deposit_records_guard_validation_evidence() -> None:
     """A typed closure becomes a non-broadcast GuardV0 success.
 
@@ -1723,6 +1763,7 @@ def test_simulated_closed_deposit_is_persisted_as_terminal_success() -> None:
     attempt = SimpleNamespace(
         vault=SimpleNamespace(
             metadata=SimpleNamespace(
+                deposit_status=VaultDepositStatus.closed,
                 deposit_closed_reason="Global deposit cap reached",
             ),
         ),
@@ -1786,7 +1827,10 @@ def test_simulated_closed_deposit_open_json_gets_directional_result() -> None:
     )
     attempt = SimpleNamespace(
         vault=SimpleNamespace(
-            metadata=SimpleNamespace(deposit_closed_reason=None),
+            metadata=SimpleNamespace(
+                deposit_status=VaultDepositStatus.open,
+                deposit_closed_reason=None,
+            ),
         ),
         executable_vault=MagicMock(),
         pair=MagicMock(),
@@ -1861,6 +1905,7 @@ def test_simulated_open_deposit_closed_json_is_executed_and_persisted() -> None:
     attempt = SimpleNamespace(
         vault=SimpleNamespace(
             metadata=SimpleNamespace(
+                deposit_status=VaultDepositStatus.closed,
                 deposit_closed_reason="Scanner reported deposits closed",
             ),
         ),

--- a/tradeexecutor/cli/vault_trade/runner.py
+++ b/tradeexecutor/cli/vault_trade/runner.py
@@ -353,7 +353,13 @@ def get_incorrect_deposit_status_reporting(
     attempt: "VaultAttempt",
     onchain_deposit_status: str,
 ) -> dict | None:
-    """Return evidence when vault JSON disagrees with the onchain deposit status."""
+    """Return evidence when an explicit vault JSON status disagrees onchain.
+
+    ``deposit_closed_reason`` is useful context but cannot establish availability:
+    it may be stale, absent, or retained after the producer observed a later
+    opening. Only the typed ``deposit_status`` field is authoritative. Missing,
+    unknown and future producer values deliberately remain non-blocking.
+    """
 
     assert onchain_deposit_status in {"open", "closed"}
 
@@ -361,22 +367,35 @@ def get_incorrect_deposit_status_reporting(
     if metadata is None:
         return None
 
-    missing = object()
-    deposit_closed_reason = getattr(metadata, "deposit_closed_reason", missing)
-    if deposit_closed_reason is missing:
+    deposit_status = getattr(metadata, "deposit_status", None)
+    deposit_status = getattr(deposit_status, "value", deposit_status)
+    if deposit_status not in {"open", "closed"}:
         return None
 
-    vault_json_deposit_status = (
-        "open" if deposit_closed_reason is None else "closed"
-    )
-    if vault_json_deposit_status == onchain_deposit_status:
+    if deposit_status == onchain_deposit_status:
         return None
 
-    return {
-        "vault_json_deposit_status": vault_json_deposit_status,
-        "vault_json_deposit_closed_reason": deposit_closed_reason,
+    outcome_data = {
+        "vault_json_deposit_status": deposit_status,
+        "vault_json_deposit_closed_reason": getattr(
+            metadata,
+            "deposit_closed_reason",
+            None,
+        ),
         "onchain_deposit_status": onchain_deposit_status,
     }
+    for field in (
+        "deposit_status_source",
+        "deposit_status_observed_block",
+    ):
+        value = getattr(metadata, field, None)
+        if value is not None:
+            outcome_data[f"vault_json_{field}"] = value
+    observed_at = getattr(metadata, "deposit_status_observed_at", None)
+    if observed_at is not None:
+        outcome_data["vault_json_deposit_status_observed_at"] = observed_at.isoformat()
+
+    return outcome_data
 
 
 def get_adapter_unsupported_detail(


### PR DESCRIPTION
## Why

Vault JSON availability is a scanner observation, while `vault-test-trade`
observes the forked chain at execution time. Trade-executor must compare those
two sources only when the data producer explicitly published a recognised
availability state. Inferring availability from a free-text closure reason can
report a false disagreement when that reason is stale or retained for context.

## Lessons learnt

`deposit_status` and `deposit_closed_reason` have different contracts. The
typed status determines whether the JSON reports an open or closed deposit
window; the reason is supporting diagnostic context only. A missing status,
explicit `unknown`, or future producer value is not an assertion that should
block or relabel a simulated interaction.

## Summary

- Bump trading-strategy to the merged typed deposit-status metadata client.
- Compare explicit `open` and `closed` JSON status values with the simulated
  on-chain observation.
- Preserve JSON status source, observation timestamp and block in mismatch
  evidence when supplied.
- Add coverage for enum values plus missing, unknown and future status values.
- Label the older 129-vault plan counts as a historical baseline and link the
  later published rerun.
