### PR TITLE
fix: make HyperCore deposit settlement recovery-safe

### DIFF
--- a/.claude/docs/hypercore-vault.md
+++ b/.claude/docs/hypercore-vault.md
@@ -93,7 +93,7 @@ the contract between `setup_trades()` and `settle_trade()`:
 | `hypercore_phase1_perp_baseline_usdc` | setup, before withdrawal phase 1 | Perp withdrawable baseline; captured *before* broadcast because `vaultTransfer` can settle before receipt handling. |
 | `hypercore_phase1_vault_equity_usdc` | setup / preflight | Pre-withdrawal vault equity, the "before" value for detecting whether a withdrawal already reduced equity. |
 | `hypercore_activation_cost_raw` | setup, first buy | USDC consumed activating the Safe on HyperCore (deducted once per cycle). |
-| `hypercore_deposit_capital_at_risk` | before deposit phase 1 broadcast | Conservative checkpoint for USDC a node may already have accepted from the Safe. It blocks generic failed-buy refunds after a crash or indeterminate broadcast until live reconciliation. |
+| `hypercore_deposit_capital_at_risk` | during phase-1 preparation, persisted immediately before broadcast | Conservative checkpoint for USDC a node may already have accepted from the Safe. It blocks generic failed-buy refunds after a crash or indeterminate broadcast until live reconciliation. |
 | `hypercore_capped_deposit_raw` | deposit preflight | Deposit capped to actual Safe EVM USDC balance. |
 | `hypercore_capped_withdrawal_raw` | withdrawal preflight / retry | Withdrawal capped to live vault equity minus safety margin. |
 | `hypercore_stranded_usdc` | on failure | Records USDC stranded mid-pipeline (perp/spot) for operator recovery and retains its reserve allocation. |
@@ -203,12 +203,14 @@ deposit action automatically.
 | Perp→vault broadcast/confirmation is indeterminate | `hypercore_perp_or_vault` | Recheck both perp and vault equity before repeating anything. |
 | Receipt definitely reverts | Previous account (spot or perp) | The attempted action did not move funds. |
 
-`hypercore_deposit_capital_at_risk` is written before phase 1 is broadcast. It
-remains on a trade if the process dies, a receipt is missing, or a broadcast is
-ambiguous. Both automatic unconfirmed-trade repair and state-only `repair`
-refuse to release that allocation: inspect the Safe, EVM escrow, spot, perp
-and vault first with `check-hypercore-user.py`. A confirmed phase-1 revert is
-the only path that clears the marker and allows ordinary failed-buy accounting.
+`hypercore_deposit_capital_at_risk` is written during phase-1 preparation, and
+the execution model persists state after preparation and immediately before
+broadcast. It remains on a trade if the process dies, a receipt is missing, or
+a broadcast is ambiguous. Both automatic unconfirmed-trade repair and
+state-only `repair` refuse to release that allocation: inspect the Safe, EVM
+escrow, spot, perp and vault first with `check-hypercore-user.py`. A confirmed
+phase-1 revert clears the marker for ordinary failed-buy accounting; a fully
+confirmed vault deposit clears it as successful, non-transit capital.
 
 For recovery, USDC in perp must move **perp → spot** before `spotSend` can
 bridge it back to the HyperEVM Safe. Never run a recovery action from a timeout

--- a/.claude/docs/hypercore-vault.md
+++ b/.claude/docs/hypercore-vault.md
@@ -93,6 +93,7 @@ the contract between `setup_trades()` and `settle_trade()`:
 | `hypercore_phase1_perp_baseline_usdc` | setup, before withdrawal phase 1 | Perp withdrawable baseline; captured *before* broadcast because `vaultTransfer` can settle before receipt handling. |
 | `hypercore_phase1_vault_equity_usdc` | setup / preflight | Pre-withdrawal vault equity, the "before" value for detecting whether a withdrawal already reduced equity. |
 | `hypercore_activation_cost_raw` | setup, first buy | USDC consumed activating the Safe on HyperCore (deducted once per cycle). |
+| `hypercore_deposit_capital_at_risk` | before deposit phase 1 broadcast | Conservative checkpoint for USDC a node may already have accepted from the Safe. It blocks generic failed-buy refunds after a crash or indeterminate broadcast until live reconciliation. |
 | `hypercore_capped_deposit_raw` | deposit preflight | Deposit capped to actual Safe EVM USDC balance. |
 | `hypercore_capped_withdrawal_raw` | withdrawal preflight / retry | Withdrawal capped to live vault equity minus safety margin. |
 | `hypercore_stranded_usdc` | on failure | Records USDC stranded mid-pipeline (perp/spot) for operator recovery and retains its reserve allocation. |
@@ -127,7 +128,8 @@ A deposit walks USDC from the HyperEVM Safe into the HyperCore vault:
    HyperEVM Safe into HyperCore **spot** (built in `setup_trades`).
 2. **Escrow wait**: poll `spotClearinghouseState` until the bridged USDC clears
    the EVM escrow into spot (`wait_for_evm_escrow_clear`).
-3. **Phase 2**: `transferUsdClass(spot→perp)` then poll the perp balance.
+3. **Phase 2**: `transferUsdClass(spot→perp)` then prove both the spot
+   decrease and the perp increase.
 4. **Phase 3**: `vaultTransfer(perp→vault)` after the perp arrival is visible;
    `wait_for_vault_deposit_confirmation` verifies vault equity rose.
 
@@ -185,6 +187,33 @@ the funds were safely in the vault. The relative tolerance was raised to **5%**
 to absorb normal perp-vault volatility over the window while still catching
 genuinely rejected deposits (which show ~0% increase, not a few-percent
 shortfall).
+
+### Deposit failures, recovery and crashes
+
+The three CoreWriter actions are not atomic at the HyperCore boundary. A
+successful EVM receipt proves only EVM inclusion: HyperCore can apply the
+spot→perp action while silently not applying the following perp→vault action.
+The router records a conservative location and stops; it never retries a
+deposit action automatically.
+
+| Failure | Recorded location | Operator rule |
+|---|---|---|
+| Escrow wait times out | `hypercore_evm_escrow_or_spot` | Inspect before acting. |
+| Spot→perp broadcast/poll is indeterminate | `hypercore_spot_or_perp` | Do not send a vault transfer. |
+| Perp→vault broadcast/confirmation is indeterminate | `hypercore_perp_or_vault` | Recheck both perp and vault equity before repeating anything. |
+| Receipt definitely reverts | Previous account (spot or perp) | The attempted action did not move funds. |
+
+`hypercore_deposit_capital_at_risk` is written before phase 1 is broadcast. It
+remains on a trade if the process dies, a receipt is missing, or a broadcast is
+ambiguous. Both automatic unconfirmed-trade repair and state-only `repair`
+refuse to release that allocation: inspect the Safe, EVM escrow, spot, perp
+and vault first with `check-hypercore-user.py`. A confirmed phase-1 revert is
+the only path that clears the marker and allows ordinary failed-buy accounting.
+
+For recovery, USDC in perp must move **perp → spot** before `spotSend` can
+bridge it back to the HyperEVM Safe. Never run a recovery action from a timeout
+message alone; a late HyperCore settlement can otherwise turn a retry into a
+double deposit.
 
 ## Withdrawal (sell) flow
 
@@ -417,7 +446,8 @@ balance readers and `time.time` / `time.sleep`, then call a single verifier
 `_settle_withdrawal`) and assert on tolerances, fee handling, retries and
 failure branches. Files: `test_hypercore_dual_chain.py`,
 `test_hypercore_routing.py`, `test_hypercore_deposit_verification.py`,
-`test_hypercore_stranded_usdc.py`, `test_hypercore_escrow_robust.py`.
+`test_hypercore_deposit_settlement.py`, `test_hypercore_stranded_usdc.py`,
+`test_hypercore_escrow_robust.py`.
 
 When mocking, patch in the module namespace
 (`tradeexecutor.ethereum.vault.hypercore_routing.<name>`), and remember that

--- a/.claude/docs/hypercore-vault.md
+++ b/.claude/docs/hypercore-vault.md
@@ -253,24 +253,9 @@ For #1486, the default dry run above plans exactly
 option is necessary. The recovery is on by default for every eligible
 HyperCore vault strategy, as are the other HyperCore repair checks.
 
-When the amount and failed vault outcome are independently verified, an
-operator can optionally request a narrower incident amount. Its dry run is:
-
-```shell
-poetry run trade-executor correct-accounts \
-  --dry-run \
-  --recover-hypercore-transit-usdc 48.884068
-```
-
-It plans only the requested amount, preserving the pre-existing 0.50 USDC perp
-dust and 0.217882 USDC spot balance recorded for this Safe. A live invocation must add
-`--confirm-hypercore-transit-recovery`; that confirmation means the operator
-has checked live vault equity and established that the amount was not a late
-deposit. The explicit amount is never inferred from an EVM-success receipt.
-
 This does **not** make generic repair safe. A state file that predates a failed
 deposit can still show the trade as planned and lack its at-risk marker. After
-confirmed recovery, expire/reconcile that stale planned trade before restarting
+recovery, expire/reconcile that stale planned trade before restarting
 the executor, then use the normal account correction to align reserve state.
 
 ## Withdrawal (sell) flow

--- a/.claude/docs/hypercore-vault.md
+++ b/.claude/docs/hypercore-vault.md
@@ -225,7 +225,7 @@ as HyperAI trade #1486 and is expanded in PR #1593: a CoreWriter receipt can
 be successful while USDC is actually stranded in HyperCore perp or spot.
 Generic ERC-20 account correction cannot see either internal balance class.
 
-For a Lagoon Safe with closed HyperCore positions, the command snapshots live
+For a Lagoon Safe with open, frozen, or closed HyperCore positions, the command snapshots live
 EVM, spot and perp balances. It refuses to act when the Safe has any active
 perp position; otherwise it plans `perp → spot`, waits for that exact movement,
 then plans `spot → EVM` and waits for the Safe's EVM USDC balance to increase.
@@ -234,7 +234,9 @@ perp dust margin, but requests the entire amount just recovered from perp to
 spot before separately considering pre-existing spot USDC. That distinction
 returns all of the current stranded transfer when the existing spot balance
 has the 0.01 USDC bridge-fee headroom; otherwise the protocol retains only that
-fee margin rather than an arbitrary 0.50 USDC spot dust balance.
+fee margin rather than an arbitrary 0.50 USDC spot dust balance. If the amount
+left after that margin is too small to balance-verify, no first leg is sent and
+the tiny balance remains safely in perp for a later recovery.
 
 Always start with:
 

--- a/.claude/docs/hypercore-vault.md
+++ b/.claude/docs/hypercore-vault.md
@@ -217,6 +217,54 @@ bridge it back to the HyperEVM Safe. Never run a recovery action from a timeout
 message alone; a late HyperCore settlement can otherwise turn a retry into a
 double deposit.
 
+### Correct-accounts transit recovery
+
+`correct-accounts` includes a Safe-level HyperCore transit recovery before it
+performs generic reserve correction. This was added for the same failure class
+as HyperAI trade #1486 and is expanded in PR #1593: a CoreWriter receipt can
+be successful while USDC is actually stranded in HyperCore perp or spot.
+Generic ERC-20 account correction cannot see either internal balance class.
+
+For a Lagoon Safe with closed HyperCore positions, the command snapshots live
+EVM, spot and perp balances. It refuses to act when the Safe has any active
+perp position; otherwise it plans `perp → spot`, waits for that exact movement,
+then plans `spot → EVM` and waits for the Safe's EVM USDC balance to increase.
+The normal recovery planner retains its configured dust margin rather than
+attempting to drain an internal account to zero.
+
+Always start with:
+
+```shell
+poetry run trade-executor correct-accounts --dry-run
+```
+
+Dry-run now executes the same live snapshot and transit-action planner, and
+prints each proposed recovery action, but does not require the Safe signer,
+sign or broadcast a transaction, alter state, or create a state backup. It is
+therefore the safe way to inspect a normal dust-preserving sweep before running
+the live command.
+
+When the amount and failed vault outcome are independently verified, use the
+narrow incident path instead of the sweep.  For #1486 its dry run is:
+
+```shell
+poetry run trade-executor correct-accounts \
+  --dry-run \
+  --recover-hypercore-transit-usdc 48.884068
+```
+
+It plans exactly `perp_to_spot 48.884068` followed by
+`spot_to_evm 48.884068`, preserving the pre-existing 0.50 USDC perp dust and
+0.217882 USDC spot balance recorded for this Safe. A live invocation must add
+`--confirm-hypercore-transit-recovery`; that confirmation means the operator
+has checked live vault equity and established that the amount was not a late
+deposit. The explicit amount is never inferred from an EVM-success receipt.
+
+This does **not** make generic repair safe. A state file that predates a failed
+deposit can still show the trade as planned and lack its at-risk marker. After
+confirmed recovery, expire/reconcile that stale planned trade before restarting
+the executor, then use the normal account correction to align reserve state.
+
 ## Withdrawal (sell) flow
 
 A withdrawal walks USDC back from the vault to the HyperEVM Safe through three

--- a/.claude/docs/hypercore-vault.md
+++ b/.claude/docs/hypercore-vault.md
@@ -229,8 +229,12 @@ For a Lagoon Safe with closed HyperCore positions, the command snapshots live
 EVM, spot and perp balances. It refuses to act when the Safe has any active
 perp position; otherwise it plans `perp → spot`, waits for that exact movement,
 then plans `spot → EVM` and waits for the Safe's EVM USDC balance to increase.
-The normal recovery planner retains its configured dust margin rather than
-attempting to drain an internal account to zero.
+The normal recovery planner is enabled by default. It retains the configured
+perp dust margin, but requests the entire amount just recovered from perp to
+spot before separately considering pre-existing spot USDC. That distinction
+returns all of the current stranded transfer when the existing spot balance
+has the 0.01 USDC bridge-fee headroom; otherwise the protocol retains only that
+fee margin rather than an arbitrary 0.50 USDC spot dust balance.
 
 Always start with:
 
@@ -244,8 +248,13 @@ sign or broadcast a transaction, alter state, or create a state backup. It is
 therefore the safe way to inspect a normal dust-preserving sweep before running
 the live command.
 
-When the amount and failed vault outcome are independently verified, use the
-narrow incident path instead of the sweep.  For #1486 its dry run is:
+For #1486, the default dry run above plans exactly
+`perp_to_spot 48.884068` followed by `spot_to_evm 48.884068`: no incident
+option is necessary. The recovery is on by default for every eligible
+HyperCore vault strategy, as are the other HyperCore repair checks.
+
+When the amount and failed vault outcome are independently verified, an
+operator can optionally request a narrower incident amount. Its dry run is:
 
 ```shell
 poetry run trade-executor correct-accounts \
@@ -253,9 +262,8 @@ poetry run trade-executor correct-accounts \
   --recover-hypercore-transit-usdc 48.884068
 ```
 
-It plans exactly `perp_to_spot 48.884068` followed by
-`spot_to_evm 48.884068`, preserving the pre-existing 0.50 USDC perp dust and
-0.217882 USDC spot balance recorded for this Safe. A live invocation must add
+It plans only the requested amount, preserving the pre-existing 0.50 USDC perp
+dust and 0.217882 USDC spot balance recorded for this Safe. A live invocation must add
 `--confirm-hypercore-transit-recovery`; that confirmation means the operator
 has checked live vault equity and established that the amount was not a late
 deposit. The explicit amount is never inferred from an EVM-success receipt.

--- a/.claude/docs/hypercore-vault.md
+++ b/.claude/docs/hypercore-vault.md
@@ -95,7 +95,7 @@ the contract between `setup_trades()` and `settle_trade()`:
 | `hypercore_activation_cost_raw` | setup, first buy | USDC consumed activating the Safe on HyperCore (deducted once per cycle). |
 | `hypercore_capped_deposit_raw` | deposit preflight | Deposit capped to actual Safe EVM USDC balance. |
 | `hypercore_capped_withdrawal_raw` | withdrawal preflight / retry | Withdrawal capped to live vault equity minus safety margin. |
-| `hypercore_stranded_usdc` | on failure | Records USDC stranded mid-pipeline (perp/spot) for operator recovery. |
+| `hypercore_stranded_usdc` | on failure | Records USDC stranded mid-pipeline (perp/spot) for operator recovery and retains its reserve allocation. |
 | `hypercore_failure_diagnosis` | on failure | Full diagnostic snapshot string. |
 
 ## How execution is wired
@@ -127,8 +127,8 @@ A deposit walks USDC from the HyperEVM Safe into the HyperCore vault:
    HyperEVM Safe into HyperCore **spot** (built in `setup_trades`).
 2. **Escrow wait**: poll `spotClearinghouseState` until the bridged USDC clears
    the EVM escrow into spot (`wait_for_evm_escrow_clear`).
