### PR TITLE
fix: rehearse HyperCore cleanup before broadcast

### DIFF
--- a/.claude/docs/cli-command.md
+++ b/.claude/docs/cli-command.md
@@ -96,16 +96,16 @@ Representative code:
 - `tradeexecutor/cli/commands/close_position.py`
 - `tradeexecutor/cli/commands/start.py`
 
-`correct-accounts --dry-run` is the read-only variant for live reconciliation.
-It loads the existing state through `SimulateStore`, reads current balances,
-and rehearses HyperCore small-position cleanup on isolated state copies. The
-rehearsal performs the live lock-up and withdrawal preflight, supersedes
-unstarted planned trades, creates the close trade, and constructs and signs
-the phase-1 transaction. It stops before broadcast and settlement, then
-reports generic accounting corrections. It does not create a backup,
-broadcast, or persist state. Do not substitute `--skip-save`: that option
-skips the final state write but does not prevent earlier transaction
-broadcasts.
+`correct-accounts --dry-run` is the non-persisting rehearsal for live
+reconciliation. It loads the existing state through `SimulateStore`, reads
+current balances, and rehearses HyperCore small-position cleanup on isolated
+state copies. The rehearsal performs the live lock-up and withdrawal preflight,
+supersedes planned trades that have not entered execution, creates the close
+trade, and constructs and signs the phase-1 transaction. It stops before
+broadcast and settlement. After a successful rehearsal, it reports generic
+accounting corrections. It does not create a backup, broadcast, or persist
+state. Do not substitute `--skip-save`: that option skips the final state write
+but does not prevent earlier transaction broadcasts.
 
 ### Hybrid commands
 

--- a/.claude/docs/cli-command.md
+++ b/.claude/docs/cli-command.md
@@ -98,11 +98,14 @@ Representative code:
 
 `correct-accounts --dry-run` is the read-only variant for live reconciliation.
 It loads the existing state through `SimulateStore`, reads current balances,
-reports HyperCore small-position redemptions and generic accounting
-corrections, and returns before transaction builders or correction execution.
-It does not create a backup, broadcast, or persist state. Do not substitute
-`--skip-save`: that option skips the final state write but does not prevent
-earlier transaction broadcasts.
+and rehearses HyperCore small-position cleanup on isolated state copies. The
+rehearsal performs the live lock-up and withdrawal preflight, supersedes
+unstarted planned trades, creates the close trade, and constructs and signs
+the phase-1 transaction. It stops before broadcast and settlement, then
+reports generic accounting corrections. It does not create a backup,
+broadcast, or persist state. Do not substitute `--skip-save`: that option
+skips the final state write but does not prevent earlier transaction
+broadcasts.
 
 ### Hybrid commands
 

--- a/.claude/docs/cli-command.md
+++ b/.claude/docs/cli-command.md
@@ -100,10 +100,11 @@ Representative code:
 reconciliation. It loads the existing state through `SimulateStore`, reads
 current balances, and rehearses HyperCore small-position cleanup on isolated
 state copies. The rehearsal performs the live lock-up and withdrawal preflight,
-supersedes planned trades that have not entered execution, creates the close
-trade, and constructs and signs the phase-1 transaction. It stops before
-broadcast and settlement. After a successful rehearsal, it reports generic
-accounting corrections. It does not create a backup, broadcast, or persist
+expires planned trades that have not entered execution before it acts on the
+candidate, creates a close trade when eligible, and constructs and signs the
+phase-1 transaction. It stops before broadcast and settlement. After a
+successful rehearsal, it reports generic accounting corrections. It does not
+create a backup, broadcast, or persist
 state. Do not substitute `--skip-save`: that option skips the final state write
 but does not prevent earlier transaction broadcasts.
 

--- a/.claude/docs/hypercore-vault.md
+++ b/.claude/docs/hypercore-vault.md
@@ -379,11 +379,18 @@ is locally closed with a zero-quantity repair. If a routed cleanup trade
 fails, its state is saved and it is left for the normal failed-trade repair
 flow rather than being silently written off.
 
-Use `correct-accounts --dry-run` to refresh live balances and report eligible
-HyperCore redemptions and accounting corrections without persisting trades,
-broadcasting transactions, backing up, or saving state. `--skip-save` is not a
-dry-run flag: it can still broadcast transactions before skipping the final
-state write.
+An unstarted planned trade has no transaction allocated and cannot execute by
+itself, but it still changes the position's planned quantity. Cleanup expires
+such trades before creating its replacement full close. Started or broadcast
+trades are never superseded and keep the position ineligible for cleanup.
+
+Use `correct-accounts --dry-run` to refresh live balances and rehearse every
+pre-broadcast cleanup step: stale-plan reconciliation, close-trade planning,
+live lock-up and withdrawal preflight, routing, transaction construction, and
+signing. The rehearsal uses isolated state copies and stops before broadcast
+or settlement. It then reports accounting corrections without persisting
+trades, backing up, or saving state. `--skip-save` is not a dry-run flag: it
+can still broadcast transactions before skipping the final state write.
 
 ## Testing
 

--- a/.claude/docs/hypercore-vault.md
+++ b/.claude/docs/hypercore-vault.md
@@ -379,18 +379,19 @@ is locally closed with a zero-quantity repair. If a routed cleanup trade
 fails, its state is saved and it is left for the normal failed-trade repair
 flow rather than being silently written off.
 
-An unstarted planned trade has no transaction allocated and cannot execute by
-itself, but it still changes the position's planned quantity. Cleanup expires
-such trades before creating its replacement full close. Started or broadcast
-trades are never superseded and keep the position ineligible for cleanup.
+A planned trade has not entered execution and cannot execute by itself, but it
+still changes the position's planned quantity. Cleanup expires such trades
+before creating its replacement full close. Started or broadcast trades are
+never superseded and keep the position ineligible for cleanup.
 
 Use `correct-accounts --dry-run` to refresh live balances and rehearse every
 pre-broadcast cleanup step: stale-plan reconciliation, close-trade planning,
 live lock-up and withdrawal preflight, routing, transaction construction, and
 signing. The rehearsal uses isolated state copies and stops before broadcast
-or settlement. It then reports accounting corrections without persisting
-trades, backing up, or saving state. `--skip-save` is not a dry-run flag: it
-can still broadcast transactions before skipping the final state write.
+or settlement. After a successful rehearsal, it reports accounting corrections
+without persisting trades, backing up, or saving state. `--skip-save` is not a
+dry-run flag: it can still broadcast transactions before skipping the final
+state write.
 
 ## Testing
 

--- a/.claude/docs/hypercore-vault.md
+++ b/.claude/docs/hypercore-vault.md
@@ -381,8 +381,11 @@ flow rather than being silently written off.
 
 A planned trade has not entered execution and cannot execute by itself, but it
 still changes the position's planned quantity. Cleanup expires such trades
-before creating its replacement full close. Started or broadcast trades are
-never superseded and keep the position ineligible for cleanup.
+after it refreshes live equity but before it decides how to handle the
+position, including a lock-up deferral or local dust closure. It creates a
+replacement full close only when the refreshed position is eligible. Started
+or broadcast trades are never superseded and keep the position ineligible for
+cleanup.
 
 Use `correct-accounts --dry-run` to refresh live balances and rehearse every
 pre-broadcast cleanup step: stale-plan reconciliation, close-trade planning,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 0.2
 
