### PR TITLE
fix: unblock HyperCore account recovery commands

### DIFF
--- a/.claude/docs/hypercore-vault.md
+++ b/.claude/docs/hypercore-vault.md
@@ -251,9 +251,9 @@ therefore the safe way to inspect a normal dust-preserving sweep before running
 the live command.
 
 Before either a live recovery or this dry-run planner, `correct-accounts`
-checks that no open or frozen position has a planned/started trade affecting its
-available quantity. This preflight is intentionally before all HyperCore calls
-and mutations. It was added after the HyperAI #1486 recovery: the first
+checks that no open or frozen position has a planned trade or a started trade
+without a transaction. This preflight is intentionally before all HyperCore
+calls and mutations. It was added after the HyperAI #1486 recovery: the first
 implementation returned real USDC to the Safe and only afterwards discovered an
 unrelated unexecuted trade, so the command could not complete its accounting
 pass. A preflight failure now proves that no Safe action was broadcast.

--- a/.claude/docs/hypercore-vault.md
+++ b/.claude/docs/hypercore-vault.md
@@ -266,7 +266,9 @@ deposit with an at-risk or stranded-USDC marker, it logs the trade and leaves
 that position frozen; it does not create a counter-trade or refund an unknown
 HyperCore balance. This partial repair is deliberate: it clears unrelated
 coherence blockers so that the next `correct-accounts --dry-run` can inspect
-the live transit balance safely.
+the live transit balance safely. If every candidate is protected, repair makes
+no state change and does not show an interactive confirmation prompt: there is
+nothing safe for it to repair.
 
 The safe operator sequence is therefore:
 

--- a/.claude/docs/hypercore-vault.md
+++ b/.claude/docs/hypercore-vault.md
@@ -250,15 +250,42 @@ sign or broadcast a transaction, alter state, or create a state backup. It is
 therefore the safe way to inspect a normal dust-preserving sweep before running
 the live command.
 
+Before either a live recovery or this dry-run planner, `correct-accounts`
+checks that no open or frozen position has a planned/started trade affecting its
+available quantity. This preflight is intentionally before all HyperCore calls
+and mutations. It was added after the HyperAI #1486 recovery: the first
+implementation returned real USDC to the Safe and only afterwards discovered an
+unrelated unexecuted trade, so the command could not complete its accounting
+pass. A preflight failure now proves that no Safe action was broadcast.
+
+When the preflight names an unfinished trade, use `repair` first. Repair treats
+an `expired` no-transaction trade as valid terminal history, rather than trying
+to repair it: expiry happens before a transaction is created. It repairs only
+planned/started no-transaction trades. If it also finds a failed HyperCore
+deposit with an at-risk or stranded-USDC marker, it logs the trade and leaves
+that position frozen; it does not create a counter-trade or refund an unknown
+HyperCore balance. This partial repair is deliberate: it clears unrelated
+coherence blockers so that the next `correct-accounts --dry-run` can inspect
+the live transit balance safely.
+
+The safe operator sequence is therefore:
+
+1. Run `repair` to clear ordinary missing-transaction trades; review any
+   explicitly deferred HyperCore trade.
+2. Run `correct-accounts --dry-run`; it must pass preflight and show the
+   proposed `perp → spot → EVM` actions without broadcasting them.
+3. Run `correct-accounts` only after reviewing that plan. It reconciles the
+   recovered Safe balance through the normal accounting path.
+
 For #1486, the default dry run above plans exactly
 `perp_to_spot 48.884068` followed by `spot_to_evm 48.884068`: no incident
 option is necessary. The recovery is on by default for every eligible
 HyperCore vault strategy, as are the other HyperCore repair checks.
 
 This does **not** make generic repair safe. A state file that predates a failed
-deposit can still show the trade as planned and lack its at-risk marker. After
-recovery, expire/reconcile that stale planned trade before restarting
-the executor, then use the normal account correction to align reserve state.
+deposit can still show the trade as planned and lack its at-risk marker. Do not
+manually expire an ambiguous deposit merely to pass the preflight: reconcile
+its live Safe, escrow, spot, perp, and vault balances first.
 
 ## Withdrawal (sell) flow
 

--- a/tests/hyperliquid/test_hypercore_stranded_usdc.py
+++ b/tests/hyperliquid/test_hypercore_stranded_usdc.py
@@ -96,30 +96,38 @@ def test_phase1_at_risk_marker_is_written_before_broadcast() -> None:
 
 
 def test_state_only_repair_defers_unreconciled_hypercore_deposit() -> None:
-    """State-only repair must defer a deposit whose location is unknown.
+    """Repair must leave an unreconciled HyperCore deposit frozen without prompting.
 
     1. Create a failed trade carrying the HyperCore at-risk marker.