-3. **Phase 2**: `transferUsdClass(spot→perp)` + `vaultTransfer(perp→vault)` —
-   move into the vault (built in `_settle_deposit`); then
+3. **Phase 2**: `transferUsdClass(spot→perp)` then poll the perp balance.
+4. **Phase 3**: `vaultTransfer(perp→vault)` after the perp arrival is visible;
    `wait_for_vault_deposit_confirmation` verifies vault equity rose.
 
 ```mermaid
@@ -148,7 +148,9 @@ sequenceDiagram
     EX->>R: settle_trade(buy)
     R->>HC: poll spotClearinghouseState (escrow wait)
     HC-->>R: USDC cleared into spot
-    R->>Safe: phase 2 — transferUsdClass(spot→perp) + vaultTransfer(perp→vault)
+    R->>Safe: phase 2 — transferUsdClass(spot→perp)
+    R->>HC: poll perp balance until USDC arrived
+    R->>Safe: phase 3 — vaultTransfer(perp→vault)
     R->>HC: wait_for_vault_deposit_confirmation (equity rose?)
     alt confirmed
         R->>EX: mark_trade_success (executed = net deposited)

--- a/.claude/docs/vault-deposit-redeem.md
+++ b/.claude/docs/vault-deposit-redeem.md
@@ -366,6 +366,11 @@ How each command or context takes a request from pending to settled:
 - **`repair` / `retry`** — not involved: they act on *failed* trades, and a
   pending settlement is not a failure. Both explicitly leave
   `vault_settlement_pending` trades alone.
+- **HyperCore native vaults** — use neither this pending-event model nor its
+  generic repair path. Their bridge deposit is a separate spot → perp → vault
+  state machine. Once phase 1 may have left the Safe, the failed trade retains
+  its allocation until HyperCore live balances are reconciled; see
+  [`hypercore-vault.md`](./hypercore-vault.md).
 - **`close-position` / `close-all`** — the full re-run pattern. Each run
   first sweeps claimable settlements (so a re-run after the operator settles
   claims the earlier redeem and may close the position with no new on-chain

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 0.2
 
+- Fix HyperCore vault deposits whose spot-to-perp CoreWriter action succeeded while the batched perp-to-vault action silently no-op'd: execute and verify the two legs separately, and retain recoverable stranded capital in state rather than restoring it to Safe reserve accounting (2026-07-30)
+
 - Fix default-on `correct-accounts` cleanup for undersized HyperCore vault positions to redeem directly without deposits or new lock-ups, keep verifiable residuals tracked, supersede stale planned close trades, use a valid live confirmation count, and make `--dry-run` rehearse live preflight, routing, and transaction construction without state writes or broadcasts (2026-07-30)
 
 - Extend `vault-test-trade` simulations to validate typed closed deposits through GuardV0 without broadcasting, and distinguish vault JSON statuses that incorrectly report deposits open or closed (2026-07-28)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 0.2
 
-- Fix HyperCore vault deposits whose spot-to-perp CoreWriter action succeeded while the batched perp-to-vault action silently no-op'd: execute and verify the two legs separately, and retain recoverable stranded capital in state rather than restoring it to Safe reserve accounting (2026-07-30)
+- Fix HyperCore vault deposits whose spot-to-perp CoreWriter action succeeded while the batched perp-to-vault action silently no-op'd: execute and verify the two legs separately, retain recoverable stranded capital in state rather than restoring it to Safe reserve accounting, and fail closed across phase-1 broadcast crashes or ambiguous CoreWriter settlement until live Safe/escrow/spot/perp/vault reconciliation proves the destination (2026-07-30)
 
 - Fix default-on `correct-accounts` cleanup for undersized HyperCore vault positions to redeem directly without deposits or new lock-ups, keep verifiable residuals tracked, supersede stale planned close trades, use a valid live confirmation count, and make `--dry-run` rehearse live preflight, routing, and transaction construction without state writes or broadcasts (2026-07-30)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 0.2
 
-- Fix HyperCore vault deposits whose spot-to-perp CoreWriter action succeeded while the batched perp-to-vault action silently no-op'd: execute and verify the two legs separately, retain recoverable stranded capital in state rather than restoring it to Safe reserve accounting, and fail closed across phase-1 broadcast crashes or ambiguous CoreWriter settlement until live Safe/escrow/spot/perp/vault reconciliation proves the destination (2026-07-30)
+- Fix HyperCore vault deposits whose spot-to-perp CoreWriter action succeeded while the batched perp-to-vault action silently no-op'd: execute and verify the two legs separately, retain recoverable stranded capital in state rather than restoring it to Safe reserve accounting, fail closed across phase-1 broadcast crashes or ambiguous CoreWriter settlement until live Safe/escrow/spot/perp/vault reconciliation proves the destination, and let `correct-accounts --dry-run` rehearse an explicit, operator-verified transit recovery before a confirmed live transfer (2026-07-30)
 
 - Fix default-on `correct-accounts` cleanup for undersized HyperCore vault positions to redeem directly without deposits or new lock-ups, keep verifiable residuals tracked, supersede stale planned close trades, use a valid live confirmation count, and make `--dry-run` rehearse live preflight, routing, and transaction construction without state writes or broadcasts (2026-07-30)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 0.2
 
-- Fix HyperCore vault deposits whose spot-to-perp CoreWriter action succeeded while the batched perp-to-vault action silently no-op'd: execute and verify the two legs separately, retain recoverable stranded capital in state rather than restoring it to Safe reserve accounting, fail closed across phase-1 broadcast crashes or ambiguous CoreWriter settlement until live Safe/escrow/spot/perp/vault reconciliation proves the destination, and let `correct-accounts --dry-run` rehearse an explicit, operator-verified transit recovery before a confirmed live transfer (2026-07-30)
+- Fix HyperCore vault deposits whose spot-to-perp CoreWriter action succeeded while the batched perp-to-vault action silently no-op'd: execute and verify the two legs separately, retain recoverable stranded capital in state rather than restoring it to Safe reserve accounting, fail closed across phase-1 broadcast crashes or ambiguous CoreWriter settlement until live Safe/escrow/spot/perp/vault reconciliation proves the destination, and enable default `correct-accounts` recovery of the full perp-to-spot transit amount before any separate spot cleanup (2026-07-30)
 
 - Fix default-on `correct-accounts` cleanup for undersized HyperCore vault positions to redeem directly without deposits or new lock-ups, keep verifiable residuals tracked, supersede stale planned close trades, use a valid live confirmation count, and make `--dry-run` rehearse live preflight, routing, and transaction construction without state writes or broadcasts (2026-07-30)
 

--- a/docs/plans/hypercore-deposit-partial-settlement.md
+++ b/docs/plans/hypercore-deposit-partial-settlement.md
@@ -1,0 +1,357 @@
+# Fix plan: recovery-safe HyperCore vault deposits
+
+## Goal
+
+Make a HyperCore vault buy safe when HyperCore accepts only part of a
+multi-action settlement. The executor must verify every balance transition
+before starting the next one, stop the remaining trade batch on failure, and
+must not make already-bridged USDC spendable in internal reserve accounting.
+
+This plan is based on:
+
+- `.claude/docs/vault-deposit-redeem.md`, especially the continuous-equity and
+  no-double-spend accounting invariants;
+- `.claude/docs/hypercore-vault.md`, especially the separate HyperCore state
+  machine and the rule that an EVM receipt does not prove a HyperCore action
+  settled; and
+- the production evidence for HyperAI trade #1486 on 2026-07-30.
+
+The ERC-7540/Lagoon asynchronous vault state machine is not reused. HyperCore
+has a separate spot → perp → vault flow and separate recovery semantics.
+
+## Incident and root cause
+
+Trade #1486 attempted to deposit 48.884068 USDC into Citadel:
+
+1. The HyperEVM approval and deposit receipts succeeded, moving the USDC from
+   the Safe towards HyperCore.
+2. The former phase-2 EVM transaction submitted
+   `transferUsdClass(spot→perp)` and `vaultTransfer(perp→vault)` together.
+3. The EVM transaction succeeded, but HyperCore applied only the first action.
+   The perp account rose to 49.384068 USDC, which is the 48.884068 USDC
+   deposit plus its pre-existing 0.5 USDC. Spot stayed at its 0.217882 USDC
+   baseline and the vault equity never rose.
+4. Vault verification correctly timed out, but generic failed-buy accounting
+   then added 48.884069 USDC back to reserves even though the money was in the
+   HyperCore perp account. This overstated spendable cash and could allow the
+   same capital to be allocated twice.
+
+The protocol boundary is the cause: HyperCore actions requested through
+CoreWriter settle asynchronously, so EVM atomicity and receipt status do not
+make a group of HyperCore actions atomic. The bundled settlement assumed an
+atomicity guarantee that does not exist.
+
+Recent merged pull requests are not the trigger:
+
+- #1585, #1586, and #1587 changed HyperCore withdrawal and dust-cleanup paths,
+  not the deposit action bundle.
+- #1588 changed typed vault JSON handling.
+- #1589, the deployed commit `85c8f9cd`, added GuardV0-aware Lagoon treasury
+  settlement. It did not change `hypercore_routing.py`; its eth_defi submodule
+  bump did not change the relevant CoreWriter deposit helper.
+
+The incident exposed an existing deposit-path assumption. It was not a
+regression introduced by the deployed GuardV0 change.
+
+## Safety invariants
+
+The implementation must preserve these invariants:
+
+1. A successful EVM receipt proves only EVM inclusion. Each HyperCore balance
+   transition must be observed through the Info API.
+2. The perp → vault action must not be sent until the expected spot → perp
+   increase is visible.
+3. Once phase 1 has removed USDC from the Safe, a failed trade must not return
+   that USDC to spendable reserves or available bridge capital.
+4. Failure location must be conservative. If a poll cannot distinguish two
+   locations, record both rather than guessing.
+5. The position remains frozen and sequential execution stops after a failed
+   settlement. Recovery is explicit; the executor must not retry a transfer
+   blindly and risk depositing twice.
+6. A failure before phase 1 consumes Safe capital keeps the existing generic
+   failed-buy refund behaviour.
+7. A process crash or indeterminate broadcast must fail closed. Generic
+   startup or trade repair must not refund a HyperCore buy until the phase-1
+   transaction and live Safe/HyperCore balances prove the capital never left
+   the Safe.
+
+## Implementation
+
+### 1. Split the deposit settlement legs
+
+Replace the bundled deposit phase with two separately broadcast and verified
+CoreWriter transactions in
+`tradeexecutor/ethereum/vault/hypercore_routing.py`:
+
+1. Wait for the phase-1 EVM escrow to clear into spot.
+2. Snapshot current vault equity, spot USDC and the current perp withdrawable
+   balance.
+3. Broadcast only `transferUsdClass(spot→perp)`.
+4. Check its EVM receipt and use a deposit-specific verifier to observe the
+   spot decrease and corresponding perp increase. Compare human USDC values
+   after the correct per-account conversion and allow only a small explicit
+   rounding tolerance; do not reuse the vault performance-fee tolerance.
+   Accept an increase of at least the threshold rather than exact equality so
+   unrelated positive balance movement cannot cause a false timeout.
+5. Only after that poll succeeds, broadcast
+   `vaultTransfer(perp→vault)`.
+6. Check its EVM receipt and use
+   `wait_for_vault_deposit_confirmation()` to prove the vault equity rose.
+
+Append both transactions to `trade.blockchain_transactions` with distinct
+phase notes. Keep nonce synchronisation between the two broadcasts. A
+broadcast exception must retain the partially constructed transaction for
+diagnostics, as the existing `SettlementBroadcastError` contract does.
+
+The Safe is not expected to hold open perp positions, but the verifier must
+still tolerate unrelated positive balance movement and must log both sides of
+the transfer. The existing vault-equity drift tolerance remains appropriate
+only for the final vault confirmation. It must not be used to accept a missing
+spot → perp transfer.
+
+### 2. Classify partial settlement failures
+
+Every failure after the phase-1 bridge has consumed Safe USDC calls
+`_mark_stranded_usdc()` with the narrowest defensible location:
+
+| Failure point | Recorded location | Next action sent? |
+|---|---|---|
+| Escrow clear times out | `hypercore_evm_escrow_or_spot` | No |
+| Vault equity baseline cannot be read | `hypercore_spot` | No |
+| Spot → perp receipt definitely reverted | `hypercore_spot` | No |
+| Spot → perp broadcast result is indeterminate | `hypercore_spot_or_perp` | No vault transfer |
+| Spot → perp balance poll times out | `hypercore_spot_or_perp` | No vault transfer |
+| Perp → vault receipt definitely reverted | `hypercore_perp` | No further action |
+| Perp → vault broadcast result is indeterminate | `hypercore_perp_or_vault` | No further action |
+| Vault equity confirmation times out | `hypercore_perp_or_vault` | No further action |
+
+The last row reproduces the failure class seen in trade #1486. Its diagnostic
+snapshot showed the exact amount in perp, but a timeout alone does not prove
+that an accepted vault action cannot settle later. Recovery therefore rechecks
+both the perp balance and vault equity instead of blindly repeating
+`vaultTransfer`.
+
+Diagnostics should name the failed phase, Safe, vault, raw and human amount,
+all three HyperCore balances, Safe EVM balance, and transaction hashes. The
+operator message must be location-aware:
+
+- spot: transfer spot → perp to finish the deposit, or bridge spot → EVM;
+- perp: finish perp → vault, or transfer perp → spot before bridging to EVM;
+- ambiguous: inspect with `check-hypercore-user.py` before taking either
+  action.
+
+### 3. Fail closed across crashes and repair
+
+Persist a `hypercore_deposit_capital_at_risk` marker before broadcasting the
+phase-1 deposit transaction. This is earlier than the normal stranded-location
+classification because the process can die after a node accepts the
+transaction but before receipt handling or the next state save.
+
+- A definite phase-1 revert or a definite pre-broadcast failure clears the
+  marker and keeps the ordinary failed-buy refund path.
+- A successful receipt, missing receipt or indeterminate broadcast keeps the
+  marker until live reconciliation locates the capital.
+- Once a location is known, `_mark_stranded_usdc()` adds the amount and
+  location metadata. Ambiguous results remain ambiguous.
+
+`EthereumExecution.repair_unconfirmed_trades()` and the state-only
+`repair_trades()` flow must refuse to turn an at-risk HyperCore deposit into a
+generic refunded failed buy. They must require receipt lookup plus a live Safe,
+escrow, spot, perp and vault reconciliation. State-only repair cannot perform
+that reconciliation and must stop with operator instructions.
+
+This is a safety checkpoint, not automatic settlement resumption. It ensures a
+crash cannot bypass the accounting marker even if no exception handler ran.
+
+### 4. Preserve accounting for stranded capital
+
+`_mark_stranded_usdc()` stores both:
+
+- `hypercore_stranded_usdc`, containing amount, location, Safe and recovery
+  guidance; and
+- `retain_reserve_allocation_on_failure = True`.
+
+Update `State.mark_trade_failed()` so a failed buy with this explicit marker:
+
+- is still marked failed and freezes its position;
+- does not call `portfolio.adjust_reserves()` for a reserve-funded buy; and
+- does not release `bridge_currency_allocated` for a bridge-funded buy.
+
+This is deliberately conservative: NAV may temporarily under-report the
+recoverable transit balance, but spendable cash cannot be overstated. Normal
+pre-bridge failures, which do not have the marker, continue to unroll their
+allocation.
+
+The marker is specific to externally stranded capital. The earlier at-risk
+marker is allowed to retain capital conservatively until a live check proves a
+refund safe; neither condition is inferred from failure text.
+
+### 5. Keep recovery manual and idempotent
+
+Do not automatically re-run a failed phase from the normal live loop. The
+failed trade, its transaction list, its phase-specific location and the live
+balance inspection provide the recovery checkpoint. An operator first
+confirms the actual location, then either completes the vault deposit or
+returns the USDC to the Safe and reconciles state.
+
+Automatic crash-resume across these HyperCore legs is a separate change. It
+would require a persisted phase enum plus pre-action balance checks that prove
+whether an action has already settled. The at-risk marker in this fix prevents
+unsafe accounting repair but does not automatically repeat a transfer. Adding
+an unverified automatic retry would recreate the double-spend/double-deposit
+risk.
+
+### 6. Make reconciliation marker-aware
+
+Audit reserve sync, HyperCore account checks, `correct-accounts` and stranded
+USDC cleanup consumers. While either recovery marker is present:
+
+- Safe EVM reserve sync must observe the lower real Safe balance and must not
+  manufacture a reserve correction for the missing amount;
+- HyperCore account checks should report the known transit amount and location
+  rather than treating it as unexplained drift or vault dust; and
+- no cleanup or repair command may clear the marker or release allocation
+  without recording the operator's confirmed recovery destination.
+
+When recovery finishes, one explicit reconciliation operation clears the
+marker and accounts for exactly one destination: increased vault equity or
+USDC returned to the Safe. This avoids both permanent under-reporting and a
+second credit.
+
+## Mocked regression tests
+
+HyperCore/CoreWriter settlement cannot be reproduced on a normal EVM testnet,
+so add focused unit tests in
+`tests/hyperliquid/test_hypercore_deposit_settlement.py` with `MagicMock` and
+module-level patches. The mocks are necessary to deterministically reproduce
+the protocol behaviour where an EVM receipt succeeds but only one HyperCore
+action changes balance. Keep activation-cost-specific coverage in
+`test_hypercore_activation_cost.py`.
+
+### Deposit ordering and happy path
+
+1. Build a live buy with phase-1 receipts and mock the escrow clear.
+2. Mock the vault-equity/spot/perp baselines, spot → perp broadcast, dual
+   balance poll, perp → vault broadcast and vault confirmation.
+3. Assert strict call ordering: the vault broadcast happens only after the
+   perp poll returns successfully.
+4. Assert the raw amount passed to both legs, separate phase-2/phase-3
+   transactions are persisted, and the trade succeeds with no failure report.
+
+### Production incident regression
+
+In the same module:
+
+1. Use the trade #1486 amount, a 0.5 USDC perp baseline, the 0.217882 USDC spot
+   baseline and a successful spot → perp receipt/poll returning 49.384068
+   USDC.
+2. Return a successful perp → vault EVM receipt, then make
+   `wait_for_vault_deposit_confirmation()` raise
+   `HypercoreDepositVerificationError`.
+3. Assert the trade reports failure, records `hypercore_perp_or_vault`, sets
+   `retain_reserve_allocation_on_failure`, and persists both settlement
+   transactions.
+4. Assert no additional transfer is broadcast after the failed confirmation.
+
+### Intermediate failure guard
+
+1. Make the spot → perp EVM receipt succeed but its balance poll raise
+   `HypercoreWithdrawalVerificationError`.
+2. Assert `_broadcast_deposit_perp_to_vault()` is never called.
+3. Assert the location is `hypercore_spot_or_perp` and the allocation-retention
+   marker is set.
+
+### Broadcast ambiguity and crash repair
+
+1. Raise a broadcast exception after returning a signed transaction for each
+   settlement leg.
+2. Assert spot → perp records `hypercore_spot_or_perp`, while perp → vault
+   records `hypercore_perp_or_vault`.
+3. Create a broadcast HyperCore buy with
+   `hypercore_deposit_capital_at_risk` but no stranded-location metadata,
+   reproducing a process death before failure classification.
+4. Assert unconfirmed-trade repair cannot refund it without live
+   reconciliation, and state-only `repair_trades()` refuses it.
+5. Add the definite phase-1 revert guard and assert it clears the at-risk
+   marker before the normal refund.
+
+### State accounting tests
+
+In `tests/test_state.py`:
+
+1. Start a reserve-funded buy so its planned reserve is debited.
+2. Mark it as recoverably stranded and fail it.
+3. Assert the trade is failed but portfolio cash is not increased.
+4. Repeat for a bridge-funded buy and assert available bridge capital is not
+   released.
+5. Add a negative guard without the marker and assert an ordinary failed buy
+   still restores unused reserve capital.
+
+### Reconciliation test
+
+In `tests/hyperliquid/test_hypercore_accounting.py`:
+
+1. Construct a failed deposit with the reserve debited and a known perp transit
+   balance.
+2. Run the relevant account-check/correction path with mocked Safe and
+   HyperCore balances.
+3. Assert no reserve correction, dust cleanup or bridge-capital release occurs
+   while the recovery marker exists.
+4. Simulate one explicit recovery destination and assert the marker is cleared
+   only as the returned Safe cash or increased vault equity is accounted once.
+
+All new pytest tests must have a docstring that lists their high-level steps
+as `1.`, `2.`, `3.`, with matching numbered comments in the body. Fixtures
+must be type hinted, and mock comments must explain why live HyperCore cannot
+be used. Use `pytest.approx()` for USDC/balance comparisons where decimals are
+not deliberately exact.
+
+## Documentation updates
+
+Update the following documentation in the same pull request:
+
+- `.claude/docs/hypercore-vault.md`: show separate deposit phases, the perp
+  balance checkpoint, the no-EVM-atomicity rule, persisted stranded-capital
+  and at-risk metadata, the failure-location table, crash/repair guard and test
+  pattern.
+- `.claude/docs/vault-deposit-redeem.md`: retain the scope boundary, and
+  cross-reference the HyperCore document when discussing committed capital
+  and no-double-spend accounting. Do not imply HyperCore uses the ERC-7540
+  pending-event model.
+- `tradeexecutor/ethereum/vault/README-vault-position-manual.md`: document
+  location-aware inspection and recovery. In particular, perp USDC cannot be
+  sent directly to EVM; it must first move perp → spot.
+- `CHANGELOG.md`: record the recovery-safe deposit settlement and accounting
+  correction with the pull request date.
+
+## Validation
+
+Run focused tests from the worktree with the repository environment and parent
+Poetry environment:
+
+```shell
+source .local-test.env && PYTHONPATH="$(pwd):$PYTHONPATH" poetry run pytest -n auto tests/hyperliquid/test_hypercore_deposit_settlement.py
+source .local-test.env && PYTHONPATH="$(pwd):$PYTHONPATH" poetry run pytest tests/test_state.py -k failed
+source .local-test.env && PYTHONPATH="$(pwd):$PYTHONPATH" poetry run pytest tests/hyperliquid/test_hypercore_accounting.py -k stranded
+```
+
+Then run `git diff --check`. Do not require a live mainnet transfer for CI.
+Before production deployment, use `check-hypercore-user.py` to reconcile trade
+#1486 separately; deploying the code does not recover its 48.884068 USDC.
+
+## Acceptance criteria
+
+- No EVM transaction contains both deposit settlement actions.
+- The vault action cannot be broadcast before the perp increase is observed.
+- Every post-bridge failure records a conservative recovery location.
+- A crash or indeterminate phase-1 broadcast cannot reach generic refund
+  without live reconciliation.
+- A failed post-bridge buy cannot restore or release its stranded allocation.
+- An ordinary pre-bridge failed buy still refunds unused allocation.
+- Timeout and broadcast-unknown locations never instruct an operator to repeat
+  an action without rechecking live balances.
+- The mocked trade #1486 path fails safely with the USDC classified as
+  `hypercore_perp_or_vault` until reconciliation confirms its final location.
+- Account sync and correction cannot re-credit marked transit capital.
+- Operator and architecture documentation match the implemented phases and
+  recovery steps.

--- a/docs/plans/hypercore-deposit-partial-settlement.md
+++ b/docs/plans/hypercore-deposit-partial-settlement.md
@@ -88,11 +88,12 @@ CoreWriter transactions in
    balance.
 3. Broadcast only `transferUsdClass(spot→perp)`.
 4. Check its EVM receipt and use a deposit-specific verifier to observe the
-   spot decrease and corresponding perp increase. Compare human USDC values
-   after the correct per-account conversion and allow only a small explicit
-   rounding tolerance; do not reuse the vault performance-fee tolerance.
-   Accept an increase of at least the threshold rather than exact equality so
-   unrelated positive balance movement cannot cause a false timeout.
+   full spot decrease and corresponding perp increase. Compare human USDC
+   values after the correct per-account conversion; six-decimal USDC values
+   exactly represent the raw transfer amount, so no monetary tolerance is
+   permitted. Do not reuse the vault performance-fee tolerance. Unrelated
+   positive movement may exceed the requested amount, but either side must
+   still have moved by at least the complete requested amount.
 5. Only after that poll succeeds, broadcast
    `vaultTransfer(perp→vault)`.
 6. Check its EVM receipt and use
@@ -343,6 +344,8 @@ Before production deployment, use `check-hypercore-user.py` to reconcile trade
 
 - No EVM transaction contains both deposit settlement actions.
 - The vault action cannot be broadcast before the perp increase is observed.
+- The phase-2 proof rejects any partial spot or perp movement, including a
+  shortfall that would otherwise be hidden by a monetary tolerance.
 - Every post-bridge failure records a conservative recovery location.
 - A crash or indeterminate phase-1 broadcast cannot reach generic refund
   without live reconciliation.

--- a/tests/hyperliquid/test_hypercore_activation_cost.py
+++ b/tests/hyperliquid/test_hypercore_activation_cost.py
@@ -579,9 +579,11 @@ def test_settlement_second_buy_no_activation_cost(
         locked_until=datetime.datetime(2030, 1, 1),
     )
 
-    # Phase 2 broadcast
+    # Deposit settlement broadcasts and verifies each HyperCore leg separately.
     phase2_tx = MagicMock(tx_hash="0xbb")
     phase2_receipt = {"status": 1, "blockNumber": 101}
+    phase3_tx = MagicMock(tx_hash="0xcc")
+    phase3_receipt = {"status": 1, "blockNumber": 102}
 
     # Deposit confirmation
     confirmed_eq = UserVaultEquity(
@@ -591,8 +593,14 @@ def test_settlement_second_buy_no_activation_cost(
     )
     mock_wait_confirm.return_value = confirmed_eq
 
-    mock_phase2 = MagicMock(return_value=(phase2_tx, phase2_receipt))
-    with patch.object(routing, "_broadcast_phase2", mock_phase2):
+    mock_spot_to_perp = MagicMock(return_value=(phase2_tx, phase2_receipt))
+    mock_perp_to_vault = MagicMock(return_value=(phase3_tx, phase3_receipt))
+    with (
+        patch.object(routing, "_broadcast_deposit_spot_to_perp", mock_spot_to_perp),
+        patch.object(routing, "_broadcast_deposit_perp_to_vault", mock_perp_to_vault),
+        patch.object(routing, "_fetch_safe_perp_withdrawable_balance", return_value=Decimal("0")),
+        patch.object(routing, "_wait_for_perp_withdrawable_balance", return_value=Decimal("50")),
+    ):
         routing._settle_deposit(
             routing.web3, state, trade, receipts,
             stop_on_execution_failure=False,
@@ -610,8 +618,8 @@ def test_settlement_second_buy_no_activation_cost(
         f"activation cost was incorrectly deducted"
     )
 
-    # Verify _broadcast_phase2 received the full 50 USDC raw (not 48)
-    deposit_raw_passed = mock_phase2.call_args[0][2]
+    # Verify spot-to-perp received the full 50 USDC raw (not 48)
+    deposit_raw_passed = mock_spot_to_perp.call_args[0][1]
     assert deposit_raw_passed == 50_000_000
 
     mock_escrow.assert_called_once_with(
@@ -972,9 +980,11 @@ def test_settlement_uses_capped_deposit_and_refunds_reserve(
         locked_until=datetime.datetime(2030, 1, 1),
     )
 
-    # 2. Phase 2 broadcast.
+    # 2. Deposit settlement broadcasts and verifies each HyperCore leg separately.
     phase2_tx = MagicMock(tx_hash="0xbb")
     phase2_receipt = {"status": 1, "blockNumber": 101}
+    phase3_tx = MagicMock(tx_hash="0xcc")
+    phase3_receipt = {"status": 1, "blockNumber": 102}
 
     # 3. Deposit confirmation.
     confirmed_eq = UserVaultEquity(
@@ -984,15 +994,21 @@ def test_settlement_uses_capped_deposit_and_refunds_reserve(
     )
     mock_wait_confirm.return_value = confirmed_eq
 
-    mock_phase2 = MagicMock(return_value=(phase2_tx, phase2_receipt))
-    with patch.object(routing, "_broadcast_phase2", mock_phase2):
+    mock_spot_to_perp = MagicMock(return_value=(phase2_tx, phase2_receipt))
+    mock_perp_to_vault = MagicMock(return_value=(phase3_tx, phase3_receipt))
+    with (
+        patch.object(routing, "_broadcast_deposit_spot_to_perp", mock_spot_to_perp),
+        patch.object(routing, "_broadcast_deposit_perp_to_vault", mock_perp_to_vault),
+        patch.object(routing, "_fetch_safe_perp_withdrawable_balance", return_value=Decimal("0")),
+        patch.object(routing, "_wait_for_perp_withdrawable_balance", return_value=Decimal("80")),
+    ):
         routing._settle_deposit(
             routing.web3, state, trade, receipts,
             stop_on_execution_failure=False,
         )
 
     # 3. Verify phase 2 received capped amount.
-    deposit_raw_passed = mock_phase2.call_args[0][2]
+    deposit_raw_passed = mock_spot_to_perp.call_args[0][1]
     assert deposit_raw_passed == 80_000_000
 
     # 4. Verify mark_trade_success with correct values.
@@ -1061,9 +1077,11 @@ def test_settlement_capped_deposit_with_activation_cost(
         locked_until=datetime.datetime(2030, 1, 1),
     )
 
-    # 2. Phase 2 broadcast.
+    # 2. Deposit settlement broadcasts and verifies each HyperCore leg separately.
     phase2_tx = MagicMock(tx_hash="0xbb")
     phase2_receipt = {"status": 1, "blockNumber": 101}
+    phase3_tx = MagicMock(tx_hash="0xcc")
+    phase3_receipt = {"status": 1, "blockNumber": 102}
 
     # 3. Deposit confirmation.
     confirmed_eq = UserVaultEquity(
@@ -1073,15 +1091,21 @@ def test_settlement_capped_deposit_with_activation_cost(
     )
     mock_wait_confirm.return_value = confirmed_eq
 
-    mock_phase2 = MagicMock(return_value=(phase2_tx, phase2_receipt))
-    with patch.object(routing, "_broadcast_phase2", mock_phase2):
+    mock_spot_to_perp = MagicMock(return_value=(phase2_tx, phase2_receipt))
+    mock_perp_to_vault = MagicMock(return_value=(phase3_tx, phase3_receipt))
+    with (
+        patch.object(routing, "_broadcast_deposit_spot_to_perp", mock_spot_to_perp),
+        patch.object(routing, "_broadcast_deposit_perp_to_vault", mock_perp_to_vault),
+        patch.object(routing, "_fetch_safe_perp_withdrawable_balance", return_value=Decimal("0")),
+        patch.object(routing, "_wait_for_perp_withdrawable_balance", return_value=Decimal("95")),
+    ):
         routing._settle_deposit(
             routing.web3, state, trade, receipts,
             stop_on_execution_failure=False,
         )
 
     # 3. Verify phase 2 received capped deposit amount (not including activation).
-    deposit_raw_passed = mock_phase2.call_args[0][2]
+    deposit_raw_passed = mock_spot_to_perp.call_args[0][1]
     assert deposit_raw_passed == 95_000_000
 
     # 4. Verify mark_trade_success with correct values.
@@ -1152,6 +1176,8 @@ def test_settlement_capped_deposit_refunds_bridge_not_reserves(
 
     phase2_tx = MagicMock(tx_hash="0xbb")
     phase2_receipt = {"status": 1, "blockNumber": 101}
+    phase3_tx = MagicMock(tx_hash="0xcc")
+    phase3_receipt = {"status": 1, "blockNumber": 102}
 
     confirmed_eq = UserVaultEquity(
         vault_address="0xVAULT",
@@ -1161,8 +1187,14 @@ def test_settlement_capped_deposit_refunds_bridge_not_reserves(
     mock_wait_confirm.return_value = confirmed_eq
 
     # 2. Run settlement.
-    mock_phase2 = MagicMock(return_value=(phase2_tx, phase2_receipt))
-    with patch.object(routing, "_broadcast_phase2", mock_phase2):
+    mock_spot_to_perp = MagicMock(return_value=(phase2_tx, phase2_receipt))
+    mock_perp_to_vault = MagicMock(return_value=(phase3_tx, phase3_receipt))
+    with (
+        patch.object(routing, "_broadcast_deposit_spot_to_perp", mock_spot_to_perp),
+        patch.object(routing, "_broadcast_deposit_perp_to_vault", mock_perp_to_vault),
+        patch.object(routing, "_fetch_safe_perp_withdrawable_balance", return_value=Decimal("0")),
+        patch.object(routing, "_wait_for_perp_withdrawable_balance", return_value=Decimal("80")),
+    ):
         routing._settle_deposit(
             routing.web3, state, trade, receipts,
             stop_on_execution_failure=False,
@@ -1218,3 +1250,22 @@ def test_deposit_cap_skipped_when_balance_below_minimum():
     build_approve.assert_called_once_with(routing.lagoon_vault, evm_usdc_amount=100_000_000)
     build_deposit.assert_called_once_with(routing.lagoon_vault, evm_usdc_amount=100_000_000)
     assert "hypercore_capped_deposit_raw" not in trade.other_data
+
+
+def test_stranded_hypercore_usdc_retains_reserve_allocation():
+    """A partial HyperCore deposit must not be restored to Safe reserve accounting.
+
+    1. Create a live HyperCore buy trade.
+    2. Record USDC stranded after a successful bridge leg.
+    3. Verify the failed-trade accounting marker and recovery location are persisted.
+    """
+    # 1. Create a live HyperCore buy trade.
+    routing = _make_routing(simulate=False)
+    trade = _make_trade(planned_reserve=Decimal("48.884068"))
+
+    # 2. Record USDC stranded after a successful bridge leg.
+    routing._mark_stranded_usdc(trade, 48_884_068, "hypercore_perp")
+
+    # 3. Verify the failed-trade accounting marker and recovery location are persisted.
+    assert trade.other_data["retain_reserve_allocation_on_failure"] is True
+    assert trade.other_data["hypercore_stranded_usdc"]["location"] == "hypercore_perp"

--- a/tests/hyperliquid/test_hypercore_activation_cost.py
+++ b/tests/hyperliquid/test_hypercore_activation_cost.py
@@ -599,7 +599,7 @@ def test_settlement_second_buy_no_activation_cost(
         patch.object(routing, "_broadcast_deposit_spot_to_perp", mock_spot_to_perp),
         patch.object(routing, "_broadcast_deposit_perp_to_vault", mock_perp_to_vault),
         patch.object(routing, "_fetch_safe_perp_withdrawable_balance", return_value=Decimal("0")),
-        patch.object(routing, "_wait_for_perp_withdrawable_balance", return_value=Decimal("50")),
+        patch.object(routing, "_wait_for_deposit_spot_to_perp_transfer", return_value=(Decimal("0"), Decimal("50"))),
     ):
         routing._settle_deposit(
             routing.web3, state, trade, receipts,
@@ -1000,7 +1000,7 @@ def test_settlement_uses_capped_deposit_and_refunds_reserve(
         patch.object(routing, "_broadcast_deposit_spot_to_perp", mock_spot_to_perp),
         patch.object(routing, "_broadcast_deposit_perp_to_vault", mock_perp_to_vault),
         patch.object(routing, "_fetch_safe_perp_withdrawable_balance", return_value=Decimal("0")),
-        patch.object(routing, "_wait_for_perp_withdrawable_balance", return_value=Decimal("80")),
+        patch.object(routing, "_wait_for_deposit_spot_to_perp_transfer", return_value=(Decimal("0"), Decimal("80"))),
     ):
         routing._settle_deposit(
             routing.web3, state, trade, receipts,
@@ -1097,7 +1097,7 @@ def test_settlement_capped_deposit_with_activation_cost(
         patch.object(routing, "_broadcast_deposit_spot_to_perp", mock_spot_to_perp),
         patch.object(routing, "_broadcast_deposit_perp_to_vault", mock_perp_to_vault),
         patch.object(routing, "_fetch_safe_perp_withdrawable_balance", return_value=Decimal("0")),
-        patch.object(routing, "_wait_for_perp_withdrawable_balance", return_value=Decimal("95")),
+        patch.object(routing, "_wait_for_deposit_spot_to_perp_transfer", return_value=(Decimal("0"), Decimal("95"))),
     ):
         routing._settle_deposit(
             routing.web3, state, trade, receipts,
@@ -1193,7 +1193,7 @@ def test_settlement_capped_deposit_refunds_bridge_not_reserves(
         patch.object(routing, "_broadcast_deposit_spot_to_perp", mock_spot_to_perp),
         patch.object(routing, "_broadcast_deposit_perp_to_vault", mock_perp_to_vault),
         patch.object(routing, "_fetch_safe_perp_withdrawable_balance", return_value=Decimal("0")),
-        patch.object(routing, "_wait_for_perp_withdrawable_balance", return_value=Decimal("80")),
+        patch.object(routing, "_wait_for_deposit_spot_to_perp_transfer", return_value=(Decimal("0"), Decimal("80"))),
     ):
         routing._settle_deposit(
             routing.web3, state, trade, receipts,

--- a/tests/hyperliquid/test_hypercore_deposit_settlement.py
+++ b/tests/hyperliquid/test_hypercore_deposit_settlement.py
@@ -1,0 +1,213 @@
+"""Recovery-safe HyperCore vault deposit settlement tests.
+
+These are mocked because CoreWriter receipts and HyperCore Info API state live
+on different protocol layers and cannot be reproduced on a normal EVM testnet.
+"""
+
+import datetime
+from decimal import Decimal
+from unittest.mock import MagicMock, patch
+
+from eth_defi.hyperliquid.api import HypercoreDepositVerificationError, UserVaultEquity
+from hexbytes import HexBytes
+
+from tradeexecutor.ethereum.vault.hypercore_routing import (
+    HypercoreVaultRouting,
+    HypercoreWithdrawalVerificationError,
+)
+
+
+def _make_routing() -> HypercoreVaultRouting:
+    """Create an isolated routing instance because live HyperCore is not deterministic."""
+    routing = object.__new__(HypercoreVaultRouting)
+    routing.web3 = MagicMock()
+    routing.lagoon_vault = MagicMock()
+    routing.lagoon_vault.safe_address = "0xSAFE"
+    routing.deployer = MagicMock()
+    routing.chain_id = 999
+    routing.is_testnet = False
+    routing.simulate = False
+    routing.reserve_token_address = "0xusdc"
+    routing._session = MagicMock()
+    routing.allowed_intermediary_pairs = {}
+    return routing
+
+
+def _make_trade() -> MagicMock:
+    """Create the minimal live buy trade required by deposit settlement."""
+    trade = MagicMock()
+    trade.is_buy.return_value = True
+    trade.is_vault.return_value = True
+    trade.get_planned_reserve.return_value = Decimal("48.884068")
+    trade.trade_id = 1486
+    trade.planned_quantity = Decimal("48.884068")
+    trade.flags = set()
+    trade.other_data = {
+        "hypercore_phase1_spot_baseline_usdc": "0.217882",
+        "hypercore_deposit_capital_at_risk": {
+            "amount_raw": 48_884_068,
+            "phase": "phase1_broadcast_pending",
+        },
+    }
+    trade.blockchain_transactions = [MagicMock(tx_hash="0xaaa")]
+    trade.pair = MagicMock()
+    trade.pair.pool_address = "0xVAULT"
+    return trade
+
+
+def _make_equity(value: Decimal) -> UserVaultEquity:
+    """Create an Info API-like vault equity response."""
+    return UserVaultEquity(
+        vault_address="0xVAULT",
+        equity=value,
+        locked_until=datetime.datetime(2030, 1, 1),
+    )
+
+
+@patch("tradeexecutor.ethereum.vault.hypercore_routing.report_failure")
+@patch("tradeexecutor.ethereum.vault.hypercore_routing.get_block_timestamp")
+@patch("tradeexecutor.ethereum.vault.hypercore_routing.wait_for_evm_escrow_clear")
+@patch("tradeexecutor.ethereum.vault.hypercore_routing.wait_for_vault_deposit_confirmation")
+@patch("tradeexecutor.ethereum.vault.hypercore_routing.fetch_user_vault_equity")
+def test_deposit_confirmation_timeout_keeps_capital_at_risk_in_perp_or_vault(
+    mock_fetch_equity: MagicMock,
+    mock_wait_confirmation: MagicMock,
+    mock_wait_escrow: MagicMock,
+    mock_block_timestamp: MagicMock,
+    mock_report_failure: MagicMock,
+) -> None:
+    """A successful receipt and timed-out confirmation must retain USDC conservatively.
+
+    1. Reproduce trade #1486 with the 0.5 USDC perp baseline and successful spot-to-perp proof.
+    2. Return a successful perp-to-vault receipt but time out vault equity confirmation.
+    3. Verify retained allocation and the ambiguous perp-or-vault recovery location.
+    """
+    # 1. Reproduce the production balances with mocked CoreWriter and Info API calls.
+    routing = _make_routing()
+    trade = _make_trade()
+    state = MagicMock()
+    phase2_tx = MagicMock(tx_hash="0xbbb")
+    phase3_tx = MagicMock(tx_hash="0xccc")
+    receipts = {HexBytes("0xaaa"): {"status": 1, "blockNumber": 100}}
+    mock_block_timestamp.return_value = datetime.datetime(2026, 7, 30)
+    mock_fetch_equity.return_value = _make_equity(Decimal("9326.891623"))
+    mock_wait_confirmation.side_effect = HypercoreDepositVerificationError("vault unchanged")
+
+    # 2. Settle phase 2 then receive a successful phase-3 receipt without vault confirmation.
+    with (
+        patch.object(routing, "_fetch_safe_spot_free_usdc_balance", return_value=Decimal("49.101950")),
+        patch.object(routing, "_fetch_safe_perp_withdrawable_balance", return_value=Decimal("0.5")),
+        patch.object(
+            routing,
+            "_wait_for_deposit_spot_to_perp_transfer",
+            return_value=(Decimal("0.217882"), Decimal("49.384068")),
+        ),
+        patch.object(routing, "_broadcast_deposit_spot_to_perp", return_value=(phase2_tx, {"status": 1, "blockNumber": 101})),
+        patch.object(routing, "_broadcast_deposit_perp_to_vault", return_value=(phase3_tx, {"status": 1, "blockNumber": 102})),
+    ):
+        routing._settle_deposit(routing.web3, state, trade, receipts, stop_on_execution_failure=False)
+
+    # 3. A timeout cannot prove where an accepted vault action will finally settle.
+    assert trade.other_data["retain_reserve_allocation_on_failure"] is True
+    assert trade.other_data["hypercore_stranded_usdc"]["location"] == "hypercore_perp_or_vault"
+    assert len(trade.blockchain_transactions) == 3
+    mock_report_failure.assert_called_once()
+
+
+@patch("tradeexecutor.ethereum.vault.hypercore_routing.report_failure")
+@patch("tradeexecutor.ethereum.vault.hypercore_routing.get_block_timestamp")
+@patch("tradeexecutor.ethereum.vault.hypercore_routing.wait_for_evm_escrow_clear")
+@patch("tradeexecutor.ethereum.vault.hypercore_routing.fetch_user_vault_equity")
+def test_deposit_does_not_send_vault_leg_without_spot_to_perp_proof(
+    mock_fetch_equity: MagicMock,
+    mock_wait_escrow: MagicMock,
+    mock_block_timestamp: MagicMock,
+    mock_report_failure: MagicMock,
+) -> None:
+    """A missing spot-to-perp balance movement must stop before vault transfer.
+
+    1. Settle phase 1 and return a successful spot-to-perp EVM receipt.
+    2. Make the dual-balance proof time out.
+    3. Verify the vault leg is never broadcast and recovery remains ambiguous.
+    """
+    # 1. Set up the confirmed phase-1 and phase-2 receipt.
+    routing = _make_routing()
+    trade = _make_trade()
+    state = MagicMock()
+    phase2_tx = MagicMock(tx_hash="0xbbb")
+    receipts = {HexBytes("0xaaa"): {"status": 1, "blockNumber": 100}}
+    mock_block_timestamp.return_value = datetime.datetime(2026, 7, 30)
+    mock_fetch_equity.return_value = _make_equity(Decimal("9326.891623"))
+
+    # 2. Simulate the protocol no-op through the mocked balance verifier.
+    with (
+        patch.object(routing, "_fetch_safe_spot_free_usdc_balance", return_value=Decimal("49.101950")),
+        patch.object(routing, "_fetch_safe_perp_withdrawable_balance", return_value=Decimal("0.5")),
+        patch.object(
+            routing,
+            "_wait_for_deposit_spot_to_perp_transfer",
+            side_effect=HypercoreWithdrawalVerificationError("perp unchanged"),
+        ),
+        patch.object(routing, "_broadcast_deposit_spot_to_perp", return_value=(phase2_tx, {"status": 1, "blockNumber": 101})),
+        patch.object(routing, "_broadcast_deposit_perp_to_vault") as mock_perp_to_vault,
+    ):
+        routing._settle_deposit(routing.web3, state, trade, receipts, stop_on_execution_failure=False)
+
+    # 3. Do not create a second, potentially duplicate, vault action.
+    mock_perp_to_vault.assert_not_called()
+    assert trade.other_data["hypercore_stranded_usdc"]["location"] == "hypercore_spot_or_perp"
+    mock_report_failure.assert_called_once()
+
+
+def test_spot_to_perp_verifier_requires_both_balance_movements() -> None:
+    """The deposit verifier requires coherent spot and perp changes.
+
+    1. Create a mocked routing instance with post-transfer spot and perp balances.
+    2. Run the dual-balance verifier for a 48.884068 USDC transfer.
+    3. Verify it accepts only after both expected movements are visible.
+    """
+    # 1. The mocks model the Info API after a confirmed internal transfer.
+    routing = _make_routing()
+
+    # 2. Run the verifier against the exact production transfer amount.
+    with (
+        patch.object(routing, "_fetch_safe_spot_free_usdc_balance", return_value=Decimal("0.217882")),
+        patch.object(routing, "_fetch_safe_perp_withdrawable_balance", return_value=Decimal("49.384068")),
+    ):
+        spot, perp = routing._wait_for_deposit_spot_to_perp_transfer(
+            spot_baseline=Decimal("49.101950"),
+            perp_baseline=Decimal("0.5"),
+            expected_increase_raw=48_884_068,
+        )
+
+    # 3. Both balances prove the same transfer rather than receipt status alone.
+    assert spot == Decimal("0.217882")
+    assert perp == Decimal("49.384068")
+
+
+@patch("tradeexecutor.ethereum.vault.hypercore_routing.report_failure")
+@patch("tradeexecutor.ethereum.vault.hypercore_routing.get_block_timestamp")
+def test_phase1_revert_clears_at_risk_marker_for_normal_refund(
+    mock_block_timestamp: MagicMock,
+    mock_report_failure: MagicMock,
+) -> None:
+    """A definite phase-1 revert must restore ordinary failed-buy accounting.
+
+    1. Create a deposit carrying the pre-broadcast at-risk marker.
+    2. Return a reverted phase-1 receipt.
+    3. Verify the marker is cleared before failed-trade processing.
+    """
+    # 1. The marker exists before the phase-1 receipt is known.
+    routing = _make_routing()
+    trade = _make_trade()
+    state = MagicMock()
+    mock_block_timestamp.return_value = datetime.datetime(2026, 7, 30)
+    receipts = {HexBytes("0xaaa"): {"status": 0, "blockNumber": 100}}
+
+    # 2. A reverted deposit transaction cannot have removed USDC from the Safe.
+    routing._settle_deposit(routing.web3, state, trade, receipts, stop_on_execution_failure=False)
+
+    # 3. The generic failed-buy path may now refund normally.
+    assert "hypercore_deposit_capital_at_risk" not in trade.other_data
+    assert "retain_reserve_allocation_on_failure" not in trade.other_data
+    mock_report_failure.assert_called_once()

--- a/tests/hyperliquid/test_hypercore_deposit_settlement.py
+++ b/tests/hyperliquid/test_hypercore_deposit_settlement.py
@@ -78,41 +78,104 @@ def test_deposit_confirmation_timeout_keeps_capital_at_risk_in_perp_or_vault(
     mock_block_timestamp: MagicMock,
     mock_report_failure: MagicMock,
 ) -> None:
-    """A successful receipt and timed-out confirmation must retain USDC conservatively.
+    """The complete #1486 sequence must fail closed after a silent final-leg no-op.
 
-    1. Reproduce trade #1486 with the 0.5 USDC perp baseline and successful spot-to-perp proof.
-    2. Return a successful perp-to-vault receipt but time out vault equity confirmation.
-    3. Verify retained allocation and the ambiguous perp-or-vault recovery location.
+    1. Simulate the real spot→perp movement from trade #1486 using stateful Info API balances.
+    2. Return an EVM-success receipt for perp→vault while deliberately leaving vault equity unchanged.
+    3. Verify the router detects the no-op, halts success accounting and retains the allocation.
+
+    The mocks represent the two independent protocol layers that no testnet can
+    reproduce: a CoreWriter receipt can be successful while the subsequent
+    HyperCore vault action silently does nothing.  Unlike a shallow call-order
+    mock, phase 2 uses the real dual-balance verifier against changing balances.
     """
-    # 1. Reproduce the production balances with mocked CoreWriter and Info API calls.
+    # 1. Reproduce #1486's 0.5 USDC perp float, 0.217882 USDC spot baseline,
+    # and 48.884068 USDC phase-1 arrival. The mutable balances make the real
+    # phase-2 poll prove the transfer before the final leg is allowed.
     routing = _make_routing()
     trade = _make_trade()
     state = MagicMock()
     phase2_tx = MagicMock(tx_hash="0xbbb")
     phase3_tx = MagicMock(tx_hash="0xccc")
     receipts = {HexBytes("0xaaa"): {"status": 1, "blockNumber": 100}}
-    mock_block_timestamp.return_value = datetime.datetime(2026, 7, 30)
-    mock_fetch_equity.return_value = _make_equity(Decimal("9326.891623"))
-    mock_wait_confirmation.side_effect = HypercoreDepositVerificationError("vault unchanged")
+    spot_usdc = Decimal("49.101950")
+    perp_usdc = Decimal("0.5")
+    vault_equity = Decimal("9326.891623")
+    requested_usdc = Decimal("48.884068")
+    action_order: list[str] = []
 
-    # 2. Settle phase 2 then receive a successful phase-3 receipt without vault confirmation.
+    def broadcast_spot_to_perp(mock_trade: MagicMock, raw_amount: int) -> tuple[MagicMock, dict]:
+        """Model the first CoreWriter action applying fully on HyperCore."""
+        nonlocal spot_usdc, perp_usdc
+        assert mock_trade is trade
+        assert raw_amount == 48_884_068
+        spot_usdc -= requested_usdc
+        perp_usdc += requested_usdc
+        action_order.append("spot_to_perp")
+        return phase2_tx, {"status": 1, "blockNumber": 101}
+
+    def confirm_phase1_spot_arrival(
+        session: MagicMock,
+        user: str,
+        timeout: float,
+        poll_interval: float,
+        expected_usdc: Decimal,
+        baseline_usdc: Decimal,
+    ) -> None:
+        """Model the phase-1 escrow proof before internal settlement begins."""
+        assert session is routing._session
+        assert user == "0xSAFE"
+        assert timeout == 60.0
+        assert poll_interval == 2.0
+        assert expected_usdc == requested_usdc
+        assert baseline_usdc == Decimal("0.217882")
+        action_order.append("phase1_spot_arrival")
+
+    def broadcast_perp_to_vault(mock_trade: MagicMock, vault_address: str, raw_amount: int) -> tuple[MagicMock, dict]:
+        """Model #1486: EVM accepts phase 3 but HyperCore silently no-ops it."""
+        assert mock_trade is trade
+        assert vault_address == "0xVAULT"
+        assert raw_amount == 48_884_068
+        assert spot_usdc == Decimal("0.217882")
+        assert perp_usdc == Decimal("49.384068")
+        action_order.append("perp_to_vault")
+        # Crucially do not debit perp or increase vault_equity. This is the
+        # asynchronous HyperCore no-op the old bundled transaction concealed.
+        return phase3_tx, {"status": 1, "blockNumber": 102}
+
+    def confirm_unchanged_vault(session: MagicMock, **kwargs) -> UserVaultEquity:
+        """Reject the successful EVM receipt because vault equity did not move."""
+        assert session is routing._session
+        action_order.append("vault_confirmation")
+        assert kwargs["existing_equity"] == vault_equity
+        assert kwargs["expected_deposit"] == requested_usdc
+        raise HypercoreDepositVerificationError("vault equity unchanged after successful EVM receipt")
+
+    mock_block_timestamp.return_value = datetime.datetime(2026, 7, 30)
+    mock_fetch_equity.return_value = _make_equity(vault_equity)
+    mock_wait_escrow.side_effect = confirm_phase1_spot_arrival
+    mock_wait_confirmation.side_effect = confirm_unchanged_vault
+
+    # 2. CoreWriter phase 2 changes both real mock balances, phase 3 returns
+    # receipt status 1 but preserves them and vault equity exactly as #1486 did.
     with (
-        patch.object(routing, "_fetch_safe_spot_free_usdc_balance", return_value=Decimal("49.101950")),
-        patch.object(routing, "_fetch_safe_perp_withdrawable_balance", return_value=Decimal("0.5")),
-        patch.object(
-            routing,
-            "_wait_for_deposit_spot_to_perp_transfer",
-            return_value=(Decimal("0.217882"), Decimal("49.384068")),
-        ),
-        patch.object(routing, "_broadcast_deposit_spot_to_perp", return_value=(phase2_tx, {"status": 1, "blockNumber": 101})),
-        patch.object(routing, "_broadcast_deposit_perp_to_vault", return_value=(phase3_tx, {"status": 1, "blockNumber": 102})),
+        patch.object(routing, "_fetch_safe_spot_free_usdc_balance", side_effect=lambda: spot_usdc),
+        patch.object(routing, "_fetch_safe_perp_withdrawable_balance", side_effect=lambda: perp_usdc),
+        patch.object(routing, "_broadcast_deposit_spot_to_perp", side_effect=broadcast_spot_to_perp),
+        patch.object(routing, "_broadcast_deposit_perp_to_vault", side_effect=broadcast_perp_to_vault),
     ):
         routing._settle_deposit(routing.web3, state, trade, receipts, stop_on_execution_failure=False)
 
-    # 3. A timeout cannot prove where an accepted vault action will finally settle.
+    # 3. The successful phase-3 receipt cannot create a successful trade or a
+    # reserve refund when its asynchronous vault action failed to settle.
+    assert action_order == ["phase1_spot_arrival", "spot_to_perp", "perp_to_vault", "vault_confirmation"]
+    assert spot_usdc == Decimal("0.217882")
+    assert perp_usdc == Decimal("49.384068")
+    assert vault_equity == Decimal("9326.891623")
     assert trade.other_data["retain_reserve_allocation_on_failure"] is True
     assert trade.other_data["hypercore_stranded_usdc"]["location"] == "hypercore_perp_or_vault"
     assert len(trade.blockchain_transactions) == 3
+    state.mark_trade_success.assert_not_called()
     mock_report_failure.assert_called_once()
 
 

--- a/tests/hyperliquid/test_hypercore_deposit_settlement.py
+++ b/tests/hyperliquid/test_hypercore_deposit_settlement.py
@@ -10,11 +10,13 @@ from unittest.mock import MagicMock, patch
 
 from eth_defi.hyperliquid.api import HypercoreDepositVerificationError, UserVaultEquity
 from hexbytes import HexBytes
+import pytest
 
 from tradeexecutor.ethereum.vault.hypercore_routing import (
     HypercoreVaultRouting,
     HypercoreWithdrawalVerificationError,
 )
+from tradeexecutor.ethereum.execution import EthereumExecution
 
 
 def _make_routing() -> HypercoreVaultRouting:
@@ -181,8 +183,134 @@ def test_spot_to_perp_verifier_requires_both_balance_movements() -> None:
         )
 
     # 3. Both balances prove the same transfer rather than receipt status alone.
-    assert spot == Decimal("0.217882")
-    assert perp == Decimal("49.384068")
+    assert spot == pytest.approx(Decimal("0.217882"))
+    assert perp == pytest.approx(Decimal("49.384068"))
+
+
+def test_spot_to_perp_verifier_rejects_partial_movement() -> None:
+    """A partial transfer cannot authorise the full vault transfer.
+
+    1. Model a 5 USDC deposit whose balances moved by only 4.90 USDC.
+    2. Run the exact dual-balance verifier with no time left to poll.
+    3. Verify it rejects the partial transfer before phase 3 can be created.
+    """
+    # 1. Use the minimum supported deposit to make the formerly permitted
+    # 0.10 USDC shortfall materially visible.
+    routing = _make_routing()
+
+    # 2. A receipt alone must not make this incomplete move eligible for phase 3.
+    with (
+        patch.object(routing, "_fetch_safe_spot_free_usdc_balance", return_value=Decimal("0.10")),
+        patch.object(routing, "_fetch_safe_perp_withdrawable_balance", return_value=Decimal("4.90")),
+        pytest.raises(HypercoreWithdrawalVerificationError, match="Expected 5"),
+    ):
+        routing._wait_for_deposit_spot_to_perp_transfer(
+            spot_baseline=Decimal("5.00"),
+            perp_baseline=Decimal("0"),
+            expected_increase_raw=5_000_000,
+            timeout=0,
+        )
+
+    # 3. The raised error is the stop condition; phase 3 was never available.
+
+
+@patch("tradeexecutor.ethereum.vault.hypercore_routing.get_block_timestamp")
+@patch("tradeexecutor.ethereum.vault.hypercore_routing.wait_for_evm_escrow_clear")
+@patch("tradeexecutor.ethereum.vault.hypercore_routing.wait_for_vault_deposit_confirmation")
+@patch("tradeexecutor.ethereum.vault.hypercore_routing.fetch_user_vault_equity")
+def test_successful_deposit_clears_at_risk_marker(
+    mock_fetch_equity: MagicMock,
+    mock_wait_confirmation: MagicMock,
+    mock_wait_escrow: MagicMock,
+    mock_block_timestamp: MagicMock,
+) -> None:
+    """A confirmed vault deposit must stop looking like stranded transit capital.
+
+    1. Settle all three deposit phases with mocked protocol evidence.
+    2. Confirm the expected vault-equity increase.
+    3. Verify success clears both conservative failure-accounting markers.
+    """
+    # 1. Mock each external protocol layer because their receipt and Info API
+    # states cannot be made deterministic on a normal EVM testnet.
+    routing = _make_routing()
+    trade = _make_trade()
+    state = MagicMock()
+    phase2_tx = MagicMock(tx_hash="0xbbb")
+    phase3_tx = MagicMock(tx_hash="0xccc")
+    receipts = {HexBytes("0xaaa"): {"status": 1, "blockNumber": 100}}
+    mock_block_timestamp.return_value = datetime.datetime(2026, 7, 30)
+    mock_fetch_equity.return_value = _make_equity(Decimal("9326.891623"))
+    mock_wait_confirmation.return_value = _make_equity(Decimal("9375.775691"))
+
+    # 2. Provide exact phase-2 proof and final vault confirmation.
+    with (
+        patch.object(routing, "_fetch_safe_spot_free_usdc_balance", return_value=Decimal("49.101950")),
+        patch.object(routing, "_fetch_safe_perp_withdrawable_balance", return_value=Decimal("0.5")),
+        patch.object(
+            routing,
+            "_wait_for_deposit_spot_to_perp_transfer",
+            return_value=(Decimal("0.217882"), Decimal("49.384068")),
+        ),
+        patch.object(routing, "_broadcast_deposit_spot_to_perp", return_value=(phase2_tx, {"status": 1, "blockNumber": 101})),
+        patch.object(routing, "_broadcast_deposit_perp_to_vault", return_value=(phase3_tx, {"status": 1, "blockNumber": 102})),
+    ):
+        routing._settle_deposit(routing.web3, state, trade, receipts, stop_on_execution_failure=False)
+
+    # 3. Future account checks must see an ordinary successful position.
+    assert "hypercore_deposit_capital_at_risk" not in trade.other_data
+    assert "retain_reserve_allocation_on_failure" not in trade.other_data
+    state.mark_trade_success.assert_called_once()
+
+
+def test_execution_persists_at_risk_marker_before_broadcast() -> None:
+    """The prepared at-risk marker is checkpointed before a node sees the transaction.
+
+    1. Make routing setup create the phase-1 marker for a sequential trade.
+    2. Capture the pre-broadcast state checkpoint and then enter broadcast.
+    3. Verify the checkpoint already contains the marker, modelling crash restart.
+    """
+    # 1. Use mocks because this is the execution-order contract between the
+    # generic executor and HyperCore routing, not a chain integration test.
+    execution = object.__new__(EthereumExecution)
+    execution.max_slippage = None
+    execution._pre_broadcast_state_sync_callback = None
+    trade = MagicMock()
+    trade.trade_id = 1486
+    trade.get_planned_value.return_value = 48.884068
+    trade.pair.get_ticker.return_value = "Citadel-USDC"
+    trade.is_failed.return_value = False
+    trade.other_data = {}
+    state = MagicMock()
+    routing = MagicMock()
+    checkpointed_markers: list[dict] = []
+
+    def create_marker(*args, **kwargs) -> None:
+        trade.other_data["hypercore_deposit_capital_at_risk"] = {"phase": "phase1_broadcast_pending"}
+
+    def checkpoint() -> None:
+        checkpointed_markers.append(dict(trade.other_data))
+
+    def broadcast(*args, **kwargs) -> None:
+        assert checkpointed_markers == [{"hypercore_deposit_capital_at_risk": {"phase": "phase1_broadcast_pending"}}]
+
+    routing.setup_trades.side_effect = create_marker
+    execution.set_pre_broadcast_state_sync_callback(checkpoint)
+    execution._execute_trade_batch = broadcast
+
+    # 2. Execute the sequential preparation-to-broadcast path.
+    execution._execute_trades_sequentially(
+        datetime.datetime(2026, 7, 30),
+        state,
+        [trade],
+        routing,
+        MagicMock(),
+        check_balances=False,
+        rebroadcast=False,
+        triggered=False,
+    )
+
+    # 3. The persisted snapshot supplies the marker after a hard restart.
+    assert checkpointed_markers == [{"hypercore_deposit_capital_at_risk": {"phase": "phase1_broadcast_pending"}}]
 
 
 @patch("tradeexecutor.ethereum.vault.hypercore_routing.report_failure")

--- a/tests/hyperliquid/test_hypercore_snapshot_failure.py
+++ b/tests/hyperliquid/test_hypercore_snapshot_failure.py
@@ -92,7 +92,12 @@ def test_snapshot_success_proceeds_with_phase2(
     mock_fetch_equity, mock_wait_confirm, mock_escrow, mock_block_ts,
     mock_report_failure,
 ):
-    """When equity snapshot succeeds, phase 2 proceeds normally."""
+    """When equity snapshot succeeds, the separated deposit legs proceed normally.
+
+    1. Build a successful phase-1 receipt and a vault-equity snapshot.
+    2. Mock the verified spot-to-perp and perp-to-vault settlement legs.
+    3. Assert the final equity confirmation marks the trade successful.
+    """
     from eth_defi.hyperliquid.api import UserVaultEquity
 
     routing = _make_routing()
@@ -105,7 +110,7 @@ def test_snapshot_success_proceeds_with_phase2(
 
     mock_escrow.return_value = None
 
-    # Snapshot returns existing equity
+    # Step 1: Snapshot returns existing equity after a successful phase 1.
     eq = UserVaultEquity(
         vault_address=VAULT_ADDR,
         equity=Decimal("100.0"),
@@ -113,9 +118,11 @@ def test_snapshot_success_proceeds_with_phase2(
     )
     mock_fetch_equity.return_value = eq
 
-    # Phase 2 broadcast
+    # Step 2: Mock both settlement legs and the phase-2 balance proof.
     phase2_tx = MagicMock(tx_hash="0xbb")
     phase2_receipt = {"status": 1, "blockNumber": 101}
+    phase3_tx = MagicMock(tx_hash="0xcc")
+    phase3_receipt = {"status": 1, "blockNumber": 102}
 
     # Deposit verification
     confirmed_eq = UserVaultEquity(
@@ -125,13 +132,35 @@ def test_snapshot_success_proceeds_with_phase2(
     )
     mock_wait_confirm.return_value = confirmed_eq
 
-    with patch.object(routing, "_broadcast_phase2", return_value=(phase2_tx, phase2_receipt)):
+    with (
+        patch.object(
+            routing,
+            "_fetch_safe_spot_free_usdc_balance",
+            return_value=Decimal("0"),
+        ),
+        patch.object(
+            routing,
+            "_fetch_safe_perp_withdrawable_balance",
+            return_value=Decimal("0"),
+        ),
+        patch.object(
+            routing,
+            "_broadcast_deposit_spot_to_perp",
+            return_value=(phase2_tx, phase2_receipt),
+        ),
+        patch.object(routing, "_wait_for_deposit_spot_to_perp_transfer"),
+        patch.object(
+            routing,
+            "_broadcast_deposit_perp_to_vault",
+            return_value=(phase3_tx, phase3_receipt),
+        ),
+    ):
         routing._settle_deposit(
             routing.web3, state, trade, receipts,
             stop_on_execution_failure=False,
         )
 
-    # Trade should succeed
+    # Step 3: The final vault-equity proof marks the trade successful.
     state.mark_trade_success.assert_called_once()
     # report_failure should NOT have been called
     mock_report_failure.assert_not_called()

--- a/tests/hyperliquid/test_hypercore_stranded_usdc.py
+++ b/tests/hyperliquid/test_hypercore_stranded_usdc.py
@@ -8,15 +8,22 @@ from tradeexecutor.ethereum.vault.hypercore_routing import HypercoreVaultRouting
 from tradeexecutor.state.repair import HypercoreTransitRecoveryRequired, repair_trades
 
 
-def test_mark_stranded_usdc_stores_info():
-    """_mark_stranded_usdc records recovery info in trade.other_data."""
-    routing = MagicMock(spec=HypercoreVaultRouting)
-    routing.safe_address = "0xABC123"
+def test_mark_stranded_usdc_stores_info() -> None:
+    """Stranded-deposit metadata must preserve specific recovery instructions.
+
+    1. Create a minimal real routing object and failed deposit trade.
+    2. Record USDC that is known to be in HyperCore spot.
+    3. Verify the marker identifies the Safe, amount and recovery path.
+    """
+    # 1. Avoid a spec mock because this helper also calls routing recovery text.
+    routing = object.__new__(HypercoreVaultRouting)
+    routing.lagoon_vault = MagicMock(safe_address="0xABC123")
 
     trade = MagicMock()
     trade.other_data = {}
     trade.trade_id = 42
 
+    # 2. Record a known spot location and its exact raw USDC amount.
     HypercoreVaultRouting._mark_stranded_usdc(
         routing,
         trade=trade,
@@ -24,6 +31,7 @@ def test_mark_stranded_usdc_stores_info():
         location="hypercore_spot",
     )
 
+    # 3. Operators need an unambiguous marker before they reconcile balances.
     info = trade.other_data["hypercore_stranded_usdc"]
     assert info["amount_raw"] == 50_000_000
     assert info["amount_human"] == "50"
@@ -34,15 +42,22 @@ def test_mark_stranded_usdc_stores_info():
     assert "stranded" in trade.add_note.call_args[0][0].lower()
 
 
-def test_mark_stranded_usdc_creates_other_data():
-    """Works even if trade.other_data is None."""
-    routing = MagicMock(spec=HypercoreVaultRouting)
-    routing.safe_address = "0xABC123"
+def test_mark_stranded_usdc_creates_other_data() -> None:
+    """Stranded-deposit metadata must initialise an absent metadata dictionary.
+
+    1. Create a minimal routing object and a trade without metadata.
+    2. Record a deposit stranded in either spot or perp.
+    3. Verify the helper creates the metadata dictionary and recovery marker.
+    """
+    # 1. Model an older trade object that has no auxiliary metadata yet.
+    routing = object.__new__(HypercoreVaultRouting)
+    routing.lagoon_vault = MagicMock(safe_address="0xABC123")
 
     trade = MagicMock()
     trade.other_data = None
     trade.trade_id = 1
 
+    # 2. Record the uncertain intermediate transfer location.
     HypercoreVaultRouting._mark_stranded_usdc(
         routing,
         trade=trade,
@@ -50,11 +65,12 @@ def test_mark_stranded_usdc_creates_other_data():
         location="hypercore_spot_or_perp",
     )
 
+    # 3. The recovery marker is durable even without pre-existing metadata.
     assert trade.other_data is not None
     assert "hypercore_stranded_usdc" in trade.other_data
 
 
-def test_phase1_at_risk_marker_is_written_before_broadcast():
+def test_phase1_at_risk_marker_is_written_before_broadcast() -> None:
     """Phase-1 deposit protection is persisted before an uncertain broadcast.
 
     1. Create a mocked live HyperCore routing and buy trade.
@@ -62,8 +78,8 @@ def test_phase1_at_risk_marker_is_written_before_broadcast():
     3. Verify generic failed-buy accounting will retain the allocation.
     """
     # 1. Use a mock because this marker must exist even if no RPC receipt arrives.
-    routing = MagicMock(spec=HypercoreVaultRouting)
-    routing.safe_address = "0xABC123"
+    routing = object.__new__(HypercoreVaultRouting)
+    routing.lagoon_vault = MagicMock(safe_address="0xABC123")
     trade = MagicMock()
     trade.other_data = {}
 
@@ -81,7 +97,7 @@ def test_phase1_at_risk_marker_is_written_before_broadcast():
     assert trade.other_data["retain_reserve_allocation_on_failure"] is True
 
 
-def test_state_only_repair_refuses_unreconciled_hypercore_deposit():
+def test_state_only_repair_refuses_unreconciled_hypercore_deposit() -> None:
     """State-only repair must not refund a deposit whose location is unknown.
 
     1. Create a failed trade carrying the HyperCore at-risk marker.

--- a/tests/hyperliquid/test_hypercore_stranded_usdc.py
+++ b/tests/hyperliquid/test_hypercore_stranded_usdc.py
@@ -1,9 +1,11 @@
 """Test P5: Stranded USDC marker on failed Hypercore deposits."""
 
-from decimal import Decimal
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
+
+import pytest
 
 from tradeexecutor.ethereum.vault.hypercore_routing import HypercoreVaultRouting
+from tradeexecutor.state.repair import HypercoreTransitRecoveryRequired, repair_trades
 
 
 def test_mark_stranded_usdc_stores_info():
@@ -50,3 +52,51 @@ def test_mark_stranded_usdc_creates_other_data():
 
     assert trade.other_data is not None
     assert "hypercore_stranded_usdc" in trade.other_data
+
+
+def test_phase1_at_risk_marker_is_written_before_broadcast():
+    """Phase-1 deposit protection is persisted before an uncertain broadcast.
+
+    1. Create a mocked live HyperCore routing and buy trade.
+    2. Mark the phase-1 amount as at risk before broadcast.
+    3. Verify generic failed-buy accounting will retain the allocation.
+    """
+    # 1. Use a mock because this marker must exist even if no RPC receipt arrives.
+    routing = MagicMock(spec=HypercoreVaultRouting)
+    routing.safe_address = "0xABC123"
+    trade = MagicMock()
+    trade.other_data = {}
+
+    # 2. Persist the conservative phase-1 checkpoint.
+    HypercoreVaultRouting._mark_deposit_capital_at_risk(
+        routing,
+        trade=trade,
+        raw_amount=48_884_068,
+    )
+
+    # 3. A crash can no longer look like an unused reserve allocation.
+    marker = trade.other_data["hypercore_deposit_capital_at_risk"]
+    assert marker["amount_raw"] == 48_884_068
+    assert marker["phase"] == "phase1_broadcast_pending"
+    assert trade.other_data["retain_reserve_allocation_on_failure"] is True
+
+
+def test_state_only_repair_refuses_unreconciled_hypercore_deposit():
+    """State-only repair must not refund a deposit whose location is unknown.
+
+    1. Create a failed trade carrying the HyperCore at-risk marker.
+    2. Present it to the state-only repair workflow.
+    3. Verify repair stops and instructs the operator to reconcile live balances.
+    """
+    # 1. This mock represents a crash before HyperCore receipt classification.
+    state = MagicMock()
+    state.portfolio.frozen_positions.values.return_value = []
+    trade = MagicMock()
+    trade.trade_id = 1486
+    trade.other_data = {"hypercore_deposit_capital_at_risk": {"amount_raw": 48_884_068}}
+
+    # 2. State-only repair has no RPC/Info API evidence to resolve the location.
+    with patch("tradeexecutor.state.repair.find_trades_to_be_repaired", return_value=[trade]):
+        # 3. It must fail closed rather than manufacture a counter-trade refund.
+        with pytest.raises(HypercoreTransitRecoveryRequired, match="check-hypercore-user.py"):
+            repair_trades(state, attempt_repair=True, interactive=False)

--- a/tests/hyperliquid/test_hypercore_transit_recovery.py
+++ b/tests/hyperliquid/test_hypercore_transit_recovery.py
@@ -113,6 +113,23 @@ def test_hypercore_transit_plan_keeps_bridge_fee_margin_for_perp_only_balance() 
     assert actions[1].amount == Decimal("9.49")
 
 
+def test_hypercore_transit_plan_keeps_unbridgeable_perp_dust_in_perp() -> None:
+    """Planner does not strand a dust-sized perp-to-spot first leg.
+
+    1. Build a perp-only snapshot whose recovered excess cannot cover bridge headroom.
+    2. Plan HyperCore transit recovery actions.
+    3. Assert neither half of an unexecutable two-leg recovery is emitted.
+    """
+    # Step 1: 0.021 USDC excess becomes an unbridgeable 0.011 USDC after the fee margin.
+    snapshot = _snapshot(perp_withdrawable=Decimal("0.521"))
+
+    # Step 2: Plan recovery before any Safe/CoreWriter transaction is created.
+    actions = plan_hypercore_transit_recovery_actions(snapshot)
+
+    # Step 3: Retain the tiny perp balance instead of stranding it in spot.
+    assert actions == []
+
+
 def test_hypercore_transit_plan_recovers_incident_amount_by_default() -> None:
     """Default #1486 recovery preserves pre-existing HyperCore balances.
 
@@ -394,6 +411,33 @@ def test_correct_accounts_recovery_helper_executes_for_open_hypercore_position(m
     assert executed == ["spot_to_evm"]
     assert executed_arguments["actions"] == [action]
     hot_wallet.sync_nonce.assert_called_once()
+
+
+def test_correct_accounts_detects_frozen_hypercore_position() -> None:
+    """Frozen HyperCore positions enable the default Safe-level recovery check.
+
+    1. Build a state with only a frozen HyperCore vault position.
+    2. Check whether the correct-accounts gate detects HyperCore strategy usage.
+    3. Assert the Safe-level transit recovery remains enabled for that strategy.
+    """
+    # Step 1: A frozen position can retain the only state evidence after a failed trade.
+    state = SimpleNamespace(
+        portfolio=SimpleNamespace(
+            open_positions={},
+            frozen_positions={
+                1: SimpleNamespace(
+                    pair=SimpleNamespace(is_hyperliquid_vault=lambda: True)
+                )
+            },
+            closed_positions={},
+        )
+    )
+
+    # Step 2: Inspect the state-only gate before any live HyperCore API read.
+    has_hypercore_position = correct_accounts_command._has_hypercore_vault_positions(state)
+
+    # Step 3: Frozen strategies use the same default recovery path as open ones.
+    assert has_hypercore_position is True
 
 
 def test_correct_accounts_dry_run_plans_transit_recovery_without_signer(monkeypatch) -> None:

--- a/tests/hyperliquid/test_hypercore_transit_recovery.py
+++ b/tests/hyperliquid/test_hypercore_transit_recovery.py
@@ -46,12 +46,12 @@ def _snapshot(
     )
 
 
-def test_hypercore_transit_plan_leaves_perp_and_spot_dust() -> None:
-    """Perp and spot recovery leaves fixed dust on both HyperCore balances.
+def test_hypercore_transit_plan_recovers_perp_excess_before_existing_spot() -> None:
+    """Default recovery returns all newly recovered perp USDC before spot cleanup.
 
     1. Build a snapshot with meaningful Safe-level spot and perp USDC.
     2. Plan HyperCore transit recovery actions.
-    3. Assert the planner moves only balances above the fixed dust amount.
+    3. Assert the planner bridges the full perp excess, then cleans old spot USDC.
     """
     # Step 1: Build a snapshot with meaningful Safe-level spot and perp USDC.
     snapshot = _snapshot(
@@ -62,13 +62,15 @@ def test_hypercore_transit_plan_leaves_perp_and_spot_dust() -> None:
     # Step 2: Plan HyperCore transit recovery actions.
     actions = plan_hypercore_transit_recovery_actions(snapshot)
 
-    # Step 3: Assert the planner moves only balances above the fixed dust amount.
+    # Step 3: Assert the full perp excess returns before old spot cleanup.
     assert [action.action_kind for action in actions] == [
         "perp_to_spot",
         "spot_to_evm",
+        "spot_to_evm",
     ]
     assert actions[0].amount == Decimal("768.375892")
-    assert actions[1].amount == Decimal("801.487490")
+    assert actions[1].amount == Decimal("768.375892")
+    assert actions[2].amount == Decimal("33.111598")
 
 
 def test_hypercore_transit_plan_handles_spot_only_balance() -> None:
@@ -90,11 +92,11 @@ def test_hypercore_transit_plan_handles_spot_only_balance() -> None:
 
 
 def test_hypercore_transit_plan_handles_perp_only_balance() -> None:
-    """Perp-only recovery plans perp-to-spot and then bridges the post-transfer spot balance.
+    """Perp-only recovery requests the complete recovered amount for HyperEVM.
 
     1. Build a snapshot with only Safe-level perp USDC.
     2. Plan HyperCore transit recovery actions.
-    3. Assert the planner leaves fixed dust in both perp and spot.
+    3. Assert the planner retains perp dust and requests all newly recovered USDC.
     """
     # Step 1: Build a snapshot with only Safe-level perp USDC.
     snapshot = _snapshot(perp_withdrawable=Decimal("10"))
@@ -102,21 +104,21 @@ def test_hypercore_transit_plan_handles_perp_only_balance() -> None:
     # Step 2: Plan HyperCore transit recovery actions.
     actions = plan_hypercore_transit_recovery_actions(snapshot)
 
-    # Step 3: Assert the planner leaves fixed dust in both perp and spot.
+    # Step 3: Assert the planner retains perp dust and requests the recovered USDC.
     assert [action.action_kind for action in actions] == [
         "perp_to_spot",
         "spot_to_evm",
     ]
     assert actions[0].amount == Decimal("9.50")
-    assert actions[1].amount == Decimal("9.00")
+    assert actions[1].amount == Decimal("9.50")
 
 
-def test_hypercore_transit_plan_recovers_only_verified_incident_amount() -> None:
-    """Verified #1486 recovery preserves pre-existing HyperCore balances.
+def test_hypercore_transit_plan_recovers_incident_amount_by_default() -> None:
+    """Default #1486 recovery preserves pre-existing HyperCore balances.
 
     1. Build the incident snapshot: 48.884068 USDC above 0.50 perp dust and
        0.217882 USDC already in spot.
-    2. Plan the exact operator-verified recovery amount.
+    2. Plan the default HyperCore transit recovery.
     3. Assert both transfer legs use exactly that amount, not a dust sweep.
     """
     # Step 1: Build the #1486 balances recorded after the failed vault deposit.
@@ -125,13 +127,10 @@ def test_hypercore_transit_plan_recovers_only_verified_incident_amount() -> None
         perp_withdrawable=Decimal("49.384068"),
     )
 
-    # Step 2: Plan the amount independently verified as absent from vault equity.
-    actions = plan_hypercore_transit_recovery_actions(
-        snapshot,
-        verified_recovery_amount=Decimal("48.884068"),
-    )
+    # Step 2: Plan default recovery; no incident-specific command option is needed.
+    actions = plan_hypercore_transit_recovery_actions(snapshot)
 
-    # Step 3: The original spot/perp balances remain untouched by the exact plan.
+    # Step 3: The original spot/perp balances remain untouched by the default plan.
     assert [action.action_kind for action in actions] == [
         "perp_to_spot",
         "spot_to_evm",
@@ -400,7 +399,6 @@ def test_correct_accounts_dry_run_plans_transit_recovery_without_signer(monkeypa
         state=state,
         skip_hypercore_transit_recovery=False,
         dry_run=True,
-        verified_recovery_amount=Decimal("48.884068"),
     )
 
     # Step 3: The operator can inspect the exact incident recovery with no mutation.

--- a/tests/hyperliquid/test_hypercore_transit_recovery.py
+++ b/tests/hyperliquid/test_hypercore_transit_recovery.py
@@ -91,12 +91,12 @@ def test_hypercore_transit_plan_handles_spot_only_balance() -> None:
     assert actions[0].amount == Decimal("9.50")
 
 
-def test_hypercore_transit_plan_handles_perp_only_balance() -> None:
-    """Perp-only recovery requests the complete recovered amount for HyperEVM.
+def test_hypercore_transit_plan_keeps_bridge_fee_margin_for_perp_only_balance() -> None:
+    """Perp-only recovery leaves only HyperCore's bridge-fee margin in spot.
 
     1. Build a snapshot with only Safe-level perp USDC.
     2. Plan HyperCore transit recovery actions.
-    3. Assert the planner retains perp dust and requests all newly recovered USDC.
+    3. Assert the planner retains perp dust and its required bridge-fee margin.
     """
     # Step 1: Build a snapshot with only Safe-level perp USDC.
     snapshot = _snapshot(perp_withdrawable=Decimal("10"))
@@ -104,13 +104,13 @@ def test_hypercore_transit_plan_handles_perp_only_balance() -> None:
     # Step 2: Plan HyperCore transit recovery actions.
     actions = plan_hypercore_transit_recovery_actions(snapshot)
 
-    # Step 3: Assert the planner retains perp dust and requests the recovered USDC.
+    # Step 3: Assert the planner retains perp dust and the required fee margin.
     assert [action.action_kind for action in actions] == [
         "perp_to_spot",
         "spot_to_evm",
     ]
     assert actions[0].amount == Decimal("9.50")
-    assert actions[1].amount == Decimal("9.50")
+    assert actions[1].amount == Decimal("9.49")
 
 
 def test_hypercore_transit_plan_recovers_incident_amount_by_default() -> None:
@@ -264,17 +264,69 @@ def test_hypercore_transit_execution_uses_dust_safe_spot_amount(monkeypatch) -> 
     ]
 
 
-def test_correct_accounts_recovery_helper_executes_for_closed_hypercore_position(monkeypatch) -> None:
-    """Correct-accounts recovery helper executes when a closed Hypercore position exists.
+def test_hypercore_spot_to_evm_execution_keeps_bridge_fee_margin(monkeypatch) -> None:
+    """Spot-to-EVM execution leaves HyperCore's mandatory fee headroom.
 
-    1. Build a fake Lagoon sync model and state with one closed Hypercore position.
+    1. Mock a spot account which contains only newly recovered perp USDC.
+    2. Execute the requested full bridge amount through the real fee calculation.
+    3. Assert the CoreWriter call keeps exactly the 0.01 USDC bridge-fee margin.
+
+    The account reader, transaction builder, broadcaster, and confirmation wait
+    are mocked because this verifies the client-side fee-safety calculation,
+    not a live Safe/module transaction.
+    """
+    # Step 1: Model a 4.50 USDC perp recovery with no pre-existing spot headroom.
+    monkeypatch.setattr(
+        hypercore_transit_recovery,
+        "fetch_hypercore_transit_balances",
+        lambda **kwargs: _snapshot(spot_free_usdc=Decimal("4.50")),
+    )
+    reserve_token = MagicMock()
+    reserve_token.convert_to_raw.side_effect = lambda amount: int(
+        (Decimal(amount) * Decimal(10**6)).to_integral_value()
+    )
+    sent_calls: list[tuple[str, int]] = []
+    monkeypatch.setattr(
+        hypercore_transit_recovery,
+        "build_hypercore_send_asset_to_evm_call",
+        lambda lagoon_vault, evm_usdc_amount: ("spot_to_evm", evm_usdc_amount),
+    )
+    monkeypatch.setattr(
+        hypercore_transit_recovery,
+        "broadcast_bound_call",
+        lambda web3, hot_wallet, bound_func, gas_limit=650000: sent_calls.append(bound_func) or "0x1",
+    )
+    monkeypatch.setattr(
+        hypercore_transit_recovery,
+        "wait_for_evm_usdc_balance",
+        lambda token, address, baseline_balance, expected_increase: expected_increase,
+    )
+
+    # Step 2: Request the full recovered amount; execution applies the protocol margin.
+    hypercore_transit_recovery.execute_spot_to_evm(
+        web3=MagicMock(),
+        hot_wallet=MagicMock(),
+        lagoon_vault=SimpleNamespace(safe_address=SAFE_ADDRESS),
+        session=object(),
+        reserve_token=reserve_token,
+        amount=Decimal("4.50"),
+    )
+
+    # Step 3: The builder receives 4.49 USDC, retaining exactly 0.01 USDC in spot.
+    assert sent_calls == [("spot_to_evm", 4_490_000)]
+
+
+def test_correct_accounts_recovery_helper_executes_for_open_hypercore_position(monkeypatch) -> None:
+    """Correct-accounts recovery runs for an open HyperCore position by default.
+
+    1. Build a fake Lagoon sync model and state with one open HyperCore position.
     2. Mock HyperCore snapshot planning and execution.
     3. Assert recovery is broadcast through the shared executor.
 
     The Lagoon sync model is mocked because this is a command hook test, not a
     Lagoon vault deployment test.
     """
-    # Step 1: Build a fake Lagoon sync model and state with one closed Hypercore position.
+    # Step 1: Build a fake Lagoon sync model and state with one open HyperCore position.
     class FakeLagoonVaultSyncModel:
         def __init__(self) -> None:
             self.vault = SimpleNamespace(
@@ -287,11 +339,13 @@ def test_correct_accounts_recovery_helper_executes_for_closed_hypercore_position
 
     state = SimpleNamespace(
         portfolio=SimpleNamespace(
-            closed_positions={
+            open_positions={
                 1: SimpleNamespace(
                     pair=SimpleNamespace(is_hyperliquid_vault=lambda: True)
                 )
-            }
+            },
+            frozen_positions={},
+            closed_positions={},
         )
     )
     sync_model = FakeLagoonVaultSyncModel()
@@ -403,62 +457,6 @@ def test_correct_accounts_dry_run_plans_transit_recovery_without_signer(monkeypa
 
     # Step 3: The operator can inspect the exact incident recovery with no mutation.
     assert planned == ["perp_to_spot", "spot_to_evm"]
-    broadcast.assert_not_called()
-
-
-def test_correct_accounts_requires_confirmation_for_exact_recovery(monkeypatch) -> None:
-    """Exact live recovery refuses to move funds without the second operator confirmation.
-
-    1. Build the stale-state #1486 condition and mock its live HyperCore balances.
-    2. Attempt the exact recovery without the confirmation option.
-    3. Assert no Safe broadcaster is reached and the command requests confirmation.
-
-    The live balance reader and broadcaster are mocked because this safety test
-    verifies the command gate, rather than a live transfer from a real Safe.
-    """
-    # Step 1: Model the stale state and the exact #1486 perp balance.
-    class FakeLagoonVaultSyncModel:
-        def __init__(self) -> None:
-            self.vault = SimpleNamespace(
-                safe_address=SAFE_ADDRESS,
-                underlying_token=MagicMock(),
-            )
-
-        def get_token_storage_address(self) -> str:
-            return SAFE_ADDRESS
-
-    state = SimpleNamespace(portfolio=SimpleNamespace(closed_positions={}))
-    monkeypatch.setattr(
-        correct_accounts_command,
-        "LagoonVaultSyncModel",
-        FakeLagoonVaultSyncModel,
-    )
-    monkeypatch.setattr(
-        hypercore_transit_recovery,
-        "fetch_hypercore_transit_balances",
-        lambda **kwargs: _snapshot(perp_withdrawable=Decimal("49.384068")),
-    )
-    broadcast = MagicMock(side_effect=AssertionError("unconfirmed recovery must not broadcast"))
-    monkeypatch.setattr(
-        hypercore_transit_recovery,
-        "execute_hypercore_transit_recovery_actions",
-        broadcast,
-    )
-
-    # Step 2: Request recovery with the known amount but omit confirmation.
-    with pytest.raises(RuntimeError, match="--confirm-hypercore-transit-recovery"):
-        correct_accounts_command._recover_hypercore_transit_balances(
-            asset_management_mode=AssetManagementMode.lagoon,
-            sync_model=FakeLagoonVaultSyncModel(),
-            web3=SimpleNamespace(eth=SimpleNamespace(chain_id=999)),
-            hot_wallet=MagicMock(),
-            state=state,
-            skip_hypercore_transit_recovery=False,
-            dry_run=False,
-            verified_recovery_amount=Decimal("48.884068"),
-        )
-
-    # Step 3: The command failed before a nonce sync or a Safe transaction.
     broadcast.assert_not_called()
 
 

--- a/tests/hyperliquid/test_hypercore_transit_recovery.py
+++ b/tests/hyperliquid/test_hypercore_transit_recovery.py
@@ -111,6 +111,37 @@ def test_hypercore_transit_plan_handles_perp_only_balance() -> None:
     assert actions[1].amount == Decimal("9.00")
 
 
+def test_hypercore_transit_plan_recovers_only_verified_incident_amount() -> None:
+    """Verified #1486 recovery preserves pre-existing HyperCore balances.
+
+    1. Build the incident snapshot: 48.884068 USDC above 0.50 perp dust and
+       0.217882 USDC already in spot.
+    2. Plan the exact operator-verified recovery amount.
+    3. Assert both transfer legs use exactly that amount, not a dust sweep.
+    """
+    # Step 1: Build the #1486 balances recorded after the failed vault deposit.
+    snapshot = _snapshot(
+        spot_free_usdc=Decimal("0.217882"),
+        perp_withdrawable=Decimal("49.384068"),
+    )
+
+    # Step 2: Plan the amount independently verified as absent from vault equity.
+    actions = plan_hypercore_transit_recovery_actions(
+        snapshot,
+        verified_recovery_amount=Decimal("48.884068"),
+    )
+
+    # Step 3: The original spot/perp balances remain untouched by the exact plan.
+    assert [action.action_kind for action in actions] == [
+        "perp_to_spot",
+        "spot_to_evm",
+    ]
+    assert [action.amount for action in actions] == [
+        Decimal("48.884068"),
+        Decimal("48.884068"),
+    ]
+
+
 def test_hypercore_transit_plan_ignores_dust_only_balances() -> None:
     """Dust-only spot and perp balances do not produce recovery actions.
 
@@ -286,7 +317,7 @@ def test_correct_accounts_recovery_helper_executes_for_closed_hypercore_position
     monkeypatch.setattr(
         hypercore_transit_recovery,
         "plan_hypercore_transit_recovery_actions",
-        lambda snapshot: [action],
+        lambda snapshot, **kwargs: [action],
     )
     executed_arguments = {}
     monkeypatch.setattr(
@@ -303,12 +334,134 @@ def test_correct_accounts_recovery_helper_executes_for_closed_hypercore_position
         hot_wallet=hot_wallet,
         state=state,
         skip_hypercore_transit_recovery=False,
+        dry_run=False,
     )
 
     # Step 3: Assert recovery is broadcast through the shared executor.
     assert executed == ["spot_to_evm"]
     assert executed_arguments["actions"] == [action]
     hot_wallet.sync_nonce.assert_called_once()
+
+
+def test_correct_accounts_dry_run_plans_transit_recovery_without_signer(monkeypatch) -> None:
+    """Dry-run exposes #1486-style transit recovery without broadcasting it.
+
+    1. Build a Lagoon state with a closed HyperCore position and stranded perp USDC.
+    2. Run the correct-accounts recovery hook in dry-run mode without a hot-wallet signer.
+    3. Verify it reports the planned recovery while never invoking the broadcaster.
+
+    The HyperCore snapshot and broadcaster are mocked because this test checks
+    the command's no-side-effect contract rather than a live Safe transaction.
+    """
+    # Step 1: Model the legacy-state condition: closed positions exist even
+    # though the state may predate the #1486 failure marker.
+    class FakeLagoonVaultSyncModel:
+        def __init__(self) -> None:
+            self.vault = SimpleNamespace(
+                safe_address=SAFE_ADDRESS,
+                underlying_token=MagicMock(),
+            )
+
+        def get_token_storage_address(self) -> str:
+            return SAFE_ADDRESS
+
+    state = SimpleNamespace(
+        portfolio=SimpleNamespace(
+            closed_positions={
+                1: SimpleNamespace(
+                    pair=SimpleNamespace(is_hyperliquid_vault=lambda: True)
+                )
+            }
+        )
+    )
+    monkeypatch.setattr(
+        correct_accounts_command,
+        "LagoonVaultSyncModel",
+        FakeLagoonVaultSyncModel,
+    )
+    monkeypatch.setattr(
+        hypercore_transit_recovery,
+        "fetch_hypercore_transit_balances",
+        lambda **kwargs: _snapshot(perp_withdrawable=Decimal("49.384068")),
+    )
+    broadcast = MagicMock(side_effect=AssertionError("dry run must not broadcast"))
+    monkeypatch.setattr(
+        hypercore_transit_recovery,
+        "execute_hypercore_transit_recovery_actions",
+        broadcast,
+    )
+
+    # Step 2: Dry-run must require only read access, not the Safe's private key.
+    planned = correct_accounts_command._recover_hypercore_transit_balances(
+        asset_management_mode=AssetManagementMode.lagoon,
+        sync_model=FakeLagoonVaultSyncModel(),
+        web3=SimpleNamespace(eth=SimpleNamespace(chain_id=999)),
+        hot_wallet=None,
+        state=state,
+        skip_hypercore_transit_recovery=False,
+        dry_run=True,
+        verified_recovery_amount=Decimal("48.884068"),
+    )
+
+    # Step 3: The operator can inspect the exact incident recovery with no mutation.
+    assert planned == ["perp_to_spot", "spot_to_evm"]
+    broadcast.assert_not_called()
+
+
+def test_correct_accounts_requires_confirmation_for_exact_recovery(monkeypatch) -> None:
+    """Exact live recovery refuses to move funds without the second operator confirmation.
+
+    1. Build the stale-state #1486 condition and mock its live HyperCore balances.
+    2. Attempt the exact recovery without the confirmation option.
+    3. Assert no Safe broadcaster is reached and the command requests confirmation.
+
+    The live balance reader and broadcaster are mocked because this safety test
+    verifies the command gate, rather than a live transfer from a real Safe.
+    """
+    # Step 1: Model the stale state and the exact #1486 perp balance.
+    class FakeLagoonVaultSyncModel:
+        def __init__(self) -> None:
+            self.vault = SimpleNamespace(
+                safe_address=SAFE_ADDRESS,
+                underlying_token=MagicMock(),
+            )
+
+        def get_token_storage_address(self) -> str:
+            return SAFE_ADDRESS
+
+    state = SimpleNamespace(portfolio=SimpleNamespace(closed_positions={}))
+    monkeypatch.setattr(
+        correct_accounts_command,
+        "LagoonVaultSyncModel",
+        FakeLagoonVaultSyncModel,
+    )
+    monkeypatch.setattr(
+        hypercore_transit_recovery,
+        "fetch_hypercore_transit_balances",
+        lambda **kwargs: _snapshot(perp_withdrawable=Decimal("49.384068")),
+    )
+    broadcast = MagicMock(side_effect=AssertionError("unconfirmed recovery must not broadcast"))
+    monkeypatch.setattr(
+        hypercore_transit_recovery,
+        "execute_hypercore_transit_recovery_actions",
+        broadcast,
+    )
+
+    # Step 2: Request recovery with the known amount but omit confirmation.
+    with pytest.raises(RuntimeError, match="--confirm-hypercore-transit-recovery"):
+        correct_accounts_command._recover_hypercore_transit_balances(
+            asset_management_mode=AssetManagementMode.lagoon,
+            sync_model=FakeLagoonVaultSyncModel(),
+            web3=SimpleNamespace(eth=SimpleNamespace(chain_id=999)),
+            hot_wallet=MagicMock(),
+            state=state,
+            skip_hypercore_transit_recovery=False,
+            dry_run=False,
+            verified_recovery_amount=Decimal("48.884068"),
+        )
+
+    # Step 3: The command failed before a nonce sync or a Safe transaction.
+    broadcast.assert_not_called()
 
 
 def test_correct_accounts_recovery_helper_can_be_skipped(monkeypatch) -> None:
@@ -343,6 +496,7 @@ def test_correct_accounts_recovery_helper_can_be_skipped(monkeypatch) -> None:
         hot_wallet=MagicMock(),
         state=state,
         skip_hypercore_transit_recovery=True,
+        dry_run=False,
     )
 
     # Step 3: Assert no HyperCore session or broadcast is attempted.

--- a/tests/hyperliquid/test_hyperliquid_cleanup.py
+++ b/tests/hyperliquid/test_hyperliquid_cleanup.py
@@ -276,14 +276,15 @@ def test_hyperliquid_cleanup_recovers_stranded_safe_balances(
     assert [action.action_kind for action in report.planned_actions] == [
         "perp_to_spot",
         "spot_to_evm",
+        "spot_to_evm",
     ]
     assert "vault_to_perp" not in {
         action.action_kind for action in report.planned_actions
     }
 
     # Step 5: Confirm the mocked broadcasts executed in the expected order.
-    assert broadcast_order == ["perp_to_spot", "spot_to_evm"]
-    assert report.executed_action_kinds == ["perp_to_spot", "spot_to_evm"]
+    assert broadcast_order == ["perp_to_spot", "spot_to_evm", "spot_to_evm"]
+    assert report.executed_action_kinds == ["perp_to_spot", "spot_to_evm", "spot_to_evm"]
 
     # Step 6: Confirm repair, account correction, and final save completed.
     assert repair_calls == ["repair"]
@@ -292,18 +293,8 @@ def test_hyperliquid_cleanup_recovers_stranded_safe_balances(
     assert report.state_saved is True
     assert state_file.with_suffix(".backup-1.json").exists()
 
-    # Step 7: Confirm the spot->EVM withdrawal leaves the configured spot dust.
-    # Total spot after perp->spot recovery: 1 + (6.99345 - 0.50) = 7.49345 USDC.
-    # The withdrawal should be 7.49345 - 0.50 = 6.99345 USDC
-    # = 6_993_450 raw (6 decimals).
-    assert len(captured_evm_usdc_amounts) == 1
-    total_spot = Decimal("1") + Decimal("6.99345") - Decimal("0.50")
-    expected_raw = int(
-        (
-            (total_spot - Decimal("0.50")) * Decimal(10**6)
-        ).to_integral_value()
-    )
-    assert captured_evm_usdc_amounts[0] == expected_raw
+    # Step 7: Return the recovered perp amount first, then clean old spot to dust.
+    assert captured_evm_usdc_amounts == [6_493_450, 500_000]
 
 
 def test_hyperliquid_cleanup_raises_on_dust_spot_balance(monkeypatch):
@@ -433,7 +424,7 @@ def test_hyperliquid_cleanup_allows_live_vault_rows_when_stranded_recovery_exist
         "spot_to_evm",
     ]
     assert actions[0].amount == Decimal("4177.23")
-    assert actions[1].amount == Decimal("4176.739252")
+    assert actions[1].amount == Decimal("4177.229252")
 
 
 def test_wait_for_spot_free_balance_accepts_threshold_instead_of_exact_match(

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -1318,6 +1318,44 @@ def test_single_buy_failed(usdc, weth, weth_usdc, start_ts):
     assert trade.portfolio_value_at_creation == 1000.0
 
 
+def test_failed_buy_with_recoverable_stranded_capital_keeps_reserve_allocation(
+    usdc: AssetIdentifier,
+    weth_usdc: TradingPairIdentifier,
+    start_ts: datetime.datetime,
+):
+    """A failed HyperCore buy keeps reserve capital allocated while it is stranded.
+
+    1. Start and broadcast a normal reserve-funded vault-like buy.
+    2. Mark the trade as having recoverable capital outside the Safe.
+    3. Fail the trade and verify the reserve remains debited until recovery.
+    """
+    # 1. Start and broadcast a normal reserve-funded vault-like buy.
+    state = State()
+    state.update_reserves([
+        ReservePosition(usdc, Decimal(1000), start_ts, 1.0, start_ts),
+    ])
+    _position, trade, _created = state.create_trade(
+        strategy_cycle_at=start_ts,
+        pair=weth_usdc,
+        quantity=Decimal("0.1"),
+        reserve=None,
+        assumed_price=1700,
+        trade_type=TradeType.rebalance,
+        reserve_currency=usdc,
+        reserve_currency_price=1.0,
+    )
+    state.start_execution(start_ts, trade, "0xffffff", 1)
+    state.mark_broadcasted(start_ts, trade)
+
+    # 2. Mark the trade as having recoverable capital outside the Safe.
+    trade.other_data["retain_reserve_allocation_on_failure"] = True
+
+    # 3. Fail the trade and verify the reserve remains debited until recovery.
+    state.mark_trade_failed(start_ts, trade)
+    assert trade.get_status() == TradeStatus.failed
+    assert state.portfolio.get_cash() == 830
+
+
 def test_serialize_state(usdc, weth_usdc, start_ts: datetime.datetime):
     """Dump and reload the internal state."""
 

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -1356,6 +1356,47 @@ def test_failed_buy_with_recoverable_stranded_capital_keeps_reserve_allocation(
     assert state.portfolio.get_cash() == 830
 
 
+def test_failed_buy_with_hypercore_phase1_at_risk_keeps_reserve_allocation(
+    usdc: AssetIdentifier,
+    weth_usdc: TradingPairIdentifier,
+    start_ts: datetime.datetime,
+):
+    """An unclassified HyperCore phase-1 crash must retain reserve allocation.
+
+    1. Start and broadcast a reserve-funded buy.
+    2. Persist only the pre-broadcast HyperCore capital-at-risk marker.
+    3. Fail the trade and verify generic accounting cannot refund it.
+    """
+    # 1. Start and broadcast a reserve-funded buy.
+    state = State()
+    state.update_reserves([
+        ReservePosition(usdc, Decimal(1000), start_ts, 1.0, start_ts),
+    ])
+    _position, trade, _created = state.create_trade(
+        strategy_cycle_at=start_ts,
+        pair=weth_usdc,
+        quantity=Decimal("0.1"),
+        reserve=None,
+        assumed_price=1700,
+        trade_type=TradeType.rebalance,
+        reserve_currency=usdc,
+        reserve_currency_price=1.0,
+    )
+    state.start_execution(start_ts, trade, "0xffffff", 1)
+    state.mark_broadcasted(start_ts, trade)
+
+    # 2. Reproduce a process death after phase-1 broadcast but before receipt classification.
+    trade.other_data["hypercore_deposit_capital_at_risk"] = {
+        "amount_raw": 170_000_000,
+        "phase": "phase1_broadcast_pending",
+    }
+
+    # 3. The failed-buy handler fails closed until a live reconciliation clears it.
+    state.mark_trade_failed(start_ts, trade)
+    assert trade.get_status() == TradeStatus.failed
+    assert state.portfolio.get_cash() == 830
+
+
 def test_serialize_state(usdc, weth_usdc, start_ts: datetime.datetime):
     """Dump and reload the internal state."""
 

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -1394,7 +1394,7 @@ def test_failed_buy_with_hypercore_phase1_at_risk_keeps_reserve_allocation(
     # 3. The failed-buy handler fails closed until a live reconciliation clears it.
     state.mark_trade_failed(start_ts, trade)
     assert trade.get_status() == TradeStatus.failed
-    assert state.portfolio.get_cash() == 830
+    assert state.portfolio.get_cash() == pytest.approx(830)
 
 
 def test_serialize_state(usdc, weth_usdc, start_ts: datetime.datetime):

--- a/tradeexecutor/cli/commands/correct_accounts.py
+++ b/tradeexecutor/cli/commands/correct_accounts.py
@@ -276,12 +276,32 @@ def _recover_hypercore_transit_balances(
     hot_wallet: HotWallet | None,
     state,
     skip_hypercore_transit_recovery: bool,
+    dry_run: bool,
+    verified_recovery_amount: Decimal | None = None,
+    confirm_verified_recovery: bool = False,
 ) -> list[str]:
-    """Recover Safe-level HyperCore spot/perp USDC before account correction."""
+    """Plan or recover Safe-level HyperCore spot/perp USDC before correction.
+
+    HyperAI trade #1486 (Citadel, 2026-07-30; PR #1593) is the reason this runs before
+    generic account correction. Its combined CoreWriter request received a
+    successful HyperEVM receipt, moved 48.884068 USDC from spot to perp, and
+    silently did not move that USDC from perp to the vault. Generic accounting
+    cannot see HyperCore's internal USDC classes, so it must never decide that
+    the stranded balance is Safe cash.
+
+    The live snapshot is authoritative: recovery is Safe-level rather than
+    trade-level because an older state file can predate the failure marker.
+    Recovery only returns unencumbered spot/perp USDC to HyperEVM, and the
+    lower-level planner refuses active perp positions. ``dry_run`` deliberately
+    follows the same snapshot and planning path without requiring a signer or
+    broadcasting.  A ``verified_recovery_amount`` is more conservative than
+    the normal dust-preserving sweep: it plans only an amount independently
+    confirmed as stranded and requires an explicit live-run confirmation.
+    """
     if not asset_management_mode.is_vault():
         return []
 
-    if not _has_closed_hypercore_positions(state):
+    if not _has_closed_hypercore_positions(state) and verified_recovery_amount is None:
         return []
 
     if skip_hypercore_transit_recovery:
@@ -294,12 +314,6 @@ def _recover_hypercore_transit_balances(
         raise RuntimeError(
             "Closed Hypercore positions exist, but automatic HyperCore transit recovery "
             f"is only implemented for Lagoon vaults. Got sync model {type(sync_model)}."
-        )
-
-    if hot_wallet is None:
-        raise RuntimeError(
-            "Closed Hypercore positions exist and HyperCore transit recovery is needed, "
-            "but no hot wallet/private key is configured for broadcasting Safe transactions."
         )
 
     from eth_defi.hyperliquid.session import (
@@ -328,7 +342,10 @@ def _recover_hypercore_transit_balances(
         safe_address=safe_address,
         reserve_token=reserve_token,
     )
-    actions = plan_hypercore_transit_recovery_actions(snapshot)
+    actions = plan_hypercore_transit_recovery_actions(
+        snapshot,
+        verified_recovery_amount=verified_recovery_amount,
+    )
     if not actions:
         logger.info("No HyperCore spot/perp transit balances need recovery")
         return []
@@ -339,6 +356,35 @@ def _recover_hypercore_transit_balances(
             action.action_kind,
             action.amount,
             action.reason,
+        )
+
+    if dry_run:
+        # This is intentionally after the live snapshot and action planner.
+        # Before this change, correct-accounts --dry-run skipped the exact
+        # perp->spot->EVM plan that would have made the #1486 recovery visible.
+        logger.warning(
+            "Dry run: HyperCore transit recovery would broadcast %s for Safe %s; "
+            "no transaction is signed, broadcast, or persisted.",
+            ", ".join(action.action_kind for action in actions),
+            safe_address,
+        )
+        return [action.action_kind for action in actions]
+
+    if verified_recovery_amount is not None and not confirm_verified_recovery:
+        # An EVM-success receipt does not prove that every CoreWriter action
+        # settled.  Therefore the exact #1486-style path has an additional
+        # opt-in beyond the value itself before it can alter Safe balances.
+        raise RuntimeError(
+            "Refusing to broadcast an operator-verified HyperCore transit recovery "
+            "without --confirm-hypercore-transit-recovery. First run the same "
+            "command with --dry-run and verify the vault equity did not receive "
+            "the stated amount."
+        )
+
+    if hot_wallet is None:
+        raise RuntimeError(
+            "Closed Hypercore positions exist and HyperCore transit recovery is needed, "
+            "but no hot wallet/private key is configured for broadcasting Safe transactions."
         )
 
     hot_wallet.sync_nonce(web3)
@@ -394,9 +440,11 @@ def correct_accounts(
     process_redemption_end_block_hint: int = Option(None, "--process-redemption-end-block-hint", envvar="PROCESS_REDEMPTION_END_BLOCK_HINT", help="Used in integration testing."),
     transfer_away: bool = Option(False, "--transfer-away", envvar="TRANSFER_AWAY", help="For tokens without assigned position, scoop them to the hot wallet instead of trying to construct a new position"),
     raise_on_unclean: bool = typer.Option(False, is_flag=True, envvar="RAISE_ON_UNCLEAN", help="Raise an exception if unclean. Unit test option."),
-    skip_hypercore_transit_recovery: bool = Option(False, "--skip-hypercore-transit-recovery", envvar="SKIP_HYPERCORE_TRANSIT_RECOVERY", help="Skip automatic Safe-level HyperCore spot/perp USDC recovery before account correction."),
+    skip_hypercore_transit_recovery: bool = Option(False, "--skip-hypercore-transit-recovery", envvar="SKIP_HYPERCORE_TRANSIT_RECOVERY", help="Skip Safe-level HyperCore spot/perp USDC recovery before account correction."),
+    recover_hypercore_transit_usdc: Decimal | None = Option(None, "--recover-hypercore-transit-usdc", envvar="RECOVER_HYPERCORE_TRANSIT_USDC", help="Exact USDC independently verified as stranded in this Safe's HyperCore spot or perp balance. Use --dry-run first; live recovery also requires --confirm-hypercore-transit-recovery."),
+    confirm_hypercore_transit_recovery: bool = Option(False, "--confirm-hypercore-transit-recovery", envvar="CONFIRM_HYPERCORE_TRANSIT_RECOVERY", help="Confirm the exact --recover-hypercore-transit-usdc amount was checked against live vault equity before a live Safe transfer."),
     cleanup_hypercore_small_positions: bool = Option(True, "--cleanup-hypercore-small-positions/--no-cleanup-hypercore-small-positions", envvar="CLEANUP_HYPERCORE_SMALL_POSITIONS", help="Redeem open HyperCore vault positions below the strategy minimum allocation before correcting accounts."),
-    dry_run: bool = Option(False, "--dry-run", envvar="DRY_RUN", help="Read live balances, rehearse HyperCore cleanup through phase-1 transaction construction without persisting state or broadcasting, then report accounting corrections."),
+    dry_run: bool = Option(False, "--dry-run", envvar="DRY_RUN", help="Read live balances and print any Safe-level HyperCore perp->spot->EVM recovery plan without signing, broadcasting, persisting state, or applying accounting corrections."),
 
     # Derive exchange account options
     derive_owner_private_key: Optional[str] = Option(None, envvar="DERIVE_OWNER_PRIVATE_KEY", help="Derive owner wallet private key"),
@@ -422,10 +470,12 @@ def correct_accounts(
     positions cannot carry over with the current event based tracking logic.
 
     This command is interactive and you need to confirm any changes applied to the state.
-    Use ``--dry-run`` for a read-only rehearsal. HyperCore cleanup performs
-    every pre-broadcast step on isolated state copies, including transaction
-    construction and signing. Dry-run never broadcasts transactions and does
-    not write or back up the state file.
+    Use ``--dry-run`` for a read-only rehearsal. It includes the live
+    Safe-level HyperCore transit-recovery planner: this reads spot/perp/EVM
+    balances and prints any ``perp -> spot -> EVM`` actions, but never signs or
+    broadcasts them. This makes a partial CoreWriter settlement visible before
+    generic correction changes state. Dry-run never writes or backs up the
+    state file.
 
     An old state file is automatically backed up.
     """
@@ -783,15 +833,17 @@ def correct_accounts(
             len(closed_dust_trades),
         )
 
-    if not dry_run:
-        _recover_hypercore_transit_balances(
-            asset_management_mode=asset_management_mode,
-            sync_model=sync_model,
-            web3=web3,
-            hot_wallet=hot_wallet,
-            state=state,
-            skip_hypercore_transit_recovery=skip_hypercore_transit_recovery,
-        )
+    _recover_hypercore_transit_balances(
+        asset_management_mode=asset_management_mode,
+        sync_model=sync_model,
+        web3=web3,
+        hot_wallet=hot_wallet,
+        state=state,
+        skip_hypercore_transit_recovery=skip_hypercore_transit_recovery,
+        dry_run=dry_run,
+        verified_recovery_amount=recover_hypercore_transit_usdc,
+        confirm_verified_recovery=confirm_hypercore_transit_recovery,
+    )
 
     block_number = get_almost_latest_block_number(web3)
     logger.info(f"Correcting accounts at block {block_number:,}")

--- a/tradeexecutor/cli/commands/correct_accounts.py
+++ b/tradeexecutor/cli/commands/correct_accounts.py
@@ -260,11 +260,24 @@ def _sync_hypercore_vault_positions(
     return closed_phantom
 
 
-def _has_closed_hypercore_positions(state) -> bool:
-    """Check whether state has closed Hypercore vault positions."""
+def _has_hypercore_vault_positions(state) -> bool:
+    """Check whether the strategy tracks any HyperCore vault position.
+
+    This deliberately includes open, frozen, and closed positions. Transit USDC
+    belongs to the Safe rather than a position, so only looking at closed
+    positions could skip the default #1486 recovery for a strategy which has
+    started following HyperCore vaults but has not closed one yet. The planner
+    separately reads the live perp account and refuses recovery when it finds
+    an actual active perp position.
+    """
     return any(
         position.pair.is_hyperliquid_vault()
-        for position in state.portfolio.closed_positions.values()
+        for position_collection in (
+            getattr(state.portfolio, "open_positions", {}),
+            getattr(state.portfolio, "frozen_positions", {}),
+            getattr(state.portfolio, "closed_positions", {}),
+        )
+        for position in position_collection.values()
     )
 
 
@@ -277,8 +290,6 @@ def _recover_hypercore_transit_balances(
     state,
     skip_hypercore_transit_recovery: bool,
     dry_run: bool,
-    verified_recovery_amount: Decimal | None = None,
-    confirm_verified_recovery: bool = False,
 ) -> list[str]:
     """Plan or recover Safe-level HyperCore spot/perp USDC before correction.
 
@@ -295,26 +306,26 @@ def _recover_hypercore_transit_balances(
     lower-level planner refuses active perp positions. ``dry_run`` deliberately
     follows the same snapshot and planning path without requiring a signer or
     broadcasting. The normal planner is enabled by default for every eligible
-    HyperCore vault strategy and returns the full excess which it just moved
-    from perp to spot; this prevents the #1486 amount being reduced by an
-    unrelated pre-existing spot dust balance. A ``verified_recovery_amount``
-    is an optional, narrower override that requires a live-run confirmation.
+    HyperCore vault strategy and returns the transferable excess which it just
+    moved from perp to spot; it leaves only HyperCore's mandatory bridge-fee
+    margin when the pre-existing spot balance cannot cover it. This prevents
+    the #1486 amount being reduced by unrelated pre-existing spot dust.
     """
     if not asset_management_mode.is_vault():
         return []
 
-    if not _has_closed_hypercore_positions(state) and verified_recovery_amount is None:
+    if not _has_hypercore_vault_positions(state):
         return []
 
     if skip_hypercore_transit_recovery:
         logger.info(
-            "Skipping HyperCore transit recovery although closed Hypercore positions exist"
+            "Skipping HyperCore transit recovery although HyperCore vault positions exist"
         )
         return []
 
     if not isinstance(sync_model, LagoonVaultSyncModel):
         raise RuntimeError(
-            "Closed Hypercore positions exist, but automatic HyperCore transit recovery "
+            "HyperCore vault positions exist, but automatic HyperCore transit recovery "
             f"is only implemented for Lagoon vaults. Got sync model {type(sync_model)}."
         )
 
@@ -336,7 +347,7 @@ def _recover_hypercore_transit_balances(
     reserve_token = sync_model.vault.underlying_token
 
     logger.info(
-        "Closed Hypercore positions detected; checking Safe-level HyperCore transit balances for %s",
+        "HyperCore vault positions detected; checking Safe-level HyperCore transit balances for %s",
         safe_address,
     )
     snapshot = fetch_hypercore_transit_balances(
@@ -344,10 +355,7 @@ def _recover_hypercore_transit_balances(
         safe_address=safe_address,
         reserve_token=reserve_token,
     )
-    actions = plan_hypercore_transit_recovery_actions(
-        snapshot,
-        verified_recovery_amount=verified_recovery_amount,
-    )
+    actions = plan_hypercore_transit_recovery_actions(snapshot)
     if not actions:
         logger.info("No HyperCore spot/perp transit balances need recovery")
         return []
@@ -372,20 +380,9 @@ def _recover_hypercore_transit_balances(
         )
         return [action.action_kind for action in actions]
 
-    if verified_recovery_amount is not None and not confirm_verified_recovery:
-        # An EVM-success receipt does not prove that every CoreWriter action
-        # settled.  Therefore the exact #1486-style path has an additional
-        # opt-in beyond the value itself before it can alter Safe balances.
-        raise RuntimeError(
-            "Refusing to broadcast an operator-verified HyperCore transit recovery "
-            "without --confirm-hypercore-transit-recovery. First run the same "
-            "command with --dry-run and verify the vault equity did not receive "
-            "the stated amount."
-        )
-
     if hot_wallet is None:
         raise RuntimeError(
-            "Closed Hypercore positions exist and HyperCore transit recovery is needed, "
+            "HyperCore vault positions exist and HyperCore transit recovery is needed, "
             "but no hot wallet/private key is configured for broadcasting Safe transactions."
         )
 
@@ -443,8 +440,6 @@ def correct_accounts(
     transfer_away: bool = Option(False, "--transfer-away", envvar="TRANSFER_AWAY", help="For tokens without assigned position, scoop them to the hot wallet instead of trying to construct a new position"),
     raise_on_unclean: bool = typer.Option(False, is_flag=True, envvar="RAISE_ON_UNCLEAN", help="Raise an exception if unclean. Unit test option."),
     skip_hypercore_transit_recovery: bool = Option(False, "--skip-hypercore-transit-recovery", envvar="SKIP_HYPERCORE_TRANSIT_RECOVERY", help="Skip Safe-level HyperCore spot/perp USDC recovery before account correction."),
-    recover_hypercore_transit_usdc: Decimal | None = Option(None, "--recover-hypercore-transit-usdc", envvar="RECOVER_HYPERCORE_TRANSIT_USDC", help="Optional exact USDC override for an independently verified stranded Safe balance. Normal eligible HyperCore transit recovery is already on by default. Use --dry-run first; this narrower live override also requires --confirm-hypercore-transit-recovery."),
-    confirm_hypercore_transit_recovery: bool = Option(False, "--confirm-hypercore-transit-recovery", envvar="CONFIRM_HYPERCORE_TRANSIT_RECOVERY", help="Confirm the exact --recover-hypercore-transit-usdc amount was checked against live vault equity before a live Safe transfer."),
     cleanup_hypercore_small_positions: bool = Option(True, "--cleanup-hypercore-small-positions/--no-cleanup-hypercore-small-positions", envvar="CLEANUP_HYPERCORE_SMALL_POSITIONS", help="Redeem open HyperCore vault positions below the strategy minimum allocation before correcting accounts."),
     dry_run: bool = Option(False, "--dry-run", envvar="DRY_RUN", help="Read live balances and print any Safe-level HyperCore perp->spot->EVM recovery plan without signing, broadcasting, persisting state, or applying accounting corrections."),
 
@@ -843,8 +838,6 @@ def correct_accounts(
         state=state,
         skip_hypercore_transit_recovery=skip_hypercore_transit_recovery,
         dry_run=dry_run,
-        verified_recovery_amount=recover_hypercore_transit_usdc,
-        confirm_verified_recovery=confirm_hypercore_transit_recovery,
     )
 
     block_number = get_almost_latest_block_number(web3)

--- a/tradeexecutor/cli/commands/correct_accounts.py
+++ b/tradeexecutor/cli/commands/correct_accounts.py
@@ -294,9 +294,11 @@ def _recover_hypercore_transit_balances(
     Recovery only returns unencumbered spot/perp USDC to HyperEVM, and the
     lower-level planner refuses active perp positions. ``dry_run`` deliberately
     follows the same snapshot and planning path without requiring a signer or
-    broadcasting.  A ``verified_recovery_amount`` is more conservative than
-    the normal dust-preserving sweep: it plans only an amount independently
-    confirmed as stranded and requires an explicit live-run confirmation.
+    broadcasting. The normal planner is enabled by default for every eligible
+    HyperCore vault strategy and returns the full excess which it just moved
+    from perp to spot; this prevents the #1486 amount being reduced by an
+    unrelated pre-existing spot dust balance. A ``verified_recovery_amount``
+    is an optional, narrower override that requires a live-run confirmation.
     """
     if not asset_management_mode.is_vault():
         return []
@@ -441,7 +443,7 @@ def correct_accounts(
     transfer_away: bool = Option(False, "--transfer-away", envvar="TRANSFER_AWAY", help="For tokens without assigned position, scoop them to the hot wallet instead of trying to construct a new position"),
     raise_on_unclean: bool = typer.Option(False, is_flag=True, envvar="RAISE_ON_UNCLEAN", help="Raise an exception if unclean. Unit test option."),
     skip_hypercore_transit_recovery: bool = Option(False, "--skip-hypercore-transit-recovery", envvar="SKIP_HYPERCORE_TRANSIT_RECOVERY", help="Skip Safe-level HyperCore spot/perp USDC recovery before account correction."),
-    recover_hypercore_transit_usdc: Decimal | None = Option(None, "--recover-hypercore-transit-usdc", envvar="RECOVER_HYPERCORE_TRANSIT_USDC", help="Exact USDC independently verified as stranded in this Safe's HyperCore spot or perp balance. Use --dry-run first; live recovery also requires --confirm-hypercore-transit-recovery."),
+    recover_hypercore_transit_usdc: Decimal | None = Option(None, "--recover-hypercore-transit-usdc", envvar="RECOVER_HYPERCORE_TRANSIT_USDC", help="Optional exact USDC override for an independently verified stranded Safe balance. Normal eligible HyperCore transit recovery is already on by default. Use --dry-run first; this narrower live override also requires --confirm-hypercore-transit-recovery."),
     confirm_hypercore_transit_recovery: bool = Option(False, "--confirm-hypercore-transit-recovery", envvar="CONFIRM_HYPERCORE_TRANSIT_RECOVERY", help="Confirm the exact --recover-hypercore-transit-usdc amount was checked against live vault equity before a live Safe transfer."),
     cleanup_hypercore_small_positions: bool = Option(True, "--cleanup-hypercore-small-positions/--no-cleanup-hypercore-small-positions", envvar="CLEANUP_HYPERCORE_SMALL_POSITIONS", help="Redeem open HyperCore vault positions below the strategy minimum allocation before correcting accounts."),
     dry_run: bool = Option(False, "--dry-run", envvar="DRY_RUN", help="Read live balances and print any Safe-level HyperCore perp->spot->EVM recovery plan without signing, broadcasting, persisting state, or applying accounting corrections."),

--- a/tradeexecutor/cli/loop.py
+++ b/tradeexecutor/cli/loop.py
@@ -854,6 +854,7 @@ class ExecutionLoop:
             pricing_model,
             routing_state,
             long_short_metrics_latest=long_short_metrics_latest,
+            state_sync_callback=lambda: self.store.sync(state),
         )
 
         # Check that state is good before writing it to the disk

--- a/tradeexecutor/ethereum/execution.py
+++ b/tradeexecutor/ethereum/execution.py
@@ -192,6 +192,20 @@ class EthereumExecution(ExecutionModel):
         if not trades_to_be_repaired:
             return []
 
+        at_risk_hypercore_trades = [
+            trade
+            for trade in trades_to_be_repaired
+            if trade.other_data.get("hypercore_deposit_capital_at_risk") is not None
+            or trade.other_data.get("hypercore_stranded_usdc") is not None
+        ]
+        if at_risk_hypercore_trades:
+            trade_ids = ", ".join(str(trade.trade_id) for trade in at_risk_hypercore_trades)
+            raise RuntimeError(
+                f"Cannot automatically repair HyperCore deposit trade(s) {trade_ids}: "
+                "reconcile the Safe, escrow, spot, perp and vault balances with "
+                "check-hypercore-user.py before releasing any allocation."
+            )
+
         print("Found %d trades to be repaired", len(trades_to_be_repaired))
         confirmation = input("Attempt to repair [y/n]").lower()
 

--- a/tradeexecutor/ethereum/execution.py
+++ b/tradeexecutor/ethereum/execution.py
@@ -200,6 +200,11 @@ class EthereumExecution(ExecutionModel):
         ]
         if at_risk_hypercore_trades:
             trade_ids = ", ".join(str(trade.trade_id) for trade in at_risk_hypercore_trades)
+            # Do not use this generic receipt-repair loop for CoreWriter
+            # deposits. A missing receipt or a receipt for a wrapper call does
+            # not say whether HyperCore left USDC in escrow, spot, perp, or the
+            # vault. Treating it as an ordinary failed buy could re-credit the
+            # Safe and repeat the #1486 double-spend accounting failure.
             raise RuntimeError(
                 f"Cannot automatically repair HyperCore deposit trade(s) {trade_ids}: "
                 "reconcile the Safe, escrow, spot, perp and vault balances with "

--- a/tradeexecutor/ethereum/execution.py
+++ b/tradeexecutor/ethereum/execution.py
@@ -750,6 +750,12 @@ class EthereumExecution(ExecutionModel):
                 rebroadcast=rebroadcast,
             )
 
+            # setup_trades() may create a fail-closed checkpoint together with
+            # signed transactions.  Persist both before any RPC broadcast: a
+            # process crash after node acceptance must restart with the same
+            # uncertainty marker, not refund possibly moved Safe capital.
+            self.sync_state_before_broadcast()
+
             self._execute_trade_batch(
                 routing_model,
                 state,
@@ -842,6 +848,11 @@ class EthereumExecution(ExecutionModel):
             check_balances=check_balances,
             rebroadcast=rebroadcast,
         )
+
+        # See the sequential path above.  This deliberately occurs after
+        # setup, because transaction hashes and route-specific safety metadata
+        # do not exist at the runner's earlier pre-execution checkpoint.
+        self.sync_state_before_broadcast()
 
         self._execute_trade_batch(
             routing_model,

--- a/tradeexecutor/ethereum/vault/README-vault-position-manual.md
+++ b/tradeexecutor/ethereum/vault/README-vault-position-manual.md
@@ -253,6 +253,50 @@ the generic `repair` command or re-submit the last transfer.
 5. Reconcile state only after exactly one destination is confirmed: increased
    vault equity or USDC returned to the Safe.
 
+#### Correct-accounts recovery for stranded Safe-level USDC
+
+`correct-accounts` has a HyperCore-specific Safe-level transit recovery before
+ordinary reserve accounting. It exists because of HyperAI Citadel trade #1486
+(2026-07-30; PR #1593): the HyperEVM CoreWriter receipt succeeded, but the
+combined HyperCore request moved 48.884068 USDC only from spot to perp. A
+generic ERC-20 correction cannot see that perp balance and must not restore it
+as Safe cash.
+
+First inspect the recovery plan without a private key or any transaction:
+
+```shell
+poetry run trade-executor correct-accounts --dry-run
+```
+
+The dry run fetches the Safe's EVM, spot and perp balances and prints any
+`perp_to_spot` and `spot_to_evm` actions. It refuses recovery if the Safe has
+an active HyperCore perp position. It does not sign, broadcast, save or back up
+state. The live command verifies the spot increase after the first action and
+the EVM USDC increase after the second before proceeding to normal accounting.
+
+For the known #1486 amount, use the explicit dry run rather than the generic
+dust-preserving sweep:
+
+```shell
+poetry run trade-executor correct-accounts \
+  --dry-run \
+  --recover-hypercore-transit-usdc 48.884068
+```
+
+This plans exactly 48.884068 USDC from perp to spot and then from spot to EVM;
+it leaves the pre-incident spot/perp balances alone. It is safe only after
+checking that current vault equity did not receive the deposit. To perform the
+same live recovery, add `--confirm-hypercore-transit-recovery`. The explicit
+confirmation exists because a successful EVM CoreWriter receipt is not proof
+that every HyperCore action settled.
+
+Use this only after checking vault equity has not already received the deposit.
+The transit helper is deliberately Safe-level, because an old state file may
+predate the failed trade's metadata; it preserves its configured spot/perp dust
+margin rather than assuming every internal USDC cent belongs to one failed
+trade. After recovery, explicitly expire or reconcile stale planned trades
+before restarting the executor; `repair` alone cannot infer this history.
+
 ### Close single position (for single-pair strategies)
 
 ```python

