### PR TITLE
fix: recover async vault direct payouts

### DIFF
--- a/docs/reports/cross-chain-vault-test-trade-executor.md
+++ b/docs/reports/cross-chain-vault-test-trade-executor.md
@@ -1,5 +1,23 @@
 # Trade-executor cross-chain vault test report
 
+## 2026-07-30 settlement update
+
+The 2026-07-25 matrix below is a historical baseline, not the current Ember or
+Plutus support status. With the follow-up eth-defi settlement driver and
+executor direct-payout recovery, a targeted rerun completed all five previously
+unsupported async redemptions:
+
+| Protocol | Vaults | Current result |
+|---|---:|---|
+| Ember | 4 | Success (simulated): the operator queue processing was recovered as a direct payout |
+| Plutus | 1 | Success (simulated): the fulfilled redemption was claimed through the Safe module |
+
+The Ember result can include synthetic Anvil denomination-token liquidity. It
+proves that the request, operator settlement, receipt analysis and executor
+lifecycle are wired correctly; it does **not** prove that the live vault or
+operator can fund its FIFO queue. The selected rerun is not a replacement for a
+new 129-vault matrix.
+
 ## Evidence and scope
 
 The 129-vault cross-chain matrix was re-run on 2026-07-25 with the updated
@@ -20,7 +38,7 @@ per-vault table is
 the executor-side work; protocol adapter work is in the separate eth-defi
 report.
 
-## Corrected matrix output
+## 2026-07-25 historical matrix output
 
 | Status | Vaults | Baseline (eth-defi b5803bdc5) | Interpretation |
 |---|---:|---:|---|
@@ -42,13 +60,13 @@ baseline "redemption pending" rows (four Ember, two Gains) that were not
 recognised as asynchronous are now terminal typed results, and Ember's minimum
 withdrawal and async capability are surfaced with structured metadata.
 
-## What the eth-defi update changed (observed)
+## What the 2026-07-25 eth-defi update changed (observed)
 
 - **40acres: 2 → 1 gap.** 40acres Aerodrome USDC (Base) now completes deposit
   and redemption — the PR #1577 redemption-share reconciliation fix is
   effective on that path.
 - **Ember / Gains async classification.** Four Ember vaults and Gains on Base
-  now report `simulation_unsupported_async` with
+  then reported `simulation_unsupported_async` with
   `VaultDepositManagerCapability` metadata (`deposit_flow=synchronous`,
   `redemption_flow=asynchronous`) instead of the previous
   "Failed to analyse vault tx" receipt errors.
@@ -61,7 +79,7 @@ withdrawal and async capability are surfaced with structured metadata.
 | Protocol | Gaps | Baseline | Owner of remaining fix |
 |---|---:|---:|---|
 | Lagoon Finance | 6 | 6 | eth-defi (settlement diagnostics + allowance path) |
-| Ember | 5 | 5 | eth-defi (Anvil settlement driver + minimum typing) |
+| Ember | 5 | 5 | eth-defi (Anvil settlement driver + minimum typing); four queue rows resolved in the 2026-07-30 targeted rerun |
 | cSigma Finance | 2 | 2 | eth-defi (capacity typing + async withdrawal) |
 | Gains Network | 2 | 2 | eth-defi (Anvil settlement + custom error) |
 | YieldNest | 1 | 1 | eth-defi (custom error decode) |
@@ -73,10 +91,12 @@ withdrawal and async capability are surfaced with structured metadata.
 
 ## Trade-executor work items
 
-No protocol-specific settlement logic belongs in trade-executor. The items below
-are diagnostics, cross-chain reconciliation and provenance. Sections marked
-*done* were implemented on this branch; section 2 was investigated and found not
-to be an executor defect at all.
+Protocol-specific settlement actions belong in eth-defi. Trade-executor owns the
+generic lifecycle around them, including scanning closed positions and recovering
+an operator-finalised direct payout through the manager's validated transaction
+lookup. The items below are diagnostics, cross-chain reconciliation and
+provenance. Sections marked *done* were implemented on this branch; section 2
+was investigated and found not to be an executor defect at all.
 
 ### 1. Surface the real revert reason for home-chain vault redemptions — done
 

--- a/docs/reports/cross-chain-vault-test-trade-executor.md
+++ b/docs/reports/cross-chain-vault-test-trade-executor.md
@@ -4,19 +4,22 @@
 
 The 2026-07-25 matrix below is a historical baseline, not the current Ember or
 Plutus support status. With the follow-up eth-defi settlement driver and