-- Fix default-on `correct-accounts` cleanup for undersized HyperCore vault positions to redeem directly without deposits or new lock-ups, keep verifiable residuals tracked, supersede stale unstarted close plans, use a valid live confirmation count, and make `--dry-run` rehearse live preflight, routing, and transaction construction without state writes or broadcasts (2026-07-30)
+- Fix default-on `correct-accounts` cleanup for undersized HyperCore vault positions to redeem directly without deposits or new lock-ups, keep verifiable residuals tracked, supersede stale planned close trades, use a valid live confirmation count, and make `--dry-run` rehearse live preflight, routing, and transaction construction without state writes or broadcasts (2026-07-30)
 
 - Extend `vault-test-trade` simulations to validate typed closed deposits through GuardV0 without broadcasting, and distinguish vault JSON statuses that incorrectly report deposits open or closed (2026-07-28)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 0.2
 
-- Fix default-on `correct-accounts` cleanup for undersized HyperCore vault positions to redeem directly without deposits or new lock-ups, keep verifiable residuals tracked, and provide a read-only `--dry-run` preview (2026-07-30)
+- Fix default-on `correct-accounts` cleanup for undersized HyperCore vault positions to redeem directly without deposits or new lock-ups, keep verifiable residuals tracked, supersede stale unstarted close plans, use a valid live confirmation count, and make `--dry-run` rehearse live preflight, routing, and transaction construction without state writes or broadcasts (2026-07-30)
 
 - Extend `vault-test-trade` simulations to validate typed closed deposits through GuardV0 without broadcasting, and distinguish vault JSON statuses that incorrectly report deposits open or closed (2026-07-28)
 

--- a/tests/hyperliquid/test_hypercore_small_position_cleanup.py
+++ b/tests/hyperliquid/test_hypercore_small_position_cleanup.py
@@ -91,26 +91,28 @@ def test_cleanup_plans_direct_redemption_below_deposit_minimum():
     # 2. Discover it and plan the cleanup.
     candidates = discover_hypercore_small_positions(state, Decimal("50"))
     assert len(candidates) == 1
-    trades = plan_hypercore_small_position_cleanup(state, candidates[0], NOW)
+    trade = plan_hypercore_small_position_cleanup(state, candidates[0], NOW)
 
     # 3. Verify the plan is a full close and does not add capital or extend the lock-up.
-    assert len(trades) == 1
-    assert trades[0].is_sell()
-    assert trades[0].planned_quantity == -position.get_quantity()
-    assert trades[0].planned_reserve == pytest.approx(Decimal("3.45"))
-    assert trades[0].other_data["hypercore_small_position_cleanup"] is True
+    assert trade.is_sell()
+    assert trade.planned_quantity == -position.get_quantity()
+    assert trade.planned_reserve == pytest.approx(Decimal("3.45"))
+    assert trade.other_data["hypercore_small_position_cleanup"] is True
 
 
 def test_cleanup_dry_run_supersedes_planned_close_without_mutating_state():
     """Dry-run validates cleanup when an old planned close consumes the position quantity.
 
-    1. Create a live undersized position and an unstarted full-close trade.
+    1. Create a live undersized position and a planned full-close trade.
     2. Run cleanup in dry-run mode against the otherwise eligible position.
     3. Verify the isolated rehearsal expires the old trade and prepares a replacement.
     4. Verify the supplied state and state store remain untouched.
+
+    Live HyperCore reads and routing are mocked so the unit test cannot sign or
+    broadcast a mainnet transaction.
     """
 