-    2. Present it to the state-only repair workflow.
-    3. Verify repair creates no counter-trade, leaving live reconciliation to
-       correct-accounts instead of refunding an unknown balance location.
+    2. Present it as the only frozen repair candidate to interactive repair.
+    3. Verify repair creates no counter-trade, does not prompt or unfreeze, and
+       leaves live reconciliation to correct-accounts.
     """
     # 1. This mock represents a crash before HyperCore receipt classification.
     state = MagicMock()
-    state.portfolio.frozen_positions.values.return_value = []
+    position = MagicMock()
+    position.position_id = 489
+    state.portfolio.frozen_positions.values.return_value = [position]
     trade = MagicMock()
     trade.trade_id = 1486
+    trade.position_id = 489
     trade.other_data = {"hypercore_deposit_capital_at_risk": {"amount_raw": 48_884_068}}
 
     # 2. State-only repair has no RPC/Info API evidence to resolve the location.
-    with patch("tradeexecutor.state.repair.find_trades_to_be_repaired", return_value=[trade]):
+    with patch("tradeexecutor.state.repair.find_trades_to_be_repaired", return_value=[trade]), patch(
+        "tradeexecutor.state.repair.unfreeze_position",
+    ) as unfreeze_position, patch("builtins.input") as input_mock:
         # 3. It must defer rather than manufacture a counter-trade refund. This
         # lets repair unblock unrelated planned trades before correct-accounts
-        # performs the Safe-level live recovery.
-        result = repair_trades(state, attempt_repair=True, interactive=False)
+        # performs the Safe-level live recovery, without an unprompted state
+        # change when this is the only repair candidate.
+        result = repair_trades(state, attempt_repair=True, interactive=True)
 
     assert result.trades_needing_repair == [trade]
     assert result.new_trades == []
     assert result.unfrozen_positions == []
+    input_mock.assert_not_called()
+    unfreeze_position.assert_not_called()
 
 
 def test_state_only_repair_repairs_unrelated_trade_while_deferring_hypercore_deposit() -> None:

--- a/tests/hyperliquid/test_hypercore_stranded_usdc.py
+++ b/tests/hyperliquid/test_hypercore_stranded_usdc.py
@@ -2,10 +2,8 @@
 
 from unittest.mock import MagicMock, patch
 
-import pytest
-
 from tradeexecutor.ethereum.vault.hypercore_routing import HypercoreVaultRouting
-from tradeexecutor.state.repair import HypercoreTransitRecoveryRequired, repair_trades
+from tradeexecutor.state.repair import repair_trades
 
 
 def test_mark_stranded_usdc_stores_info() -> None:
@@ -97,12 +95,13 @@ def test_phase1_at_risk_marker_is_written_before_broadcast() -> None:
     assert trade.other_data["retain_reserve_allocation_on_failure"] is True
 
 
-def test_state_only_repair_refuses_unreconciled_hypercore_deposit() -> None:
-    """State-only repair must not refund a deposit whose location is unknown.
+def test_state_only_repair_defers_unreconciled_hypercore_deposit() -> None:
+    """State-only repair must defer a deposit whose location is unknown.
 
     1. Create a failed trade carrying the HyperCore at-risk marker.
     2. Present it to the state-only repair workflow.
-    3. Verify repair stops and instructs the operator to reconcile live balances.
+    3. Verify repair creates no counter-trade, leaving live reconciliation to
+       correct-accounts instead of refunding an unknown balance location.
     """
     # 1. This mock represents a crash before HyperCore receipt classification.
     state = MagicMock()
@@ -113,6 +112,51 @@ def test_state_only_repair_refuses_unreconciled_hypercore_deposit() -> None:
 
     # 2. State-only repair has no RPC/Info API evidence to resolve the location.
     with patch("tradeexecutor.state.repair.find_trades_to_be_repaired", return_value=[trade]):
-        # 3. It must fail closed rather than manufacture a counter-trade refund.
-        with pytest.raises(HypercoreTransitRecoveryRequired, match="check-hypercore-user.py"):
-            repair_trades(state, attempt_repair=True, interactive=False)
+        # 3. It must defer rather than manufacture a counter-trade refund. This
+        # lets repair unblock unrelated planned trades before correct-accounts
+        # performs the Safe-level live recovery.
+        result = repair_trades(state, attempt_repair=True, interactive=False)
+
+    assert result.trades_needing_repair == [trade]
+    assert result.new_trades == []
+    assert result.unfrozen_positions == []
+
+
+def test_state_only_repair_repairs_unrelated_trade_while_deferring_hypercore_deposit() -> None:
+    """Repair must clear independent failures without refunding stranded HyperCore USDC.
+
+    1. Model the production combination of one ordinary failed trade and one
+       failed HyperCore deposit carrying its stranded-USDC marker.
+    2. Run the state-only repair workflow without interactive confirmation.
+    3. Verify only the ordinary trade receives a counter-trade and the
+       HyperCore trade remains explicitly deferred for live reconciliation.
+
+    Trades are mocked because this test isolates the command's selection rule;
+    the real state-bookkeeping path is covered by the no-transaction regression
+    in ``test_repair_trade_missing_tx.py``.
+    """
+    # 1. The protected trade models #1486, while the ordinary trade models the
+    # independent failure which made correct-accounts' coherence check fail.
+    state = MagicMock()
+    state.portfolio.frozen_positions.values.return_value = []
+    hypercore_trade = MagicMock()
+    hypercore_trade.trade_id = 1486
+    hypercore_trade.position_id = 489
+    hypercore_trade.other_data = {"hypercore_stranded_usdc": {"amount_raw": 48_884_068}}
+    ordinary_trade = MagicMock()
+    ordinary_trade.trade_id = 4700
+    ordinary_trade.position_id = 470
+    ordinary_trade.other_data = {}
+    counter_trade = MagicMock()
+
+    # 2. Repair may create accounting entries only for the ordinary failure.
+    with patch("tradeexecutor.state.repair.find_trades_to_be_repaired", return_value=[hypercore_trade, ordinary_trade]), patch(
+        "tradeexecutor.state.repair.repair_trade",
+        return_value=counter_trade,
+    ) as repair_trade:
+        result = repair_trades(state, attempt_repair=True, interactive=False)
+
+    # 3. The command completes, but never manufactures a refund for #1486.
+    repair_trade.assert_called_once_with(state.portfolio, ordinary_trade)
+    assert result.trades_needing_repair == [hypercore_trade, ordinary_trade]
+    assert result.new_trades == [counter_trade]