-executor direct-payout recovery, a targeted rerun completed all five previously
-unsupported async redemptions:
+executor direct-payout recovery, a targeted rerun completed the selected five
+previously unresolved async redemptions:
 
 | Protocol | Vaults | Current result |
 |---|---:|---|
-| Ember | 4 | Success (simulated): the operator queue processing was recovered as a direct payout |
-| Plutus | 1 | Success (simulated): the fulfilled redemption was claimed through the Safe module |
+| Ember | 4 | Previously `simulation_unsupported_async`; now success (simulated) after operator direct-payout recovery |
+| Plutus | 1 | Previously redemption unavailable; now success (simulated) through the Safe module |
 
 The Ember result can include synthetic Anvil denomination-token liquidity. It
 proves that the request, operator settlement, receipt analysis and executor
 lifecycle are wired correctly; it does **not** prove that the live vault or
 operator can fund its FIFO queue. The selected rerun is not a replacement for a
-new 129-vault matrix.
+new 129-vault matrix. The source files were `/tmp/async-vault-settlement-final-4/report.json`
+and `/tmp/async-vault-settlement-final-4/run.log`, using trade-executor branch
+`fix/plutus-satellite-settlement` with eth-defi branch
+`fix/async-vault-anvil-settlement` first on `PYTHONPATH`.
 
 ## Evidence and scope
 

