### PR TITLE
perf: speed up CI test scheduling

### DIFF
--- a/.github/workflows/test-slow.yml
+++ b/.github/workflows/test-slow.yml
@@ -38,6 +38,7 @@ jobs:
           virtualenvs-in-project: true
           installer-parallel: true
       - name: Load cached venv
+        id: cached-poetry-dependencies
         uses: actions/cache@v6
         with:
           path: .venv

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -45,6 +45,7 @@ jobs:
 
       # Do not let Poetry to install again if we do not detect a lock file change
       - name: Load cached venv
+        id: cached-poetry-dependencies
         uses: actions/cache@v6
         with:
           path: .venv

--- a/tests/ethereum/polygon_forked/generic-router/test_generic_router.py
+++ b/tests/ethereum/polygon_forked/generic-router/test_generic_router.py
@@ -34,7 +34,7 @@ pytestmark = [
         reason="Set JSON_RPC_POLYGON env install anvil command to run these tests",
     ),
     pytest.mark.warm_rpc_high_value_group,
-    pytest.mark.xdist_group("fork:polygon:51000000:isolated"),
+    pytest.mark.xdist_group("fork:polygon:51000000:isolated:generic-router"),
 ]
 
 

--- a/tests/ethereum/polygon_forked/generic-router/test_generic_router_end_to_end.py
+++ b/tests/ethereum/polygon_forked/generic-router/test_generic_router_end_to_end.py
@@ -35,7 +35,7 @@ logger = logging.getLogger(__name__)
 
 pytestmark = [
     pytest.mark.warm_rpc_high_value_group,
-    pytest.mark.xdist_group("fork:polygon:51000000:isolated"),
+    pytest.mark.xdist_group("fork:polygon:51000000:isolated:generic-router-e2e"),
 ]
 
 

--- a/tests/ethereum/polygon_forked/generic-router/test_generic_router_multihops.py
+++ b/tests/ethereum/polygon_forked/generic-router/test_generic_router_multihops.py
@@ -35,7 +35,7 @@ pytestmark = [
         reason="Set JSON_RPC_POLYGON env install anvil command to run these tests",
     ),
     pytest.mark.warm_rpc_high_value_group,
-    pytest.mark.xdist_group("fork:polygon:51000000:isolated"),
+    pytest.mark.xdist_group("fork:polygon:51000000:isolated:generic-router-multihops"),
 ]
 
 @pytest.fixture

--- a/tests/ethereum/polygon_forked/generic-router/test_short_flags.py
+++ b/tests/ethereum/polygon_forked/generic-router/test_short_flags.py
@@ -34,7 +34,7 @@ pytestmark = [
         reason="Set JSON_RPC_POLYGON env install anvil command to run these tests",
     ),
     pytest.mark.warm_rpc_high_value_group,
-    pytest.mark.xdist_group("fork:polygon:51000000:isolated"),
+    pytest.mark.xdist_group("fork:polygon:51000000:isolated:short-flags"),
 ]
 
 
@@ -182,4 +182,3 @@ def test_short_flags(
         routing_state,
         check_balances=True,
     )
-