--- a/tests/hyperliquid/test_hypercore_transit_recovery.py
+++ b/tests/hyperliquid/test_hypercore_transit_recovery.py
@@ -21,6 +21,7 @@ from tradeexecutor.strategy.account_correction import (
     AccountingBalanceCheck,
     AccountingCorrectionCause,
     apply_accounting_correction,
+    preflight_state_for_account_correction,
 )
 from tradeexecutor.strategy.execution_model import AssetManagementMode
 
@@ -441,10 +442,11 @@ def test_correct_accounts_detects_frozen_hypercore_position() -> None:
 
 
 def test_correct_accounts_dry_run_plans_transit_recovery_without_signer(monkeypatch) -> None:
-    """Dry-run exposes #1486-style transit recovery without broadcasting it.
+    """Dry-run reaches #1486-style transit recovery after the command preflight.
 
     1. Build a Lagoon state with a closed HyperCore position and stranded perp USDC.
-    2. Run the correct-accounts recovery hook in dry-run mode without a hot-wallet signer.
+    2. Run the same state-coherence preflight used by correct-accounts, then its
+       recovery hook in dry-run mode without a hot-wallet signer.
     3. Verify it reports the planned recovery while never invoking the broadcaster.
 
     The HyperCore snapshot and broadcaster are mocked because this test checks
