### PR TITLE
fix: remove duplicate GMX-AI pre-settlement statistics

### DIFF
--- a/tests/mainnet_fork/correct_history_outliers/test_correct_history_outliers.py
+++ b/tests/mainnet_fork/correct_history_outliers/test_correct_history_outliers.py
@@ -14,7 +14,11 @@ from unittest import mock
 import pytest
 
 from tradeexecutor.cli.main import app
-from tradeexecutor.state.correct_history import detect_nav_sync_outliers, detect_share_price_outliers
+from tradeexecutor.state.correct_history import (
+    detect_duplicate_portfolio_stat_timestamps,
+    detect_nav_sync_outliers,
+    detect_share_price_outliers,
+)
 from tradeexecutor.state.state import State
 from tradeexecutor.state.statistics import PortfolioStatistics
 from tradeexecutor.state.store import JSONFileStore
@@ -277,6 +281,42 @@ def test_share_price_outlier_default_threshold_is_twenty_percent():
 
     # 3. Verify the 25% outlier is detected
     assert outliers == {2}
+
+
+def test_remove_duplicate_timestamp_stats_cli(tmp_path: Path, strategy_file: Path):
+    """Retain the final statistics snapshot when a live refresh records a duplicate timestamp.
+
+    1. Create a portfolio-statistics sequence where an intermediate snapshot and
+       its post-settlement correction share a timestamp.
+    2. Run correct-history with duplicate-timestamp cleanup enabled.
+    3. Verify the intermediate snapshot was removed and the final correction remains.
+    """
+
+    # 1. Create a portfolio-statistics sequence where an intermediate snapshot and
+    # its post-settlement correction share a timestamp.
+    state = _create_state_with_share_prices([1.0, 0.5, 1.0, 1.0])
+    state.stats.portfolio[2].calculated_at = state.stats.portfolio[1].calculated_at
+    assert detect_duplicate_portfolio_stat_timestamps(state) == {1}
+    state_file = tmp_path / "duplicate-timestamp-state.json"
+    state.write_json_file(state_file)
+
+    environment = {
+        "STRATEGY_FILE": strategy_file.as_posix(),
+        "STATE_FILE": state_file.as_posix(),
+        "UNIT_TESTING": "true",
+        "LOG_LEVEL": "disabled",
+        "REMOVE_DUPLICATE_TIMESTAMP_STATS": "true",
+    }
+
+    # 2. Run correct-history with duplicate-timestamp cleanup enabled.
+    with mock.patch.dict("os.environ", environment, clear=True):
+        app(["correct-history"], standalone_mode=False)
+
+    # 3. Verify the intermediate snapshot was removed and the final correction remains.
+    corrected_state = JSONFileStore(state_file).load()
+    assert len(corrected_state.stats.portfolio) == 3
+    assert [ps.share_price_usd for ps in corrected_state.stats.portfolio] == [1.0, 1.0, 1.0]
+    assert detect_duplicate_portfolio_stat_timestamps(corrected_state) == set()
 
 
 def test_remove_nav_sync_outliers_cli_flag(tmp_path: Path, strategy_file: Path):

