### PR TITLE
feat: expose Lagoon investor queue in state

### DIFF
--- a/.claude/docs/lagoon-treasury-settlement.md
+++ b/.claude/docs/lagoon-treasury-settlement.md
@@ -16,6 +16,32 @@ the TradingStrategyModuleV0. Stock Lagoon v0.5 can settle both queued deposits
 and redemptions through this call. A successful NAV post therefore does not
 mean that an investor queue was settled.
 
+## Persisted queue state
+
+The executor exposes the latest observed aggregate investor queue in the state
+API, not in `/metadata`:
+
+| State field | Meaning |
+|---|---|
+| `sync.treasury.pending_deposits` | Underlying-token assets still held in the pending Silo. |
+| `sync.treasury.pending_redemptions` | Underlying-token estimate needed for redemption shares still held in the Silo. |
+
+Both values are human-readable underlying-token amounts. For Lagoon's required
+stablecoin reserve, the executor also treats them as US dollar amounts.
+`None` means that the queue has not been observed by a completed post-valuation
+treasury sync; an observed empty queue is stored as `0.0`.
+
+After the NAV transaction is confirmed, a deferred, manually-required or empty
+queue is read at one queue snapshot block. The executor stores that exact block
+in `sync.treasury.last_block_scanned`, even though no settlement transaction or
+balance update occurred. A successful settlement refreshes the remaining
+deposit and redemption queues at the settlement analysis block.
+
+Queue observations do not create `BalanceUpdate` events and do not enter
+portfolio cash or NAV: pending deposits remain outside the Safe, while pending
+redemptions are a liquidity requirement until settlement. GuardV0 cap and
+cooldown policy remains separate live `/metadata` display data.
+
 ## GuardV0 policy
 
 TradingStrategyModuleV0 v0.5 may enable GuardV0 settlement safety. The Guard

--- a/.claude/docs/lagoon-treasury-settlement.md
+++ b/.claude/docs/lagoon-treasury-settlement.md
@@ -28,8 +28,11 @@ API, not in `/metadata`:
 
 Both values are human-readable underlying-token amounts. For Lagoon's required
 stablecoin reserve, the executor also treats them as US dollar amounts.
-`None` means that the queue has not been observed by a completed post-valuation
-treasury sync; an observed empty queue is stored as `0.0`.
+`None` means that the queue has not been observed by this executor version in a
+completed post-valuation treasury sync; an observed empty queue is stored as
+`0.0`. After upgrading an existing executor state, `pending_deposits` remains
+`None` until its first completed post-valuation treasury sync even if the older
+pending-redemption snapshot is populated.
 
 After the NAV transaction is confirmed, a deferred, manually-required or empty
 queue is read at one queue snapshot block. The executor stores that exact block

--- a/.claude/docs/vault-deposit-redeem.md
+++ b/.claude/docs/vault-deposit-redeem.md
@@ -15,8 +15,10 @@ map the relevant code and tests.
 **Scope note.** This is about the strategy acting as a *depositor into an
 external vault*. It is not about the strategy's own treasury being a Lagoon
 vault (external investors depositing into *us* — `has_async_deposits()`,
-`pending_redemptions`). The two systems share vocabulary but are separate code
-paths, and confusing them is the most common mistake in this area. See
+`state.sync.treasury.pending_deposits`,
+`state.sync.treasury.pending_redemptions`). The two systems share vocabulary
+but are separate code paths, and confusing them is the most common mistake in
+this area. See
 [`lagoon-treasury-settlement.md`](lagoon-treasury-settlement.md) for the
 strategy-owned Lagoon treasury flow.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 0.2
 
+- Expose current unsettled Lagoon investor deposit and redemption queues in persistent treasury state, so state consumers can distinguish live queue amounts from GuardV0 settlement-policy metadata (2026-08-04)
+
 - Fix default-on `correct-accounts` cleanup for undersized HyperCore vault positions to redeem directly without deposits or new lock-ups, keep verifiable residuals tracked, and provide a read-only `--dry-run` preview (2026-07-30)
 
 - Extend `vault-test-trade` simulations to validate typed closed deposits through GuardV0 without broadcasting, and distinguish vault JSON statuses that incorrectly report deposits open or closed (2026-07-28)