--- a/tradeexecutor/ethereum/vault/README-vault-position-manual.md
+++ b/tradeexecutor/ethereum/vault/README-vault-position-manual.md
@@ -281,6 +281,11 @@ the earlier 0.50 USDC perp dust and 0.217882 USDC spot balance. The spot
 balance exceeds HyperCore's 0.01 USDC bridge-fee headroom, so this incident
 does not need any bridge-fee adjustment.
 
+If a smaller future transit balance cannot cover the bridge-fee headroom and
+the normal balance-verification tolerance, `correct-accounts` leaves it in
+perp rather than sending only the first `perp_to_spot` leg. A later recovery
+can safely include that dust once the balance is sufficient.
+
 When resolving an ambiguous deposit, inspect vault equity before recovery: a
 late vault settlement changes which destination should retain the USDC. The
 transit helper is deliberately Safe-level, because an old state file may

--- a/tradeexecutor/ethereum/vault/README-vault-position-manual.md
+++ b/tradeexecutor/ethereum/vault/README-vault-position-manual.md
@@ -274,8 +274,15 @@ an active HyperCore perp position. It does not sign, broadcast, save or back up
 state. The live command verifies the spot increase after the first action and
 the EVM USDC increase after the second before proceeding to normal accounting.
 
-For the known #1486 amount, use the explicit dry run rather than the generic
-dust-preserving sweep:
+The normal recovery is enabled by default for eligible HyperCore vault
+strategies. For the live #1486 balances, the ordinary dry run plans exactly
+48.884068 USDC from perp to spot and then from spot to EVM, while preserving
+the earlier 0.50 USDC perp dust and 0.217882 USDC spot balance. The spot
+balance exceeds HyperCore's 0.01 USDC bridge-fee headroom, so this incident
+does not need any bridge-fee adjustment.
+
+The amount option is only for an operator who has verified a narrower amount
+than the automatic live-balance recovery should handle:
 
 ```shell
 poetry run trade-executor correct-accounts \
@@ -283,8 +290,8 @@ poetry run trade-executor correct-accounts \
   --recover-hypercore-transit-usdc 48.884068
 ```
 