--- a/tests/ethereum/test_uniswap_v3_live_stop_loss.py
+++ b/tests/ethereum/test_uniswap_v3_live_stop_loss.py
@@ -619,6 +619,7 @@ def test_broadcast_failed_and_repair_state(
 
 
 @flaky.flaky
+@pytest.mark.slow_test_group
 def test_refresh_visualisations(
         logger,
         web3: Web3,
@@ -698,6 +699,7 @@ def test_refresh_visualisations(
         open_bytes_in_browser(large_image_png)
 
 
+@pytest.mark.slow_test_group
 def test_metadata_stats(
     logger,
     web3: Web3,

--- a/tests/lagoon/test_lagoon_deposit.py
+++ b/tests/lagoon/test_lagoon_deposit.py
@@ -29,7 +29,7 @@ JSON_RPC_BASE = os.environ.get("JSON_RPC_BASE")
 pytestmark = [
     pytest.mark.skipif(not JSON_RPC_BASE, reason="No JSON_RPC_BASE environment variable"),
     pytest.mark.warm_rpc_high_value_group,
-    pytest.mark.xdist_group("fork:base:49030926:isolated"),
+    pytest.mark.xdist_group("fork:base:49030926:isolated:lagoon-deposit"),
 ]
 
 

--- a/tests/lagoon/test_lagoon_e2e.py
+++ b/tests/lagoon/test_lagoon_e2e.py
@@ -31,7 +31,7 @@ pytestmark = [
         reason="Set JSON_RPC_BASE and TRADING_STRATEGY_API_KEY needed to run this test",
     ),
     pytest.mark.warm_rpc_high_value_group,
-    pytest.mark.xdist_group("fork:base:49030926:isolated"),
+    pytest.mark.xdist_group("fork:base:49030926:isolated:lagoon-e2e"),
 ]
 from tradeexecutor.utils.hex import hexbytes_to_hex_str
 

--- a/tests/lagoon/test_lagoon_swap.py
+++ b/tests/lagoon/test_lagoon_swap.py
@@ -28,7 +28,7 @@ JSON_RPC_BASE = os.environ.get("JSON_RPC_BASE")
 pytestmark = [
     pytest.mark.skipif(not JSON_RPC_BASE, reason="No JSON_RPC_BASE environment variable"),
     pytest.mark.warm_rpc_high_value_group,
-    pytest.mark.xdist_group("fork:base:49030926:isolated"),
+    pytest.mark.xdist_group("fork:base:49030926:isolated:lagoon-swap"),
 ]
 
 

--- a/tests/test_capped_waterfall_notebook.py
+++ b/tests/test_capped_waterfall_notebook.py
@@ -16,6 +16,8 @@ import shutil
 import subprocess
 from pathlib import Path
 
+import pytest
+
 
 NOTEBOOK_PATH = Path(__file__).resolve().parents[1] / "strategies" / "test_only" / "08-backtest-capped-waterfall.ipynb"
 
@@ -65,6 +67,7 @@ def _has_any_execution_output(notebook_path: Path) -> bool:
     return any(cell.get("outputs") for cell in notebook.get("cells", []) if cell.get("cell_type") == "code")
 
 
+@pytest.mark.slow_test_group
 def test_capped_waterfall_notebook(tmp_path: Path) -> None:
     """Verify the capped-waterfall CCTP backtest notebook executes after the phase-order fix.
 

--- a/tests/test_hyperliquid_waterfall_notebook.py
+++ b/tests/test_hyperliquid_waterfall_notebook.py
@@ -10,6 +10,8 @@ import shutil
 import subprocess
 from pathlib import Path
 
+import pytest
+
 
 NOTEBOOK_PATH = Path(__file__).resolve().parents[1] / "strategies" / "test_only" / "158-backtest-hyperliquid-waterfall-release-candidate.ipynb"
 
@@ -59,6 +61,7 @@ def _has_any_execution_output(notebook_path: Path) -> bool:
     return any(cell.get("outputs") for cell in notebook.get("cells", []) if cell.get("cell_type") == "code")
 
 
+@pytest.mark.slow_test_group
 def test_hyperliquid_waterfall_release_candidate_notebook(tmp_path: Path) -> None:
     """Verify the release-candidate notebook executes and reports crashes clearly.
 


### PR DESCRIPTION
## Why

The automated test suite is the CI critical path. Long notebook and visualisation tests were competing with the ordinary suite, and warm-fork scheduling serialised independent modules.

## Lessons learnt

A cached virtualenv was never used to skip Poetry installation because the workflow condition referenced a missing step ID. Warm-RPC tests only need one xdist group per module; sharing a group across modules unnecessarily reduces parallelism.

## Summary

- Mark four long regression tests as slow so they run in the parallel slow workflow.
- Give each Base and Polygon warm-fork module an independent xdist group.
- Add the missing virtualenv-cache step ID in both test workflows.