--- a/docs/plans/lagoon-investor-queue-state.md
+++ b/docs/plans/lagoon-investor-queue-state.md
@@ -1,0 +1,244 @@
+# Lagoon investor queue state export
+
+## Objective
+
+Expose the current unsettled Lagoon investor deposit and redemption amounts in
+the persistent executor state returned by the state API.
+
+GuardV0's automatic-settlement cap and cooldown remain static/live policy
+information under `/metadata`. The investor queue is mutable treasury state and
+must instead be stored under `state.sync.treasury`, where Lagoon already records
+the pending redemption amount used by strategy allocation and yield management.
+
+The change must keep these meanings distinct:
+
+| Value | Location | Meaning |
+|---|---|---|
+| Guard cap and cooldown | `metadata.on_chain_data.smart_contracts.lagoon_guard_v0` | On-chain policy controlling automatic settlement |
+| Pending deposits | `state.sync.treasury.pending_deposits` | Underlying assets still held in the Lagoon pending Silo |
+| Pending redemptions | `state.sync.treasury.pending_redemptions` | Estimated underlying assets needed for redemption shares still held in the Silo |
+
+## Existing behaviour
+
+`Treasury.pending_redemptions` already stores the underlying-denominated
+redemption queue so strategies can retain enough liquid cash. There is no
+corresponding pending-deposit field.
+
+`LagoonVaultSyncModel.sync_treasury()` already has the correct lifecycle
+boundaries:
+
+1. reconcile the Safe reserve and calculate NAV;
+2. post and confirm the NAV transaction;
+3. inspect the Silo balances and run GuardV0 settlement preflight;
+4. either leave the queue deferred or broadcast settlement; and
+5. update treasury sync metadata.
+
+For a deferred, manual or empty queue, the method currently refreshes pending
+redemptions and share count. After successful settlement it uses the settlement
+analysis to refresh pending redemptions and share count. Pending deposits are
+not persisted in either branch.
+
+## State model
+
+Add the following optional field to `tradeexecutor.state.sync.Treasury`:
+
+```python
+pending_deposits: USDollarAmount | None = None
+```
+
+Keep the existing `pending_redemptions` field and its public semantics. Both
+values are human-readable underlying-token amounts. Lagoon strategies currently
+require a stablecoin reserve, so these are also treated as US dollar amounts by
+the existing treasury API.
+
+The value distinction is intentional:
+
+- `None` means the queue has not been observed, or the sync model does not
+  provide this Lagoon-specific information;
+- `0.0` means the queue was observed on-chain and was empty at the recorded
+  treasury block.
+
+Do not put the queue in `Portfolio`, reserve positions or `Metadata`. An
+unsettled deposit is still outside the Safe and does not belong to strategy NAV.
+A pending redemption is a liquidity requirement, not a reduction in portfolio
+ownership until settlement occurs.
+
+Do not create a `BalanceUpdate` merely because the queue snapshot changes.
+Balance updates continue to represent assets actually settled into or out of
+the strategy treasury.
+
+Adding a defaulted field keeps older state JSON readable. The normal state
+serialiser will expose the new field automatically; no webhook endpoint or
+response adapter is needed.
+
+## Queue snapshot timing
+
+Persist the queue only from a completed `sync_treasury(post_valuation=True)`
+path whose NAV transaction has been confirmed. Redemption shares are converted
+to underlying at the post-NAV share price, so a pre-NAV estimate can be stale.
+
+Use one explicit block identifier for every value in a snapshot and record that
+same block in `Treasury.last_block_scanned`. Avoid mixing a `latest` deposit read
+with a redemption conversion from another block.
+
+### Deferred, manual and empty queues
+
+After NAV confirmation and GuardV0 preflight determines that no settlement will
+be broadcast:
+
+1. choose the current confirmed snapshot block;
+2. read pending underlying deposits from the Silo at that block;
+3. calculate pending redemptions in underlying at that block;
+4. read total share supply at that block; and
+5. update `pending_deposits`, `pending_redemptions`, `share_count`, timestamps
+   and `last_block_scanned` together through `_mark_treasury_sync_completed()`.
+
+This covers an empty queue, a cooldown deferral and an oversized queue requiring
+direct Safe governance. In all three cases state reflects what remains
+unsettled, even though the method returns no `BalanceUpdate`.
+
+Update `_mark_treasury_sync_completed()` to accept `pending_deposits` alongside
+the existing pending-redemption and share-count values. Passing an observed zero
+must write zero rather than retaining a stale non-zero value.
+
+Make the signature change explicit so every caller is audited:
+
+```python
+def _mark_treasury_sync_completed(
+    self,
+    treasury_sync,
+    strategy_cycle_ts: datetime.datetime,
+    block_number: int,
+    pending_deposits: Decimal | None = None,
+    pending_redemptions: Decimal | None = None,
+    share_count: Decimal | None = None,
+) -> None:
+```
+
+The no-settlement branch currently records the NAV receipt block while reading
+queue values later. Replace that with the queue snapshot block. The two blocks
+may be equal, but state must never claim the NAV block when its queue values
+were actually sampled at a later block.
+
+### Successful settlement
+
+After the settlement receipt is confirmed and analysed:
+
+1. use the settlement/analysis block as the snapshot block;
+2. read the remaining pending deposit balance at that exact block;
+3. calculate the remaining pending redemption amount at that exact block;
+4. update both queue fields together with share count and existing treasury
+   timestamps; and
+5. keep creation of the reserve `BalanceUpdate` unchanged.
+
+Stock Lagoon normally clears the deposit queue completely, but the explicit
+post-settlement read prevents a stale preflight amount from being exported and
+documents the state as an as-of-block snapshot.
+
+Calls with `post_valuation=False`, disabled broadcasting, failed NAV posting or
+an unexpected settlement error must not claim to have produced a fresh
+post-NAV queue snapshot. Preserve their existing early-return or failure
+semantics.
+
+## Integration testing
+
+Extend the existing Base Anvil-fork GuardV0 integration coverage in
+`tests/lagoon/test_lagoon_guard_settlement.py`; do not add another expensive
+deployment fixture or a separate deployment-heavy test.
+
+In
+`test_lagoon_guard_automatically_settles_flow_below_settlement_limit()`:
+
+1. before the first treasury sync, assert `pending_deposits is None` and that
+   state JSON serialises the unobserved value as `null`;
+2. after the initial 9 USDC deposit settles, assert
+   `pending_deposits == 0` and `pending_redemptions == 0`;
+3. after the second 1 USDC deposit is deferred by cooldown, assert
+   `pending_deposits == 1` and `pending_redemptions == 0`;
+4. serialise the `State`, inspect the JSON path
+   `sync.treasury.pending_deposits`, and round-trip it through
+   `State.read_json_blob()` to prove the value is part of persisted state rather
+   than frontend metadata; and
+5. retain the existing metadata assertions to demonstrate that policy and queue
+   data remain in their separate API objects.
+
+These assertions cover the `None` to observed-zero transition without adding a
+separate unit test or another deployment.
+
+Also strengthen the existing mixed-flow assertion in
+`test_lagoon_guard_posts_nav_but_defers_oversized_flow_to_safe()`:
+
+1. assert the preserved 9 USDC Silo deposit is exported as
+   `pending_deposits == 9`;
+2. retain the existing approximately 2 USDC `pending_redemptions` assertion;
+3. assert `last_block_scanned` equals the chain block at which the preserved
+   queue was read after the NAV-only sync, rather than an earlier pre-NAV or NAV
+   receipt block; and
+4. retain the proof that no settlement transaction or balance update occurred.
+
+Use `pytest.approx()` for both money values. Update the ordered test docstrings
+and matching numbered body comments when adding the assertions.
+
+## Documentation updates
+
+Update `.claude/docs/lagoon-treasury-settlement.md` with a persisted queue-state
+section covering:
+
+- the two state JSON paths and their underlying-token units;
+- `None` versus an observed zero;
+- the post-NAV/preflight snapshot for deferred queues;
+- the post-settlement refresh for successful queues;
+- `last_block_scanned` as the queue snapshot block, including why it advances
+  even when no settlement transaction and no balance update occurs;
+- why queue changes do not create balance updates or enter NAV; and
+- the boundary between dynamic `/state` queue data and Guard policy in
+  `/metadata`.
+
+Update the scope note in `.claude/docs/vault-deposit-redeem.md` to name
+`state.sync.treasury.pending_deposits` and `pending_redemptions` as the
+strategy-owned Lagoon investor queue. This prevents these fields from being
+confused with asynchronous positions where the strategy is itself depositing
+into an external ERC-7540 vault.
+
+Add a concise `CHANGELOG.md` entry when preparing the feature pull request,
+using the pull request date required by the repository conventions.
+
+## Verification
+
+Prepare the copied worktree environment and run the two focused integration
+tests separately with the required extended timeout:
+
+```shell
+source .local-test.env
+source .local-test.env && PYTHONPATH="$(pwd):$PYTHONPATH" poetry run pytest tests/lagoon/test_lagoon_guard_settlement.py::test_lagoon_guard_automatically_settles_flow_below_settlement_limit
+source .local-test.env && PYTHONPATH="$(pwd):$PYTHONPATH" poetry run pytest tests/lagoon/test_lagoon_guard_settlement.py::test_lagoon_guard_posts_nav_but_defers_oversized_flow_to_safe
+```
+
+Do not run the full test suite for this focused state-export change.
+
+## Acceptance criteria
+
+- Lagoon state JSON exposes current unsettled deposits and redemptions under
+  `sync.treasury`.
+- Both values are sampled at, and traceable to, one recorded on-chain block.
+- A successful settlement overwrites the pre-settlement deposit amount with
+  the remaining post-settlement amount, normally zero.
+- Cooldown and oversized queues retain their non-zero state values without a
+  false `BalanceUpdate`.
+- Observed empty queues serialise as zero; an unobserved/non-Lagoon queue remains
+  `None`.
+- Existing GuardV0 policy metadata remains unchanged and separate from the
+  queue state.
+- Existing state files lacking `pending_deposits` continue to load.
+- The existing fork tests cover settlement, cooldown deferral, mixed oversized
+  flow and state serialisation without introducing a new deployment-heavy test.
+
+## Out of scope
+
+- Moving GuardV0 limit or cooldown fields out of metadata.
+- Adding per-investor queue entries; only aggregate Silo amounts are exported.
+- Adding pending deposits to strategy NAV or available cash.
+- Changing settlement eligibility, GuardV0 preflight or Safe-governance
+  recovery behaviour.
+- Emitting historical queue events or charts; this change stores only the
+  latest treasury snapshot.