--- a/tests/ethereum/test_vault_settlement_lifecycle.py
+++ b/tests/ethereum/test_vault_settlement_lifecycle.py
@@ -309,6 +309,54 @@ def test_vault_settlement_retry_scans_closed_async_redemption(
     assert resolve.call_args.args[1] is trade
 
 
+def test_vault_settlement_retry_skips_simulated_closed_redemption(
+    vault_pair: TradingPairIdentifier,
+    usdc_arbitrum: AssetIdentifier,
+) -> None:
+    """Keep persisted fork diagnostics out of the live settlement retry loop.
+
+    1. Create a closed pending redemption retained as a simulated diagnostic.
+    2. Run the generic settlement scan with the per-trade resolver mocked.
+    3. Verify no simulated trade is sent to a live-chain resolver.
+    """
+    state = State()
+    ts = datetime.datetime(2025, 1, 1)
+
+    # 1. Create a pending redemption and mark its closed position as simulated.
+    state.portfolio.initialise_reserves(usdc_arbitrum)
+    reserve = state.portfolio.get_default_reserve_position()
+    reserve.quantity = Decimal(10_000)
+    reserve.reserve_token_price = 1.0
+    trade = _create_vault_sell_trade(state, vault_pair, usdc_arbitrum, Decimal(100), ts)
+    state.start_execution(ts, trade)
+    trade.mark_broadcasted(ts)
+    state.mark_vault_settlement_pending(
+        ts,
+        trade,
+        {
+            "vault_address": OLP_ARBITRUM_ADDRESS,
+            "vault_owner": "0xTestOwner",
+            "vault_to": "0xTestOwner",
+            "vault_raw_amount": 100 * 10**18,
+            "vault_request_tx_hash": "0xsimulated_request",
+            "vault_settlement_id": 44,
+        },
+    )
+    position = state.portfolio.find_position_for_trade(trade)
+    position.simulated = True
+    state.portfolio.close_position(position, ts)
+
+    # 2. Run the live settlement scan.
+    execution_model = MagicMock()
+    with patch(
+        "tradeexecutor.ethereum.vault.settlement_retry._resolve_single_vault_trade"
+    ) as resolve:
+        check_and_resolve_vault_settlements(state=state, execution_model=execution_model)
+
+    # 3. Fork-only diagnostics cannot create live settlement transactions.
+    resolve.assert_not_called()
+
+
 def test_vault_settlement_retry_recovers_operator_direct_payout(
     monkeypatch: pytest.MonkeyPatch,
     vault_pair: TradingPairIdentifier,
@@ -347,6 +395,8 @@ def test_vault_settlement_retry_recovers_operator_direct_payout(
             "vault_initial_tx_count": 1,
         },
     )
+    position = state.portfolio.find_position_for_trade(trade)
+    state.portfolio.close_position(position, ts)
 
     # 2. Have its manager validate and return the operator payout transaction.
     ticket = MagicMock()
@@ -406,6 +456,7 @@ def test_vault_settlement_retry_recovers_operator_direct_payout(
     # 4. Verify the redemption is persisted as successful.
     assert resolved == [trade]
     assert trade.is_success()
+    assert position.is_closed()
     manager.finish_redemption.assert_not_called()
     assert trade.blockchain_transactions[-1].other["vault_settlement_action"] == "direct payout"
 

--- a/tests/ethereum/test_vault_settlement_lifecycle.py
+++ b/tests/ethereum/test_vault_settlement_lifecycle.py
@@ -259,6 +259,157 @@ def test_vault_settlement_pending_sell_not_counted(
     assert pending_value == pytest.approx(0.0)
 
 
+def test_vault_settlement_retry_scans_closed_async_redemption(
+    vault_pair: TradingPairIdentifier,
+    usdc_arbitrum: AssetIdentifier,
+) -> None:
+    """Resolve a redemption left pending after its position was closed.
+
+    1. Create an asynchronous vault redemption and move its zero-quantity
+       position to the closed collection.
+    2. Run the generic settlement scan with the per-trade resolver mocked.
+    3. Verify the pending redemption is still handed to the resolver.
+    """
+    state = State()
+    ts = datetime.datetime(2025, 1, 1)
+
+    # 1. Create and persist an asynchronous vault redemption.
+    state.portfolio.initialise_reserves(usdc_arbitrum)
+    reserve = state.portfolio.get_default_reserve_position()
+    reserve.quantity = Decimal(10_000)
+    reserve.reserve_token_price = 1.0
+    trade = _create_vault_sell_trade(state, vault_pair, usdc_arbitrum, Decimal(100), ts)
+    state.start_execution(ts, trade)
+    trade.mark_broadcasted(ts)
+    state.mark_vault_settlement_pending(
+        ts,
+        trade,
+        {
+            "vault_address": OLP_ARBITRUM_ADDRESS,
+            "vault_owner": "0xTestOwner",
+            "vault_to": "0xTestOwner",
+            "vault_raw_amount": 100 * 10**18,
+            "vault_request_tx_hash": "0xrequest_withdraw",
+            "vault_settlement_id": 43,
+        },
+    )
+    position = state.portfolio.find_position_for_trade(trade)
+    state.portfolio.close_position(position, ts)
+    assert trade.get_status() is TradeStatus.vault_settlement_pending
+
+    # 2. Resolve all pending vault trades.
+    execution_model = MagicMock()
+    with patch(
+        "tradeexecutor.ethereum.vault.settlement_retry._resolve_single_vault_trade"
+    ) as resolve:
+        check_and_resolve_vault_settlements(state=state, execution_model=execution_model)
+
+    # 3. The closed position's pending redemption remains eligible for claim.
+    resolve.assert_called_once()
+    assert resolve.call_args.args[1] is trade
+
+
+def test_vault_settlement_retry_recovers_operator_direct_payout(
+    monkeypatch: pytest.MonkeyPatch,
+    vault_pair: TradingPairIdentifier,
+    usdc_arbitrum: AssetIdentifier,
+) -> None:
+    """Resolve a redemption paid directly by a vault operator.
+
+    1. Create a pending redemption whose request has been consumed.
+    2. Have its manager validate and return the operator payout transaction.
+    3. Resolve the trade without attempting a depositor-owned claim call.
+    4. Verify the redemption is persisted as successful.
+    """
+    state = State()
+    ts = datetime.datetime(2025, 1, 1)
+
+    # 1. Create a pending redemption whose request has been consumed.
+    state.portfolio.initialise_reserves(usdc_arbitrum)
+    reserve = state.portfolio.get_default_reserve_position()
+    reserve.quantity = Decimal(10_000)
+    reserve.reserve_token_price = 1.0
+    trade = _create_vault_sell_trade(state, vault_pair, usdc_arbitrum, Decimal(100), ts)
+    state.start_execution(ts, trade)
+    trade.mark_broadcasted(ts)
+    request_tx = BlockchainTransaction()
+    request_tx.tx_hash = "0x" + "11" * 32
+    trade.blockchain_transactions = [request_tx]
+    state.mark_vault_settlement_pending(
+        ts,
+        trade,
+        {
+            "vault_address": OLP_ARBITRUM_ADDRESS,
+            "vault_owner": "0x0000000000000000000000000000000000000001",
+            "vault_to": "0x0000000000000000000000000000000000000001",
+            "vault_raw_shares": 100 * 10**18,
+            "vault_request_tx_hash": request_tx.tx_hash,
+            "vault_initial_tx_count": 1,
+        },
+    )
+
+    # 2. Have its manager validate and return the operator payout transaction.
+    ticket = MagicMock()
+    payout_tx_hash = HexBytes("0x" + "22" * 32)
+    manager = MagicMock()
+    manager.reconstruct_redemption_ticket.return_value = ticket
+    manager.get_redemption_request_status.return_value = AsyncVaultRequestStatus.none
+    manager.fetch_completed_redemption_tx_hash.return_value = payout_tx_hash
+    manager.get_redemption_ticket_delay_over.return_value = None
+    manager.analyse_redemption.return_value = DepositRedeemEventAnalysis(
+        from_="0x0000000000000000000000000000000000000001",
+        to="0x0000000000000000000000000000000000000001",
+        denomination_amount=Decimal(100),
+        share_count=Decimal(100),
+        tx_hash=payout_tx_hash,
+        block_number=123,
+        block_timestamp=ts,
+    )
+    vault = MagicMock()
+    vault.vault_contract.address = OLP_ARBITRUM_ADDRESS
+    vault.get_deposit_manager.return_value = manager
+
+    mock_web3 = MagicMock()
+    mock_web3.eth.get_transaction.return_value = {
+        "from": "0x0000000000000000000000000000000000000002",
+        "to": OLP_ARBITRUM_ADDRESS,
+        "nonce": 1,
+    }
+    receipt = {
+        "status": 1,
+        "transactionHash": payout_tx_hash,
+        "blockNumber": 123,
+        "blockHash": HexBytes("0x" + "33" * 32),
+        "effectiveGasPrice": 1,
+        "gasUsed": 2,
+    }
+    mock_web3.eth.get_transaction_receipt.return_value = receipt
+    execution_model = MagicMock()
+    execution_model.web3 = mock_web3
+
+    monkeypatch.setattr(
+        "tradeexecutor.ethereum.vault.settlement_retry.get_vault_for_pair",
+        lambda *_: vault,
+    )
+    monkeypatch.setattr(
+        "tradeexecutor.ethereum.vault.settlement_retry._find_already_completed_claim_tx_hash",
+        lambda *_: None,
+    )
+    monkeypatch.setattr(
+        "tradeexecutor.ethereum.vault.settlement_retry._wait_for_settlement_tx_receipt",
+        lambda *_: receipt,
+    )
+
+    # 3. Resolve the direct payout without constructing a user claim call.
+    resolved = check_and_resolve_vault_settlements(state, execution_model)
+
+    # 4. Verify the redemption is persisted as successful.
+    assert resolved == [trade]
+    assert trade.is_success()
+    manager.finish_redemption.assert_not_called()
+    assert trade.blockchain_transactions[-1].other["vault_settlement_action"] == "direct payout"
+
+
 def test_vault_settlement_pending_metadata_stored(
     vault_pair: TradingPairIdentifier,
     usdc_arbitrum: AssetIdentifier,

--- a/tests/ethereum/test_vault_settlement_lifecycle.py
+++ b/tests/ethereum/test_vault_settlement_lifecycle.py
@@ -297,7 +297,7 @@ def test_vault_settlement_retry_scans_closed_async_redemption(
     state.portfolio.close_position(position, ts)
     assert trade.get_status() is TradeStatus.vault_settlement_pending
 
-    # 2. Resolve all pending vault trades.
+    # 2. Mock the lower-level resolver to isolate position collection behaviour.
     execution_model = MagicMock()
     with patch(
         "tradeexecutor.ethereum.vault.settlement_retry._resolve_single_vault_trade"
@@ -346,7 +346,7 @@ def test_vault_settlement_retry_skips_simulated_closed_redemption(
     position.simulated = True
     state.portfolio.close_position(position, ts)
 
-    # 2. Run the live settlement scan.
+    # 2. Mock the lower-level resolver and run the live settlement scan.
     execution_model = MagicMock()
     with patch(
         "tradeexecutor.ethereum.vault.settlement_retry._resolve_single_vault_trade"
@@ -398,7 +398,8 @@ def test_vault_settlement_retry_recovers_operator_direct_payout(
     position = state.portfolio.find_position_for_trade(trade)
     state.portfolio.close_position(position, ts)
 
-    # 2. Have its manager validate and return the operator payout transaction.
+    # 2. Mock the manager and receipt because eth-defi owns protocol-specific
+    # event validation; this test covers the executor lifecycle only.
     ticket = MagicMock()
     payout_tx_hash = HexBytes("0x" + "22" * 32)
     manager = MagicMock()

--- a/tradeexecutor/ethereum/vault/settlement_retry.py
+++ b/tradeexecutor/ethereum/vault/settlement_retry.py
@@ -267,6 +267,10 @@ def check_and_resolve_vault_settlements(
         state.portfolio.closed_positions.values(),
     )
     for position in all_positions:
+        # vault-test-trade persists closed fork diagnostics in the ordinary
+        # state file. They must never be retried against a live chain.
+        if position.simulated:
+            continue
         for trade in position.trades.values():
             if trade.get_status() == TradeStatus.vault_settlement_pending:
                 pending_trades.append(trade)
@@ -551,6 +555,12 @@ def _resolve_single_vault_trade(
                 func = deposit_manager.finish_deposit(ticket)
             else:
                 func = deposit_manager.finish_redemption(ticket)
+            if func is None:
+                logger.error(
+                    "Vault reported claimable status without a claim call for trade #%d",
+                    trade.trade_id,
+                )
+                return
             is_reclaim_tx = False
         elif status == AsyncVaultRequestStatus.reclaimable:
             if direction == "deposit":

--- a/tradeexecutor/ethereum/vault/settlement_retry.py
+++ b/tradeexecutor/ethereum/vault/settlement_retry.py
@@ -257,11 +257,14 @@ def check_and_resolve_vault_settlements(
     """
     resolved: list[TradeExecution] = []
 
-    # Scan both open and pending positions
+    # An async redemption can move its position to closed before the operator
+    # fulfils the request. Keep scanning that trade until the later claim marks
+    # it successful.
     pending_trades: list[TradeExecution] = []
     all_positions = ichain(
         state.portfolio.open_positions.values(),
         state.portfolio.pending_positions.values(),
+        state.portfolio.closed_positions.values(),
     )
     for position in all_positions:
         for trade in position.trades.values():
@@ -495,6 +498,15 @@ def _resolve_single_vault_trade(
                 ticket,
                 direction,
             )
+            direct_payout = False
+            if recovered_tx_hash is None and direction == "redeem":
+                # Operator-finalised protocols do not emit a user claim. Their
+                # manager validates the protocol-specific direct payout event
+                # before exposing it as a terminal transaction.
+                recovered_tx_hash = deposit_manager.fetch_completed_redemption_tx_hash(
+                    ticket
+                )
+                direct_payout = recovered_tx_hash is not None
             if recovered_tx_hash is None:
                 logger.warning(
                     "Unexpected NONE status for vault trade #%d (direction=%s)",
@@ -502,11 +514,13 @@ def _resolve_single_vault_trade(
                 )
                 return
 
-            action_label = "claim"
             if direction == "deposit":
                 func = deposit_manager.finish_deposit(ticket)
-            else:
+            elif not direct_payout:
                 func = deposit_manager.finish_redemption(ticket)
+            else:
+                func = None
+            action_label = "direct payout" if direct_payout else "claim"
             # Even recovered claims need the same read-after-write guard before
             # immediate event analysis on multi-RPC providers.
             confirmed_receipt = _wait_for_settlement_tx_receipt(web3, recovered_tx_hash)
@@ -523,7 +537,8 @@ def _resolve_single_vault_trade(
             tx_already_confirmed = True
             is_reclaim_tx = False
             logger.info(
-                "Recovered already-confirmed vault claim for trade #%d from tx %s",
+                "Recovered already-confirmed vault %s for trade #%d from tx %s",
+                action_label,
                 trade.trade_id,
                 recovered_tx_hash.hex(),
             )


### PR DESCRIPTION
## Why

An asynchronous redemption can close its zero-quantity position before the
operator completes settlement. The retry loop then skipped the trade. In
addition, operator-finalised protocols such as Ember pay the receiver directly,
so there is no depositor claim transaction for the generic recovery path to
find.

## Lessons learnt

Position lifecycle and vault-settlement lifecycle are independent. Retrying a
validated direct payout must not construct a claim call: the protocol manager
must first identify the terminal payout transaction using its own event and
balance evidence.

## Summary

- Scan closed positions for trades still marked `vault_settlement_pending`.
- Exclude fork-only simulated diagnostics from the live settlement retry loop.
- Recover a manager-validated direct payout when a consumed redemption request
  has no user claim transaction.
- Preserve the normal receipt wait and redemption analysis before marking the
  trade successful.
- Add focused coverage and distinguish the historical 129-vault baseline from
  the current five-vault settlement rerun.

## Related issues and PRs

Continues #1588 and depends on
tradingstrategy-ai/web3-ethereum-defi#1415.