-    # 1. Create a live undersized position and an unstarted full-close trade.
+    # 1. Create a live undersized position and a planned full-close trade.
     state, position = _make_position(Decimal("3.45"))
     reserve_asset = state.portfolio.get_default_reserve_position().asset
     _position, old_close_trade, _created = state.portfolio.create_trade(
@@ -164,11 +166,12 @@ def test_cleanup_dry_run_supersedes_planned_close_without_mutating_state():
     assert prepared_new_trade.trade_id != old_close_trade.trade_id
     assert prepared_new_trade.is_started()
     assert prepared_new_trade.planned_quantity == -position.get_quantity()
-    rehearsed_position = report.rehearsed_state.portfolio.open_positions[
+    assert report.simulated_state is not None
+    simulated_position = report.simulated_state.portfolio.open_positions[
         position.position_id
     ]
-    assert rehearsed_position.trades[old_close_trade.trade_id].expired_at == NOW
-    assert rehearsed_position.get_quantity(planned=True) == position.get_quantity()
+    assert simulated_position.trades[old_close_trade.trade_id].expired_at == NOW
+    assert simulated_position.get_quantity(planned=True) == position.get_quantity()
     assert report.executed_trades == []
     assert report.closed_position_ids == []
 
@@ -204,13 +207,12 @@ def test_cleanup_uses_strategy_minimum_allocation_and_pending_marker():
     state, position = _make_position(Decimal("25"))
     candidates = discover_hypercore_small_positions(state, minimum_allocation)
     assert len(candidates) == 1
-    trades = plan_hypercore_small_position_cleanup(state, candidates[0], NOW)
+    trade = plan_hypercore_small_position_cleanup(state, candidates[0], NOW)
 
     # 3. Verify cleanup plans one full-close trade and preserves pending-cleanup discovery.
-    assert len(trades) == 1
-    assert trades[0].is_sell()
-    assert trades[0].planned_quantity == -position.get_quantity()
-    assert trades[0].other_data["hypercore_small_position_cleanup"] is True
+    assert trade.is_sell()
+    assert trade.planned_quantity == -position.get_quantity()
+    assert trade.other_data["hypercore_small_position_cleanup"] is True
     position.other_data[HYPERCORE_SMALL_POSITION_CLEANUP_PENDING_REDEEM] = True
     pending_candidates = discover_hypercore_small_positions(state, Decimal("5"))
     assert pending_candidates[0].is_pending_cleanup is True
@@ -391,7 +393,7 @@ def test_cleanup_directly_redeems_dust_and_defers_locked_position():
     with (
         patch(
             "tradeexecutor.ethereum.vault.hypercore_small_position_cleanup.plan_hypercore_small_position_cleanup",
-            return_value=[close_trade],
+            return_value=close_trade,
         ),
         patch(
             "tradeexecutor.ethereum.vault.hypercore_small_position_cleanup.fetch_user_vault_equity",
@@ -451,6 +453,9 @@ def test_cleanup_dry_run_validates_local_closure_without_mutating_state():
     1. Arrange a tracked HyperCore position whose live equity has become zero.
     2. Run the cleaner in dry-run mode with the live balance mocked.
     3. Verify the supplied state and state store remain untouched.
+
+    The live equity read is mocked because this test covers local state
+    simulation rather than HyperCore API behaviour.
     """
 
     # 1. Arrange a tracked HyperCore position whose live equity has become zero.
@@ -532,7 +537,7 @@ def test_cleanup_saves_preflight_failure_without_leaving_a_planned_trade():
     # 2. Run the cleaner with mocked execution because this unit test must not broadcast to HyperCore.
     with patch(
         "tradeexecutor.ethereum.vault.hypercore_small_position_cleanup.plan_hypercore_small_position_cleanup",
-        side_effect=[[failed_close_trade], [planned_close_trade]],
+        side_effect=[failed_close_trade, planned_close_trade],
     ), patch(
         "tradeexecutor.ethereum.vault.hypercore_small_position_cleanup.fetch_user_vault_equity",
         side_effect=[

--- a/tests/hyperliquid/test_hypercore_small_position_cleanup.py
+++ b/tests/hyperliquid/test_hypercore_small_position_cleanup.py
@@ -101,6 +101,85 @@ def test_cleanup_plans_direct_redemption_below_deposit_minimum():
     assert trades[0].other_data["hypercore_small_position_cleanup"] is True
 
 
+def test_cleanup_dry_run_supersedes_planned_close_without_mutating_state():
+    """Dry-run validates cleanup when an old planned close consumes the position quantity.
+
+    1. Create a live undersized position and an unstarted full-close trade.
+    2. Run cleanup in dry-run mode against the otherwise eligible position.
+    3. Verify the isolated rehearsal expires the old trade and prepares a replacement.
+    4. Verify the supplied state and state store remain untouched.
+    """
+
+    # 1. Create a live undersized position and an unstarted full-close trade.
+    state, position = _make_position(Decimal("3.45"))
+    reserve_asset = state.portfolio.get_default_reserve_position().asset
+    _position, old_close_trade, _created = state.portfolio.create_trade(
+        strategy_cycle_at=NOW,
+        pair=position.pair,
+        quantity=-position.get_quantity(),
+        reserve=None,
+        assumed_price=position.last_token_price,
+        trade_type=TradeType.rebalance,
+        reserve_currency=reserve_asset,
+        reserve_currency_price=1.0,
+        position=position,
+        closing=True,
+    )
+    candidates = discover_hypercore_small_positions(state, Decimal("5"))
+    assert len(candidates) == 1
+    state_before = state.to_json_safe()
+    execution_model = MagicMock(max_slippage=None)
+    routing_model = MagicMock()
+    routing_state = MagicMock()
+    store = MagicMock()
+
+    # 2. Run cleanup in dry-run mode against the otherwise eligible position.
+    with patch(
+        "tradeexecutor.ethereum.vault.hypercore_small_position_cleanup.fetch_user_vault_equity",
+        return_value=SimpleNamespace(
+            equity=Decimal("3.45"),
+            is_lockup_expired=True,
+            locked_until=NOW,
+        ),
+    ):
+        report = run_hypercore_small_position_cleanup(
+            state=state,
+            timestamp=NOW,
+            candidates=candidates,
+            execution_model=execution_model,
+            routing_model=routing_model,
+            routing_state=routing_state,
+            session=MagicMock(),
+            safe_address="0xSafe",
+            store=store,
+            dry_run=True,
+        )
+
+    # 3. Verify the isolated rehearsal expires the old trade and prepares a replacement.
+    prepared_state = routing_model.setup_trades.call_args.kwargs["state"]
+    prepared_position = prepared_state.portfolio.open_positions[position.position_id]
+    prepared_old_trade = prepared_position.trades[old_close_trade.trade_id]
+    prepared_new_trade = prepared_position.get_last_trade()
+    assert prepared_old_trade.expired_at == NOW
+    assert prepared_new_trade.trade_id != old_close_trade.trade_id
+    assert prepared_new_trade.is_started()
+    assert prepared_new_trade.planned_quantity == -position.get_quantity()
+    rehearsed_position = report.rehearsed_state.portfolio.open_positions[
+        position.position_id
+    ]
+    assert rehearsed_position.trades[old_close_trade.trade_id].expired_at == NOW
+    assert rehearsed_position.get_quantity(planned=True) == position.get_quantity()
+    assert report.executed_trades == []
+    assert report.closed_position_ids == []
+
+    # 4. Verify the supplied state and state store remain untouched.
+    assert old_close_trade.is_planned()
+    assert state.to_json_safe() == state_before
+    store.sync.assert_not_called()
+    execution_model.validate_confirmation_configuration.assert_called_once_with()
+    execution_model.execute_trades.assert_not_called()
+
+
 def test_cleanup_uses_strategy_minimum_allocation_and_pending_marker():
     """A redeemable position is selected from strategy parameters and pending state.
 
@@ -366,69 +445,37 @@ def test_cleanup_directly_redeems_dust_and_defers_locked_position():
     assert store.sync.call_count == 3
 
 
-def test_cleanup_dry_run_does_not_create_trades_or_write_state():
-    """Dry-run reports redeemable and locally closable positions without changing anything.
+def test_cleanup_dry_run_validates_local_closure_without_mutating_state():
+    """Dry-run validates local zero-equity closure on an isolated state copy.
 
-    1. Arrange unlocked redeemable, bridge-threshold, and zero-equity cleanup candidates.
-    2. Run the cleaner in dry-run mode with all live balances mocked.
-    3. Verify no trade is planned or executed and the state store is untouched.
+    1. Arrange a tracked HyperCore position whose live equity has become zero.
+    2. Run the cleaner in dry-run mode with the live balance mocked.
+    3. Verify the supplied state and state store remain untouched.
     """
 
-    # 1. Arrange unlocked redeemable, bridge-threshold, and zero-equity cleanup candidates.
-    positive_candidate = HypercoreSmallPositionCandidate(
-        position_id=57,
-        vault_name="Crypto Plaza",
-        vault_address="0x1111111111111111111111111111111111111111",
-        live_equity=Decimal("3.45"),
-        minimum_allocation=Decimal("5"),
-        is_pending_cleanup=False,
-    )
+    # 1. Arrange a tracked HyperCore position whose live equity has become zero.
+    state, position = _make_position(Decimal("3.45"))
     zero_candidate = HypercoreSmallPositionCandidate(
-        position_id=58,
+        position_id=position.position_id,
         vault_name="Loop Fund",
-        vault_address="0x2222222222222222222222222222222222222222",
+        vault_address=position.pair.pool_address,
         live_equity=Decimal(0),
-        minimum_allocation=Decimal("5"),
-        is_pending_cleanup=False,
-    )
-    bridge_threshold_candidate = HypercoreSmallPositionCandidate(
-        position_id=59,
-        vault_name="Tiny Fund",
-        vault_address="0x3333333333333333333333333333333333333333",
-        live_equity=HYPERCORE_SMALL_POSITION_MINIMUM_REDEEMABLE_EQUITY,
         minimum_allocation=Decimal("5"),
         is_pending_cleanup=False,
     )
     execution_model = MagicMock()
     store = MagicMock()
+    state_before = state.to_json_safe()
 
-    # 2. Run the cleaner in dry-run mode with all live balances mocked.
+    # 2. Run the cleaner in dry-run mode with the live balance mocked.
     with patch(
         "tradeexecutor.ethereum.vault.hypercore_small_position_cleanup.fetch_user_vault_equity",
-        side_effect=[
-            SimpleNamespace(
-                equity=Decimal("3.45"),
-                is_lockup_expired=True,
-                locked_until=NOW,
-            ),
-            None,
-            SimpleNamespace(
-                equity=HYPERCORE_SMALL_POSITION_MINIMUM_REDEEMABLE_EQUITY,
-                is_lockup_expired=True,
-                locked_until=NOW,
-            ),
-        ],
-    ), patch(
-        "tradeexecutor.ethereum.vault.hypercore_small_position_cleanup.plan_hypercore_small_position_cleanup",
-    ) as plan_cleanup:
+        return_value=None,
+    ):
         report = run_hypercore_small_position_cleanup(
-            state=MagicMock(),
+            state=state,
             timestamp=NOW,
-            candidates=[
-                positive_candidate,
-                zero_candidate,
-                bridge_threshold_candidate,
-            ],
+            candidates=[zero_candidate],
             execution_model=execution_model,
             routing_model=MagicMock(),
             routing_state=MagicMock(),
@@ -438,10 +485,10 @@ def test_cleanup_dry_run_does_not_create_trades_or_write_state():
             dry_run=True,
         )
 
-    # 3. Verify no trade is planned or executed and the state store is untouched.
+    # 3. Verify the supplied state and state store remain untouched.
     assert report.executed_trades == []
     assert report.closed_position_ids == []
-    plan_cleanup.assert_not_called()
+    assert state.to_json_safe() == state_before
     execution_model.execute_trades.assert_not_called()
     store.sync.assert_not_called()
 

--- a/tests/hyperliquid/test_hypercore_small_position_cleanup.py
+++ b/tests/hyperliquid/test_hypercore_small_position_cleanup.py
@@ -77,6 +77,25 @@ def _make_position(live_equity: Decimal) -> tuple[State, TradingPosition]:
     return state, position
 
 
+def _create_planned_full_close(state: State, position: TradingPosition):
+    """Create the stale planned close that previously caused cleanup to fail."""
+
+    reserve_asset = state.portfolio.get_default_reserve_position().asset
+    _position, trade, _created = state.portfolio.create_trade(
+        strategy_cycle_at=NOW,
+        pair=position.pair,
+        quantity=-position.get_quantity(),
+        reserve=None,
+        assumed_price=position.last_token_price,
+        trade_type=TradeType.rebalance,
+        reserve_currency=reserve_asset,
+        reserve_currency_price=1.0,
+        position=position,
+        closing=True,
+    )
+    return trade
+
+
 def test_cleanup_plans_direct_redemption_below_deposit_minimum():
     """A sub-5 USDC HyperCore position is redeemed without a temporary top-up.
 
@@ -114,19 +133,7 @@ def test_cleanup_dry_run_supersedes_planned_close_without_mutating_state():
 
     # 1. Create a live undersized position and a planned full-close trade.
     state, position = _make_position(Decimal("3.45"))
-    reserve_asset = state.portfolio.get_default_reserve_position().asset
-    _position, old_close_trade, _created = state.portfolio.create_trade(
-        strategy_cycle_at=NOW,
-        pair=position.pair,
-        quantity=-position.get_quantity(),
-        reserve=None,
-        assumed_price=position.last_token_price,
-        trade_type=TradeType.rebalance,
-        reserve_currency=reserve_asset,
-        reserve_currency_price=1.0,
-        position=position,
-        closing=True,
-    )
+    old_close_trade = _create_planned_full_close(state, position)
     candidates = discover_hypercore_small_positions(state, Decimal("5"))
     assert len(candidates) == 1
     state_before = state.to_json_safe()
@@ -181,6 +188,61 @@ def test_cleanup_dry_run_supersedes_planned_close_without_mutating_state():
     store.sync.assert_not_called()
     execution_model.validate_confirmation_configuration.assert_called_once_with()
     execution_model.execute_trades.assert_not_called()
+
+
+def test_cleanup_dry_run_expires_planned_close_before_lockup_deferral():
+    """Dry-run clears a stale plan even when the refreshed vault is still locked.
+
+    1. Create an undersized HyperCore position with a planned full close.
+    2. Rehearse cleanup while the live vault reports an active lock-up.
+    3. Verify the isolated state expires the stale plan without preparing or broadcasting a replacement.
+
+    The live equity read is mocked because this unit test covers cleanup state
+    handling rather than HyperCore API behaviour.
+    """
+
+    # 1. Create an undersized HyperCore position with a planned full close.
+    state, position = _make_position(Decimal("3.45"))
+    old_close_trade = _create_planned_full_close(state, position)
+    candidates = discover_hypercore_small_positions(state, Decimal("5"))
+    state_before = state.to_json_safe()
+    routing_model = MagicMock()
+    execution_model = MagicMock()
+    store = MagicMock()
+
+    # 2. Rehearse cleanup while the live vault reports an active lock-up.
+    with patch(
+        "tradeexecutor.ethereum.vault.hypercore_small_position_cleanup.fetch_user_vault_equity",
+        return_value=SimpleNamespace(
+            equity=Decimal("3.45"),
+            is_lockup_expired=False,
+            locked_until=NOW + datetime.timedelta(days=1),
+        ),
+    ):
+        report = run_hypercore_small_position_cleanup(
+            state=state,
+            timestamp=NOW,
+            candidates=candidates,
+            execution_model=execution_model,
+            routing_model=routing_model,
+            routing_state=MagicMock(),
+            session=MagicMock(),
+            safe_address="0xSafe",
+            store=store,
+            dry_run=True,
+        )
+
+    # 3. Verify the isolated state expires the stale plan without preparing or broadcasting a replacement.
+    assert report.simulated_state is not None
+    simulated_position = report.simulated_state.portfolio.open_positions[
+        position.position_id
+    ]
+    assert simulated_position.trades[old_close_trade.trade_id].expired_at == NOW
+    assert old_close_trade.is_planned()
+    assert state.to_json_safe() == state_before
+    routing_model.setup_trades.assert_not_called()
+    execution_model.execute_trades.assert_not_called()
+    store.sync.assert_not_called()
 
 
 def test_cleanup_uses_strategy_minimum_allocation_and_pending_marker():
@@ -460,6 +522,7 @@ def test_cleanup_dry_run_validates_local_closure_without_mutating_state():
 
     # 1. Arrange a tracked HyperCore position whose live equity has become zero.
     state, position = _make_position(Decimal("3.45"))
+    old_close_trade = _create_planned_full_close(state, position)
     zero_candidate = HypercoreSmallPositionCandidate(
         position_id=position.position_id,
         vault_name="Loop Fund",
@@ -490,9 +553,12 @@ def test_cleanup_dry_run_validates_local_closure_without_mutating_state():
             dry_run=True,
         )
 
-    # 3. Verify the supplied state and state store remain untouched.
+    # 3. Verify the rehearsal expires the stale plan and leaves the supplied state and state store untouched.
     assert report.executed_trades == []
     assert report.closed_position_ids == []
+    assert report.simulated_state is not None
+    closed_position = report.simulated_state.portfolio.closed_positions[position.position_id]
+    assert closed_position.trades[old_close_trade.trade_id].expired_at == NOW
     assert state.to_json_safe() == state_before
     execution_model.execute_trades.assert_not_called()
     store.sync.assert_not_called()

--- a/tradeexecutor/cli/commands/correct_accounts.py
+++ b/tradeexecutor/cli/commands/correct_accounts.py
@@ -396,7 +396,7 @@ def correct_accounts(
     raise_on_unclean: bool = typer.Option(False, is_flag=True, envvar="RAISE_ON_UNCLEAN", help="Raise an exception if unclean. Unit test option."),
     skip_hypercore_transit_recovery: bool = Option(False, "--skip-hypercore-transit-recovery", envvar="SKIP_HYPERCORE_TRANSIT_RECOVERY", help="Skip automatic Safe-level HyperCore spot/perp USDC recovery before account correction."),
     cleanup_hypercore_small_positions: bool = Option(True, "--cleanup-hypercore-small-positions/--no-cleanup-hypercore-small-positions", envvar="CLEANUP_HYPERCORE_SMALL_POSITIONS", help="Redeem open HyperCore vault positions below the strategy minimum allocation before correcting accounts."),
-    dry_run: bool = Option(False, "--dry-run", envvar="DRY_RUN", help="Read live balances and report corrections and HyperCore small-position redemptions without persisting trades, broadcasting transactions, backing up, or saving state."),
+    dry_run: bool = Option(False, "--dry-run", envvar="DRY_RUN", help="Read live balances and fully prepare HyperCore small-position redemptions without persisting state or broadcasting transactions, then report accounting corrections."),
 
     # Derive exchange account options
     derive_owner_private_key: Optional[str] = Option(None, envvar="DERIVE_OWNER_PRIVATE_KEY", help="Derive owner wallet private key"),
@@ -422,8 +422,10 @@ def correct_accounts(
     positions cannot carry over with the current event based tracking logic.
 
     This command is interactive and you need to confirm any changes applied to the state.
-    Use ``--dry-run`` for a read-only report. Dry-run never broadcasts
-    transactions and does not write or back up the state file.
+    Use ``--dry-run`` for a read-only rehearsal. HyperCore cleanup performs
+    every pre-broadcast step on isolated state copies, including transaction
+    construction and signing. Dry-run never broadcasts transactions and does
+    not write or back up the state file.
 
     An old state file is automatically backed up.
     """
@@ -527,7 +529,7 @@ def correct_accounts(
         vault_address=vault_address,
         vault_adapter_address=vault_adapter_address,
         routing_hint=mod.trade_routing,
-        confirmation_block_count=0,
+        confirmation_block_count=1,
         max_slippage=slippage_tolerance,
         min_gas_balance=Decimal(0),
         vault_payment_forwarder_address=vault_payment_forwarder,
@@ -746,15 +748,17 @@ def correct_accounts(
                         state=state,
                         timestamp=native_datetime_utc_now(),
                         candidates=cleanup_candidates,
-                        execution_model=None if dry_run else execution_model,
-                        routing_model=None if dry_run else runner.routing_model,
-                        routing_state=None if dry_run else routing_state,
+                        execution_model=execution_model,
+                        routing_model=runner.routing_model,
+                        routing_state=routing_state,
                         session=session,
                         safe_address=sync_model.get_token_storage_address(),
                         store=store,
                         dry_run=dry_run,
                     )
                     if dry_run:
+                        assert cleanup_report.rehearsed_state is not None
+                        state = cleanup_report.rehearsed_state
                         logger.info(
                             "Dry run: HyperCore small-position cleanup found %d candidate(s)",
                             len(cleanup_report.candidates),

--- a/tradeexecutor/cli/commands/correct_accounts.py
+++ b/tradeexecutor/cli/commands/correct_accounts.py
@@ -396,7 +396,7 @@ def correct_accounts(
     raise_on_unclean: bool = typer.Option(False, is_flag=True, envvar="RAISE_ON_UNCLEAN", help="Raise an exception if unclean. Unit test option."),
     skip_hypercore_transit_recovery: bool = Option(False, "--skip-hypercore-transit-recovery", envvar="SKIP_HYPERCORE_TRANSIT_RECOVERY", help="Skip automatic Safe-level HyperCore spot/perp USDC recovery before account correction."),
     cleanup_hypercore_small_positions: bool = Option(True, "--cleanup-hypercore-small-positions/--no-cleanup-hypercore-small-positions", envvar="CLEANUP_HYPERCORE_SMALL_POSITIONS", help="Redeem open HyperCore vault positions below the strategy minimum allocation before correcting accounts."),
-    dry_run: bool = Option(False, "--dry-run", envvar="DRY_RUN", help="Read live balances and fully prepare HyperCore small-position redemptions without persisting state or broadcasting transactions, then report accounting corrections."),
+    dry_run: bool = Option(False, "--dry-run", envvar="DRY_RUN", help="Read live balances, rehearse HyperCore cleanup through phase-1 transaction construction without persisting state or broadcasting, then report accounting corrections."),
 
     # Derive exchange account options
     derive_owner_private_key: Optional[str] = Option(None, envvar="DERIVE_OWNER_PRIVATE_KEY", help="Derive owner wallet private key"),
@@ -743,7 +743,7 @@ def correct_accounts(
                 api_url = HYPERLIQUID_TESTNET_API_URL if is_testnet else HYPERLIQUID_API_URL
                 session = create_hyperliquid_session(api_url=api_url)
                 ensure_routing_setup()
-                if dry_run or routing_state is not None:
+                if routing_state is not None:
                     cleanup_report = run_hypercore_small_position_cleanup(
                         state=state,
                         timestamp=native_datetime_utc_now(),
@@ -757,8 +757,8 @@ def correct_accounts(
                         dry_run=dry_run,
                     )
                     if dry_run:
-                        assert cleanup_report.rehearsed_state is not None
-                        state = cleanup_report.rehearsed_state
+                        assert cleanup_report.simulated_state is not None
+                        state = cleanup_report.simulated_state
                         logger.info(
                             "Dry run: HyperCore small-position cleanup found %d candidate(s)",
                             len(cleanup_report.candidates),

--- a/tradeexecutor/ethereum/execution.py
+++ b/tradeexecutor/ethereum/execution.py
@@ -47,7 +47,6 @@ from tradeexecutor.strategy.generic.generic_router import GenericRouting
 from tradeexecutor.strategy.routing import RoutingModel, RoutingState
 from tradeexecutor.strategy.trading_strategy_universe import TradingStrategyUniverse
 from tradeexecutor.ethereum.ethereum_protocol_adapters import EthereumPairConfigurator
-from eth_defi.compat import native_datetime_utc_now
 
 
 logger = logging.getLogger(__name__)
@@ -794,9 +793,7 @@ class EthereumExecution(ExecutionModel):
         if self.disable_broadcast:
             return
 
-        if self.web3.eth.chain_id not in (ChainId.ethereum_tester.value, ChainId.anvil.value):
-            if not self.mainnet_fork:
-                assert self.confirmation_block_count > 0, f"confirmation_block_count set to {self.confirmation_block_count} "
+        self.validate_confirmation_configuration()
 
         if routing_model.needs_sequential_trade_execution(trades) and not rebroadcast:
             self._execute_trades_sequentially(
@@ -838,6 +835,18 @@ class EthereumExecution(ExecutionModel):
         freeze_position_on_failed_trade(ts, state, trades)
         for trade in trades:
             self._log_trade_outcome(trade)
+
+    def validate_confirmation_configuration(self) -> None:
+        """Check that live transaction confirmation can run before broadcasting."""
+
+        is_development_chain = self.web3.eth.chain_id in (
+            ChainId.ethereum_tester.value,
+            ChainId.anvil.value,
+        )
+        if not is_development_chain and not self.mainnet_fork:
+            assert self.confirmation_block_count > 0, (
+                f"confirmation_block_count set to {self.confirmation_block_count}"
+            )
 
     def get_routing_state_details(self) -> RoutingStateDetails:
         return {

--- a/tradeexecutor/ethereum/vault/README-vault-position-manual.md
+++ b/tradeexecutor/ethereum/vault/README-vault-position-manual.md
@@ -215,12 +215,21 @@ instead of the normal 1.50 USDC full-close margin, then falls back to 0.25,
 0.50, and 1.00 USDC verified retry margins if HyperCore silently no-ops.
 Positions at or below 0.30 USDC are closed locally because they cannot produce
 enough balance movement to verify every withdrawal phase safely. Larger
-residuals remain tracked for another direct redemption pass. Preview the live
-actions without changing persisted state or broadcasting transactions:
+residuals remain tracked for another direct redemption pass. An unstarted
+planned trade is expired before cleanup replaces it; started or broadcast
+trades are left alone.
+
+Preview the live actions without changing persisted state or broadcasting
+transactions:
 
 ```shell
 poetry run trade-executor correct-accounts --dry-run
 ```
+
+Dry-run uses isolated state copies to perform live lock-up and withdrawal
+preflight checks, supersede unstarted plans, create the replacement close
+trade, route it, and construct and sign the phase-1 transaction. It stops
+before broadcast and settlement.
 
 Do not use `--skip-save` as a dry-run substitute: it only skips the final state
 write and may still broadcast transactions.

--- a/tradeexecutor/ethereum/vault/README-vault-position-manual.md
+++ b/tradeexecutor/ethereum/vault/README-vault-position-manual.md
@@ -215,9 +215,9 @@ instead of the normal 1.50 USDC full-close margin, then falls back to 0.25,
 0.50, and 1.00 USDC verified retry margins if HyperCore silently no-ops.
 Positions at or below 0.30 USDC are closed locally because they cannot produce
 enough balance movement to verify every withdrawal phase safely. Larger
-residuals remain tracked for another direct redemption pass. An unstarted
-planned trade is expired before cleanup replaces it; started or broadcast
-trades are left alone.
+residuals remain tracked for another direct redemption pass. A planned trade
+that has not entered execution is expired before cleanup replaces it; started
+or broadcast trades are left alone.
 
 Preview the live actions without changing persisted state or broadcasting
 transactions:
@@ -227,9 +227,9 @@ poetry run trade-executor correct-accounts --dry-run
 ```
 
 Dry-run uses isolated state copies to perform live lock-up and withdrawal
-preflight checks, supersede unstarted plans, create the replacement close
-trade, route it, and construct and sign the phase-1 transaction. It stops
-before broadcast and settlement.
+preflight checks, supersede planned trades that have not entered execution,
+create the replacement close trade, route it, and construct and sign the
+phase-1 transaction. It stops before broadcast and settlement.
 
 Do not use `--skip-save` as a dry-run substitute: it only skips the final state
 write and may still broadcast transactions.

--- a/tradeexecutor/ethereum/vault/hypercore_small_position_cleanup.py
+++ b/tradeexecutor/ethereum/vault/hypercore_small_position_cleanup.py
@@ -20,6 +20,7 @@ locally as protocol dust. If a routed trade fails, the updated state is saved
 and the normal failed-trade repair flow takes over.
 """
 
+import copy
 import datetime
 import logging
 from dataclasses import dataclass, replace
@@ -33,6 +34,7 @@ from tradeexecutor.ethereum.vault.hypercore_routing import (
 )
 from tradeexecutor.state.freeze import freeze_position_on_failed_trade
 from tradeexecutor.state.repair import close_position_with_empty_trade
+from tradeexecutor.state.state import State
 from tradeexecutor.state.trade import TradeExecution, TradeType
 from tradeexecutor.strategy.dust import (
     HYPERCORE_SMALL_POSITION_CLEANUP_CLOSE_EPSILON,
@@ -80,6 +82,7 @@ class HypercoreSmallPositionCleanupReport:
     candidates: list[HypercoreSmallPositionCandidate]
     executed_trades: list[TradeExecution]
     closed_position_ids: list[int]
+    rehearsed_state: State | None = None
 
 
 def get_hypercore_minimum_allocation(parameters) -> Decimal | None:
@@ -152,6 +155,35 @@ def discover_hypercore_small_positions(
     return candidates
 
 
+def _expire_unstarted_hypercore_trades(
+    position,
+    timestamp: datetime.datetime,
+) -> None:
+    """Expire stale plans that cleanup must supersede.
+
+    Started and broadcast trades are filtered out during candidate discovery.
+    A merely planned trade has no allocated transaction and cannot execute by
+    itself, but its quantity still affects ``get_quantity(planned=True)``.
+    """
+
+    planned_trades = [
+        trade
+        for trade in position.trades.values()
+        if trade.is_planned()
+    ]
+    for trade in planned_trades:
+        trade.mark_expired(timestamp)
+        trade.add_note(
+            "Expired by correct-accounts before HyperCore small-position cleanup "
+            "superseded this unstarted trade."
+        )
+        logger.warning(
+            "Expired unstarted trade %d before cleaning HyperCore position %d",
+            trade.trade_id,
+            position.position_id,
+        )
+
+
 def plan_hypercore_small_position_cleanup(
     state,
     candidate: HypercoreSmallPositionCandidate,
@@ -179,6 +211,8 @@ def plan_hypercore_small_position_cleanup(
             f"allocation {candidate.minimum_allocation:.6f} USDC"
         )
     note_prefix = f"correct-accounts HyperCore small-position cleanup: {cleanup_reason}."
+
+    _expire_unstarted_hypercore_trades(position, timestamp)
 
     close_quantity = -position.get_quantity(planned=True)
     assert close_quantity < 0, (
@@ -271,10 +305,12 @@ def run_hypercore_small_position_cleanup(
     without broadcasting.
 
     :param dry_run:
-        Refresh and report eligible positions without creating trades,
-        broadcasting transactions, or saving state.
+        Rehearse local position closure or the complete trade preparation path
+        on an isolated state copy. No transactions are broadcast and neither
+        the supplied state nor its store is changed.
     """
 
+    working_state = copy.deepcopy(state) if dry_run else state
     executed_trades: list[TradeExecution] = []
     closed_position_ids: list[int] = []
 
@@ -297,18 +333,19 @@ def run_hypercore_small_position_cleanup(
 
         live_equity = Decimal(0) if live_equity_result is None else live_equity_result.equity
         if live_equity <= 0:
-            if dry_run:
-                logger.info(
-                    "Dry run: would close zero-equity HyperCore position %d (%s)",
-                    candidate.position_id,
-                    candidate.vault_name,
-                )
-                continue
-            position = state.portfolio.open_positions.get(candidate.position_id)
+            position = working_state.portfolio.open_positions.get(candidate.position_id)
             if position is not None:
-                close_position_with_empty_trade(state.portfolio, position)
-                store.sync(state)
-                closed_position_ids.append(candidate.position_id)
+                close_position_with_empty_trade(working_state.portfolio, position)
+                if dry_run:
+                    logger.info(
+                        "Dry run: validated local closure of zero-equity HyperCore "
+                        "position %d (%s)",
+                        candidate.position_id,
+                        candidate.vault_name,
+                    )
+                else:
+                    store.sync(working_state)
+                    closed_position_ids.append(candidate.position_id)
             continue
         if live_equity >= candidate.minimum_allocation and not candidate.is_pending_cleanup:
             logger.info(
@@ -331,38 +368,72 @@ def run_hypercore_small_position_cleanup(
         current_candidate = replace(candidate, live_equity=live_equity)
 
         if live_equity <= HYPERCORE_SMALL_POSITION_MINIMUM_REDEEMABLE_EQUITY:
-            if dry_run:
-                logger.info(
-                    "Dry run: would close HyperCore position %d (%s) locally because "
-                    "%.6f USDC is not enough to verify all withdrawal phases",
-                    candidate.position_id,
-                    candidate.vault_name,
-                    live_equity,
-                )
-                continue
-            position = state.portfolio.open_positions.get(candidate.position_id)
+            position = working_state.portfolio.open_positions.get(candidate.position_id)
             if position is not None:
-                close_position_with_empty_trade(state.portfolio, position)
+                close_position_with_empty_trade(working_state.portfolio, position)
                 position.add_notes_message(
                     "correct-accounts closed the HyperCore position locally because "
                     f"{live_equity:.6f} USDC was not enough to verify all withdrawal phases"
                 )
-                store.sync(state)
-                closed_position_ids.append(candidate.position_id)
+                if dry_run:
+                    logger.info(
+                        "Dry run: validated local closure of HyperCore position %d "
+                        "(%s) because %.6f USDC is not enough to verify all "
+                        "withdrawal phases",
+                        candidate.position_id,
+                        candidate.vault_name,
+                        live_equity,
+                    )
+                else:
+                    store.sync(working_state)
+                    closed_position_ids.append(candidate.position_id)
             continue
 
         if dry_run:
+            working_position = working_state.portfolio.open_positions[
+                current_candidate.position_id
+            ]
+            _expire_unstarted_hypercore_trades(working_position, timestamp)
+        preparation_state = copy.deepcopy(working_state) if dry_run else working_state
+
+        trades = plan_hypercore_small_position_cleanup(
+            preparation_state,
+            current_candidate,
+            timestamp,
+        )
+        if dry_run:
+            assert execution_model is not None
+            assert routing_model is not None
+            assert routing_state is not None
+            execution_model.validate_confirmation_configuration()
+            trade = trades[0]
+            preparation_state.start_execution(
+                timestamp,
+                trade,
+                underflow_check=False,
+            )
+            max_slippage = getattr(execution_model, "max_slippage", None)
+            if max_slippage is not None:
+                trade.planned_max_slippage = max_slippage
+            routing_model.setup_trades(
+                state=preparation_state,
+                routing_state=routing_state,
+                trades=trades,
+                check_balances=False,
+                rebroadcast=False,
+            )
             logger.info(
-                "Dry run: would redeem HyperCore small position %d (%s), "
-                "live equity %.6f USDC, strategy minimum allocation %.6f USDC",
+                "Dry run: validated HyperCore small-position withdrawal %d (%s), "
+                "live equity %.6f USDC, strategy minimum allocation %.6f USDC, "
+                "prepared %d transaction(s) without broadcasting",
                 current_candidate.position_id,
                 current_candidate.vault_name,
                 current_candidate.live_equity,
                 current_candidate.minimum_allocation,
+                len(trade.blockchain_transactions),
             )
             continue
 
-        trades = plan_hypercore_small_position_cleanup(state, current_candidate, timestamp)
         logger.info(
             "Cleaning HyperCore small position %d (%s): equity %.6f USDC, "
             "minimum allocation %.6f USDC, action=redeem",
@@ -374,7 +445,7 @@ def run_hypercore_small_position_cleanup(
         try:
             execution_model.execute_trades(
                 timestamp,
-                state,
+                working_state,
                 trades,
                 routing_model,
                 routing_state,
@@ -383,8 +454,8 @@ def run_hypercore_small_position_cleanup(
         except (ExecutionHaltableIssue, HypercoreWithdrawalPreflightError) as e:
             trade = trades[0]
             if isinstance(e, HypercoreWithdrawalPreflightError) and trade.is_started():
-                state.mark_trade_failed(timestamp, trade)
-                freeze_position_on_failed_trade(timestamp, state, [trade])
+                working_state.mark_trade_failed(timestamp, trade)
+                freeze_position_on_failed_trade(timestamp, working_state, [trade])
             elif isinstance(e, HypercoreWithdrawalPreflightError) and trade.is_planned():
                 trade.mark_expired(timestamp)
             logger.error(
@@ -398,19 +469,19 @@ def run_hypercore_small_position_cleanup(
         else:
             executed_trades.extend(trades)
         finally:
-            store.sync(state)
+            store.sync(working_state)
 
         trade = trades[0]
         if not trade.is_success():
             continue
 
         residual_equity = _close_confirmed_hypercore_residual(
-            state=state,
+            state=working_state,
             candidate=current_candidate,
             session=session,
             safe_address=safe_address,
         )
-        store.sync(state)
+        store.sync(working_state)
         if residual_equity is None:
             closed_position_ids.append(candidate.position_id)
 
@@ -418,4 +489,5 @@ def run_hypercore_small_position_cleanup(
         candidates=candidates,
         executed_trades=executed_trades,
         closed_position_ids=closed_position_ids,
+        rehearsed_state=working_state if dry_run else None,
     )

--- a/tradeexecutor/ethereum/vault/hypercore_small_position_cleanup.py
+++ b/tradeexecutor/ethereum/vault/hypercore_small_position_cleanup.py
@@ -164,7 +164,7 @@ def _expire_planned_hypercore_trades(
     position,
     timestamp: datetime.datetime,
 ) -> None:
-    """Expire stale plans that cleanup must supersede.
+    """Expire stale plans before cleanup evaluates a candidate.
 
     Started and broadcast trades are filtered out during candidate discovery.
     A planned trade has not entered execution and cannot execute by itself, but
@@ -180,10 +180,10 @@ def _expire_planned_hypercore_trades(
         trade.mark_expired(timestamp)
         trade.add_note(
             "Expired by correct-accounts before HyperCore small-position cleanup "
-            "superseded this planned trade."
+            "evaluated this position."
         )
         logger.warning(
-            "Expired planned trade %d before cleaning HyperCore position %d",
+            "Expired planned trade %d before evaluating HyperCore position %d",
             trade.trade_id,
             position.position_id,
         )
@@ -324,6 +324,12 @@ def run_hypercore_small_position_cleanup(
     closed_position_ids: list[int] = []
 
     for candidate in candidates:
+        working_position = working_state.portfolio.open_positions.get(
+            candidate.position_id
+        )
+        if working_position is None:
+            continue
+
         try:
             live_equity_result = fetch_user_vault_equity(
                 session,
@@ -340,21 +346,20 @@ def run_hypercore_small_position_cleanup(
             )
             continue
 
+        _expire_planned_hypercore_trades(working_position, timestamp)
         live_equity = Decimal(0) if live_equity_result is None else live_equity_result.equity
         if live_equity <= 0:
-            position = working_state.portfolio.open_positions.get(candidate.position_id)
-            if position is not None:
-                close_position_with_empty_trade(working_state.portfolio, position)
-                if dry_run:
-                    logger.info(
-                        "Dry run: validated local closure of zero-equity HyperCore "
-                        "position %d (%s)",
-                        candidate.position_id,
-                        candidate.vault_name,
-                    )
-                else:
-                    store.sync(working_state)
-                    closed_position_ids.append(candidate.position_id)
+            close_position_with_empty_trade(working_state.portfolio, working_position)
+            if dry_run:
+                logger.info(
+                    "Dry run: validated local closure of zero-equity HyperCore "
+                    "position %d (%s)",
+                    candidate.position_id,
+                    candidate.vault_name,
+                )
+            else:
+                store.sync(working_state)
+                closed_position_ids.append(candidate.position_id)
             continue
         if live_equity >= candidate.minimum_allocation and not candidate.is_pending_cleanup:
             logger.info(
@@ -377,31 +382,25 @@ def run_hypercore_small_position_cleanup(
         current_candidate = replace(candidate, live_equity=live_equity)
 
         if live_equity <= HYPERCORE_SMALL_POSITION_MINIMUM_REDEEMABLE_EQUITY:
-            position = working_state.portfolio.open_positions.get(candidate.position_id)
-            if position is not None:
-                close_position_with_empty_trade(working_state.portfolio, position)
-                position.add_notes_message(
-                    "correct-accounts closed the HyperCore position locally because "
-                    f"{live_equity:.6f} USDC was not enough to verify all withdrawal phases"
+            close_position_with_empty_trade(working_state.portfolio, working_position)
+            working_position.add_notes_message(
+                "correct-accounts closed the HyperCore position locally because "
+                f"{live_equity:.6f} USDC was not enough to verify all withdrawal phases"
+            )
+            if dry_run:
+                logger.info(
+                    "Dry run: validated local closure of HyperCore position %d "
+                    "(%s) because %.6f USDC is not enough to verify all "
+                    "withdrawal phases",
+                    candidate.position_id,
+                    candidate.vault_name,
+                    live_equity,
                 )
-                if dry_run:
-                    logger.info(
-                        "Dry run: validated local closure of HyperCore position %d "
-                        "(%s) because %.6f USDC is not enough to verify all "
-                        "withdrawal phases",
-                        candidate.position_id,
-                        candidate.vault_name,
-                        live_equity,
-                    )
-                else:
-                    store.sync(working_state)
-                    closed_position_ids.append(candidate.position_id)
+            else:
+                store.sync(working_state)
+                closed_position_ids.append(candidate.position_id)
             continue
 
-        working_position = working_state.portfolio.open_positions[
-            current_candidate.position_id
-        ]
-        _expire_planned_hypercore_trades(working_position, timestamp)
         preparation_state = copy.deepcopy(working_state) if dry_run else working_state
 
         trade = plan_hypercore_small_position_cleanup(

--- a/tradeexecutor/ethereum/vault/hypercore_small_position_cleanup.py
+++ b/tradeexecutor/ethereum/vault/hypercore_small_position_cleanup.py
@@ -77,12 +77,17 @@ class HypercoreSmallPositionCandidate:
 
 @dataclass(slots=True)
 class HypercoreSmallPositionCleanupReport:
-    """Outcome of one small-position cleanup pass."""
+    """Outcome of one small-position cleanup pass.
+
+    ``executed_trades`` and ``closed_position_ids`` contain live outcomes only.
+    ``simulated_state`` contains dry-run local closures and expired plans, but
+    not the replacement trade or its signed transaction.
+    """
 
     candidates: list[HypercoreSmallPositionCandidate]
     executed_trades: list[TradeExecution]
     closed_position_ids: list[int]
-    rehearsed_state: State | None = None
+    simulated_state: State | None = None
 
 
 def get_hypercore_minimum_allocation(parameters) -> Decimal | None:
@@ -123,7 +128,7 @@ def discover_hypercore_small_positions(
         if position.has_unexecuted_trades():
             logger.warning(
                 "Skipping HyperCore small-position cleanup for position %d: "
-                "it has unfinished trades",
+                "it has a started or broadcast trade",
                 position.position_id,
             )
             continue
@@ -155,15 +160,15 @@ def discover_hypercore_small_positions(
     return candidates
 
 
-def _expire_unstarted_hypercore_trades(
+def _expire_planned_hypercore_trades(
     position,
     timestamp: datetime.datetime,
 ) -> None:
     """Expire stale plans that cleanup must supersede.
 
     Started and broadcast trades are filtered out during candidate discovery.
-    A merely planned trade has no allocated transaction and cannot execute by
-    itself, but its quantity still affects ``get_quantity(planned=True)``.
+    A planned trade has not entered execution and cannot execute by itself, but
+    its quantity still affects ``get_quantity(planned=True)``.
     """
 
     planned_trades = [
@@ -175,10 +180,10 @@ def _expire_unstarted_hypercore_trades(
         trade.mark_expired(timestamp)
         trade.add_note(
             "Expired by correct-accounts before HyperCore small-position cleanup "
-            "superseded this unstarted trade."
+            "superseded this planned trade."
         )
         logger.warning(
-            "Expired unstarted trade %d before cleaning HyperCore position %d",
+            "Expired planned trade %d before cleaning HyperCore position %d",
             trade.trade_id,
             position.position_id,
         )
@@ -188,7 +193,7 @@ def plan_hypercore_small_position_cleanup(
     state,
     candidate: HypercoreSmallPositionCandidate,
     timestamp: datetime.datetime,
-) -> list[TradeExecution]:
+) -> TradeExecution:
     """Create a full-close trade for a cleanup candidate with redeemable equity.
 
     ``MINIMUM_VAULT_DEPOSIT`` is deliberately irrelevant here because the
@@ -201,6 +206,12 @@ def plan_hypercore_small_position_cleanup(
     assert position.last_token_price > 0, (
         f"HyperCore cleanup position {position.position_id} has no usable price"
     )
+    assert not position.has_unexecuted_trades(), (
+        f"HyperCore cleanup position {position.position_id} has a trade in execution"
+    )
+    assert not position.has_planned_trades(), (
+        f"HyperCore cleanup position {position.position_id} has a stale planned trade"
+    )
 
     reserve_asset = state.portfolio.get_default_reserve_position().asset
     if candidate.is_pending_cleanup:
@@ -212,9 +223,7 @@ def plan_hypercore_small_position_cleanup(
         )
     note_prefix = f"correct-accounts HyperCore small-position cleanup: {cleanup_reason}."
 
-    _expire_unstarted_hypercore_trades(position, timestamp)
-
-    close_quantity = -position.get_quantity(planned=True)
+    close_quantity = -position.get_quantity()
     assert close_quantity < 0, (
         f"HyperCore cleanup position {position.position_id} has no positive quantity to close"
     )
@@ -230,12 +239,12 @@ def plan_hypercore_small_position_cleanup(
         position=position,
         closing=True,
         notes=(
-            f"{note_prefix} Redeeming the full planned quantity with the "
+            f"{note_prefix} Redeeming the full position quantity with the "
             "HyperCore small-position retry margin."
         ),
     )
     close_trade.other_data["hypercore_small_position_cleanup"] = True
-    return [close_trade]
+    return close_trade
 
 
 def _close_confirmed_hypercore_residual(
@@ -389,32 +398,30 @@ def run_hypercore_small_position_cleanup(
                     closed_position_ids.append(candidate.position_id)
             continue
 
-        if dry_run:
-            working_position = working_state.portfolio.open_positions[
-                current_candidate.position_id
-            ]
-            _expire_unstarted_hypercore_trades(working_position, timestamp)
+        working_position = working_state.portfolio.open_positions[
+            current_candidate.position_id
+        ]
+        _expire_planned_hypercore_trades(working_position, timestamp)
         preparation_state = copy.deepcopy(working_state) if dry_run else working_state
 
-        trades = plan_hypercore_small_position_cleanup(
+        trade = plan_hypercore_small_position_cleanup(
             preparation_state,
             current_candidate,
             timestamp,
         )
+        trades = [trade]
         if dry_run:
             assert execution_model is not None
             assert routing_model is not None
             assert routing_state is not None
             execution_model.validate_confirmation_configuration()
-            trade = trades[0]
             preparation_state.start_execution(
                 timestamp,
                 trade,
                 underflow_check=False,
             )
-            max_slippage = getattr(execution_model, "max_slippage", None)
-            if max_slippage is not None:
-                trade.planned_max_slippage = max_slippage
+            if execution_model.max_slippage is not None:
+                trade.planned_max_slippage = execution_model.max_slippage
             routing_model.setup_trades(
                 state=preparation_state,
                 routing_state=routing_state,
@@ -452,7 +459,6 @@ def run_hypercore_small_position_cleanup(
                 check_balances=False,
             )
         except (ExecutionHaltableIssue, HypercoreWithdrawalPreflightError) as e:
-            trade = trades[0]
             if isinstance(e, HypercoreWithdrawalPreflightError) and trade.is_started():
                 working_state.mark_trade_failed(timestamp, trade)
                 freeze_position_on_failed_trade(timestamp, working_state, [trade])
@@ -471,7 +477,6 @@ def run_hypercore_small_position_cleanup(
         finally:
             store.sync(working_state)
 
-        trade = trades[0]
         if not trade.is_success():
             continue
 
@@ -489,5 +494,5 @@ def run_hypercore_small_position_cleanup(
         candidates=candidates,
         executed_trades=executed_trades,
         closed_position_ids=closed_position_ids,
-        rehearsed_state=working_state if dry_run else None,
+        simulated_state=working_state if dry_run else None,
     )


### PR DESCRIPTION
## Why

Production `correct-accounts` selected HyperCore position 57 even though an unstarted planned close already consumed its planned quantity. The live command then failed while constructing the replacement close. The earlier dry-run did not catch this because it stopped before trade planning, routing, transaction construction, and execution configuration validation.

## Lessons learnt

A useful dry-run must execute the same pre-broadcast path as the live command on isolated state, rather than merely report eligible candidates. HyperCore cleanup must also distinguish unstarted plans from started or broadcast trades: unstarted plans cannot execute by themselves but still affect planned quantity and must be deliberately superseded.

## Summary

- Rehearse local closure, stale-plan reconciliation, close planning, live withdrawal preflight, routing, signing, and phase-1 transaction construction on isolated state copies.
- Expire unstarted planned trades before creating the replacement HyperCore cleanup close, while continuing to defer positions with started or broadcast trades.
- Reuse live confirmation configuration validation during dry-run and configure `correct-accounts` with one confirmation block.
- Carry a reconciled shadow state through the remaining dry-run accounting and coherence checks without writing the state file.
- Add regression coverage for the production planned-close state shape and document the expanded dry-run behaviour.