-This plans exactly 48.884068 USDC from perp to spot and then from spot to EVM;
-it leaves the pre-incident spot/perp balances alone. It is safe only after
+This plans only the explicitly requested amount and leaves the pre-incident
+spot/perp balances alone. It is safe only after
 checking that current vault equity did not receive the deposit. To perform the
 same live recovery, add `--confirm-hypercore-transit-recovery`. The explicit
 confirmation exists because a successful EVM CoreWriter receipt is not proof

--- a/tradeexecutor/ethereum/vault/README-vault-position-manual.md
+++ b/tradeexecutor/ethereum/vault/README-vault-position-manual.md
@@ -281,24 +281,9 @@ the earlier 0.50 USDC perp dust and 0.217882 USDC spot balance. The spot
 balance exceeds HyperCore's 0.01 USDC bridge-fee headroom, so this incident
 does not need any bridge-fee adjustment.
 
-The amount option is only for an operator who has verified a narrower amount
-than the automatic live-balance recovery should handle:
-
-```shell
-poetry run trade-executor correct-accounts \
-  --dry-run \
-  --recover-hypercore-transit-usdc 48.884068
-```
-
-This plans only the explicitly requested amount and leaves the pre-incident
-spot/perp balances alone. It is safe only after
-checking that current vault equity did not receive the deposit. To perform the
-same live recovery, add `--confirm-hypercore-transit-recovery`. The explicit
-confirmation exists because a successful EVM CoreWriter receipt is not proof
-that every HyperCore action settled.
-
-Use this only after checking vault equity has not already received the deposit.
-The transit helper is deliberately Safe-level, because an old state file may
+When resolving an ambiguous deposit, inspect vault equity before recovery: a
+late vault settlement changes which destination should retain the USDC. The
+transit helper is deliberately Safe-level, because an old state file may
 predate the failed trade's metadata; it preserves its configured spot/perp dust
 margin rather than assuming every internal USDC cent belongs to one failed
 trade. After recovery, explicitly expire or reconcile stale planned trades