--- a/tradeexecutor/cli/commands/correct_history.py
+++ b/tradeexecutor/cli/commands/correct_history.py
@@ -25,6 +25,7 @@ from tradeexecutor.state.correct_history import (
     DEFAULT_NAV_SYNC_OUTLIER_THRESHOLD,
     DEFAULT_NAV_SYNC_OUTLIER_WINDOW_SIZE,
     DEFAULT_SHARE_PRICE_OUTLIER_THRESHOLD,
+    detect_duplicate_portfolio_stat_timestamps,
     detect_nav_sync_outliers,
     detect_share_price_outliers,
     prune_history,
@@ -68,6 +69,12 @@ def correct_history(
         envvar="REMOVE_NAV_SYNC_OUTLIERS",
         help="Detect and remove clustered NAV/share price discontinuities caused by reserve cash and exchange account equity syncing out of phase.",
     ),
+    remove_duplicate_timestamp_stats: bool = Option(
+        False,
+        "--remove-duplicate-timestamp-stats",
+        envvar="REMOVE_DUPLICATE_TIMESTAMP_STATS",
+        help="Keep only the final portfolio statistics snapshot for each timestamp, removing intermediate pre-settlement snapshots.",
+    ),
     nav_sync_window_size: int = Option(
         DEFAULT_NAV_SYNC_OUTLIER_WINDOW_SIZE,
         "--nav-sync-window-size",
@@ -102,13 +109,23 @@ def correct_history(
     2. Load the state
     3. Optionally remove share price outlier entries (--remove-share-price-outliers)
     4. Optionally remove NAV sync outlier entries (--remove-nav-sync-outliers)
-    5. Optionally remove statistics before a cutoff date (--cutoff-date)
-    6. Save the modified state
-    7. Report statistics
+    5. Optionally remove superseded duplicate-timestamp snapshots (--remove-duplicate-timestamp-stats)
+    6. Optionally remove statistics before a cutoff date (--cutoff-date)
+    7. Save the modified state
+    8. Report statistics
     """
 
-    if cutoff_date is None and not remove_share_price_outliers and not remove_nav_sync_outliers:
-        print("Error: At least one of --cutoff-date, --remove-share-price-outliers or --remove-nav-sync-outliers must be specified.")
+    if (
+        cutoff_date is None
+        and not remove_share_price_outliers
+        and not remove_nav_sync_outliers
+        and not remove_duplicate_timestamp_stats
+    ):
+        print(
+            "Error: At least one of --cutoff-date, --remove-share-price-outliers, "
+            "--remove-nav-sync-outliers or --remove-duplicate-timestamp-stats "
+            "must be specified."
+        )
         raise SystemExit(1)
 
     parsed_cutoff = None
@@ -137,9 +154,9 @@ def correct_history(
     # Get original file size
     original_size = state_file.stat().st_size if state_file.exists() else 0
 
-    # Outlier removal runs first so the detectors see full neighbourhood
+    # Statistics cleanup runs first so the detectors see full neighbourhood
     # context before cutoff pruning truncates the series
-    if remove_share_price_outliers or remove_nav_sync_outliers:
+    if remove_share_price_outliers or remove_nav_sync_outliers or remove_duplicate_timestamp_stats:
         outlier_sources: dict[int, list[str]] = {}
 
         def _add_outlier_source(indices: set[int], source: str):
@@ -165,7 +182,12 @@ def correct_history(
         )
         _add_outlier_source(nav_sync_outlier_indices, "nav_sync")
 
-    if remove_share_price_outliers or remove_nav_sync_outliers:
+    if remove_duplicate_timestamp_stats:
+        print("Detecting duplicate-timestamp portfolio statistics snapshots...")
+        duplicate_timestamp_indices = detect_duplicate_portfolio_stat_timestamps(state)
+        _add_outlier_source(duplicate_timestamp_indices, "duplicate_timestamp")
+
+    if remove_share_price_outliers or remove_nav_sync_outliers or remove_duplicate_timestamp_stats:
         outlier_indices = set(outlier_sources.keys())
 
         if outlier_indices:

--- a/tradeexecutor/state/correct_history.py
+++ b/tradeexecutor/state/correct_history.py
@@ -298,6 +298,29 @@ def remove_portfolio_stat_indices(
     return len(indices)
 
 
+def detect_duplicate_portfolio_stat_timestamps(state: State) -> set[int]:
+    """Find superseded portfolio statistics snapshots with the same timestamp.
+
+    A live valuation refresh can record an intermediate snapshot before treasury
+    settlement has reconciled reserve cash. The post-settlement snapshot is then
+    appended with the same timestamp. The final entry is the complete snapshot,
+    so retain it and remove all earlier entries for that timestamp.
+
+    :return:
+        Indices of earlier duplicate-timestamp statistics entries to remove.
+    """
+    last_index_by_timestamp: dict[datetime.datetime, int] = {}
+    duplicates: set[int] = set()
+
+    for index, portfolio_stat in enumerate(state.stats.portfolio):
+        previous_index = last_index_by_timestamp.get(portfolio_stat.calculated_at)
+        if previous_index is not None:
+            duplicates.add(previous_index)
+        last_index_by_timestamp[portfolio_stat.calculated_at] = index
+
+    return duplicates
+
+
 def remove_share_price_outliers(
     state: State,
     outlier_indices: set[int],


### PR DESCRIPTION
## Why

GMX-AI can retain two `PortfolioStatistics` snapshots for one timestamp when a GMX account valuation is recorded before Lagoon treasury settlement reconciles Safe cash. The first, intermediate snapshot combines fresh GMX equity with stale cash and produces a non-economic equity-curve move; the final snapshot at the same timestamp is the complete NAV.

For example, on 2026-06-03 22:00 the first snapshot showed a $67.31 decrease in GMX account equity and a false -6.98% share-price move. The next snapshot reconciled Safe cash by +$62.25, producing a false +6.89% rebound. The completed economic move was about -0.6%.

The production history cleanup command is:

```shell
docker compose run --rm gmx-ai correct-history \
  --cutoff-date 2026-06-01 \
  --remove-share-price-outliers \
  --remove-nav-sync-outliers \
  --outlier-threshold 0.10 \
  --nav-sync-threshold 0.08 \
  --remove-duplicate-timestamp-stats
```

## Lessons learnt

Outlier detection alone can miss a pre-settlement snapshot when both the intermediate and completed snapshots share a timestamp. Equity curves must keep the final snapshot for that timestamp, otherwise temporary accounting state is displayed as economic PnL and distorts adjacent returns and drawdown.

## Summary

- Add `--remove-duplicate-timestamp-stats` to `correct-history`.
- Retain the final portfolio-statistics snapshot for each timestamp and remove superseded earlier snapshots.
- Permit duplicate-timestamp cleanup as a standalone correction action.
- Add CLI coverage for the intermediate/pre-settlement snapshot case.