@@ -468,7 +470,8 @@ def test_correct_accounts_dry_run_plans_transit_recovery_without_signer(monkeypa
                 1: SimpleNamespace(
                     pair=SimpleNamespace(is_hyperliquid_vault=lambda: True)
                 )
-            }
+            },
+            get_open_and_frozen_positions=lambda: [],
         )
     )
     monkeypatch.setattr(
@@ -488,7 +491,10 @@ def test_correct_accounts_dry_run_plans_transit_recovery_without_signer(monkeypa
         broadcast,
     )
 
-    # Step 2: Dry-run must require only read access, not the Safe's private key.
+    # Step 2: A coherent repaired state reaches dry-run recovery without a
+    # signer. The actual CLI invokes this preflight immediately after loading
+    # state, before the transit hook can broadcast a Safe transaction.
+    preflight_state_for_account_correction(state)
     planned = correct_accounts_command._recover_hypercore_transit_balances(
         asset_management_mode=AssetManagementMode.lagoon,
         sync_model=FakeLagoonVaultSyncModel(),

--- a/tests/hyperliquid/test_hyperliquid_cleanup.py
+++ b/tests/hyperliquid/test_hyperliquid_cleanup.py
@@ -21,6 +21,7 @@ from hexbytes import HexBytes
 
 from tradeexecutor.ethereum.vault import hyperliquid_cleanup
 from tradeexecutor.ethereum.vault import hypercore_transit_recovery
+from tradeexecutor.state.repair import RepairResult
 from tradeexecutor.state.state import State
 from tradeexecutor.state.store import JSONFileStore
 
@@ -490,3 +491,47 @@ def test_wait_for_evm_usdc_balance_accepts_threshold_instead_of_exact_match():
 
     # Step 3: Verify the helper accepts the observed balance without requiring an exact final match.
     assert result == Decimal("108.992")
+
+
+def test_cleanup_stops_before_accounting_for_deferred_hypercore_deposit(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Cleanup must not apply generic accounting after a protected deposit is deferred.
+
+    1. Mock the state repair report for a failed deposit whose USDC location is unknown.
+    2. Run the isolated repair-and-correct phase used by the cleanup command.
+    3. Verify it returns unclean without constructing accounting or saving state.
+
+    Mocks isolate this fail-closed gate: reaching the accounting context would
+    require live RPC, strategy-universe, and Safe data unrelated to the guard.
+    """
+    # 1. A marker means generic repair deliberately did not create a refund.
+    state = MagicMock()
+    store = MagicMock()
+    protected_trade = MagicMock()
+    protected_trade.trade_id = 1486
+    protected_trade.other_data = {
+        "hypercore_stranded_usdc": {"amount_raw": 48_884_068},
+    }
+    repair_result = RepairResult(
+        frozen_positions=[],
+        unfrozen_positions=[],
+        trades_needing_repair=[protected_trade],
+        new_trades=[],
+    )
+    context = MagicMock()
+    context.state_file = Path("unused-state.json")
+    context.unit_testing = True
+    build_accounting_context = MagicMock()
+    monkeypatch.setattr(hyperliquid_cleanup, "backup_state", lambda *args, **kwargs: (store, state))
+    monkeypatch.setattr(hyperliquid_cleanup, "repair_trades", lambda *args, **kwargs: repair_result)
+    monkeypatch.setattr(hyperliquid_cleanup, "_build_accounting_correction_context", build_accounting_context)
+
+    # 2. The cleanup command reaches the repair report before any account action.
+    accounts_clean, state_saved = hyperliquid_cleanup._repair_and_correct_state(context)
+
+    # 3. The unknown HyperCore location prevents both accounting and persistence.
+    assert accounts_clean is False
+    assert state_saved is False
+    build_accounting_context.assert_not_called()
+    store.sync.assert_not_called()

--- a/tests/legacy/test_repair_trade_missing_tx.py
+++ b/tests/legacy/test_repair_trade_missing_tx.py
@@ -77,8 +77,9 @@ def test_repair_trade_missing_tx(
 def test_repair_skips_expired_trade_then_unblocks_correct_accounts_preflight() -> None:
     """Repair clears executable no-TX trades without mistaking expired history for a failure.
 
-    1. Load a real state fixture with planned no-transaction trades and expire one,
-       reproducing the terminal trade #1482 shape from the HyperAI incident.
+    1. Load a real state fixture with planned no-transaction trades, expire one,
+       and mark another started without a transaction, reproducing both relevant
+       HyperAI command blockers.
     2. Verify correct-accounts' side-effect-free preflight refuses the still
        unexecuted state, then run the state-only missing-TX repair.
     3. Verify the expired trade remains terminal, all repairable trades receive
@@ -89,7 +90,7 @@ def test_repair_skips_expired_trade_then_unblocks_correct_accounts_preflight() -
     bookkeeping interacting exactly as the command does in production.
     """
     # 1. Build the production-shaped state: one intentionally expired no-TX
-    # trade and several separate planned no-TX trades that really need repair.
+    # trade, one started no-TX crash, and separate planned trades needing repair.
     fixture_path = Path(__file__).with_name("trade-missing-tx.json")
     state = State.from_json(fixture_path.read_text())
     original_missing_transaction_trades = [
@@ -100,6 +101,8 @@ def test_repair_skips_expired_trade_then_unblocks_correct_accounts_preflight() -
     assert len(original_missing_transaction_trades) > 1
     expired_trade = original_missing_transaction_trades[0]
     expired_trade.mark_expired(datetime.datetime(2026, 7, 30, 21, 2))
+    started_trade = original_missing_transaction_trades[1]
+    started_trade.started_at = datetime.datetime(2026, 7, 30, 21, 2)
 
     # 2. The account-correction command must refuse before it can recover
     # HyperCore funds. Repair then fixes only the genuinely unexecuted trades.
@@ -107,10 +110,11 @@ def test_repair_skips_expired_trade_then_unblocks_correct_accounts_preflight() -
         preflight_state_for_account_correction(state)
     repair_trades = repair_tx_not_generated(state, interactive=False)
 
-    # 3. Expiry is a legitimate terminal state, while the independent planned
-    # trades become repaired and no longer make correct-accounts halt.
+    # 3. Expiry is legitimate terminal history, while both the started crash
+    # and independent planned trades become repaired before account correction.
     assert expired_trade.get_status() == TradeStatus.expired
     assert expired_trade.blockchain_transactions == []
+    assert started_trade.get_status() == TradeStatus.repaired
     assert len(repair_trades) == len(original_missing_transaction_trades) - 1
     assert all(
         trade.get_status() in (TradeStatus.repaired, TradeStatus.expired)

--- a/tests/legacy/test_repair_trade_missing_tx.py
+++ b/tests/legacy/test_repair_trade_missing_tx.py
@@ -4,6 +4,7 @@
 import datetime
 import os
 from decimal import Decimal
+from pathlib import Path
 
 import pytest
 
@@ -13,6 +14,7 @@ from tradeexecutor.state.repair import repair_trades, repair_tx_not_generated
 from tradeexecutor.state.state import State
 from tradeexecutor.state.trade import TradeStatus, TradeType
 from tradeexecutor.statistics.core import calculate_statistics
+from tradeexecutor.strategy.account_correction import preflight_state_for_account_correction
 from tradeexecutor.strategy.execution_context import ExecutionMode
 from tradingstrategy.client import Client
 
@@ -70,3 +72,48 @@ def test_repair_trade_missing_tx(
 
     assert pos.get_value() == pytest.approx(2822.223554)
     assert portfolio.calculate_total_equity() == pytest.approx(4049.33755226)
+
+
+def test_repair_skips_expired_trade_then_unblocks_correct_accounts_preflight() -> None:
+    """Repair clears executable no-TX trades without mistaking expired history for a failure.
+
+    1. Load a real state fixture with planned no-transaction trades and expire one,
+       reproducing the terminal trade #1482 shape from the HyperAI incident.
+    2. Verify correct-accounts' side-effect-free preflight refuses the still
+       unexecuted state, then run the state-only missing-TX repair.
+    3. Verify the expired trade remains terminal, all repairable trades receive
+       counter-trades, and the next correct-accounts preflight succeeds.
+
+    The state fixture is used instead of an all-Mock portfolio because the
+    regression depends on real trade status, reserve, and position-quantity
+    bookkeeping interacting exactly as the command does in production.
+    """
+    # 1. Build the production-shaped state: one intentionally expired no-TX
+    # trade and several separate planned no-TX trades that really need repair.
+    fixture_path = Path(__file__).with_name("trade-missing-tx.json")
+    state = State.from_json(fixture_path.read_text())
+    original_missing_transaction_trades = [
+        trade
+        for trade in state.portfolio.get_all_trades()
+        if trade.get_status() == TradeStatus.planned and not trade.blockchain_transactions
+    ]
+    assert len(original_missing_transaction_trades) > 1
+    expired_trade = original_missing_transaction_trades[0]
+    expired_trade.mark_expired(datetime.datetime(2026, 7, 30, 21, 2))
+
+    # 2. The account-correction command must refuse before it can recover
+    # HyperCore funds. Repair then fixes only the genuinely unexecuted trades.
+    with pytest.raises(AssertionError, match="before any HyperCore transit recovery"):
+        preflight_state_for_account_correction(state)
+    repair_trades = repair_tx_not_generated(state, interactive=False)
+
+    # 3. Expiry is a legitimate terminal state, while the independent planned
+    # trades become repaired and no longer make correct-accounts halt.
+    assert expired_trade.get_status() == TradeStatus.expired
+    assert expired_trade.blockchain_transactions == []
+    assert len(repair_trades) == len(original_missing_transaction_trades) - 1
+    assert all(
+        trade.get_status() in (TradeStatus.repaired, TradeStatus.expired)
+        for trade in original_missing_transaction_trades
+    )
+    preflight_state_for_account_correction(state)

--- a/tradeexecutor/cli/commands/correct_accounts.py
+++ b/tradeexecutor/cli/commands/correct_accounts.py
@@ -24,7 +24,7 @@ from eth_defi.provider.broken_provider import get_almost_latest_block_number
 
 from tradeexecutor.exchange_account.derive import DeriveNetwork
 from tradeexecutor.exchange_account.utils import create_exchange_account_value_func
-from tradeexecutor.strategy.account_correction import correct_accounts as _correct_accounts, check_accounts, UnknownTokenPositionFix, check_state_internal_coherence
+from tradeexecutor.strategy.account_correction import correct_accounts as _correct_accounts, check_accounts, UnknownTokenPositionFix, preflight_state_for_account_correction
 from .app import app
 from ..bootstrap import prepare_executor_id, create_web3_config, create_sync_model, create_client, backup_state, create_execution_and_sync_model, resolve_deployment_file, configure_default_chain, create_state_store
 from ..double_position import check_double_position
@@ -542,6 +542,13 @@ def correct_accounts(
     else:
         store, state = backup_state(state_file, unit_testing=unit_testing)
 
+    # This must precede universe construction, vault synchronisation, and the
+    # HyperCore transit hook below.  The hook can broadcast real Safe actions;
+    # discovering an unfinished trade afterwards reproduces the #1486 incident
+    # where funds were recovered but the command could not complete its state
+    # reconciliation.
+    preflight_state_for_account_correction(state)
+
     slippage_tolerance = 0.013
     if mod:
         if mod.parameters:
@@ -872,8 +879,6 @@ def correct_accounts(
 
     if len(corrections) == 0:
         logger.info("No account corrections found")
-
-    check_state_internal_coherence(state)
 
     if dry_run:
         logger.info("Dry run found %d accounting correction(s)", len(corrections))

--- a/tradeexecutor/cli/commands/correct_accounts.py
+++ b/tradeexecutor/cli/commands/correct_accounts.py
@@ -837,6 +837,13 @@ def correct_accounts(
             len(closed_dust_trades),
         )
 
+    # The initial preflight protects external work performed during command
+    # setup. Recheck immediately before the transit hook as a defence against
+    # any position-discovery or cleanup step above introducing an unfinished
+    # trade. This preserves the #1486 invariant: a transit recovery is never
+    # the first irreversible action after a coherence failure.
+    preflight_state_for_account_correction(state)
+
     _recover_hypercore_transit_balances(
         asset_management_mode=asset_management_mode,
         sync_model=sync_model,

--- a/tradeexecutor/ethereum/vault/README-vault-position-manual.md
+++ b/tradeexecutor/ethereum/vault/README-vault-position-manual.md
@@ -244,7 +244,9 @@ The guarded `repair` command deliberately leaves that position frozen and does
 not create a counter-trade for it, but it may safely repair an unrelated
 planned/started trade with no transaction. Run it first when
 `correct-accounts` preflight reports an unfinished trade; then inspect the
-marked HyperCore trade with `correct-accounts --dry-run`.
+marked HyperCore trade with `correct-accounts --dry-run`. If every repair
+candidate is protected, `repair` deliberately makes no state change and shows
+no confirmation prompt.
 
 1. Run `check-hypercore-user.py` for the Safe and inspect Safe EVM USDC, EVM
    escrow, spot USDC, perp withdrawable USDC and vault equity.

--- a/tradeexecutor/ethereum/vault/README-vault-position-manual.md
+++ b/tradeexecutor/ethereum/vault/README-vault-position-manual.md
@@ -239,7 +239,12 @@ write and may still broadcast transactions.
 A HyperCore deposit moves USDC Safe → EVM escrow → spot → perp → vault. An EVM
 receipt does not prove that every HyperCore action applied. If a trade reports
 `hypercore_stranded_usdc` or `hypercore_deposit_capital_at_risk`, do not run
-the generic `repair` command or re-submit the last transfer.
+the generic repair logic for that marked trade or re-submit the last transfer.
+The guarded `repair` command deliberately leaves that position frozen and does
+not create a counter-trade for it, but it may safely repair an unrelated
+planned/started trade with no transaction. Run it first when
+`correct-accounts` preflight reports an unfinished trade; then inspect the
+marked HyperCore trade with `correct-accounts --dry-run`.
 
 1. Run `check-hypercore-user.py` for the Safe and inspect Safe EVM USDC, EVM
    escrow, spot USDC, perp withdrawable USDC and vault equity.
@@ -292,7 +297,9 @@ transit helper is deliberately Safe-level, because an old state file may
 predate the failed trade's metadata; it preserves its configured spot/perp dust
 margin rather than assuming every internal USDC cent belongs to one failed
 trade. After recovery, explicitly expire or reconcile stale planned trades
-before restarting the executor; `repair` alone cannot infer this history.
+before restarting the executor. `repair` cannot determine the destination of
+an ambiguous HyperCore deposit and intentionally preserves that evidence for
+the account-correction planner.
 
 ### Close single position (for single-pair strategies)
 

--- a/tradeexecutor/ethereum/vault/hyperliquid_cleanup.py
+++ b/tradeexecutor/ethereum/vault/hyperliquid_cleanup.py
@@ -747,11 +747,31 @@ def _repair_and_correct_state(
 ) -> tuple[bool, bool]:
     """Repair failed trades, correct accounts, and save when clean."""
     store, state = backup_state(context.state_file, unit_testing=context.unit_testing)
-    repair_trades(
+    repair_result = repair_trades(
         state,
         attempt_repair=True,
         interactive=False,
     )
+    deferred_hypercore_trades = [
+        trade
+        for trade in repair_result.trades_needing_repair
+        if trade.other_data.get("hypercore_deposit_capital_at_risk") is not None
+        or trade.other_data.get("hypercore_stranded_usdc") is not None
+    ]
+    if deferred_hypercore_trades:
+        # This legacy cleanup tool has no transaction-level evidence for a
+        # failed deposit and no Safe-level transit-recovery planner. Letting
+        # generic account correction continue could re-credit Safe reserves
+        # while the same USDC still has an unknown HyperCore location. Keep
+        # the historical fail-closed behaviour and leave reconciliation to
+        # ``correct-accounts --dry-run`` followed by the live command.
+        logger.error(
+            "Hyperliquid cleanup stopped: deferred HyperCore deposit trade(s) %s "
+            "need live reconciliation before account correction",
+            ", ".join(str(trade.trade_id) for trade in deferred_hypercore_trades),
+        )
+        return False, False
+
     closed_dust_trades = close_hypercore_dust_positions(state.portfolio)
     if closed_dust_trades:
         logger.info(

--- a/tradeexecutor/state/repair.py
+++ b/tradeexecutor/state/repair.py
@@ -722,10 +722,11 @@ def repair_trades(
         if trade.other_data.get("hypercore_deposit_capital_at_risk") is not None
         or trade.other_data.get("hypercore_stranded_usdc") is not None
     ]
+    protected_position_ids = {trade.position_id for trade in at_risk_hypercore_trades}
     repairable_trades = [
         trade
         for trade in trades_to_be_repaired
-        if trade not in at_risk_hypercore_trades
+        if trade.position_id not in protected_position_ids
     ]
     if at_risk_hypercore_trades:
         trade_ids = ", ".join(str(trade.trade_id) for trade in at_risk_hypercore_trades)
@@ -764,7 +765,7 @@ def repair_trades(
 
     unfrozen_positions = []
     for p in frozen_positions:
-        if any(trade.position_id == p.position_id for trade in at_risk_hypercore_trades):
+        if p.position_id in protected_position_ids:
             logger.warning(
                 "Leaving position %s frozen because its HyperCore deposit still needs live reconciliation",
                 p,

--- a/tradeexecutor/state/repair.py
+++ b/tradeexecutor/state/repair.py
@@ -58,7 +58,9 @@ class RepairResult:
     #: What positions we managed to unfreeze
     unfrozen_positions: List[TradingPosition]
 
-    #: How many individual trades we repaired
+    #: Individual trades that needed repair or were deliberately deferred for
+    #: live reconciliation. Deferred HyperCore deposits must not be mistaken
+    #: for completed accounting repairs.
     trades_needing_repair: List[TradeExecution]
 
     #: New trades we made to fix the accounting

--- a/tradeexecutor/state/repair.py
+++ b/tradeexecutor/state/repair.py
@@ -748,6 +748,17 @@ def repair_trades(
             "releasing any allocation.",
             trade_ids,
         )
+        if not repairable_trades:
+            # Do not reach the unfreeze loop when every repair candidate is
+            # protected. In interactive mode there is no safe mutation for the
+            # operator to confirm, and silently unfreezing another position
+            # would make ``repair`` stateful despite showing no prompt.
+            return RepairResult(
+                frozen_positions,
+                [],
+                trades_to_be_repaired,
+                [],
+            )
 
     if interactive:
 

--- a/tradeexecutor/state/repair.py
+++ b/tradeexecutor/state/repair.py
@@ -41,17 +41,6 @@ class RepairAborted(Exception):
     """User chose no"""
 
 
-class HypercoreTransitRecoveryRequired(RepairAborted):
-    """A failed HyperCore deposit needs live balance reconciliation first.
-
-    State-only repair has no HyperCore Info API evidence. It cannot determine
-    whether a failed buy's allocation is still in EVM escrow, spot, perp, or
-    already deposited into the vault, so creating a zero-value counter trade
-    would be an unaudited refund. This exception protects the #1486 accounting
-    invariant: physical USDC must have exactly one state-side home.
-    """
-
-
 class HypercoreDuplicateCloseError(Exception):
     """A Hypercore duplicate group was not safe to close automatically."""
 
@@ -733,33 +722,54 @@ def repair_trades(
         if trade.other_data.get("hypercore_deposit_capital_at_risk") is not None
         or trade.other_data.get("hypercore_stranded_usdc") is not None
     ]
+    repairable_trades = [
+        trade
+        for trade in trades_to_be_repaired
+        if trade not in at_risk_hypercore_trades
+    ]
     if at_risk_hypercore_trades:
         trade_ids = ", ".join(str(trade.trade_id) for trade in at_risk_hypercore_trades)
         # ``repair_trade()`` would otherwise make a counter trade and restore
-        # the planned reserve without querying HyperCore. Refuse rather than
-        # infer a location from the failed status or a successful EVM wrapper
-        # receipt; both were misleading in the production incident.
-        raise HypercoreTransitRecoveryRequired(
-            f"Cannot state-repair HyperCore deposit trade(s) {trade_ids}: USDC may be in "
-            "HyperCore escrow, spot, perp, or vault. Run check-hypercore-user.py and "
-            "reconcile the live destination before releasing any allocation."
+        # the planned reserve without querying HyperCore.  Never infer a
+        # location from a failed status or a successful EVM wrapper receipt:
+        # trade #1486 proved that either can coexist with USDC in HyperCore.
+        #
+        # Do not abort the entire repair command, however.  Production also had
+        # an unrelated planned no-transaction trade which blocked
+        # correct-accounts' coherence check.  Deferring the protected trade
+        # lets repair clear that independent blocker, after which
+        # correct-accounts --dry-run can safely inspect and plan the live
+        # HyperCore recovery.  The affected position remains frozen below.
+        logger.error(
+            "Deferring state repair for HyperCore deposit trade(s) %s: USDC may be in "
+            "HyperCore escrow, spot, perp, or vault. Their positions remain frozen; "
+            "run correct-accounts --dry-run and reconcile the live destination before "
+            "releasing any allocation.",
+            trade_ids,
         )
 
     if interactive:
 
-        for t in trades_to_be_repaired:
+        for t in repairable_trades:
             print("Needs repair:", t)
 
-        confirmation = input("Attempt to repair [y/n]").lower()
-        if confirmation != "y":
-            raise RepairAborted()
+        if repairable_trades:
+            confirmation = input("Attempt to repair [y/n]").lower()
+            if confirmation != "y":
+                raise RepairAborted()
 
     new_trades = []
-    for t in trades_to_be_repaired:
+    for t in repairable_trades:
         new_trades.append(repair_trade(state.portfolio, t))
 
     unfrozen_positions = []
     for p in frozen_positions:
+        if any(trade.position_id == p.position_id for trade in at_risk_hypercore_trades):
+            logger.warning(
+                "Leaving position %s frozen because its HyperCore deposit still needs live reconciliation",
+                p,
+            )
+            continue
         if unfreeze_position(state.portfolio, p):
             unfrozen_positions.append(p)
             logger.info("Position unfrozen: %s", p)
@@ -776,13 +786,20 @@ def repair_trades(
 
 
 def repair_tx_not_generated(state: State, interactive=True):
-    """Repair command to fix trades that did not generate tranasctions.
+    """Repair planned/started trades that did not generate transactions.
 
     - Reasons include
 
     - Currently only manually callable from console
 
-    - Simple deletes trades that have an empty transaction list
+    - Creates accounting counter-trades for planned/started trades with an
+      empty transaction list
+
+    - Ignores terminal trades such as expired triggers.  An expired trade is
+      deliberately a planned trade without a transaction, so treating every
+      empty transaction list as broken makes ``repair`` abort on valid history.
+      This happened during the HyperAI #1486 recovery incident and prevented
+      repair from clearing a different genuinely unexecuted trade.
 
     Example exception:
 
@@ -825,9 +842,19 @@ def repair_tx_not_generated(state: State, interactive=True):
             # Already repaired
             continue
 
-        if not t.blockchain_transactions:
-            assert t.get_status() in (TradeStatus.planned, TradeStatus.started), f"Trade missing tx, but status is not planned/repaired {t}"
+        if not t.blockchain_transactions and t.get_status() in (TradeStatus.planned, TradeStatus.started):
             tx_missing_trades.add(t)
+        elif not t.blockchain_transactions:
+            # ``expired`` is the important normal case: mark_expired() can
+            # only be called for a planned trade, before it has any on-chain
+            # work. Other non-repairable states are also left for their
+            # dedicated recovery paths instead of making an unsafe counter
+            # trade merely to satisfy this legacy command.
+            logger.info(
+                "Ignoring no-transaction trade %s with non-repairable status %s",
+                t.trade_id,
+                t.get_status().value,
+            )
 
     if not tx_missing_trades:
         if interactive:

--- a/tradeexecutor/strategy/account_correction.py
+++ b/tradeexecutor/strategy/account_correction.py
@@ -32,7 +32,7 @@ from tradeexecutor.ethereum.tx import TransactionBuilder
 from tradeexecutor.state.generic_position import GenericPosition
 from tradeexecutor.state.portfolio import Portfolio
 from tradeexecutor.state.repair import close_position_with_empty_trade
-from tradeexecutor.state.trade import TradeFlag, TradeExecution, TradeType
+from tradeexecutor.state.trade import TradeFlag, TradeExecution, TradeStatus, TradeType
 from tradeexecutor.strategy.dust import DEFAULT_DUST_EPSILON, get_close_epsilon_for_pair, get_dust_epsilon_for_asset, DEFAULT_RELATIVE_EPSILON, \
     get_relative_epsilon_for_asset, get_relative_epsilon_for_pair, DEFAULT_USD_LOW_VALUE_THRESHOLD
 from tradeexecutor.strategy.lending_protocol_leverage import reset_credit_supply_loan
@@ -1514,12 +1514,29 @@ def _format_account_check_row(
 
 
 def check_state_internal_coherence(state: State):
-    """Check that we do not have any positions with non-executed trades."""
+    """Check that no position has a trade which makes accounting unsafe.
+
+    A planned trade is included in a position's available trading quantity, so
+    the existing quantity comparison detects it. A started trade without a
+    transaction is a separate crash window: reserve capital may already be
+    allocated, but no transaction exists for the normal on-chain checks to
+    reconcile. Detect it explicitly before any account correction can move
+    funds or make that allocation look available again.
+    """
 
     for p in state.portfolio.get_open_and_frozen_positions():
         quantity = p.get_quantity()
         trading_quantity = p.get_available_trading_quantity()
         assert quantity == trading_quantity, f"Position {p}, quantity {quantity}, available for trading {trading_quantity}, probably unexecuted trades. You need to run repair command first."
+        started_without_transaction = [
+            trade
+            for trade in p.trades.values()
+            if trade.get_status() == TradeStatus.started and not trade.blockchain_transactions
+        ]
+        assert not started_without_transaction, (
+            f"Position {p} has started trade(s) without blockchain transactions "
+            f"{started_without_transaction}. Run repair command first."
+        )
 
 
 def preflight_state_for_account_correction(state: State) -> None:

--- a/tradeexecutor/strategy/account_correction.py
+++ b/tradeexecutor/strategy/account_correction.py
@@ -1520,3 +1520,21 @@ def check_state_internal_coherence(state: State):
         quantity = p.get_quantity()
         trading_quantity = p.get_available_trading_quantity()
         assert quantity == trading_quantity, f"Position {p}, quantity {quantity}, available for trading {trading_quantity}, probably unexecuted trades. You need to run repair command first."
+
+
+def preflight_state_for_account_correction(state: State) -> None:
+    """Refuse account correction before an unexecuted trade can cause a partial run.
+
+    Account correction may include external side effects such as protocol-specific
+    balance recovery.  Validate the internal state before those effects so a
+    caller either receives a complete reconciliation or makes no balance move.
+    """
+    try:
+        check_state_internal_coherence(state)
+    except AssertionError as exc:
+        raise AssertionError(
+            "Cannot run correct-accounts because state has unexecuted trades. "
+            "Run repair first, then retry correct-accounts --dry-run. "
+            "This preflight runs before any HyperCore transit recovery or "
+            "accounting mutation."
+        ) from exc


### PR DESCRIPTION
## Why

HyperAI's 2026-07-30 trade #1486 left 48.884068 USDC in HyperCore perp after the CoreWriter vault transfer silently did not settle. The new default `correct-accounts` recovery correctly returned that USDC to the Safe, but it did so before detecting an unrelated unexecuted trade. The command then failed without completing account reconciliation. The prescribed `repair` command also failed first because it treated terminal expired trade #1482, which correctly has no blockchain transactions, as an invalid state.

The two commands therefore formed an unusable recovery loop: correct-accounts required repair first, while repair aborted before clearing the independent coherence blocker.

## Lessons learnt

Recovery commands must validate all state preconditions before broadcasting any protocol-specific transaction. A missing transaction list is not itself evidence of a broken trade: trigger expiry is a valid terminal state that occurs before transaction generation. Conversely, an at-risk HyperCore failed deposit must never receive a generic accounting refund simply to make command progress; it must remain frozen until live balance reconciliation establishes its location.

Every caller of state-only repair needs the same fail-closed rule. A specialised cleanup command that lacks the Safe-level transit planner must stop before generic accounting when a protected deposit is deferred. A started trade with no transaction is also an unsafe crash window, even though the normal planned-quantity comparison cannot see it.

## Summary

- Add state-coherence preflight immediately after `correct-accounts` loads state and again before HyperCore transit recovery; it detects planned trades and started trades with no transaction.
- Let repair ignore terminal no-transaction history, repair ordinary planned/started no-transaction trades, and defer protected HyperCore deposit trades without aborting unrelated repairs.
- Leave deferred HyperCore positions frozen, make all-protected interactive repair a no-op without a prompt, and give the operator an explicit `repair` then `correct-accounts --dry-run` sequence.
- Preserve fail-closed behaviour in the older Hyperliquid cleanup command so it does not run generic account correction after a protected deposit is deferred.
- Add production-shaped and mocked regression coverage for expired plus started/planned no-TX trades, protected HyperCore deferral, the cleanup guard, preflight, and the #1486 dry-run recovery plan.
- Update the HyperCore operational documentation with the incident rationale and safe recovery runbook.