--- a/tests/lagoon/test_lagoon_guard_settlement.py
+++ b/tests/lagoon/test_lagoon_guard_settlement.py
@@ -164,6 +164,8 @@ def test_lagoon_guard_automatically_settles_flow_below_settlement_limit(
     assert events == []
     assert web3.eth.get_transaction_count(asset_manager.address) == nonce_before
     assert base_usdc_token.fetch_balance_of(vault.silo_address) == Decimal(1)
+    assert state.sync.treasury.pending_deposits == pytest.approx(1)
+    assert state.sync.treasury.pending_redemptions == pytest.approx(0)
     assert "not posting NAV or settling the investor queue" in caplog.text
 
 

--- a/tests/lagoon/test_lagoon_guard_settlement.py
+++ b/tests/lagoon/test_lagoon_guard_settlement.py
@@ -82,8 +82,9 @@ def test_lagoon_guard_automatically_settles_flow_below_settlement_limit(
     2. Queue a 9 USDC investor deposit below the 10 USDC Guard limit.
     3. Post NAV and automatically settle the deposit through the guarded module.
     4. Serialise GuardV0's live cap and cooldown into the frontend metadata.
-    5. Queue another below-cap deposit during cooldown and verify its queue state persists.
-    6. Disable broadcasts and verify it suppresses both the mandatory NAV post and settlement.
+    5. Post NAV with an empty queue and verify its observed zero state persists.
+    6. Queue another below-cap deposit during cooldown and verify its queue state persists.
+    7. Disable broadcasts and verify it suppresses both the mandatory NAV post and settlement.
     """
     vault = guarded_lagoon_vault.vault
     sync_model = LagoonVaultSyncModel(vault=vault, hot_wallet=asset_manager)
@@ -135,7 +136,15 @@ def test_lagoon_guard_automatically_settles_flow_below_settlement_limit(
         "next_automatic_settlement_timestamp": safety_config[7],
     }
 
-    # 5. Queue another below-cap deposit during cooldown and verify its queue state persists.
+    # 5. Post NAV with an empty queue and verify its observed zero state persists.
+    nonce_before = web3.eth.get_transaction_count(asset_manager.address)
+    events = sync_model.sync_treasury(native_datetime_utc_now(), state, post_valuation=True)
+    assert events == []
+    assert web3.eth.get_transaction_count(asset_manager.address) == nonce_before + 1
+    assert state.sync.treasury.pending_deposits == pytest.approx(0)
+    assert state.sync.treasury.pending_redemptions == pytest.approx(0)
+
+    # 6. Queue another below-cap deposit during cooldown and verify its queue state persists.
     _request_deposit(guarded_lagoon_vault, base_usdc_token, depositor, Decimal(1))
     nonce_before = web3.eth.get_transaction_count(asset_manager.address)
     with caplog.at_level(logging.INFO):
@@ -156,7 +165,7 @@ def test_lagoon_guard_automatically_settles_flow_below_settlement_limit(
     assert legacy_state.sync.treasury.pending_deposits is None
     assert "The queue will be retried automatically" in caplog.text
 
-    # 6. Disable broadcasts and verify it suppresses both the mandatory NAV post and settlement.
+    # 7. Disable broadcasts and verify it suppresses both the mandatory NAV post and settlement.
     sync_model.disable_broadcast = True
     nonce_before = web3.eth.get_transaction_count(asset_manager.address)
     with caplog.at_level(logging.INFO):

--- a/tests/lagoon/test_lagoon_guard_settlement.py
+++ b/tests/lagoon/test_lagoon_guard_settlement.py
@@ -77,11 +77,12 @@ def test_lagoon_guard_automatically_settles_flow_below_settlement_limit(
 ) -> None:
     """Settle a below-cap investor queue automatically and post NAV without an empty settlement.
 
-    1. Initialise the executor treasury for a fresh GuardV0-capped Lagoon vault.
+    1. Initialise the executor treasury for a fresh GuardV0-capped Lagoon vault
+       and verify its unobserved queue state.
     2. Queue a 9 USDC investor deposit below the 10 USDC Guard limit.
     3. Post NAV and automatically settle the deposit through the guarded module.
     4. Serialise GuardV0's live cap and cooldown into the frontend metadata.
-    5. Queue another below-cap deposit during the cooldown and verify NAV-only deferral.
+    5. Queue another below-cap deposit during cooldown and verify its queue state persists.
     6. Disable broadcasts and verify it suppresses both the mandatory NAV post and settlement.
     """
     vault = guarded_lagoon_vault.vault
@@ -89,8 +90,11 @@ def test_lagoon_guard_automatically_settles_flow_below_settlement_limit(
     state = State()
     sync_model.sync_initial(state, reserve_asset=vault_strategy_universe.get_reserve_asset(), reserve_token_price=1.0)
 
-    # 1. Initialise the executor treasury for a fresh GuardV0-capped Lagoon vault.
+    # 1. Initialise the executor treasury for a fresh GuardV0-capped Lagoon vault
+    #    and verify its unobserved queue state.
     assert state.portfolio.get_cash() == 0
+    assert state.sync.treasury.pending_deposits is None
+    assert json.loads(state.to_json_safe())["sync"]["treasury"]["pending_deposits"] is None
 
     # 2. Queue a 9 USDC investor deposit below the 10 USDC Guard limit.
     _request_deposit(guarded_lagoon_vault, base_usdc_token, depositor, Decimal(9))
@@ -102,6 +106,8 @@ def test_lagoon_guard_automatically_settles_flow_below_settlement_limit(
     assert base_usdc_token.fetch_balance_of(vault.silo_address) == Decimal(0)
     assert state.portfolio.get_cash() == pytest.approx(9)
     assert vault.get_flow_manager().fetch_pending_deposit(web3.eth.block_number) == Decimal(0)
+    assert state.sync.treasury.pending_deposits == pytest.approx(0)
+    assert state.sync.treasury.pending_redemptions == pytest.approx(0)
     safety_config = vault.trading_strategy_module.functions.getLagoonSettlementSafetyConfig(vault.address).call()
     assert safety_config[6] > 0
     assert safety_config[7] == safety_config[6] + 86_400
@@ -129,7 +135,7 @@ def test_lagoon_guard_automatically_settles_flow_below_settlement_limit(
         "next_automatic_settlement_timestamp": safety_config[7],
     }
 
-    # 5. Queue another below-cap deposit during the cooldown and verify NAV-only deferral.
+    # 5. Queue another below-cap deposit during cooldown and verify its queue state persists.
     _request_deposit(guarded_lagoon_vault, base_usdc_token, depositor, Decimal(1))
     nonce_before = web3.eth.get_transaction_count(asset_manager.address)
     with caplog.at_level(logging.INFO):
@@ -138,6 +144,16 @@ def test_lagoon_guard_automatically_settles_flow_below_settlement_limit(
     assert web3.eth.get_transaction_count(asset_manager.address) == nonce_before + 1
     assert base_usdc_token.fetch_balance_of(vault.silo_address) == Decimal(1)
     assert vault.trading_strategy_module.functions.getLagoonSettlementSafetyConfig(vault.address).call()[6:] == safety_config[6:]
+    assert state.sync.treasury.pending_deposits == pytest.approx(1)
+    assert state.sync.treasury.pending_redemptions == pytest.approx(0)
+    state_json = state.to_json_safe()
+    state_data = json.loads(state_json)
+    assert state_data["sync"]["treasury"]["pending_deposits"] == pytest.approx(1)
+    restored_state = State.read_json_blob(state_json)
+    assert restored_state.sync.treasury.pending_deposits == pytest.approx(1)
+    del state_data["sync"]["treasury"]["pending_deposits"]
+    legacy_state = State.read_json_blob(json.dumps(state_data))
+    assert legacy_state.sync.treasury.pending_deposits is None
     assert "The queue will be retried automatically" in caplog.text
 
     # 6. Disable broadcasts and verify it suppresses both the mandatory NAV post and settlement.
@@ -165,7 +181,7 @@ def test_lagoon_guard_posts_nav_but_defers_oversized_flow_to_safe(
     1. Bootstrap and finalise a below-cap deposit so the investor has redeemable shares.
     2. Queue opposing deposit and redemption flows whose gross amount exceeds the Guard cap.
     3. Run the post-valuation treasury sync once more.
-    4. Verify it broadcasts NAV only, preserves both queues and emits the Safe-governance error.
+    4. Verify it broadcasts NAV only, persists both queues and emits the Safe-governance error.
     """
     vault = guarded_lagoon_vault.vault
     sync_model = LagoonVaultSyncModel(vault=vault, hot_wallet=asset_manager)
@@ -194,7 +210,7 @@ def test_lagoon_guard_posts_nav_but_defers_oversized_flow_to_safe(
     with caplog.at_level(logging.ERROR):
         events = sync_model.sync_treasury(cycle, state, post_valuation=True)
 
-    # 4. Verify it broadcasts NAV only, preserves both queues and emits the Safe-governance error.
+    # 4. Verify it broadcasts NAV only, persists both queues and emits the Safe-governance error.
     assert events == []
     assert web3.eth.get_transaction_count(asset_manager.address) == nonce_before + 1
     assert state.sync.treasury.last_cycle_at == cycle
@@ -203,7 +219,9 @@ def test_lagoon_guard_posts_nav_but_defers_oversized_flow_to_safe(
     assert base_usdc_token.fetch_balance_of(vault.safe_address) == safe_balance_before
     assert base_usdc_token.fetch_balance_of(vault.address) == vault_balance_before
     assert vault.trading_strategy_module.functions.getLagoonSettlementSafetyConfig(vault.address).call()[6:] == safety_before[6:]
+    assert state.sync.treasury.pending_deposits == pytest.approx(9)
     assert state.sync.treasury.pending_redemptions == pytest.approx(2)
+    assert state.sync.treasury.last_block_scanned == web3.eth.block_number
     assert "direct Safe-governance settlement required" in caplog.text
     assert "gross_flow=" in caplog.text
     assert "(10999999 raw)" in caplog.text

--- a/tradeexecutor/ethereum/lagoon/vault.py
+++ b/tradeexecutor/ethereum/lagoon/vault.py
@@ -576,6 +576,7 @@ class LagoonVaultSyncModel(AddressSyncModel):
         treasury_sync,
         strategy_cycle_ts: datetime.datetime,
         block_number: int,
+        pending_deposits: Decimal | None = None,
         pending_redemptions: Decimal | None = None,
         share_count: Decimal | None = None,
     ) -> None:
@@ -583,10 +584,23 @@ class LagoonVaultSyncModel(AddressSyncModel):
         treasury_sync.last_updated_at = native_datetime_utc_now()
         treasury_sync.last_cycle_at = strategy_cycle_ts
         treasury_sync.last_block_scanned = block_number
+        if pending_deposits is not None:
+            treasury_sync.pending_deposits = float(pending_deposits)
         if pending_redemptions is not None:
             treasury_sync.pending_redemptions = float(pending_redemptions)
         if share_count is not None:
             treasury_sync.share_count = share_count
+
+    def _fetch_lagoon_queue_amounts(
+        self,
+        block_number: int,
+    ) -> tuple[Decimal, Decimal]:
+        """Read aggregate investor queue amounts at one specific block."""
+        flow_manager = self.vault.get_flow_manager()
+        return (
+            flow_manager.fetch_pending_deposit(block_number),
+            flow_manager.calculate_underlying_needed_for_redemptions(block_number),
+        )
 
     def _has_lagoon_settlement_safety(self) -> bool:
         """Check whether the supported module enables GuardV0 settlement safety."""
@@ -941,8 +955,6 @@ class LagoonVaultSyncModel(AddressSyncModel):
 
         # Do not pre-sign settlement: GuardV0 is evaluated against the state
         # after this confirmed NAV transaction.
-        nav_block_number = nav_receipt["blockNumber"]
-
         logger.info("Preparing to settle Lagoon")
 
         # This is an operator liquidity warning only. GuardV0 preflight below
@@ -995,10 +1007,13 @@ class LagoonVaultSyncModel(AddressSyncModel):
         # particular, pending redemptions must remain reserved so yield logic
         # cannot allocate cash needed for a deferred or manual settlement.
         if not preflight.should_settle:
-            metadata_block_number = web3.eth.block_number
-            flow_manager = vault.get_flow_manager()
-            pending_redemptions = flow_manager.calculate_underlying_needed_for_redemptions(metadata_block_number)
-            share_count = vault.fetch_total_supply(metadata_block_number)
+            # Persist one self-consistent queue snapshot. The queue can be
+            # observed at a later block than the NAV receipt, so persist this
+            # block rather than incorrectly attributing these values to the
+            # NAV receipt block.
+            queue_snapshot_block = self.get_safe_latest_block()
+            pending_deposits, pending_redemptions = self._fetch_lagoon_queue_amounts(queue_snapshot_block)
+            share_count = vault.fetch_total_supply(queue_snapshot_block)
 
             if preflight.manual_settlement_required:
                 # Gross flow is above the GuardV0 cap. The Safe, rather than
@@ -1023,7 +1038,8 @@ class LagoonVaultSyncModel(AddressSyncModel):
             self._mark_treasury_sync_completed(
                 treasury_sync=treasury_sync,
                 strategy_cycle_ts=strategy_cycle_ts,
-                block_number=nav_block_number,
+                block_number=queue_snapshot_block,
+                pending_deposits=pending_deposits,
                 pending_redemptions=pending_redemptions,
                 share_count=share_count,
             )
@@ -1128,18 +1144,22 @@ class LagoonVaultSyncModel(AddressSyncModel):
         # Add in the event cross reference list
         ref = BalanceEventRef.from_balance_update_event(evt)
         treasury_sync.balance_update_refs.append(ref)
-        treasury_sync.last_block_scanned = analysis.block_number
-        treasury_sync.last_updated_at = native_datetime_utc_now()
-        treasury_sync.last_cycle_at = strategy_cycle_ts
-        treasury_sync.pending_redemptions = float(analysis.pending_redemptions_underlying)
-        treasury_sync.share_count = share_count
+        pending_deposits, pending_redemptions = self._fetch_lagoon_queue_amounts(analysis.block_number)
+        self._mark_treasury_sync_completed(
+            treasury_sync=treasury_sync,
+            strategy_cycle_ts=strategy_cycle_ts,
+            block_number=analysis.block_number,
+            pending_deposits=pending_deposits,
+            pending_redemptions=pending_redemptions,
+            share_count=share_count,
+        )
 
         logger.info(
             f"Lagoon settlements done, the last block is now {treasury_sync.last_block_scanned:,}\n"
             f"Safe address: {vault.safe_address}, vault address: {vault.vault_address}, silo address: {vault.silo_address}\n"
             f"Settled {analysis.get_underlying_diff()} USD\n"
             f"Non-deposit valuation is {valuation:,.2f} USD, with-deposit valuation is {valuation_with_deposits:,.2f} USD\n"
-            f"Pending redemptions {analysis.pending_redemptions_underlying} USD\n"
+            f"Pending redemptions {pending_redemptions} USD\n"
             f"Share count {share_count} {vault.share_token.symbol}"
         )
         return [evt]

--- a/tradeexecutor/ethereum/lagoon/vault.py
+++ b/tradeexecutor/ethereum/lagoon/vault.py
@@ -580,7 +580,7 @@ class LagoonVaultSyncModel(AddressSyncModel):
         pending_redemptions: Decimal | None = None,
         share_count: Decimal | None = None,
     ) -> None:
-        """Mark Lagoon treasury as synced even when no settlement was needed."""
+        """Mark a Lagoon treasury queue snapshot as complete."""
         treasury_sync.last_updated_at = native_datetime_utc_now()
         treasury_sync.last_cycle_at = strategy_cycle_ts
         treasury_sync.last_block_scanned = block_number
@@ -1011,7 +1011,7 @@ class LagoonVaultSyncModel(AddressSyncModel):
             # observed at a later block than the NAV receipt, so persist this
             # block rather than incorrectly attributing these values to the
             # NAV receipt block.
-            queue_snapshot_block = self.get_safe_latest_block()
+            queue_snapshot_block = web3.eth.block_number
             pending_deposits, pending_redemptions = self._fetch_lagoon_queue_amounts(queue_snapshot_block)
             share_count = vault.fetch_total_supply(queue_snapshot_block)
 
@@ -1113,6 +1113,7 @@ class LagoonVaultSyncModel(AddressSyncModel):
 
         share_count = vault.fetch_total_supply(analysis.block_number)
         other_data["share_count"] = share_count
+        pending_deposits, pending_redemptions = self._fetch_lagoon_queue_amounts(analysis.block_number)
 
         evt = BalanceUpdate(
             balance_update_id=event_id,
@@ -1144,7 +1145,6 @@ class LagoonVaultSyncModel(AddressSyncModel):
         # Add in the event cross reference list
         ref = BalanceEventRef.from_balance_update_event(evt)
         treasury_sync.balance_update_refs.append(ref)
-        pending_deposits, pending_redemptions = self._fetch_lagoon_queue_amounts(analysis.block_number)
         self._mark_treasury_sync_completed(
             treasury_sync=treasury_sync,
             strategy_cycle_ts=strategy_cycle_ts,

--- a/tradeexecutor/state/sync.py
+++ b/tradeexecutor/state/sync.py
@@ -173,7 +173,8 @@ class Treasury:
     #:
     #: For Lagoon based vaults, this is the pending Silo balance observed during
     #: the most recent successful post-valuation treasury sync. It is outside
-    #: the Safe and therefore does not belong to portfolio cash or NAV.
+    #: the Safe and therefore does not belong to portfolio cash or NAV. It stays
+    #: ``None`` after an upgrade until the first such sync records a snapshot.
     #:
     pending_deposits: USDollarAmount | None = None
 

--- a/tradeexecutor/state/sync.py
+++ b/tradeexecutor/state/sync.py
@@ -150,9 +150,12 @@ class Treasury:
     #: Wall clock time, at the beginning on the sync cycle.
     last_cycle_at: Optional[datetime.datetime] = None
 
-    #: What is the last processed block for deposit
+    #: What is the last block at which treasury state was observed.
     #:
-    #: 0 = not scanned yet
+    #: For Lagoon, queue amounts are an as-of-block snapshot. This advances
+    #: after a NAV-only sync even when no deposit or redemption was settled.
+    #:
+    #: ``None`` = not scanned yet.
     last_block_scanned: Optional[int] = None
 
     #: List of refences to all balance update events.
@@ -160,15 +163,23 @@ class Treasury:
     #: The actual balance update content is stored on the position itself.
     balance_update_refs: List[BalanceEventRef] = field(default_factory=list)
 
-    #: How much pending redemptions we have?
+    #: How much underlying is required to settle pending redemptions.
     #:
     #: For Lagoon based vaults, we need to sell assets to satisfy redemptions on the next cycle.
     #:
     pending_redemptions: Optional[USDollarAmount] = None
 
+    #: How much underlying-token deposits are waiting in the investor queue.
+    #:
+    #: For Lagoon based vaults, this is the pending Silo balance observed during
+    #: the most recent successful post-valuation treasury sync. It is outside
+    #: the Safe and therefore does not belong to portfolio cash or NAV.
+    #:
+    pending_deposits: USDollarAmount | None = None
+
     #: Number of issued shares.
     #:
-    #: For Lagoon based vaults, needed to calcualte share price.
+    #: For Lagoon based vaults, needed to calculate share price.
     #:
     share_count: Optional[Decimal] = None
 
@@ -247,4 +258,3 @@ class Sync:
     def is_initialised(self) -> bool:
         """Have we scanned the initial deployment event for the sync model."""
         return self.deployment.block_number is not None
-


### PR DESCRIPTION
## Why

GuardV0 cap and cooldown are settlement-policy metadata, whereas unsettled investor queues are mutable treasury state. State consumers need the latest observed queue to distinguish a pending investor flow from assets already included in the Safe and NAV.

## Lessons learnt

A queue snapshot must use one explicit, post-NAV block for deposits, redemptions and share supply. A NAV-only cycle can refresh that snapshot without creating a balance update.

## Summary

- Persist Lagoon pending deposits beside pending redemptions under `sync.treasury`.
- Refresh both amounts after a successful settlement or a deferred/manual/empty post-NAV cycle.
- Extend existing GuardV0 fork tests for settlement, deferred mixed flow, state serialisation and backwards compatibility.
- Document state-versus-metadata ownership and add the changelog entry.