--- a/tradeexecutor/ethereum/vault/README-vault-position-manual.md
+++ b/tradeexecutor/ethereum/vault/README-vault-position-manual.md
@@ -234,6 +234,25 @@ phase-1 transaction. It stops before broadcast and settlement.
 Do not use `--skip-save` as a dry-run substitute: it only skips the final state
 write and may still broadcast transactions.
 
+### Recovering an interrupted HyperCore deposit
+
+A HyperCore deposit moves USDC Safe → EVM escrow → spot → perp → vault. An EVM
+receipt does not prove that every HyperCore action applied. If a trade reports
+`hypercore_stranded_usdc` or `hypercore_deposit_capital_at_risk`, do not run
+the generic `repair` command or re-submit the last transfer.
+
+1. Run `check-hypercore-user.py` for the Safe and inspect Safe EVM USDC, EVM
+   escrow, spot USDC, perp withdrawable USDC and vault equity.
+2. If USDC is confirmed in spot, either complete spot → perp → vault or bridge
+   spot → EVM.
+3. If USDC is confirmed in perp, either complete perp → vault or first move
+   **perp → spot**, then use `spotSend` to bridge back to EVM. Perp USDC cannot
+   be sent directly to EVM.
+4. If the recorded location is `*_or_*`, recheck live balances before acting:
+   the queued action may still settle after the original timeout.
+5. Reconcile state only after exactly one destination is confirmed: increased
+   vault equity or USDC returned to the Safe.
+
 ### Close single position (for single-pair strategies)
 
 ```python

--- a/tradeexecutor/ethereum/vault/hypercore_routing.py
+++ b/tradeexecutor/ethereum/vault/hypercore_routing.py
@@ -246,13 +246,22 @@ HYPERCORE_RELATIVE_BALANCE_TOLERANCE = Decimal("0.01")
 
 #: Fixed USDC tolerance for the deposit ``spot -> perp`` balance proof.
 #:
-#: This is not a vault-NAV or performance-fee tolerance.  It only absorbs API
+#: Production incident reference: HyperAI trade #1486 (Citadel, 2026-07-30)
+#: submitted ``transferUsdClass(spot->perp)`` and ``vaultTransfer(perp->vault)``
+#: together. The EVM receipt succeeded but only the first CoreWriter action
+#: settled. The Safe's perp account rose by exactly 48.884068 USDC while vault
+#: equity did not move. This tolerance is therefore *not* a vault-NAV or
+#: performance-fee tolerance: accepting a shortfall large enough to hide a
+#: missing transfer would reproduce the incident. It only absorbs Info API
 #: rounding while requiring both sides of the internal transfer to move.
 HYPERCORE_DEPOSIT_TRANSFER_TOLERANCE = Decimal("0.10")
 
 #: Persisted trade metadata keys for a deposit that may already have consumed
-#: Safe USDC.  The at-risk marker is written before phase 1 is broadcast, so a
-#: process crash cannot fall through to generic failed-buy reserve recovery.
+#: Safe USDC. The at-risk marker is written before phase 1 is broadcast, so a
+#: process crash, RPC timeout, or node failover cannot fall through to generic
+#: failed-buy reserve recovery. Re-crediting a Safe after the deposit was in
+#: fact accepted would make the same USDC both spendable in portfolio state and
+#: present on HyperCore: the accounting half of the #1486 incident.
 HYPERCORE_DEPOSIT_CAPITAL_AT_RISK_KEY = "hypercore_deposit_capital_at_risk"
 HYPERCORE_STRANDED_USDC_KEY = "hypercore_stranded_usdc"
 RETAIN_RESERVE_ALLOCATION_ON_FAILURE_KEY = "retain_reserve_allocation_on_failure"
@@ -1121,13 +1130,30 @@ class HypercoreVaultRouting(RoutingModel):
         timeout: float = 60.0,
         poll_interval: float = 2.0,
     ) -> tuple[Decimal, Decimal]:
-        """Prove the deposit ``spot -> perp`` transfer before vault deposit.
+        """Prove the deposit ``spot -> perp`` transfer before the vault action.
 
-        A successful CoreWriter receipt is not sufficient: HyperCore may apply
-        only a prefix of the requested actions.  Observe the spot decrease and
-        the corresponding perp increase, using only a small API-rounding
-        tolerance.  This is deliberately separate from withdrawal verification
-        because deposits do not incur vault performance fees.
+        This is the safety boundary introduced after HyperAI trade #1486
+        (Citadel, 2026-07-30). Its EVM phase-2 receipt was successful, but
+        HyperCore applied only ``transferUsdClass(spot->perp)`` and silently
+        skipped the following ``vaultTransfer(perp->vault)``. A receipt is
+        consequently evidence only that the CoreWriter request reached EVM;
+        it is not evidence that either, or both, HyperCore balance changes
+        happened.
+
+        The caller has already waited for the EVM escrow to clear, then captures
+        fresh spot and perp baselines immediately before sending the transfer.
+        We require both of the following from the Info API before the next
+        irreversible action is permitted:
+
+        1. Free HyperCore spot USDC decreased by the expected deposit amount.
+        2. HyperCore perp withdrawable USDC increased by the same amount.
+
+        A small fixed tolerance covers API rounding only. It intentionally does
+        not reuse vault NAV, trade slippage, or leader-performance-fee tolerance:
+        none apply to this internal USDC class transfer. Requiring coherent
+        movement on both sides prevents a later vault action from being sent on
+        stale or partially-settled state, which would otherwise create another
+        stranded or duplicate deposit.
         """
         expected_increase = raw_to_usdc(expected_increase_raw)
         expected_threshold = expected_increase - HYPERCORE_DEPOSIT_TRANSFER_TOLERANCE
@@ -1496,7 +1522,21 @@ class HypercoreVaultRouting(RoutingModel):
         trade: TradeExecution,
         raw_amount: int,
     ):
-        """Fail closed before phase-1 deposit broadcast can consume Safe USDC."""
+        """Persist a fail-closed checkpoint before phase 1 can consume Safe USDC.
+
+        The marker is deliberately written *before* signing and broadcasting
+        ``CoreDepositWallet.deposit``. A node can accept the signed transaction
+        and the process can then die before receipt handling records whether
+        USDC reached EVM escrow or HyperCore spot. Without this checkpoint,
+        startup repair would see only a failed buy and restore its allocation
+        to reserves, duplicating funds that may already be outside the Safe.
+
+        This is not a claim that the deposit definitely settled. It records an
+        uncertainty boundary: generic accounting must retain the allocation
+        until a confirmed phase-1 revert or an operator's live reconciliation
+        resolves the location. Keeping cash unavailable is conservative; making
+        unverified cash spendable is unsafe.
+        """
         if not hasattr(trade, "other_data") or trade.other_data is None:
             trade.other_data = {}
 
@@ -1517,7 +1557,13 @@ class HypercoreVaultRouting(RoutingModel):
         )
 
     def _clear_deposit_capital_at_risk(self, trade: TradeExecution):
-        """Allow normal failed-buy accounting after phase-1 non-consumption is proven."""
+        """Allow normal failed-buy accounting only after phase-1 non-consumption is proven.
+
+        Call this only for a definite phase-1 receipt revert or a local signing
+        failure before any transaction could reach a node. Do not clear it for
+        RPC errors, missing receipts, or settlement timeouts: all of those can
+        coexist with a transaction that HyperCore processes later.
+        """
         if not getattr(trade, "other_data", None):
             return
 
@@ -1530,7 +1576,15 @@ class HypercoreVaultRouting(RoutingModel):
         human_amount: Decimal,
         location: str,
     ) -> str:
-        """Build recovery guidance that cannot suggest an unsafe repeated transfer."""
+        """Build recovery guidance that cannot suggest an unsafe repeated transfer.
+
+        ``hypercore_perp_or_vault`` is intentional after a vault-confirmation
+        timeout. Trade #1486 happened to show the full amount in perp during its
+        diagnostic snapshot, but an asynchronous vault action may also settle
+        after the timeout. Recovery text must therefore require a fresh balance
+        inspection rather than tell an operator to submit another vault transfer
+        and potentially deposit the same USDC twice.
+        """
         prefix = (
             f"USDC ({human_amount}) is stranded or pending in {location} for Safe "
             f"{self.safe_address}. Use check-hypercore-user.py to inspect live "
@@ -1548,11 +1602,19 @@ class HypercoreVaultRouting(RoutingModel):
         raw_amount: int,
         location: str,
     ):
-        """Record stranded USDC info on a failed trade for operator recovery.
+        """Record potentially stranded USDC and preserve its allocation.
 
-        When phase 2 fails after phase 1 bridged USDC to HyperCore,
-        or when the vault deposit is silently rejected, this method
-        stores recovery info in ``trade.other_data``.
+        HyperCore can acknowledge an EVM transaction while moving no USDC, or
+        while moving only the first action from a requested sequence. Once phase
+        1 may have left the Safe, a generic failed-buy refund is no longer valid:
+        it would overstate cash and make the already-bridged amount available to
+        later strategy trades. This method ties the operational diagnosis and
+        accounting invariant together by persisting the location *and* the
+        reserve-retention marker in the same durable trade metadata.
+
+        Locations use ``*_or_*`` whenever the evidence cannot distinguish a
+        pending action from a completed one. Ambiguity is intentionally exposed
+        to the operator rather than hidden behind a tempting but unsafe retry.
 
         :param trade:
             The failed trade.
@@ -2351,12 +2413,27 @@ class HypercoreVaultRouting(RoutingModel):
     ):
         """Settle a Hypercore vault deposit (buy).
 
-        Phase 1 approve + deposit txs were broadcast by the execution model. This method:
+        Phase 1 approve + deposit txs were broadcast by the execution model.
+        The remaining legs are intentionally not bundled, despite sharing the
+        same Safe and CoreWriter precompile. HyperAI trade #1486 demonstrated
+        that a successful wrapper receipt is not an atomic HyperCore settlement:
+        spot->perp settled, perp->vault did not, and old generic failure
+        accounting briefly treated the still-stranded USDC as Safe cash.
+
+        This method establishes a durable, verified state machine:
 
         1. Verifies the phase 1 receipt.
         2. Waits for EVM escrow to clear.
-        3. Builds and broadcasts phase 2 (transferUsdClass + vaultTransfer).
-        4. Queries vault equity and marks trade success.
+        3. Snapshots spot, perp and vault-equity baselines.
+        4. Broadcasts only spot->perp and proves both Info API balance changes.
+        5. Broadcasts perp->vault only after the phase-2 proof succeeds.
+        6. Queries vault equity and marks trade success only after the final
+           deposit confirmation.
+
+        Any uncertainty after phase 1 records stranded metadata and freezes the
+        trade with its allocation retained. This deliberately halts sequential
+        execution rather than allowing the next buy to spend capital whose
+        physical location is not yet known.
 
         Activation (if needed) was already handled in :py:meth:`setup_trades`.
         """
@@ -2384,6 +2461,8 @@ class HypercoreVaultRouting(RoutingModel):
             return
 
         if trade.other_data.get(HYPERCORE_DEPOSIT_CAPITAL_AT_RISK_KEY):
+            # Receipt success only proves inclusion. Keep the allocation locked
+            # until every later HyperCore balance proof has succeeded.
             trade.other_data[HYPERCORE_DEPOSIT_CAPITAL_AT_RISK_KEY]["phase"] = "phase1_confirmed"
 
         vault_address = self._get_vault_address(trade)
@@ -2485,10 +2564,11 @@ class HypercoreVaultRouting(RoutingModel):
             return
 
         # --- Phase 2: spot -> perp ---
-        # CoreWriter actions can have a successful EVM receipt while only a
-        # prefix takes effect on HyperCore. Keep the legs separate and prove
-        # both sides of the internal transfer before asking HyperCore to
-        # deposit from perp.
+        # Do not collapse this with phase 3. In #1486, a bundled CoreWriter
+        # request received EVM status=1 while HyperCore performed exactly this
+        # first leg and silently omitted the vault transfer. These fresh
+        # baselines make the following proof about this action only, not an
+        # earlier bridge arrival or pre-existing perp float.
         try:
             spot_baseline = self._fetch_safe_spot_free_usdc_balance()
             perp_baseline = self._fetch_safe_perp_withdrawable_balance()
@@ -2508,7 +2588,8 @@ class HypercoreVaultRouting(RoutingModel):
             logger.error("Deposit spot-to-perp broadcast failed: %s", e.__cause__)
             trade.blockchain_transactions.append(e.tx)
             # A timeout or RPC error does not prove the signed action was not
-            # accepted. Do not tell an operator to repeat it blindly.
+            # accepted. The only safe statement is "spot or perp"; telling an
+            # operator to repeat it blindly can double-transfer the deposit.
             self._mark_stranded_usdc(trade, deposit_raw, "hypercore_spot_or_perp")
             self.diagnose_hyperliquid_vault_redemption_failure(
                 trade, vault_address, "deposit_spot_to_perp_broadcast",
@@ -2547,6 +2628,9 @@ class HypercoreVaultRouting(RoutingModel):
             return
 
         # --- Phase 3: perp -> vault ---
+        # Reaching this point means phase 2 was observed in both balances. This
+        # is the crucial ordering rule that the former bundled implementation
+        # lacked: vaultTransfer is never requested against unverified perp USDC.
         self.deployer.sync_nonce(web3)
         try:
             phase3_tx, phase3_receipt = self._broadcast_deposit_perp_to_vault(
@@ -2629,8 +2713,10 @@ class HypercoreVaultRouting(RoutingModel):
                 "Vault deposit verification failed for trade %s: %s",
                 trade.trade_id, e,
             )
-            # The vault action may still settle after the timeout. Require a
-            # fresh perp/vault inspection before any manual recovery action.
+            # The vault action may still settle after the timeout. The #1486
+            # snapshot showed the money in perp, but the timeout alone cannot
+            # prove a late vault credit will not occur. Require a fresh
+            # perp/vault inspection before any manual recovery action.
             self._mark_stranded_usdc(trade, deposit_raw, "hypercore_perp_or_vault")
             self.diagnose_hyperliquid_vault_redemption_failure(
                 trade, vault_address, "deposit_verification",

--- a/tradeexecutor/ethereum/vault/hypercore_routing.py
+++ b/tradeexecutor/ethereum/vault/hypercore_routing.py
@@ -244,18 +244,6 @@ HYPERCORE_SMALL_POSITION_CLEANUP_MIN_REDEMPTION_RAW = (
 # tolerance to avoid false failures.
 HYPERCORE_RELATIVE_BALANCE_TOLERANCE = Decimal("0.01")
 
-#: Fixed USDC tolerance for the deposit ``spot -> perp`` balance proof.
-#:
-#: Production incident reference: HyperAI trade #1486 (Citadel, 2026-07-30)
-#: submitted ``transferUsdClass(spot->perp)`` and ``vaultTransfer(perp->vault)``
-#: together. The EVM receipt succeeded but only the first CoreWriter action
-#: settled. The Safe's perp account rose by exactly 48.884068 USDC while vault
-#: equity did not move. This tolerance is therefore *not* a vault-NAV or
-#: performance-fee tolerance: accepting a shortfall large enough to hide a
-#: missing transfer would reproduce the incident. It only absorbs Info API
-#: rounding while requiring both sides of the internal transfer to move.
-HYPERCORE_DEPOSIT_TRANSFER_TOLERANCE = Decimal("0.10")
-
 #: Persisted trade metadata keys for a deposit that may already have consumed
 #: Safe USDC. The at-risk marker is written before phase 1 is broadcast, so a
 #: process crash, RPC timeout, or node failover cannot fall through to generic
@@ -1148,15 +1136,13 @@ class HypercoreVaultRouting(RoutingModel):
         1. Free HyperCore spot USDC decreased by the expected deposit amount.
         2. HyperCore perp withdrawable USDC increased by the same amount.
 
-        A small fixed tolerance covers API rounding only. It intentionally does
-        not reuse vault NAV, trade slippage, or leader-performance-fee tolerance:
-        none apply to this internal USDC class transfer. Requiring coherent
-        movement on both sides prevents a later vault action from being sent on
-        stale or partially-settled state, which would otherwise create another
-        stranded or duplicate deposit.
+        USDC is represented to six decimals, matching the raw transfer amount,
+        so this proof uses no monetary tolerance.  Vault NAV, trade slippage,
+        and leader-performance-fee tolerances do not apply to this internal
+        class transfer.  Requiring the full coherent movement on both sides
+        prevents a vault action from being sent with insufficient perp USDC.
         """
         expected_increase = raw_to_usdc(expected_increase_raw)
-        expected_threshold = expected_increase - HYPERCORE_DEPOSIT_TRANSFER_TOLERANCE
         deadline = time.time() + timeout
         attempt = 0
 
@@ -1167,15 +1153,15 @@ class HypercoreVaultRouting(RoutingModel):
             spot_decrease = spot_baseline - current_spot
             perp_increase = current_perp - perp_baseline
 
-            if spot_decrease >= expected_threshold and perp_increase >= expected_threshold:
+            if spot_decrease >= expected_increase and perp_increase >= expected_increase:
                 logger.info(
                     "HyperCore deposit spot->perp transfer verified for Safe %s after %d poll(s): "
-                    "spot decrease %s USDC, perp increase %s USDC (expected at least %s USDC)",
+                    "spot decrease %s USDC, perp increase %s USDC (expected %s USDC)",
                     self.safe_address,
                     attempt,
                     spot_decrease,
                     perp_increase,
-                    expected_threshold,
+                    expected_increase,
                 )
                 return current_spot, current_perp
 
@@ -1183,8 +1169,8 @@ class HypercoreVaultRouting(RoutingModel):
             if remaining <= 0:
                 raise HypercoreWithdrawalVerificationError(
                     f"HyperCore deposit spot->perp transfer could not be verified for Safe "
-                    f"{self.safe_address} within {timeout}s. Expected at least "
-                    f"{expected_threshold} USDC movement, observed spot decrease "
+                f"{self.safe_address} within {timeout}s. Expected "
+                    f"{expected_increase} USDC movement, observed spot decrease "
                     f"{spot_decrease} USDC and perp increase {perp_increase} USDC. "
                     f"Baseline spot/perp: {spot_baseline}/{perp_baseline}; current "
                     f"spot/perp: {current_spot}/{current_perp}; after {attempt} poll(s)."
@@ -1196,9 +1182,9 @@ class HypercoreVaultRouting(RoutingModel):
                 "(%.0fs remaining, poll #%d)",
                 self.safe_address,
                 spot_decrease,
-                expected_threshold,
+                expected_increase,
                 perp_increase,
-                expected_threshold,
+                expected_increase,
                 remaining,
                 attempt,
             )
@@ -1629,11 +1615,7 @@ class HypercoreVaultRouting(RoutingModel):
             "amount_human": str(human_amount),
             "location": location,
             "safe_address": self.safe_address,
-            "recovery": HypercoreVaultRouting._get_stranded_usdc_recovery_message(
-                self,
-                human_amount,
-                location,
-            ),
+            "recovery": self._get_stranded_usdc_recovery_message(human_amount, location),
         }
         if not hasattr(trade, "other_data") or trade.other_data is None:
             trade.other_data = {}
@@ -2397,6 +2379,10 @@ class HypercoreVaultRouting(RoutingModel):
             lp_fees=0,
             native_token_price=0,
         )
+        # Vault equity now proves that this deposit completed.  Remove the
+        # phase-1 uncertainty checkpoint so successful positions are never
+        # misreported as stranded capital by later account checks.
+        self._clear_deposit_capital_at_risk(trade)
 
         logger.info(
             "Hypercore vault deposit (simulate) settled: %s USDC deposited",
@@ -2736,6 +2722,12 @@ class HypercoreVaultRouting(RoutingModel):
             lp_fees=0,
             native_token_price=0,
         )
+
+        # The final vault-equity proof makes phase-1 uncertainty obsolete.
+        # Remove the retained-allocation marker before later account checks so
+        # a normal, successfully settled deposit is never treated as transit
+        # capital from the #1486 failure class.
+        self._clear_deposit_capital_at_risk(trade)
 
         # Refund the unused portion of planned reserve back to the same
         # source that funded the trade.  start_execution() allocates the full

--- a/tradeexecutor/ethereum/vault/hypercore_routing.py
+++ b/tradeexecutor/ethereum/vault/hypercore_routing.py
@@ -244,6 +244,19 @@ HYPERCORE_SMALL_POSITION_CLEANUP_MIN_REDEMPTION_RAW = (
 # tolerance to avoid false failures.
 HYPERCORE_RELATIVE_BALANCE_TOLERANCE = Decimal("0.01")
 
+#: Fixed USDC tolerance for the deposit ``spot -> perp`` balance proof.
+#:
+#: This is not a vault-NAV or performance-fee tolerance.  It only absorbs API
+#: rounding while requiring both sides of the internal transfer to move.
+HYPERCORE_DEPOSIT_TRANSFER_TOLERANCE = Decimal("0.10")
+
+#: Persisted trade metadata keys for a deposit that may already have consumed
+#: Safe USDC.  The at-risk marker is written before phase 1 is broadcast, so a
+#: process crash cannot fall through to generic failed-buy reserve recovery.
+HYPERCORE_DEPOSIT_CAPITAL_AT_RISK_KEY = "hypercore_deposit_capital_at_risk"
+HYPERCORE_STRANDED_USDC_KEY = "hypercore_stranded_usdc"
+RETAIN_RESERVE_ALLOCATION_ON_FAILURE_KEY = "retain_reserve_allocation_on_failure"
+
 #: Last-resort HyperCore vault leader performance fee, as a fraction.
 #:
 #: The fee differs per vault (leader vaults ~10%, protocol/HLP vaults 0%), so it
@@ -1100,6 +1113,71 @@ class HypercoreVaultRouting(RoutingModel):
             )
             time.sleep(min(poll_interval, remaining))
 
+    def _wait_for_deposit_spot_to_perp_transfer(
+        self,
+        spot_baseline: Decimal,
+        perp_baseline: Decimal,
+        expected_increase_raw: int,
+        timeout: float = 60.0,
+        poll_interval: float = 2.0,
+    ) -> tuple[Decimal, Decimal]:
+        """Prove the deposit ``spot -> perp`` transfer before vault deposit.
+
+        A successful CoreWriter receipt is not sufficient: HyperCore may apply
+        only a prefix of the requested actions.  Observe the spot decrease and
+        the corresponding perp increase, using only a small API-rounding
+        tolerance.  This is deliberately separate from withdrawal verification
+        because deposits do not incur vault performance fees.
+        """
+        expected_increase = raw_to_usdc(expected_increase_raw)
+        expected_threshold = expected_increase - HYPERCORE_DEPOSIT_TRANSFER_TOLERANCE
+        deadline = time.time() + timeout
+        attempt = 0
+
+        while True:
+            attempt += 1
+            current_spot = self._fetch_safe_spot_free_usdc_balance()
+            current_perp = self._fetch_safe_perp_withdrawable_balance()
+            spot_decrease = spot_baseline - current_spot
+            perp_increase = current_perp - perp_baseline
+
+            if spot_decrease >= expected_threshold and perp_increase >= expected_threshold:
+                logger.info(
+                    "HyperCore deposit spot->perp transfer verified for Safe %s after %d poll(s): "
+                    "spot decrease %s USDC, perp increase %s USDC (expected at least %s USDC)",
+                    self.safe_address,
+                    attempt,
+                    spot_decrease,
+                    perp_increase,
+                    expected_threshold,
+                )
+                return current_spot, current_perp
+
+            remaining = deadline - time.time()
+            if remaining <= 0:
+                raise HypercoreWithdrawalVerificationError(
+                    f"HyperCore deposit spot->perp transfer could not be verified for Safe "
+                    f"{self.safe_address} within {timeout}s. Expected at least "
+                    f"{expected_threshold} USDC movement, observed spot decrease "
+                    f"{spot_decrease} USDC and perp increase {perp_increase} USDC. "
+                    f"Baseline spot/perp: {spot_baseline}/{perp_baseline}; current "
+                    f"spot/perp: {current_spot}/{current_perp}; after {attempt} poll(s)."
+                )
+
+            logger.info(
+                "Waiting for HyperCore deposit spot->perp transfer for Safe %s: "
+                "spot decrease %s/%s USDC, perp increase %s/%s USDC "
+                "(%.0fs remaining, poll #%d)",
+                self.safe_address,
+                spot_decrease,
+                expected_threshold,
+                perp_increase,
+                expected_threshold,
+                remaining,
+                attempt,
+            )
+            time.sleep(min(poll_interval, remaining))
+
     def _wait_for_perp_withdrawable_balance(
         self,
         baseline_balance: Decimal,
@@ -1413,6 +1491,57 @@ class HypercoreVaultRouting(RoutingModel):
             )
             time.sleep(min(poll_interval, remaining))
 
+    def _mark_deposit_capital_at_risk(
+        self,
+        trade: TradeExecution,
+        raw_amount: int,
+    ):
+        """Fail closed before phase-1 deposit broadcast can consume Safe USDC."""
+        if not hasattr(trade, "other_data") or trade.other_data is None:
+            trade.other_data = {}
+
+        existing = trade.other_data.get(HYPERCORE_DEPOSIT_CAPITAL_AT_RISK_KEY)
+        if existing is not None:
+            return
+
+        human_amount = raw_to_usdc(raw_amount)
+        trade.other_data[HYPERCORE_DEPOSIT_CAPITAL_AT_RISK_KEY] = {
+            "amount_raw": raw_amount,
+            "amount_human": str(human_amount),
+            "safe_address": self.safe_address,
+            "phase": "phase1_broadcast_pending",
+        }
+        trade.other_data[RETAIN_RESERVE_ALLOCATION_ON_FAILURE_KEY] = True
+        trade.add_note(
+            f"HyperCore deposit capital at risk ({human_amount} USDC) until phase 1 is reconciled"
+        )
+
+    def _clear_deposit_capital_at_risk(self, trade: TradeExecution):
+        """Allow normal failed-buy accounting after phase-1 non-consumption is proven."""
+        if not getattr(trade, "other_data", None):
+            return
+
+        trade.other_data.pop(HYPERCORE_DEPOSIT_CAPITAL_AT_RISK_KEY, None)
+        if HYPERCORE_STRANDED_USDC_KEY not in trade.other_data:
+            trade.other_data.pop(RETAIN_RESERVE_ALLOCATION_ON_FAILURE_KEY, None)
+
+    def _get_stranded_usdc_recovery_message(
+        self,
+        human_amount: Decimal,
+        location: str,
+    ) -> str:
+        """Build recovery guidance that cannot suggest an unsafe repeated transfer."""
+        prefix = (
+            f"USDC ({human_amount}) is stranded or pending in {location} for Safe "
+            f"{self.safe_address}. Use check-hypercore-user.py to inspect live "
+            "spot, perp and vault balances first. "
+        )
+        if location == "hypercore_spot":
+            return prefix + "After confirming spot holds the amount, either complete spot->perp->vault or bridge spot->EVM."
+        if location == "hypercore_perp":
+            return prefix + "After confirming perp holds the amount, either complete perp->vault or move perp->spot before bridging to EVM."
+        return prefix + "The final location is ambiguous; do not repeat a transfer until the live balance check resolves it."
+
     def _mark_stranded_usdc(
         self,
         trade: TradeExecution,
@@ -1438,11 +1567,10 @@ class HypercoreVaultRouting(RoutingModel):
             "amount_human": str(human_amount),
             "location": location,
             "safe_address": self.safe_address,
-            "recovery": (
-                f"USDC ({human_amount}) is stranded in {location} for "
-                f"Safe {self.safe_address}. Use check-hypercore-user.py to "
-                f"verify, then manually execute spotSend to bridge back to EVM "
-                f"or complete the vault deposit."
+            "recovery": HypercoreVaultRouting._get_stranded_usdc_recovery_message(
+                self,
+                human_amount,
+                location,
             ),
         }
         if not hasattr(trade, "other_data") or trade.other_data is None:
@@ -1450,8 +1578,12 @@ class HypercoreVaultRouting(RoutingModel):
         # The phase-1 bridge has already removed this USDC from the Safe. Do
         # not let the generic failed-buy handler add it back to reserve
         # accounting: it is a recoverable HyperCore balance, not Safe cash.
-        trade.other_data["retain_reserve_allocation_on_failure"] = True
-        trade.other_data["hypercore_stranded_usdc"] = stranded_info
+        trade.other_data[RETAIN_RESERVE_ALLOCATION_ON_FAILURE_KEY] = True
+        trade.other_data[HYPERCORE_STRANDED_USDC_KEY] = stranded_info
+        at_risk = trade.other_data.get(HYPERCORE_DEPOSIT_CAPITAL_AT_RISK_KEY)
+        if at_risk is not None:
+            at_risk["phase"] = "stranded"
+            at_risk["location"] = location
         trade.add_note(
             f"USDC stranded on HyperCore ({human_amount} USDC in {location})"
         )
@@ -1794,24 +1926,36 @@ class HypercoreVaultRouting(RoutingModel):
                     raw_amount,
                     vault_address,
                 )
-                approve_fn = build_hypercore_approve_deposit_wallet_call(
-                    self.lagoon_vault,
-                    evm_usdc_amount=raw_amount,
-                )
-                deposit_fn = build_hypercore_deposit_to_spot_call(
-                    self.lagoon_vault,
-                    evm_usdc_amount=raw_amount,
-                )
-                approve_tx = self._sign_module_call(
-                    approve_fn,
-                    notes=f"Hypercore deposit phase 1 approval: {raw_amount} raw USDC",
-                    logical_function_name="approve",
-                )
-                deposit_tx = self._sign_module_call(
-                    deposit_fn,
-                    notes=f"Hypercore deposit phase 1 deposit: {raw_amount} raw USDC",
-                    logical_function_name="deposit",
-                )
+                # Persist this before signing/broadcasting the irreversible
+                # Safe->HyperCore leg. If the process dies after a node accepts
+                # the deposit, generic failed-buy repair must not re-credit
+                # capital until live HyperCore reconciliation proves it safe.
+                self._mark_deposit_capital_at_risk(trade, raw_amount)
+                try:
+                    approve_fn = build_hypercore_approve_deposit_wallet_call(
+                        self.lagoon_vault,
+                        evm_usdc_amount=raw_amount,
+                    )
+                    deposit_fn = build_hypercore_deposit_to_spot_call(
+                        self.lagoon_vault,
+                        evm_usdc_amount=raw_amount,
+                    )
+                    approve_tx = self._sign_module_call(
+                        approve_fn,
+                        notes=f"Hypercore deposit phase 1 approval: {raw_amount} raw USDC",
+                        logical_function_name="approve",
+                    )
+                    deposit_tx = self._sign_module_call(
+                        deposit_fn,
+                        notes=f"Hypercore deposit phase 1 deposit: {raw_amount} raw USDC",
+                        logical_function_name="deposit",
+                    )
+                except Exception:
+                    # Signing failed before a transaction could reach a node.
+                    # This is the one pre-broadcast path where normal failed
+                    # buy accounting may safely refund the allocation.
+                    self._clear_deposit_capital_at_risk(trade)
+                    raise
                 return [approve_tx, deposit_tx]
 
         else:
@@ -2233,8 +2377,14 @@ class HypercoreVaultRouting(RoutingModel):
                 broadcast_tx.tx_hash,
                 trade.trade_id,
             )
+            # The phase-1 deposit definitively reverted, so no USDC left the
+            # Safe and normal failed-buy reserve recovery is correct.
+            self._clear_deposit_capital_at_risk(trade)
             report_failure(ts, state, trade, stop_on_execution_failure)
             return
+
+        if trade.other_data.get(HYPERCORE_DEPOSIT_CAPITAL_AT_RISK_KEY):
+            trade.other_data[HYPERCORE_DEPOSIT_CAPITAL_AT_RISK_KEY]["phase"] = "phase1_confirmed"
 
         vault_address = self._get_vault_address(trade)
         # Read per-trade activation cost (only set on the first buy).
@@ -2337,8 +2487,19 @@ class HypercoreVaultRouting(RoutingModel):
         # --- Phase 2: spot -> perp ---
         # CoreWriter actions can have a successful EVM receipt while only a
         # prefix takes effect on HyperCore. Keep the legs separate and prove
-        # the perp arrival before asking HyperCore to deposit from perp.
-        perp_baseline = self._fetch_safe_perp_withdrawable_balance()
+        # both sides of the internal transfer before asking HyperCore to
+        # deposit from perp.
+        try:
+            spot_baseline = self._fetch_safe_spot_free_usdc_balance()
+            perp_baseline = self._fetch_safe_perp_withdrawable_balance()
+        except Exception as e:
+            logger.error("Cannot snapshot deposit settlement balances: %s", e)
+            self._mark_stranded_usdc(trade, deposit_raw, "hypercore_spot")
+            self.diagnose_hyperliquid_vault_redemption_failure(
+                trade, vault_address, "deposit_settlement_balance_snapshot_failed", str(e),
+            )
+            report_failure(ts, state, trade, stop_on_execution_failure)
+            return
         self.deployer.sync_nonce(web3)
 
         try:
@@ -2346,7 +2507,9 @@ class HypercoreVaultRouting(RoutingModel):
         except SettlementBroadcastError as e:
             logger.error("Deposit spot-to-perp broadcast failed: %s", e.__cause__)
             trade.blockchain_transactions.append(e.tx)
-            self._mark_stranded_usdc(trade, deposit_raw, "hypercore_spot")
+            # A timeout or RPC error does not prove the signed action was not
+            # accepted. Do not tell an operator to repeat it blindly.
+            self._mark_stranded_usdc(trade, deposit_raw, "hypercore_spot_or_perp")
             self.diagnose_hyperliquid_vault_redemption_failure(
                 trade, vault_address, "deposit_spot_to_perp_broadcast",
                 str(e.__cause__),
@@ -2368,10 +2531,10 @@ class HypercoreVaultRouting(RoutingModel):
 
         ts = get_block_timestamp(web3, phase2_receipt["blockNumber"])
         try:
-            self._wait_for_perp_withdrawable_balance(
+            self._wait_for_deposit_spot_to_perp_transfer(
+                spot_baseline,
                 perp_baseline,
                 deposit_raw,
-                relative_tolerance=Decimal(0),
                 timeout=60.0,
             )
         except HypercoreWithdrawalVerificationError as e:
@@ -2394,7 +2557,7 @@ class HypercoreVaultRouting(RoutingModel):
         except SettlementBroadcastError as e:
             logger.error("Deposit perp-to-vault broadcast failed: %s", e.__cause__)
             trade.blockchain_transactions.append(e.tx)
-            self._mark_stranded_usdc(trade, deposit_raw, "hypercore_perp")
+            self._mark_stranded_usdc(trade, deposit_raw, "hypercore_perp_or_vault")
             self.diagnose_hyperliquid_vault_redemption_failure(
                 trade,
                 vault_address,
@@ -2466,8 +2629,9 @@ class HypercoreVaultRouting(RoutingModel):
                 "Vault deposit verification failed for trade %s: %s",
                 trade.trade_id, e,
             )
-            # Deposit silently rejected — USDC stranded in spot or perp
-            self._mark_stranded_usdc(trade, deposit_raw, "hypercore_spot_or_perp")
+            # The vault action may still settle after the timeout. Require a
+            # fresh perp/vault inspection before any manual recovery action.
+            self._mark_stranded_usdc(trade, deposit_raw, "hypercore_perp_or_vault")
             self.diagnose_hyperliquid_vault_redemption_failure(
                 trade, vault_address, "deposit_verification",
                 str(e),

--- a/tradeexecutor/ethereum/vault/hypercore_routing.py
+++ b/tradeexecutor/ethereum/vault/hypercore_routing.py
@@ -8,7 +8,8 @@ Hypercore vault deposits/withdrawals use a multi-phase flow:
    :py:func:`~eth_defi.hyperliquid.evm_escrow.activate_account` in ``setup_trades()``
 1. Phase 1: separate ``approve`` and ``CDW.deposit`` Safe calls — bridge USDC to HyperCore spot
 2. Escrow wait: poll ``spotClearinghouseState`` until USDC clears
-3. Phase 2: ``transferUsdClass`` + ``vaultTransfer`` — move to perp, deposit into vault
+3. Phase 2: ``transferUsdClass`` — move USDC from spot to perp and verify it
+4. Phase 3: ``vaultTransfer`` — deposit the verified perp USDC into the vault
 
 If the Safe is already activated, step 0 is skipped.
 
@@ -85,7 +86,7 @@ from eth_defi.hyperliquid.core_writer import (
     build_hypercore_approve_deposit_wallet_call,
     build_hypercore_deposit_multicall,
     build_hypercore_deposit_to_spot_call,
-    build_hypercore_deposit_phase2,
+    build_hypercore_deposit_to_vault_call,
     compute_spot_to_evm_withdrawal_amount,
     build_hypercore_withdraw_from_vault_call,
     build_hypercore_send_asset_to_evm_call,
@@ -1446,6 +1447,10 @@ class HypercoreVaultRouting(RoutingModel):
         }
         if not hasattr(trade, "other_data") or trade.other_data is None:
             trade.other_data = {}
+        # The phase-1 bridge has already removed this USDC from the Safe. Do
+        # not let the generic failed-buy handler add it back to reserve
+        # accounting: it is a recoverable HyperCore balance, not Safe cash.
+        trade.other_data["retain_reserve_allocation_on_failure"] = True
         trade.other_data["hypercore_stranded_usdc"] = stranded_info
         trade.add_note(
             f"USDC stranded on HyperCore ({human_amount} USDC in {location})"
@@ -1993,13 +1998,12 @@ class HypercoreVaultRouting(RoutingModel):
     # Settlement helpers
     # ------------------------------------------------------------------
 
-    def _broadcast_phase2(
+    def _broadcast_deposit_spot_to_perp(
         self,
         trade: TradeExecution,
-        vault_address: str,
         raw_amount: int,
     ) -> tuple[BlockchainTransaction, dict]:
-        """Build, sign, and broadcast phase 2 (transferUsdClass + vaultTransfer).
+        """Build, sign, and broadcast the deposit spot-to-perp leg.
 
         :return:
             Tuple of (BlockchainTransaction, receipt dict).
@@ -2007,14 +2011,39 @@ class HypercoreVaultRouting(RoutingModel):
             If the broadcast or confirmation fails.  The exception carries
             the signed ``BlockchainTransaction`` with error info.
         """
-        fn = build_hypercore_deposit_phase2(
+        fn = build_hypercore_transfer_usd_class_call(
             self.lagoon_vault,
             hypercore_usdc_amount=raw_amount,
-            vault_address=vault_address,
+            to_perp=True,
         )
         tx = self._sign_module_call(
             fn,
-            notes=f"Hypercore deposit phase 2: {raw_amount} raw USDC to vault {vault_address}",
+            notes=f"Hypercore deposit phase 2: {raw_amount} raw USDC spot->perp",
+            logical_function_name="sendRawAction",
+        )
+
+        try:
+            receipt = self._broadcast_and_confirm_settlement_tx(tx)
+        except Exception as e:
+            raise SettlementBroadcastError(tx, e) from e
+        return tx, receipt
+
+    def _broadcast_deposit_perp_to_vault(
+        self,
+        trade: TradeExecution,
+        vault_address: str,
+        raw_amount: int,
+    ) -> tuple[BlockchainTransaction, dict]:
+        """Build, sign, and broadcast the verified deposit perp-to-vault leg."""
+        fn = build_hypercore_deposit_to_vault_call(
+            self.lagoon_vault,
+            vault_address=vault_address,
+            hypercore_usdc_amount=raw_amount,
+        )
+        tx = self._sign_module_call(
+            fn,
+            notes=f"Hypercore deposit phase 3: {raw_amount} raw USDC to vault {vault_address}",
+            logical_function_name="sendRawAction",
         )
 
         try:
@@ -2261,6 +2290,11 @@ class HypercoreVaultRouting(RoutingModel):
             )
         except TimeoutError as e:
             logger.error("EVM escrow did not clear: %s", e)
+            self._mark_stranded_usdc(
+                trade,
+                deposit_raw,
+                "hypercore_evm_escrow_or_spot",
+            )
             self.diagnose_hyperliquid_vault_redemption_failure(
                 trade, vault_address, "deposit_escrow_timeout",
                 str(e),
@@ -2268,7 +2302,7 @@ class HypercoreVaultRouting(RoutingModel):
             report_failure(ts, state, trade, stop_on_execution_failure)
             return
 
-        logger.info("Escrow cleared. Building and broadcasting phase 2...")
+        logger.info("Escrow cleared. Building and broadcasting deposit settlement legs...")
 
         # Snapshot existing vault equity before phase 2 so we can detect
         # the increase after deposit.  If the snapshot fails, abort: without
@@ -2300,19 +2334,21 @@ class HypercoreVaultRouting(RoutingModel):
             report_failure(ts, state, trade, stop_on_execution_failure)
             return
 
-        # --- Phase 2 ---
-        # Note: RPC failure during nonce sync between phases could strand
-        # USDC in HyperCore spot.  Manual recovery via check-hypercore-user.py.
+        # --- Phase 2: spot -> perp ---
+        # CoreWriter actions can have a successful EVM receipt while only a
+        # prefix takes effect on HyperCore. Keep the legs separate and prove
+        # the perp arrival before asking HyperCore to deposit from perp.
+        perp_baseline = self._fetch_safe_perp_withdrawable_balance()
         self.deployer.sync_nonce(web3)
 
         try:
-            phase2_tx, phase2_receipt = self._broadcast_phase2(trade, vault_address, deposit_raw)
+            phase2_tx, phase2_receipt = self._broadcast_deposit_spot_to_perp(trade, deposit_raw)
         except SettlementBroadcastError as e:
-            logger.error("Phase 2 broadcast failed: %s", e.__cause__)
+            logger.error("Deposit spot-to-perp broadcast failed: %s", e.__cause__)
             trade.blockchain_transactions.append(e.tx)
             self._mark_stranded_usdc(trade, deposit_raw, "hypercore_spot")
             self.diagnose_hyperliquid_vault_redemption_failure(
-                trade, vault_address, "deposit_phase2_broadcast",
+                trade, vault_address, "deposit_spot_to_perp_broadcast",
                 str(e.__cause__),
             )
             report_failure(ts, state, trade, stop_on_execution_failure)
@@ -2321,17 +2357,69 @@ class HypercoreVaultRouting(RoutingModel):
         trade.blockchain_transactions.append(phase2_tx)
 
         if phase2_receipt["status"] != 1:
-            logger.error("Hypercore deposit phase 2 reverted: tx %s", phase2_tx.tx_hash)
-            self._mark_stranded_usdc(trade, deposit_raw, "hypercore_spot_or_perp")
+            logger.error("Hypercore deposit spot-to-perp reverted: tx %s", phase2_tx.tx_hash)
+            self._mark_stranded_usdc(trade, deposit_raw, "hypercore_spot")
             self.diagnose_hyperliquid_vault_redemption_failure(
-                trade, vault_address, "deposit_phase2_reverted",
+                trade, vault_address, "deposit_spot_to_perp_reverted",
                 f"tx {phase2_tx.tx_hash} reverted",
             )
             report_failure(ts, state, trade, stop_on_execution_failure)
             return
 
         ts = get_block_timestamp(web3, phase2_receipt["blockNumber"])
-        logger.info("Hypercore deposit phase 2 succeeded (tx %s)", phase2_tx.tx_hash)
+        try:
+            self._wait_for_perp_withdrawable_balance(
+                perp_baseline,
+                deposit_raw,
+                relative_tolerance=Decimal(0),
+                timeout=60.0,
+            )
+        except HypercoreWithdrawalVerificationError as e:
+            logger.error("Hypercore deposit spot-to-perp verification failed: %s", e)
+            self._mark_stranded_usdc(trade, deposit_raw, "hypercore_spot_or_perp")
+            self.diagnose_hyperliquid_vault_redemption_failure(
+                trade, vault_address, "deposit_spot_to_perp_verification", str(e),
+            )
+            report_failure(ts, state, trade, stop_on_execution_failure)
+            return
+
+        # --- Phase 3: perp -> vault ---
+        self.deployer.sync_nonce(web3)
+        try:
+            phase3_tx, phase3_receipt = self._broadcast_deposit_perp_to_vault(
+                trade,
+                vault_address,
+                deposit_raw,
+            )
+        except SettlementBroadcastError as e:
+            logger.error("Deposit perp-to-vault broadcast failed: %s", e.__cause__)
+            trade.blockchain_transactions.append(e.tx)
+            self._mark_stranded_usdc(trade, deposit_raw, "hypercore_perp")
+            self.diagnose_hyperliquid_vault_redemption_failure(
+                trade,
+                vault_address,
+                "deposit_perp_to_vault_broadcast",
+                str(e.__cause__),
+            )
+            report_failure(ts, state, trade, stop_on_execution_failure)
+            return
+
+        trade.blockchain_transactions.append(phase3_tx)
+
+        if phase3_receipt["status"] != 1:
+            logger.error("Hypercore deposit perp-to-vault reverted: tx %s", phase3_tx.tx_hash)
+            self._mark_stranded_usdc(trade, deposit_raw, "hypercore_perp")
+            self.diagnose_hyperliquid_vault_redemption_failure(
+                trade,
+                vault_address,
+                "deposit_perp_to_vault_reverted",
+                f"tx {phase3_tx.tx_hash} reverted",
+            )
+            report_failure(ts, state, trade, stop_on_execution_failure)
+            return
+
+        ts = get_block_timestamp(web3, phase3_receipt["blockNumber"])
+        logger.info("Hypercore deposit perp-to-vault succeeded (tx %s)", phase3_tx.tx_hash)
 
         # --- Verify deposit on HyperCore via poll loop ---
         # CoreWriter actions are NOT atomic: the EVM tx can succeed but the

--- a/tradeexecutor/ethereum/vault/hypercore_transit_recovery.py
+++ b/tradeexecutor/ethereum/vault/hypercore_transit_recovery.py
@@ -99,85 +99,32 @@ def plan_hypercore_transit_recovery_actions(
     snapshot: HypercoreTransitBalanceSnapshot,
     *,
     leave_dust: Decimal = HYPERCORE_TRANSIT_RECOVERY_DUST_USDC,
-    verified_recovery_amount: Decimal | None = None,
 ) -> list[HypercoreTransitRecoveryAction]:
     """Plan recovery actions for Safe-level HyperCore spot/perp USDC.
 
     By default, leaves ``leave_dust`` in the source perp balance, then returns
-    the exact perp amount which just arrived in spot to HyperEVM. This is the
+    the recovered amount which just arrived in spot to HyperEVM. This is the
     default recovery path for every eligible HyperCore vault strategy, not an
     opt-in incident tool. It preserves any pre-existing spot balance instead
     of accidentally leaving part of a newly stranded deposit behind as spot
-    dust. The executor retains the protocol's 0.01 USDC bridge-fee margin only
-    when there is not enough pre-existing spot headroom. If the original spot
-    balance also exceeds ``leave_dust``, it is planned as a separate later
-    spot-to-EVM action.
+    dust. When that balance is below HyperCore's 0.01 USDC bridge-fee margin,
+    the plan retains only the missing margin from the recovered amount. If the
+    original spot balance also exceeds ``leave_dust``, it is planned as a
+    separate later spot-to-EVM action.
 
-    ``verified_recovery_amount`` is the deliberately narrower incident path.
-    It returns precisely an amount which an operator has independently proved
-    is stranded, instead of treating all non-dust HyperCore cash as stranded.
-    This exists for HyperAI trade #1486 (Citadel, 2026-07-30; PR #1593): the
-    state snapshot predates the failed CoreWriter request, but the live account
-    showed 48.884068 USDC newly present in perp.  In that case, move the exact
-    amount from perp to spot and then from spot to HyperEVM, preserving the
-    pre-incident spot/perp balances.  The caller must never infer this amount
-    from a receipt alone: it is safe only after confirming that the vault
-    equity did not receive the deposit.
+    This behaviour exists for HyperAI trade #1486 (Citadel, 2026-07-30;
+    PR #1593). Its state snapshot predated the failed CoreWriter request, but
+    the live account showed 48.884068 USDC newly present in perp. The default
+    plan therefore uses authoritative live balances, not an incident marker or
+    an operator-supplied amount. The caller must not run it for a Safe with an
+    open perp position, because free perp USDC cannot then be interpreted as
+    recoverable transit capital.
     """
     if snapshot.perp_position_count > 0:
         raise RuntimeError(
             f"Refusing HyperCore transit recovery because Safe {snapshot.safe_address} "
             f"has {snapshot.perp_position_count} active HyperCore perp position(s). "
             "Manual review is required before stranded USDC can be interpreted safely."
-        )
-
-    if verified_recovery_amount is not None:
-        if verified_recovery_amount <= BALANCE_TOLERANCE:
-            raise ValueError(
-                "Verified HyperCore transit recovery amount must exceed the "
-                f"{BALANCE_TOLERANCE} USDC balance tolerance, got {verified_recovery_amount}"
-            )
-
-        # Do not combine partial spot and perp balances here.  An exact amount
-        # must have one unambiguous source, otherwise a transient in-flight
-        # transfer could be mistaken for the #1486-style stranded deposit.
-        if snapshot.perp_withdrawable + BALANCE_TOLERANCE >= verified_recovery_amount:
-            return [
-                HypercoreTransitRecoveryAction(
-                    action_kind="perp_to_spot",
-                    amount=verified_recovery_amount,
-                    reason=(
-                        "Return operator-verified stranded USDC from HyperCore perp to spot "
-                        "without consuming pre-existing perp dust"
-                    ),
-                ),
-                HypercoreTransitRecoveryAction(
-                    action_kind="spot_to_evm",
-                    amount=verified_recovery_amount,
-                    reason=(
-                        "Return the same operator-verified stranded USDC from HyperCore spot "
-                        "to the Safe on HyperEVM"
-                    ),
-                ),
-            ]
-
-        if snapshot.spot_free_usdc + BALANCE_TOLERANCE >= verified_recovery_amount:
-            return [
-                HypercoreTransitRecoveryAction(
-                    action_kind="spot_to_evm",
-                    amount=verified_recovery_amount,
-                    reason=(
-                        "Return operator-verified stranded USDC from HyperCore spot "
-                        "to the Safe on HyperEVM"
-                    ),
-                )
-            ]
-
-        raise RuntimeError(
-            f"Safe {snapshot.safe_address} does not hold the operator-verified "
-            f"{verified_recovery_amount} USDC recovery amount wholly in free spot or "
-            f"withdrawable perp (spot {snapshot.spot_free_usdc}, "
-            f"perp {snapshot.perp_withdrawable}). Manual review is required."
         )
 
     actions: list[HypercoreTransitRecoveryAction] = []
@@ -203,15 +150,27 @@ def plan_hypercore_transit_recovery_actions(
         # perp->spot leg.  Calculating ``projected_spot - leave_dust`` here
         # would preserve a synthetic 0.50 USDC spot dust balance and return
         # less than the stranded amount whenever spot had pre-existing dust.
-        # ``execute_spot_to_evm`` is still allowed to retain the protocol's
-        # 0.01 USDC fee margin when the pre-existing spot headroom is smaller.
+        # HyperCore requires 0.01 USDC fee headroom for spot->EVM. When the
+        # old spot balance cannot provide it, reserve only the missing margin
+        # from this recovered amount. This makes the plan match execution,
+        # avoids silently consuming pre-existing spot USDC, and makes the
+        # unavoidable residual visible to correct-accounts dry runs.
+        bridge_fee_shortfall = max(
+            Decimal(0),
+            HYPERCORE_BRIDGE_FEE_MARGIN - snapshot.spot_free_usdc,
+        )
+        perp_to_evm_amount = perp_recovery_amount - bridge_fee_shortfall
+        assert perp_to_evm_amount > 0, (
+            f"HyperCore perp recovery amount {perp_recovery_amount} for {snapshot.safe_address} "
+            f"is too small to retain the {HYPERCORE_BRIDGE_FEE_MARGIN} USDC bridge fee margin"
+        )
         actions.append(
             HypercoreTransitRecoveryAction(
                 action_kind="spot_to_evm",
-                amount=perp_recovery_amount,
+                amount=perp_to_evm_amount,
                 reason=(
-                    "Return the exact USDC just recovered from HyperCore perp to the Safe "
-                    "on HyperEVM, preserving the pre-existing spot balance"
+                    "Return USDC just recovered from HyperCore perp to the Safe on HyperEVM, "
+                    "retaining only any missing HyperCore bridge-fee margin"
                 ),
             )
         )

--- a/tradeexecutor/ethereum/vault/hypercore_transit_recovery.py
+++ b/tradeexecutor/ethereum/vault/hypercore_transit_recovery.py
@@ -133,18 +133,6 @@ def plan_hypercore_transit_recovery_actions(
         snapshot.perp_withdrawable - leave_dust
     )
     if perp_recovery_amount > 0:
-        actions.append(
-            HypercoreTransitRecoveryAction(
-                action_kind="perp_to_spot",
-                amount=perp_recovery_amount,
-                reason=(
-                    f"Recover HyperCore perp USDC back to HyperCore spot, "
-                    f"leaving {leave_dust} USDC perp dust"
-                ),
-            )
-        )
-
-    if perp_recovery_amount > 0:
         # HyperAI #1486 proved that a successful CoreWriter receipt can leave
         # the exact deposit amount in perp.  Bridge that same amount after the
         # perp->spot leg.  Calculating ``projected_spot - leave_dust`` here
@@ -160,20 +148,32 @@ def plan_hypercore_transit_recovery_actions(
             HYPERCORE_BRIDGE_FEE_MARGIN - snapshot.spot_free_usdc,
         )
         perp_to_evm_amount = perp_recovery_amount - bridge_fee_shortfall
-        assert perp_to_evm_amount > 0, (
-            f"HyperCore perp recovery amount {perp_recovery_amount} for {snapshot.safe_address} "
-            f"is too small to retain the {HYPERCORE_BRIDGE_FEE_MARGIN} USDC bridge fee margin"
-        )
-        actions.append(
-            HypercoreTransitRecoveryAction(
-                action_kind="spot_to_evm",
-                amount=perp_to_evm_amount,
-                reason=(
-                    "Return USDC just recovered from HyperCore perp to the Safe on HyperEVM, "
-                    "retaining only any missing HyperCore bridge-fee margin"
-                ),
+        if perp_to_evm_amount > BALANCE_TOLERANCE:
+            actions.extend(
+                [
+                    HypercoreTransitRecoveryAction(
+                        action_kind="perp_to_spot",
+                        amount=perp_recovery_amount,
+                        reason=(
+                            f"Recover HyperCore perp USDC back to HyperCore spot, "
+                            f"leaving {leave_dust} USDC perp dust"
+                        ),
+                    ),
+                    HypercoreTransitRecoveryAction(
+                        action_kind="spot_to_evm",
+                        amount=perp_to_evm_amount,
+                        reason=(
+                            "Return USDC just recovered from HyperCore perp to the Safe on "
+                            "HyperEVM, retaining only any missing HyperCore bridge-fee margin"
+                        ),
+                    ),
+                ]
             )
-        )
+        # Do not move dust from perp to spot unless the paired bridge action
+        # can execute and be balance-verified. Otherwise correct-accounts
+        # would strand a first leg and fail before accounting correction, e.g.
+        # 0.521 USDC perp with no spot headroom becomes a 0.011 USDC bridge
+        # after the required 0.01 margin.
 
     spot_recovery_amount = _positive_recovery_amount(
         snapshot.spot_free_usdc - leave_dust

--- a/tradeexecutor/ethereum/vault/hypercore_transit_recovery.py
+++ b/tradeexecutor/ethereum/vault/hypercore_transit_recovery.py
@@ -103,9 +103,15 @@ def plan_hypercore_transit_recovery_actions(
 ) -> list[HypercoreTransitRecoveryAction]:
     """Plan recovery actions for Safe-level HyperCore spot/perp USDC.
 
-    By default, leaves ``leave_dust`` in both perp and spot balances. The spot
-    action is planned against the post-perp-to-spot balance when a perp
-    recovery is needed.
+    By default, leaves ``leave_dust`` in the source perp balance, then returns
+    the exact perp amount which just arrived in spot to HyperEVM. This is the
+    default recovery path for every eligible HyperCore vault strategy, not an
+    opt-in incident tool. It preserves any pre-existing spot balance instead
+    of accidentally leaving part of a newly stranded deposit behind as spot
+    dust. The executor retains the protocol's 0.01 USDC bridge-fee margin only
+    when there is not enough pre-existing spot headroom. If the original spot
+    balance also exceeds ``leave_dust``, it is planned as a separate later
+    spot-to-EVM action.
 
     ``verified_recovery_amount`` is the deliberately narrower incident path.
     It returns precisely an amount which an operator has independently proved
@@ -191,8 +197,28 @@ def plan_hypercore_transit_recovery_actions(
             )
         )
 
-    projected_spot_free = snapshot.spot_free_usdc + perp_recovery_amount
-    spot_recovery_amount = _positive_recovery_amount(projected_spot_free - leave_dust)
+    if perp_recovery_amount > 0:
+        # HyperAI #1486 proved that a successful CoreWriter receipt can leave
+        # the exact deposit amount in perp.  Bridge that same amount after the
+        # perp->spot leg.  Calculating ``projected_spot - leave_dust`` here
+        # would preserve a synthetic 0.50 USDC spot dust balance and return
+        # less than the stranded amount whenever spot had pre-existing dust.
+        # ``execute_spot_to_evm`` is still allowed to retain the protocol's
+        # 0.01 USDC fee margin when the pre-existing spot headroom is smaller.
+        actions.append(
+            HypercoreTransitRecoveryAction(
+                action_kind="spot_to_evm",
+                amount=perp_recovery_amount,
+                reason=(
+                    "Return the exact USDC just recovered from HyperCore perp to the Safe "
+                    "on HyperEVM, preserving the pre-existing spot balance"
+                ),
+            )
+        )
+
+    spot_recovery_amount = _positive_recovery_amount(
+        snapshot.spot_free_usdc - leave_dust
+    )
     if spot_recovery_amount > 0:
         actions.append(
             HypercoreTransitRecoveryAction(

--- a/tradeexecutor/ethereum/vault/hypercore_transit_recovery.py
+++ b/tradeexecutor/ethereum/vault/hypercore_transit_recovery.py
@@ -99,18 +99,79 @@ def plan_hypercore_transit_recovery_actions(
     snapshot: HypercoreTransitBalanceSnapshot,
     *,
     leave_dust: Decimal = HYPERCORE_TRANSIT_RECOVERY_DUST_USDC,
+    verified_recovery_amount: Decimal | None = None,
 ) -> list[HypercoreTransitRecoveryAction]:
     """Plan recovery actions for Safe-level HyperCore spot/perp USDC.
 
-    Leaves ``leave_dust`` in both perp and spot balances. The spot action is
-    planned against the post-perp-to-spot balance when a perp recovery is
-    needed.
+    By default, leaves ``leave_dust`` in both perp and spot balances. The spot
+    action is planned against the post-perp-to-spot balance when a perp
+    recovery is needed.
+
+    ``verified_recovery_amount`` is the deliberately narrower incident path.
+    It returns precisely an amount which an operator has independently proved
+    is stranded, instead of treating all non-dust HyperCore cash as stranded.
+    This exists for HyperAI trade #1486 (Citadel, 2026-07-30; PR #1593): the
+    state snapshot predates the failed CoreWriter request, but the live account
+    showed 48.884068 USDC newly present in perp.  In that case, move the exact
+    amount from perp to spot and then from spot to HyperEVM, preserving the
+    pre-incident spot/perp balances.  The caller must never infer this amount
+    from a receipt alone: it is safe only after confirming that the vault
+    equity did not receive the deposit.
     """
     if snapshot.perp_position_count > 0:
         raise RuntimeError(
             f"Refusing HyperCore transit recovery because Safe {snapshot.safe_address} "
             f"has {snapshot.perp_position_count} active HyperCore perp position(s). "
             "Manual review is required before stranded USDC can be interpreted safely."
+        )
+
+    if verified_recovery_amount is not None:
+        if verified_recovery_amount <= BALANCE_TOLERANCE:
+            raise ValueError(
+                "Verified HyperCore transit recovery amount must exceed the "
+                f"{BALANCE_TOLERANCE} USDC balance tolerance, got {verified_recovery_amount}"
+            )
+
+        # Do not combine partial spot and perp balances here.  An exact amount
+        # must have one unambiguous source, otherwise a transient in-flight
+        # transfer could be mistaken for the #1486-style stranded deposit.
+        if snapshot.perp_withdrawable + BALANCE_TOLERANCE >= verified_recovery_amount:
+            return [
+                HypercoreTransitRecoveryAction(
+                    action_kind="perp_to_spot",
+                    amount=verified_recovery_amount,
+                    reason=(
+                        "Return operator-verified stranded USDC from HyperCore perp to spot "
+                        "without consuming pre-existing perp dust"
+                    ),
+                ),
+                HypercoreTransitRecoveryAction(
+                    action_kind="spot_to_evm",
+                    amount=verified_recovery_amount,
+                    reason=(
+                        "Return the same operator-verified stranded USDC from HyperCore spot "
+                        "to the Safe on HyperEVM"
+                    ),
+                ),
+            ]
+
+        if snapshot.spot_free_usdc + BALANCE_TOLERANCE >= verified_recovery_amount:
+            return [
+                HypercoreTransitRecoveryAction(
+                    action_kind="spot_to_evm",
+                    amount=verified_recovery_amount,
+                    reason=(
+                        "Return operator-verified stranded USDC from HyperCore spot "
+                        "to the Safe on HyperEVM"
+                    ),
+                )
+            ]
+
+        raise RuntimeError(
+            f"Safe {snapshot.safe_address} does not hold the operator-verified "
+            f"{verified_recovery_amount} USDC recovery amount wholly in free spot or "
+            f"withdrawable perp (spot {snapshot.spot_free_usdc}, "
+            f"perp {snapshot.perp_withdrawable}). Manual review is required."
         )
 
     actions: list[HypercoreTransitRecoveryAction] = []

--- a/tradeexecutor/state/repair.py
+++ b/tradeexecutor/state/repair.py
@@ -41,6 +41,10 @@ class RepairAborted(Exception):
     """User chose no"""
 
 
+class HypercoreTransitRecoveryRequired(RepairAborted):
+    """A failed HyperCore deposit needs live balance reconciliation first."""
+
+
 class HypercoreDuplicateCloseError(Exception):
     """A Hypercore duplicate group was not safe to close automatically."""
 
@@ -714,6 +718,20 @@ def repair_trades(
             [],
             trades_to_be_repaired,
             [],
+        )
+
+    at_risk_hypercore_trades = [
+        trade
+        for trade in trades_to_be_repaired
+        if trade.other_data.get("hypercore_deposit_capital_at_risk") is not None
+        or trade.other_data.get("hypercore_stranded_usdc") is not None
+    ]
+    if at_risk_hypercore_trades:
+        trade_ids = ", ".join(str(trade.trade_id) for trade in at_risk_hypercore_trades)
+        raise HypercoreTransitRecoveryRequired(
+            f"Cannot state-repair HyperCore deposit trade(s) {trade_ids}: USDC may be in "
+            "HyperCore escrow, spot, perp, or vault. Run check-hypercore-user.py and "
+            "reconcile the live destination before releasing any allocation."
         )
 
     if interactive:

--- a/tradeexecutor/state/repair.py
+++ b/tradeexecutor/state/repair.py
@@ -42,7 +42,14 @@ class RepairAborted(Exception):
 
 
 class HypercoreTransitRecoveryRequired(RepairAborted):
-    """A failed HyperCore deposit needs live balance reconciliation first."""
+    """A failed HyperCore deposit needs live balance reconciliation first.
+
+    State-only repair has no HyperCore Info API evidence. It cannot determine
+    whether a failed buy's allocation is still in EVM escrow, spot, perp, or
+    already deposited into the vault, so creating a zero-value counter trade
+    would be an unaudited refund. This exception protects the #1486 accounting
+    invariant: physical USDC must have exactly one state-side home.
+    """
 
 
 class HypercoreDuplicateCloseError(Exception):
@@ -728,6 +735,10 @@ def repair_trades(
     ]
     if at_risk_hypercore_trades:
         trade_ids = ", ".join(str(trade.trade_id) for trade in at_risk_hypercore_trades)
+        # ``repair_trade()`` would otherwise make a counter trade and restore
+        # the planned reserve without querying HyperCore. Refuse rather than
+        # infer a location from the failed status or a successful EVM wrapper
+        # receipt; both were misleading in the production incident.
         raise HypercoreTransitRecoveryRequired(
             f"Cannot state-repair HyperCore deposit trade(s) {trade_ids}: USDC may be in "
             "HyperCore escrow, spot, perp, or vault. Run check-hypercore-user.py and "

--- a/tradeexecutor/state/state.py
+++ b/tradeexecutor/state/state.py
@@ -1090,9 +1090,21 @@ class State:
             )
 
     def mark_trade_failed(self, failed_at: datetime.datetime, trade: TradeExecution):
-        """Unroll the allocated capital."""
+        """Unroll allocated capital unless it is recoverably stranded outside the Safe."""
         trade.mark_failed(failed_at)
         if trade.is_buy():
+            retain_reserve_allocation = trade.other_data.get(
+                "retain_reserve_allocation_on_failure",
+                False,
+            )
+            if retain_reserve_allocation:
+                logger.error(
+                    "Keeping %s %s allocated after failed trade %s: funds are stranded outside the Safe",
+                    trade.reserve_currency_allocated or trade.bridge_currency_allocated,
+                    trade.reserve_currency.token_symbol,
+                    trade.trade_id,
+                )
+                return
             # Return unused reserves back to accounting.
             if trade.reserve_currency_allocated is not None:
                 self.portfolio.adjust_reserves(

--- a/tradeexecutor/state/state.py
+++ b/tradeexecutor/state/state.py
@@ -1096,6 +1096,14 @@ class State:
         deliberately fails closed across a process crash or RPC timeout: the
         allocation stays committed until a live reconciliation proves that the
         Safe never lost the USDC.
+
+        Incident rationale: on 2026-07-30 HyperAI trade #1486 bridged 48.884068
+        USDC out of its Safe and reached HyperCore perp, while the following
+        vault transfer silently no-op'd. The old generic failed-buy path added
+        the same amount back to internal reserves. The strategy could then plan
+        another buy with cash that physically remained on HyperCore. The marker
+        below is intentionally generic-state-level logic, so every failure
+        caller—including startup repair—preserves the no-double-spend invariant.
         """
         trade.mark_failed(failed_at)
         if trade.is_buy():
@@ -1104,6 +1112,10 @@ class State:
                 or trade.other_data.get("hypercore_deposit_capital_at_risk") is not None
             )
             if retain_reserve_allocation:
+                # Keep ``reserve_currency_allocated`` / bridge allocation in
+                # place. This makes portfolio cash conservative until an
+                # operator resolves the physical destination; do not "tidy"
+                # this into the normal failed-buy refund path.
                 logger.error(
                     "Keeping %s %s allocated after failed trade %s: funds are stranded outside the Safe",
                     trade.reserve_currency_allocated or trade.bridge_currency_allocated,

--- a/tradeexecutor/state/state.py
+++ b/tradeexecutor/state/state.py
@@ -1090,12 +1090,18 @@ class State:
             )
 
     def mark_trade_failed(self, failed_at: datetime.datetime, trade: TradeExecution):
-        """Unroll allocated capital unless it is recoverably stranded outside the Safe."""
+        """Unroll allocated capital unless it is recoverably outside the Safe.
+
+        HyperCore deposit phase 1 is marked at risk before broadcast. This
+        deliberately fails closed across a process crash or RPC timeout: the
+        allocation stays committed until a live reconciliation proves that the
+        Safe never lost the USDC.
+        """
         trade.mark_failed(failed_at)
         if trade.is_buy():
-            retain_reserve_allocation = trade.other_data.get(
-                "retain_reserve_allocation_on_failure",
-                False,
+            retain_reserve_allocation = (
+                trade.other_data.get("retain_reserve_allocation_on_failure", False)
+                or trade.other_data.get("hypercore_deposit_capital_at_risk") is not None
             )
             if retain_reserve_allocation:
                 logger.error(

--- a/tradeexecutor/strategy/account_correction.py
+++ b/tradeexecutor/strategy/account_correction.py
@@ -1341,6 +1341,23 @@ def _build_hypercore_vault_account_checks(
         if p.pair.is_hyperliquid_vault()
     ]
 
+    transit_trades = []
+    for position in state.portfolio.get_open_and_frozen_positions():
+        for trade in position.trades.values():
+            metadata = trade.other_data or {}
+            transit = metadata.get("hypercore_stranded_usdc") or metadata.get(
+                "hypercore_deposit_capital_at_risk"
+            )
+            if transit is not None:
+                transit_trades.append((trade.trade_id, transit))
+    for trade_id, transit in transit_trades:
+        logger.warning(
+            "HyperCore transit capital retained for failed trade #%s: %s. "
+            "Account correction will not release it; reconcile live balances first.",
+            trade_id,
+            transit,
+        )
+
     logger.debug("Hypercore vault account checks discovered %d vault position(s)", len(vault_positions))
 
     if not vault_positions:

--- a/tradeexecutor/strategy/account_correction.py
+++ b/tradeexecutor/strategy/account_correction.py
@@ -1351,6 +1351,9 @@ def _build_hypercore_vault_account_checks(
             if transit is not None:
                 transit_trades.append((trade.trade_id, transit))
     for trade_id, transit in transit_trades:
+        # HyperCore transit USDC is not an ERC-20 Safe balance and must not be
+        # manufactured by account correction. Keep the condition visible to the
+        # operator while the routing/repair guards retain the allocation.
         logger.warning(
             "HyperCore transit capital retained for failed trade #%s: %s. "
             "Account correction will not release it; reconcile live balances first.",

--- a/tradeexecutor/strategy/account_correction.py
+++ b/tradeexecutor/strategy/account_correction.py
@@ -1343,7 +1343,10 @@ def _build_hypercore_vault_account_checks(
 
     transit_trades = []
     for position in state.portfolio.get_open_and_frozen_positions():
-        for trade in position.trades.values():
+        # Real TradingPosition instances always have ``trades``. Keep this
+        # audit-only scan tolerant of the lightweight position objects used by
+        # integrations which only need the vault-equity account check.
+        for trade in getattr(position, "trades", {}).values():
             metadata = trade.other_data or {}
             transit = metadata.get("hypercore_stranded_usdc") or metadata.get(
                 "hypercore_deposit_capital_at_risk"

--- a/tradeexecutor/strategy/account_correction.py
+++ b/tradeexecutor/strategy/account_correction.py
@@ -1356,7 +1356,7 @@ def _build_hypercore_vault_account_checks(
         # operator while the routing/repair guards retain the allocation.
         logger.warning(
             "HyperCore transit capital retained for failed trade #%s: %s. "
-            "Account correction will not release it; reconcile live balances first.",
+            "This HyperCore-specific check will not release it; reconcile live balances first.",
             trade_id,
             transit,
         )

--- a/tradeexecutor/strategy/execution_model.py
+++ b/tradeexecutor/strategy/execution_model.py
@@ -10,7 +10,7 @@ import abc
 import datetime
 import enum
 from types import NoneType
-from typing import List,TypedDict
+from typing import Callable, List,TypedDict
 from web3 import Web3
 
 from eth_defi.hotwallet import HotWallet
@@ -72,6 +72,27 @@ class ExecutionModel(abc.ABC):
     
     Used directly by BacktestExecutionModel, and indirectly (through EthereumExecutionModel) by UniswapV2ExecutionModel and UniswapV3ExecutionModel
     """
+
+    def set_pre_broadcast_state_sync_callback(
+        self,
+        callback: Callable[[], None] | None,
+    ) -> None:
+        """Set the live-state checkpoint used after transaction preparation.
+
+        The strategy runner supplies this only for live execution.  Transaction
+        preparation can mutate durable trade state (for example the HyperCore
+        phase-1 capital-at-risk marker) after the runner's initial checkpoint
+        but before a node accepts a signed transaction.  Keeping this callback
+        on the execution model lets every broadcast path checkpoint that state
+        at the only safe boundary: after setup and before broadcast.
+        """
+        self._pre_broadcast_state_sync_callback = callback
+
+    def sync_state_before_broadcast(self) -> None:
+        """Persist prepared transaction state when live execution provided a callback."""
+        callback = getattr(self, "_pre_broadcast_state_sync_callback", None)
+        if callback is not None:
+            callback()
 
     @abc.abstractmethod
     def get_balance_address(self) -> str | None:
@@ -288,7 +309,6 @@ class AssetManagementMode(enum.Enum):
     def is_vault(self) -> bool:
         """Are we trading using a vault smart contract"""
         return self in (AssetManagementMode.enzyme, AssetManagementMode.velvet, AssetManagementMode.lagoon,)
-
 
 
 

--- a/tradeexecutor/strategy/runner.py
+++ b/tradeexecutor/strategy/runner.py
@@ -1052,16 +1052,16 @@ class StrategyRunner(abc.ABC):
                         crash=True,
                     )
 
-                    # Sync state before broadcasting,
-                    # so we have generated tx hashes on the disk
-                    # and trades flagged with broadcasting/broadcasted status.
-                    # This allows us to recover and rebroadcast,
-                    # if the execution crashes e.g. due to blockchain being down,
-                    # node issues, or gas fee spikes
-                    if self.execution_context.mode.is_live_trading():
-                        if store is not None:
-                            logger.info("Syncing state file before the trade execution")
-                            store.sync(state)
+                    # Checkpoint planned trades before preparation.  The
+                    # execution model performs a second checkpoint after it
+                    # creates transaction hashes and route-specific safety
+                    # metadata, immediately before broadcast.
+                    if self.execution_context.mode.is_live_trading() and store is not None:
+                        logger.info("Syncing state file before the trade execution")
+                        store.sync(state)
+                        self.execution_model.set_pre_broadcast_state_sync_callback(
+                            lambda: store.sync(state),
+                        )
 
                     try:
                         self.execution_model.execute_trades(
@@ -1114,6 +1114,7 @@ class StrategyRunner(abc.ABC):
         stop_loss_pricing_model: PricingModel,
         routing_state: RoutingState,
         long_short_metrics_latest: StatisticsTable | None = None,
+        state_sync_callback: Callable[[], None] | None = None,
         ) -> List[TradeExecution]:
         """Check stop loss/take profit for positions.
 
@@ -1138,6 +1139,11 @@ class StrategyRunner(abc.ABC):
 
         assert isinstance(routing_state, RoutingState)
         assert isinstance(stop_loss_pricing_model, PricingModel)
+
+        # Trigger trades share the same irreversible-broadcast boundary as
+        # regular strategy trades.  The live loop passes its state store here;
+        # backtests and manual analysis commands deliberately leave it unset.
+        self.execution_model.set_pre_broadcast_state_sync_callback(state_sync_callback)
 
         debug_details = {}
 


### PR DESCRIPTION
## Why

HyperCore acknowledges CoreWriter wrapper calls on HyperEVM independently from the asynchronous actions on HyperCore. Trade #1486 showed the resulting failure mode: spot→perp completed for 48.884068 USDC, perp→vault did not, and generic failed-buy rollback treated the physically stranded funds as Safe cash. A process crash or uncertain broadcast before settlement classification creates the same accounting risk.

## Lessons learnt

An EVM receipt cannot prove an atomic HyperCore settlement. Every balance transition needs a protocol-state proof. When evidence is incomplete, accounting must be conservative: retained capital is preferable to a duplicated reserve. Generic repair and account-correction logic must not infer a HyperCore balance location from a failed status. A stale state snapshot can predate the failure marker, so default recovery must inspect live HyperCore balances rather than waiting for a state marker.

## Summary

- Split and verify deposit phase 2 with exact spot and perp balance proof before phase 3.
- Persist phase-1 capital-at-risk metadata after transaction preparation and immediately before broadcast; retain allocation across failures until reconciliation.
- Classify timeouts and broadcast uncertainty conservatively; guard automatic and state-only repair.
- Clear temporary transit markers only after a definite phase-1 revert or fully confirmed vault deposit.
- Let `correct-accounts --dry-run` plan default Safe-level HyperCore recovery without a signer or state writes.
- Enable recovery for every eligible HyperCore vault strategy by default: bridge the transferable amount recovered from perp to spot, retain only any mandatory bridge-fee margin, then handle pre-existing spot USDC separately.
- Keep a dust-sized amount in perp when it cannot complete a balance-verified spot-to-EVM leg, avoiding a stranded half-recovery.
- Add mocked trade #1486, phase ordering, partial-movement, crash-checkpoint, failure-accounting, and recovery-plan regression tests.
- Document incident rationale and the safe recovery path (perp → spot → EVM).
