### PR TITLE
fix: make vault test simulations reproducible

### DIFF
--- a/docs/plans/vault-test-pr1602-trade-executor-fixes.md
+++ b/docs/plans/vault-test-pr1602-trade-executor-fixes.md
@@ -1,0 +1,294 @@
+# Vault-test PR #1602 trade-executor fixes
+
+## Objective
+
+Make one `vault-test-trade --auto-simulated` invocation reproducible and
+diagnosable across the complete production vault list. This plan contains only
+trade-executor changes. It does not assume that an on-chain vault revert is an
+executor accounting bug until the recorded call evidence proves that ownership.
+
+The target run boundary is one command invocation containing every requested
+vault id. Manual shell-level chunking remains useful for research, but it is not
+part of the command's report contract and will not be supported by an implicit
+cross-process aggregation protocol.
+
+## Confirmed baseline
+
+The following behaviour is already implemented and must be preserved:
+
+- operation-scoped trade cursors prevent an earlier lifecycle operation from
+  determining a later failure result;
+- mined status-0 receipts are classified as `transaction_reverted`;
+- typed preflight, receipt-analysis, state-inference and infrastructure results
+  remain distinct;
+- unknown historical result strings survive state round-trip; and
+- attempts already record source revisions, fork blocks, Anvil generation and
+  Lagoon deployment addresses.
+
+The 2026-08-03 research rerun demonstrated one confirmed harness defect: using
+the first vault in each shell chunk as the simulated Lagoon primary changed the
+deployment topology according to chunk boundaries. Holding Ethereum as the
+primary produced 13 successful chunks and zero `infrastructure_failed` rows for
+that run.
+
+The same run observed an Aerodrome USDC redemption revert. Its executor
+ownership is not yet proven. Vault routing already reconciles planned shares
+against the transaction builder's custody balance and rejects material
+shortfalls, so the existing reconciliation path must be traced before changing
+position accounting.
+
+## Scope
+
+In scope:
+
+- stable simulated Lagoon topology;
+- optional externally documented fixed fork blocks, automatic midnight fallback
+  and persistent Foundry cache handling;
+- upstream RPC provider-domain diagnostics across Anvil replacements;
+- report rows tied to the current attempt and explicit success results; and
+- a pinned-fork Aerodrome investigation that assigns ownership from evidence.
+
+Out of scope:
+
+- Yearn, IPOR Fusion, 40acres or other protocol-specific transaction logic;
+- decoding protocol custom errors in trade-executor;
+- treating a status-0 receipt as success;
+- aggregating unrelated command invocations; and
+- persisting RPC URLs, credentials, headers or signed transactions.
+
+## Work item 1: make the simulated primary explicit
+
+The simulated deployment and runtime currently derive the primary from
+`vault_specs[0]`. Replace this implicit contract with one selected primary that
+is passed through setup, RPC filtering, fork selection and deployment.
+
+1. Select Ethereum when `json_rpc_ethereum` is configured. If it is absent,
+   fall back to the first requested vault chain.
+2. Keep the selected primary RPC when filtering configuration, even when the
+   requested vault list contains no vault on that chain.
+3. Build the selected chain list as primary first, followed by requested vault
+   chains with stable deduplication.
+4. Permit the primary chain to have no vault specifications. It still owns the
+   simulated Lagoon vault, source Safe and CCTP hub.
+5. Pass the selected primary explicitly to `start_simulated_vault_runtime()` and
+   `deploy_simulated_lagoon_multichain()`; do not recalculate it downstream.
+
+Tests:
+
+- A Base-only list with Ethereum RPC selects Ethereum and keeps only Ethereum
+  and Base RPCs.
+- A mixed list produces the same primary regardless of vault ordering.
+- Without Ethereum RPC, the first requested chain is the documented fallback.
+- A runtime integration test starts Ethereum and Base forks for a Base-only
+  list and records `primary_chain_id = 1`.
+
+## Work item 2: accept fixed blocks and define cache ownership
+
+The command needs two fork-block modes. Integration tests and published
+experiments use an explicit fixed map. Ad hoc command runs may resolve a new map
+from the preceding naive UTC midnight. Both modes produce one immutable map
+before generation one and reuse it unchanged for every Anvil replacement.
+
+### Fixed mode
+
+1. Add a repeatable CLI option:
+
+   ```text
+   --simulation-fork-block CHAIN_ID:BLOCK_NUMBER
+   ```
+
+   Example:
+
+   ```text
+   --simulation-fork-block 1:25670641 \
+   --simulation-fork-block 8453:49462926
+   ```
+
+2. Parse the values with one setup helper into `dict[ChainId, int]`. Reject
+   unknown chain ids, malformed or non-positive block numbers and duplicate
+   chain entries before creating any Web3 or Anvil process.
+3. Fixed mode is enabled when at least one option is supplied. Require exactly
+   one block for every selected chain, including the simulated primary. Reject
+   missing and unrelated chain entries instead of combining fixed and automatic
+   blocks in one run.
+4. The block values are experiment inputs. Keep their durable documentation in
+   the relevant GitHub issue, PR comment or plan/report file and pass them to
+   the command explicitly. Do not add one experiment's blocks to production
+   constants.
+5. Add an optional
+   `--simulation-fork-block-reference TEXT` value for the external issue URL,
+   PR comment URL or repository document path. Persist it as provenance; do not
+   fetch or interpret it during execution.
+
+### Automatic mode
+
+1. When no fixed block option is supplied, choose the most recent naive UTC
+   midnight once at command setup.
+2. Resolve the latest block at or before that timestamp for every selected chain
+   through `create_multi_provider_web3()` and a timestamp binary search.
+3. Fail setup with the chain id and redacted provider-domain diagnostics when a
+   selected chain cannot resolve or serve the historical block. Do not silently
+   fall back to a live tip.
+
+### Shared provenance and cache lifecycle
+
+1. Persist the complete block map in run and attempt provenance with
+   `fork_block_source` equal to `explicit` or `automatic_midnight`. In automatic
+   mode also persist the selected midnight timestamp. In fixed mode persist the
+   optional external reference.
+2. Pass the complete map to every Anvil generation. Replacement code must accept
+   the map from generation one and must not parse options or query upstream tips
+   again.
+3. Use `~/.tradingstrategy/vaults/rpc-cache` as the durable experiment cache.
+   Because Foundry cache entries include the fork block, different documented
+   experiments can safely share this directory.
+4. Seed Foundry's actual cache directory from the durable cache before generation one.
+5. Account for the current Foundry behaviour that writes fork `storage.json`
+   under `~/.foundry/cache/rpc`: seed that directory from the durable cache
+   before startup and copy it back with overwrite after shutdown.
+6. Perform copy-back in cleanup on successful completion, setup failure,
+   attempt failure and Anvil replacement. A cache-copy error is reported without
+   masking the original command error.
+7. Do not override `FOUNDRY_RPC_CACHE_DIR`: current Foundry writes fork cache
+   data to `~/.foundry/cache/rpc`, so this workflow explicitly mirrors that
+   directory instead of claiming an environment override changes Anvil output.
+
+Tests:
+
+- CLI parsing accepts a complete Ethereum/Base fixed map and rejects malformed,
+  duplicate, missing and unrelated entries.
+- A Base-only vault list still requires fixed blocks for both Base and its
+  Ethereum primary.
+- A fixed-mode integration test uses checked-in midnight block values and
+  asserts that no automatic block-resolution call occurs.
+- Automatic resolution returns the latest block whose timestamp is not after
+  the target for sparse and dense block sequences.
+- Provenance distinguishes explicit and automatic maps and retains the external
+  reference only as inert text.
+- Every replacement receives the exact generation-one block map.
+- Success and injected setup/close failures all execute cache copy-back.
+
+## Work item 3: retain provider diagnostics before teardown
+
+An infrastructure result must identify all upstream provider domains involved
+in the failed generation without exposing complete URLs.
+
+1. Before replacing or closing a failed runtime, harvest each Anvil RPC proxy's
+   per-provider request count, failure count, method counts and recent redacted
+   errors.
+2. Accumulate observations by vault id, simulation generation, chain id and
+   provider domain. Do not discard generation-one observations when a retry
+   fails in generation two.
+3. For a failed chain with no proxy counters, record the configured upstream
+   domains with `observed_failure_count = 0` and a diagnostic explaining that
+   the proxy did not classify the failure. This covers single-provider setups
+   and HTTP-200 invalid responses without inventing a provider failure.
+4. Attach accumulated diagnostics only to a terminal infrastructure failure.
+   Clear them after a successful clean rerun.
+5. Apply the existing vault-test redaction to every stored error field and test
+   that API keys, URL paths, query strings and headers are absent.
+
+Tests:
+
+- Failures from two domains and two generations are both retained.
+- A single configured provider is recorded as involved without a fabricated
+  non-zero failure count.
+- A successful retry clears transient provider-failure metadata.
+- Runtime replacement harvests diagnostics before closing the old proxies.
+
+## Work item 4: make the current invocation's report authoritative
+
+One invocation already knows its complete ordered vault list and receives one
+row from the runner for each handled result. Tighten this existing report path;
+do not add cross-invocation chunk aggregation.
+
+1. Add a run id at command setup and copy it into every attempt and report row.
+2. Resolve report attempt metadata by the row's attempt id and run id, rather
+   than selecting the latest historical position for the vault address.
+3. Validate that the final rows contain each requested vault id exactly once and
+   in request order. Report a command-level incomplete status when an unhandled
+   command failure prevents this invariant.
+4. Export an explicit `success_simulated` or `success_real` presentation result
+   when a successful legacy attempt has no raw result. Do not write this
+   normalisation back to historical state.
+5. Write a partial report from the command cleanup path when setup progressed
+   far enough to establish the run id and requested list. Include attempted and
+   unattempted ids explicitly.
+6. Define report stability as identical membership, ordering, selected blocks
+   and result classification. UUIDs, timestamps, transaction hashes and
+   deployment addresses are intentionally volatile.
+
+Tests:
+
+- A state containing an older result for the same vault exports the attempt
+  belonging to the current row.
+- Duplicate and missing current-run rows produce an incomplete report instead
+  of silently using stale state.
+- Result-less simulated and real successes export explicit presentation values
+  while their persisted raw metadata remains unchanged.
+- A controlled command failure writes attempted and unattempted rows with a
+  command-level incomplete status.
+
+## Work item 5: diagnose Aerodrome before assigning a fix
+
+Reproduce Base Aerodrome USDC through fixed CLI mode using the externally
+documented Ethereum block `25670641` and Base block `49462926`. The integration
+test may pass the same fixed map directly to the runtime setup helper. Add
+diagnostics at the generic vault routing boundary; do not add a 40acres branch.
+
+Capture before broadcast:
+
+- accounting position quantity and planned raw redemption shares;
+- transaction builder delivery address;
+- resolved vault share-token address and raw custody balance;
+- output or exception from `reconcile_vault_redemption_amount()`;
+- the manager-generated target, selector and raw share amount; and
+- the result of an `eth_call` of the exact wrapped redemption from the actual
+  sender at the pre-broadcast block.
+
+Then assign ownership using this decision table:
+
+| Evidence | Ownership and next action |
+|---|---|
+| Custody shares are materially below planned shares and routing does not stop | Fix generic trade-executor reconciliation or custody-address selection. Preserve the real-execution material-shortfall guard and prove state contains no phantom closed quantity. |
+| Custody shares cover the request and the exact preflight call reverts | The failure is a vault/adapter availability problem. Move it to the eth-defi follow-up and make no executor accounting change. |
+| Exact preflight succeeds but the unchanged transaction reverts | Trace sender, wrapper, calldata and state mutations between preflight and broadcast; fix the generic executor boundary demonstrated by the mismatch. |
+| Reconciled shares differ only within the configured epsilon | Verify raw/decimal conversion and receipt-accounted minted shares. Change epsilon behaviour only with a protocol-neutral rounding invariant and regression. |
+
+Any executor fix selected by this gate must include a focused unit test and the
+pinned Base fork regression. A partial close is not acceptable unless the plan
+also defines the remaining position quantity and proves simulated cleanup does
+not hide it.
+
+## Implementation order
+
+1. Land explicit primary selection and its runtime regression.
+2. Land fixed-block CLI input, automatic midnight fallback and cache lifecycle
+   handling.
+3. Harvest and persist provider diagnostics across replacements.
+4. Tie reporting to the current run and make success presentation explicit.
+5. Reproduce Aerodrome with the diagnostic gate and implement only the fix
+   supported by its evidence.
+6. Document one complete fixed block map in the PR, pass that map to the full
+   129-vault invocation with a warm cache, and publish the report summary.
+
+## Acceptance criteria
+
+- Vault ordering cannot change the simulated primary when Ethereum RPC is
+  configured.
+- Fixed experiments and integration tests use the externally documented block
+  map without querying block discovery; automatic runs record their resolved
+  preceding-midnight map.
+- Every generation within a run uses the same complete block map.
+- Cache copy-back runs on every exit path without masking the primary error.
+- A terminal infrastructure result lists every involved provider domain and
+  distinguishes observed proxy failures from configured-only providers.
+- The report contains one ordered row per requested vault, tied to the current
+  run, with an explicit presentation result.
+- Aerodrome ownership and any resulting code change are supported by captured
+  preflight and transaction evidence.
+- The 2026-08-04 fixed-block warm-cache rerun recorded 129 unique vaults and
+  zero `infrastructure_failed` results. It retained two transaction reverts:
+  TAU InfiniFi Pointsmax (custom sell error) and Aerodrome USDC (ERC-20 balance
+  shortfall during satellite close). This is evidence for that experiment, not
+  a claim about future provider availability.

--- a/tests/cli/test_vault_test_trade.py
+++ b/tests/cli/test_vault_test_trade.py
@@ -30,7 +30,10 @@ from web3.exceptions import BadFunctionCallOutput
 from tradeexecutor.cli.commands.lagoon_deploy_vault import (
     _write_state_sibling_deployment_artifact,
 )
-from tradeexecutor.cli.commands.vault_test_trade import _validate_vault_test_options
+from tradeexecutor.cli.commands.vault_test_trade import (
+    _complete_vault_test_report_rows,
+    _validate_vault_test_options,
+)
 from tradeexecutor.cli.vault_trade import tui as tui_module
 from tradeexecutor.cli.vault_trade import (
     runner as runner_module,
@@ -42,6 +45,7 @@ from tradeexecutor.cli.vault_trade.core import (
     parse_vault_ids,
 )
 from tradeexecutor.cli.vault_trade.state import (
+    capture_rpc_proxy_failures,
     capture_vault_test_error,
     classify_vault_test_failure,
     create_vault_test_diagnostic_pair,
@@ -56,16 +60,23 @@ from tradeexecutor.cli.vault_trade.tui import (
     VaultSearchScreen,
     VaultTestTradeApp,
 )
-from tradeexecutor.cli.vault_trade.setup import VaultTestRuntime, load_vault_test_state
+from tradeexecutor.cli.vault_trade.setup import (
+    VaultTestRuntime,
+    load_vault_test_state,
+    select_simulated_vault_test_primary_chain,
+)
 from tradeexecutor.cli.vault_trade.simulation import (
     SimulatedVaultAttemptTimeout,
     SimulatedVaultRuntime,
     get_shared_simulation_fork_blocks,
     is_simulated_infrastructure_failure,
+    parse_simulation_fork_blocks,
     queue_simulated_infrastructure_retry,
     raise_simulated_vault_attempt_timeout,
+    resolve_block_number_at_or_before_timestamp,
     rotate_simulated_rpc_upstreams,
     take_simulated_snapshots,
+    validate_simulation_fork_blocks,
 )
 from tradeexecutor.cli.vault_trade.runner import (
     VaultAttemptContext,
@@ -176,6 +187,216 @@ def test_simulated_vault_rpc_filter_keeps_only_selected_chains() -> None:
         "json_rpc_arbitrum": "arbitrum-rpc",
         "json_rpc_hyperliquid": "hyperliquid-rpc",
     }
+
+
+def test_simulated_vault_primary_keeps_ethereum_for_base_only_batch() -> None:
+    """A Base-only batch retains Ethereum as its stable simulated primary.
+
+    1. Configure Ethereum and Base RPC values for one Base vault.
+    2. Select the primary and filter the simulated RPC configuration.
+    3. Verify Ethereum remains first-class even without an Ethereum vault id.
+    """
+    # 1. Configure Ethereum and Base RPC values for one Base vault.
+    rpc_kwargs = {
+        "json_rpc_ethereum": "ethereum-rpc",
+        "json_rpc_base": "base-rpc",
+        "json_rpc_arbitrum": "arbitrum-rpc",
+    }
+    specs = [
+        VaultSpec(
+            ChainId.base.value,
+            "0x0000000000000000000000000000000000000001",
+        )
+    ]
+
+    # 2. Select the primary and filter the simulated RPC configuration.
+    primary_chain_id = select_simulated_vault_test_primary_chain(rpc_kwargs, specs)
+    filtered = filter_rpc_kwargs_for_vault_specs(
+        rpc_kwargs,
+        specs,
+        primary_chain_id=primary_chain_id,
+    )
+
+    # 3. Verify Ethereum remains first-class even without an Ethereum vault id.
+    assert primary_chain_id == ChainId.ethereum
+    assert filtered == {
+        "json_rpc_ethereum": "ethereum-rpc",
+        "json_rpc_base": "base-rpc",
+        "json_rpc_arbitrum": None,
+    }
+
+
+def test_fixed_simulation_fork_blocks_require_the_complete_selected_map() -> None:
+    """Explicit fork mode neither omits a needed chain nor accepts unrelated input.
+
+    1. Parse a valid Ethereum/Base fixed map for a Base vault.
+    2. Verify the complete map passes validation.
+    3. Verify missing, duplicate and unrelated values are rejected.
+    """
+    # 1. Parse a valid Ethereum/Base fixed map for a Base vault.
+    specs = [
+        VaultSpec(
+            ChainId.base.value,
+            "0x0000000000000000000000000000000000000001",
+        )
+    ]
+    blocks = parse_simulation_fork_blocks(["1:25670641", "8453:49462926"])
+
+    # 2. Verify the complete map passes validation.
+    validate_simulation_fork_blocks(
+        blocks,
+        specs,
+        primary_chain_id=ChainId.ethereum,
+    )
+
+    # 3. Verify missing, duplicate and unrelated values are rejected.
+    with pytest.raises(ValueError, match="missing 1"):
+        validate_simulation_fork_blocks(
+            parse_simulation_fork_blocks(["8453:49462926"]),
+            specs,
+            primary_chain_id=ChainId.ethereum,
+        )
+    with pytest.raises(ValueError, match="Duplicate"):
+        parse_simulation_fork_blocks(["1:1", "1:2"])
+    with pytest.raises(ValueError, match="unrelated 42161"):
+        validate_simulation_fork_blocks(
+            parse_simulation_fork_blocks(
+                ["1:25670641", "8453:49462926", "42161:490490945"]
+            ),
+            specs,
+            primary_chain_id=ChainId.ethereum,
+        )
+
+
+def test_simulation_block_resolution_selects_the_latest_block_before_midnight() -> None:
+    """Automatic mode resolves the latest block whose timestamp is not after midnight.
+
+    1. Provide a sparse monotonic chain of block timestamps around midnight.
+    2. Resolve the block at or before the target timestamp.
+    3. Verify the binary search selects the final eligible block.
+    """
+    # 1. Provide a sparse monotonic chain of block timestamps around midnight.
+    timestamps = {0: 10, 1: 20, 2: 30, 3: 40, 4: 50}
+    web3 = MagicMock()
+    web3.eth.block_number = 4
+    web3.eth.get_block.side_effect = lambda number: {"timestamp": timestamps[number]}
+
+    # 2. Resolve the block at or before the target timestamp.
+    selected = resolve_block_number_at_or_before_timestamp(
+        web3,
+        datetime.datetime.fromtimestamp(35),
+    )
+
+    # 3. Verify the binary search selects the final eligible block.
+    assert selected == 2
+
+
+def test_vault_rpc_cache_syncs_foundry_storage(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Simulation cleanup persists Foundry storage in the durable vault cache.
+
+    1. Point Foundry's actual cache path at a temporary storage tree.
+    2. Copy a generated storage file back to the durable cache.
+    3. Verify the copied cache entry is retained.
+    """
+    # 1. Point Foundry's actual cache path at a temporary storage tree.
+    durable_cache = tmp_path / "vault-cache"
+    foundry_cache = tmp_path / "foundry-cache"
+    storage_file = foundry_cache / "base" / "49462926" / "storage.json"
+    storage_file.parent.mkdir(parents=True)
+    storage_file.write_text('{"cached": true}')
+    monkeypatch.setattr(
+        simulation_module,
+        "DEFAULT_FOUNDRY_RPC_CACHE_DIR",
+        foundry_cache,
+    )
+    # 2. Copy a generated storage file back to the durable cache.
+    copied = simulation_module.sync_foundry_rpc_cache_to_vault_cache(durable_cache)
+
+    # 3. Verify the copied cache entry is retained.
+    assert copied == 1
+    assert (durable_cache / "base" / "49462926" / "storage.json").read_text() == (
+        '{"cached": true}'
+    )
+
+
+def test_rpc_proxy_failure_diagnostics_only_export_provider_domains() -> None:
+    """Infrastructure diagnostics retain failed providers without retaining provider URLs.
+
+    1. Construct one failed proxy provider with an API key in its URL and error.
+    2. Capture Anvil proxy diagnostics.
+    3. Verify the report retains only its domain and redacts the error URL.
+    """
+    # 1. Construct one failed proxy provider with an API key in its URL and error.
+    timestamp = datetime.datetime(2026, 8, 4)
+    stats = SimpleNamespace(
+        failure_count=1,
+        request_count=2,
+        method_failure_counts={"eth_call": 1},
+        error_replies=[
+            {
+                "timestamp": timestamp,
+                "method": "eth_call",
+                "http_status": 429,
+                "error": "https://rpc.example/path?api_key=secret timed out",
+            }
+        ],
+    )
+    anvil = SimpleNamespace(
+        proxy=SimpleNamespace(
+            get_stats=lambda: {"https://rpc.example/path?api_key=secret": stats}
+        ),
+        upstream_rpc_urls=("https://rpc.example/path?api_key=secret",),
+        fork_block_number=123,
+    )
+    web3config = SimpleNamespace(anvils={ChainId.base: anvil})
+
+    # 2. Capture Anvil proxy diagnostics.
+    domains, failures = capture_rpc_proxy_failures(web3config)
+
+    # 3. Verify the report retains only its domain and redacts the error URL.
+    assert domains == {"8453": ["rpc.example"]}
+    assert failures[0]["providers"][0]["domain"] == "rpc.example"
+    assert "secret" not in json.dumps(failures)
+
+
+def test_incomplete_command_report_preserves_requested_vault_order() -> None:
+    """A command interruption writes explicit rows for vaults it did not reach.
+
+    1. Request two vault ids and provide one completed runner row.
+    2. Complete the rows at a simulated command failure boundary.
+    3. Verify membership, order and the explicit incomplete presentation result.
+    """
+    # 1. Request two vault ids and provide one completed runner row.
+    first = VaultSpec(
+        ChainId.ethereum.value,
+        "0x0000000000000000000000000000000000000001",
+    )
+    second = VaultSpec(
+        ChainId.base.value,
+        "0x0000000000000000000000000000000000000002",
+    )
+    rows = [{"vault id": first.as_string_id(), "status": "success", "attempt": "a"}]
+
+    # 2. Complete the rows at a simulated command failure boundary.
+    completed = _complete_vault_test_report_rows(
+        [first, second],
+        rows,
+        auto_simulated=True,
+        error=RuntimeError("RPC https://rpc.example/?api_key=secret failed"),
+    )
+
+    # 3. Verify membership, order and the explicit incomplete presentation result.
+    assert [row["vault id"] for row in completed] == [
+        first.as_string_id(),
+        second.as_string_id(),
+    ]
+    assert completed[1]["result"] == "command_incomplete"
+    assert "secret" not in completed[1]["detail"]
+    report = export_vault_test_report(State(), completed)
+    assert report["results"][1]["result"] == "command_incomplete"
 
 
 def test_load_lagoon_deployment_reads_source_and_satellite_modules(tmp_path: Path):
@@ -2853,6 +3074,45 @@ def test_vault_redemption_amount_reconciles_only_small_share_shortfalls() -> Non
             Decimal("0.9"),
             epsilon=0.025,
         )
+
+
+def test_vault_redemption_preflight_replays_the_wrapped_lagoon_call() -> None:
+    """Redemption diagnostics call the exact wrapped transaction from its sender.
+
+    1. Construct a prepared Lagoon wrapper transaction with unsigned calldata.
+    2. Capture its pre-broadcast ``eth_call`` against a known fork block.
+    3. Verify the wrapper target, sender and calldata are replayed unchanged.
+    """
+    # 1. Construct a prepared Lagoon wrapper transaction with unsigned calldata.
+    transaction = BlockchainTransaction(
+        chain_id=ChainId.base.value,
+        from_address="0x0000000000000000000000000000000000000001",
+        contract_address="0x0000000000000000000000000000000000000002",
+        function_selector="prepareCall",
+        wrapped_target="0x0000000000000000000000000000000000000003",
+        wrapped_function_selector="redeem",
+        details={"data": "0x1234", "value": 0, "gas": 500_000},
+    )
+    web3 = MagicMock()
+    web3.eth.block_number = 123_456
+    web3.eth.call.return_value = b"\x01"
+
+    # 2. Capture its pre-broadcast ``eth_call`` against a known fork block.
+    result = vault_routing._capture_wrapped_redemption_preflight(transaction, web3)
+
+    # 3. Verify the wrapper target, sender and calldata are replayed unchanged.
+    assert result["pre_broadcast_block_number"] == 123_456
+    assert result["eth_call_result"] == "01"
+    web3.eth.call.assert_called_once_with(
+        {
+            "from": transaction.from_address,
+            "to": transaction.contract_address,
+            "data": "0x1234",
+            "value": 0,
+            "gas": 500_000,
+        },
+        block_identifier=123_456,
+    )
 
 
 def test_async_vault_request_transaction_roles_ignore_selectors() -> None:

--- a/tradeexecutor/cli/commands/vault_test_trade.py
+++ b/tradeexecutor/cli/commands/vault_test_trade.py
@@ -1,7 +1,9 @@
 """Typer entry point for testing external vault deposits and redemptions."""
 
+import logging
 from decimal import Decimal
 from pathlib import Path
+import uuid
 
 from tabulate import tabulate
 from typer import Option
@@ -12,7 +14,10 @@ from tradeexecutor.cli.commands.app import app
 from tradeexecutor.cli.log import setup_logging
 from tradeexecutor.cli.vault_trade.core import parse_vault_ids
 from tradeexecutor.cli.vault_trade.runner import VaultTestBatchRunner
-from tradeexecutor.cli.vault_trade.state import write_vault_test_report
+from tradeexecutor.cli.vault_trade.state import (
+    redact_vault_test_error_text,
+    write_vault_test_report,
+)
 from tradeexecutor.cli.vault_trade.setup import (
     choose_manual_vault_action,
     create_vault_test_runtime,
@@ -29,6 +34,9 @@ from tradeexecutor.strategy.execution_model import AssetManagementMode
 DEFAULT_VAULT_TEST_TRADE_AMOUNT = 1_001.0
 
 
+logger = logging.getLogger(__name__)
+
+
 def _validate_vault_test_options(
     *,
     auto_simulated: bool,
@@ -36,6 +44,8 @@ def _validate_vault_test_options(
     rerun: bool,
     settle_async_on_anvil: bool,
     asset_management_mode: AssetManagementMode | None,
+    simulation_fork_blocks: list[str] | None = None,
+    simulation_fork_block_reference: str | None = None,
 ) -> None:
     """Reject option combinations before downloading data or opening RPCs."""
 
@@ -45,8 +55,60 @@ def _validate_vault_test_options(
         raise RuntimeError("--rerun requires --auto-simulated or --auto-real")
     if settle_async_on_anvil and not auto_simulated:
         raise RuntimeError("--settle-async-on-anvil requires --auto-simulated")
+    if (simulation_fork_blocks or simulation_fork_block_reference) and not auto_simulated:
+        raise RuntimeError("--simulation-fork-block options require --auto-simulated")
+    if simulation_fork_block_reference and not simulation_fork_blocks:
+        raise RuntimeError(
+            "--simulation-fork-block-reference requires --simulation-fork-block"
+        )
     if asset_management_mode != AssetManagementMode.lagoon:
         raise RuntimeError("vault-test-trade requires ASSET_MANAGEMENT_MODE=lagoon")
+
+
+def _complete_vault_test_report_rows(
+    vault_specs,
+    rows: list[dict],
+    *,
+    auto_simulated: bool,
+    error: BaseException | None = None,
+) -> list[dict]:
+    """Return exactly one ordered report row for every requested vault id.
+
+    The runner normally fulfils this contract. Command-boundary failures can
+    interrupt it before that happens, so the report keeps the requested list
+    authoritative and marks missing or duplicate outcomes explicitly.
+    """
+
+    rows_by_vault_id: dict[str, list[dict]] = {}
+    for row in rows:
+        vault_id = row.get("vault id")
+        if vault_id is not None:
+            rows_by_vault_id.setdefault(vault_id, []).append(row)
+
+    incomplete_detail = (
+        f"Command interrupted: {redact_vault_test_error_text(error)}"
+        if error is not None
+        else "Command returned duplicate or missing vault result rows"
+    )
+    completed_rows = []
+    for spec in vault_specs:
+        vault_id = spec.as_string_id()
+        matching_rows = rows_by_vault_id.get(vault_id, [])
+        if len(matching_rows) == 1:
+            completed_rows.append(matching_rows[0])
+            continue
+        completed_rows.append(
+            {
+                "vault id": vault_id,
+                "chain": spec.chain_id,
+                "mode": "simulated" if auto_simulated else "real",
+                "status": "command_incomplete",
+                "result": "command_incomplete",
+                "attempt": None,
+                "detail": incomplete_detail,
+            }
+        )
+    return completed_rows
 
 
 @app.command()
@@ -118,6 +180,16 @@ def vault_test_trade(
         "--report-json",
         help="Write a machine-readable report containing the selected vault results.",
     ),
+    simulation_fork_block: list[str] | None = Option(
+        None,
+        "--simulation-fork-block",
+        help="Repeatable fixed simulated fork block as CHAIN_ID:BLOCK_NUMBER.",
+    ),
+    simulation_fork_block_reference: str | None = Option(
+        None,
+        "--simulation-fork-block-reference",
+        help="Issue, PR comment or document recording fixed fork block choices.",
+    ),
 ) -> None:
     """Test selected external vaults using one Lagoon executor.
 
@@ -136,6 +208,8 @@ def vault_test_trade(
         auto_real=auto_real,
         rerun=rerun,
         settle_async_on_anvil=settle_async_on_anvil,
+        simulation_fork_blocks=simulation_fork_block,
+        simulation_fork_block_reference=simulation_fork_block_reference,
         asset_management_mode=asset_management_mode,
     )
     assert asset_management_mode == AssetManagementMode.lagoon
@@ -172,8 +246,14 @@ def vault_test_trade(
         vault_specs=vault_specs,
         data=data,
         auto_simulated=auto_simulated,
+        simulation_fork_blocks=simulation_fork_block,
+        simulation_fork_block_reference=simulation_fork_block_reference,
     )
+    runtime.provenance["run_id"] = uuid.uuid4().hex
 
+    state = None
+    rows: list[dict] = []
+    runner = None
     try:
         state, store = load_vault_test_state(
             state_file=resolved_state_file,
@@ -213,9 +293,26 @@ def vault_test_trade(
             manual_action=manual_action,
             deposit_asset=deposit_asset,
         )
-        rows = runner.run()
+        rows = _complete_vault_test_report_rows(
+            vault_specs,
+            runner.run(),
+            auto_simulated=auto_simulated,
+        )
         print(tabulate(rows, headers="keys", tablefmt="rounded_outline"))
         if report_json:
             write_vault_test_report(report_json, state, rows)
+    except BaseException as error:
+        if report_json and state is not None:
+            try:
+                partial_rows = _complete_vault_test_report_rows(
+                    vault_specs,
+                    rows or (runner.rows if runner is not None else []),
+                    auto_simulated=auto_simulated,
+                    error=error,
+                )
+                write_vault_test_report(report_json, state, partial_rows)
+            except Exception:
+                logger.exception("Could not write incomplete vault-test report")
+        raise
     finally:
         runtime.close()

--- a/tradeexecutor/cli/vault_trade/core.py
+++ b/tradeexecutor/cli/vault_trade/core.py
@@ -75,13 +75,18 @@ class _SimulatedWhitelistVault(ERC4626Vault):
 
 
 def filter_rpc_kwargs_for_vault_specs(
-    rpc_kwargs: dict, vault_specs: list[VaultSpec]
+    rpc_kwargs: dict,
+    vault_specs: list[VaultSpec],
+    *,
+    primary_chain_id: ChainId | None = None,
 ) -> dict:
     """Keep only JSON-RPC connections needed by an explicit simulated batch."""
 
     selected_keys = {
         get_rpc_env_var_name(ChainId(spec.chain_id)).lower() for spec in vault_specs
     }
+    if primary_chain_id is not None:
+        selected_keys.add(get_rpc_env_var_name(primary_chain_id).lower())
     return {
         key: value if key in selected_keys else None
         for key, value in rpc_kwargs.items()
@@ -206,23 +211,25 @@ def deploy_simulated_lagoon_multichain(
     vault_universe,
     private_key: str,
     amount: Decimal,
+    primary_chain_id: ChainId | None = None,
 ) -> tuple["LagoonDeployment", dict]:
     """Deploy a temporary Lagoon topology on the selected Anvil forks.
 
     Follows the multichain Lagoon integration-test setup: one source vault on
-    the first explicitly supplied chain, deterministic satellite Safes on the
+    the explicit primary chain, deterministic satellite Safes on the
     remaining chains, per-chain transaction sequences and CCTP permissions for
     every supported source/destination route.
     """
 
-    # The first explicit id defines the hub chain.  Preserving caller order is
-    # important because all cross-chain vaults bridge through this deployment.
     assert vault_specs, "A simulated deployment needs at least one vault"
     account = Account.from_key(private_key)
-    primary_chain_id = ChainId(vault_specs[0].chain_id)
     selected_chain_ids = list(
-        dict.fromkeys(ChainId(spec.chain_id) for spec in vault_specs)
+        dict.fromkeys(
+            [primary_chain_id or ChainId(vault_specs[0].chain_id)]
+            + [ChainId(spec.chain_id) for spec in vault_specs]
+        )
     )
+    primary_chain_id = selected_chain_ids[0]
 
     # Fail before deploying any contracts if one requested chain could not be
     # forked.  Partial topologies are never useful for the sequential batch.
@@ -260,7 +267,7 @@ def deploy_simulated_lagoon_multichain(
             primary_chain_id=primary_chain_id,
             selected_chain_ids=selected_chain_ids,
             web3=chain_web3[get_chain_slug(chain_id)],
-            vault_specs=specs_by_chain[chain_id],
+            vault_specs=specs_by_chain.get(chain_id, []),
             vault_universe=vault_universe,
             account_address=account.address,
             safe_salt_nonce=safe_salt_nonce,

--- a/tradeexecutor/cli/vault_trade/runner.py
+++ b/tradeexecutor/cli/vault_trade/runner.py
@@ -39,6 +39,7 @@ from tradeexecutor.cli.vault_trade.state import (
     VAULT_TEST_RESULTS,
     close_simulated_positions,
     capture_vault_test_error,
+    capture_rpc_proxy_failures,
     classify_vault_test_failure,
     create_vault_test_diagnostic_pair,
     get_latest_vault_position,
@@ -1066,6 +1067,14 @@ class VaultTestBatchRunner:
     )
     restart_requested: BaseException | None = field(default=None, init=False)
     current_attempt: VaultAttemptContext | None = field(default=None, init=False)
+    infrastructure_failure_rpc_provider_domains: dict[str, dict[str, list[str]]] = field(
+        default_factory=dict,
+        init=False,
+    )
+    infrastructure_failure_rpc_proxy_failures: dict[str, list[dict]] = field(
+        default_factory=dict,
+        init=False,
+    )
 
     def __post_init__(self) -> None:
         """Preserve the caller's vault order in a mutable work queue."""
@@ -1224,6 +1233,7 @@ class VaultTestBatchRunner:
             alarm.close()
             if fork_snapshots and infrastructure_failure is None:
                 self._restore_simulated_attempt(spec, fork_snapshots)
+                self._clear_infrastructure_rpc_proxy_failures(spec)
             self.current_attempt = None
 
         return stop_batch
@@ -2057,6 +2067,7 @@ class VaultTestBatchRunner:
     ) -> None:
         """Queue one clean rerun or record a repeated Anvil failure."""
 
+        self._remember_infrastructure_rpc_proxy_failures(spec)
         if queue_simulated_infrastructure_retry(
             spec,
             self.pending_specs,
@@ -2086,9 +2097,17 @@ class VaultTestBatchRunner:
             error,
             state=getattr(error, "vault_test_failure_state", self.state),
             original_trade_ids=original_trade_ids,
-            web3config=self.runtime.web3config,
+            web3config=None,
             phase=phase,
             capture_chain_blocks=False,
+            extra_failing_upstream_rpc_providers=self.infrastructure_failure_rpc_provider_domains.pop(
+                spec.as_string_id(),
+                {},
+            ),
+            extra_rpc_proxy_failures=self.infrastructure_failure_rpc_proxy_failures.pop(
+                spec.as_string_id(),
+                [],
+            ),
         )
         record_attempt_result(
             self.state,
@@ -2109,6 +2128,55 @@ class VaultTestBatchRunner:
         )
         self.store.sync(self.state)
         self._append_result(vault, spec, detail)
+
+    def _remember_infrastructure_rpc_proxy_failures(self, spec: VaultSpec) -> None:
+        """Keep proxy observations before a failed Anvil generation is closed."""
+
+        failed_chain_ids = {str(spec.chain_id)}
+        if self.runtime.simulated_runtime is not None:
+            failed_chain_ids.add(
+                str(self.runtime.simulated_runtime.deployment.primary_chain_id.value)
+            )
+        domains, failures = capture_rpc_proxy_failures(
+            self.runtime.web3config,
+            failed_chain_ids=failed_chain_ids,
+        )
+        if not domains and not failures:
+            return
+
+        vault_id = spec.as_string_id()
+        remembered_domains = self.infrastructure_failure_rpc_provider_domains.setdefault(
+            vault_id,
+            {},
+        )
+        for chain_id, chain_domains in domains.items():
+            remembered_chain_domains = remembered_domains.setdefault(chain_id, [])
+            for domain in chain_domains:
+                if domain not in remembered_chain_domains:
+                    remembered_chain_domains.append(domain)
+
+        generation = (
+            self.runtime.simulated_runtime.generation
+            if self.runtime.simulated_runtime is not None
+            else None
+        )
+        remembered_failures = self.infrastructure_failure_rpc_proxy_failures.setdefault(
+            vault_id,
+            [],
+        )
+        for failure in failures:
+            entry = {key: value for key, value in failure.items() if key != "providers"}
+            if generation is not None:
+                entry["simulation_generation"] = generation
+            entry["providers"] = [dict(provider) for provider in failure["providers"]]
+            remembered_failures.append(entry)
+
+    def _clear_infrastructure_rpc_proxy_failures(self, spec: VaultSpec) -> None:
+        """Forget transient provider observations after a successful rerun."""
+
+        vault_id = spec.as_string_id()
+        self.infrastructure_failure_rpc_provider_domains.pop(vault_id, None)
+        self.infrastructure_failure_rpc_proxy_failures.pop(vault_id, None)
 
     def _record_failure(
         self,

--- a/tradeexecutor/cli/vault_trade/setup.py
+++ b/tradeexecutor/cli/vault_trade/setup.py
@@ -18,6 +18,7 @@ from typing import Any
 from eth_defi.compat import native_datetime_utc_now
 from eth_defi.vault.base import VaultSpec
 from tradingstrategy.client import Client
+from tradingstrategy.chain import ChainId
 
 from tradeexecutor.cli.bootstrap import (
     create_execution_and_sync_model,
@@ -34,8 +35,12 @@ from tradeexecutor.cli.vault_trade.core import (
 )
 from tradeexecutor.cli.vault_trade.simulation import (
     SimulatedVaultRuntime,
+    get_last_midnight_utc,
+    get_shared_simulation_fork_blocks,
+    parse_simulation_fork_blocks,
     rotate_simulated_rpc_upstreams,
     start_simulated_vault_runtime_with_replacement,
+    validate_simulation_fork_blocks,
 )
 from tradeexecutor.cli.vault_trade.tui import (
     VaultChoice,
@@ -54,6 +59,21 @@ from tradeexecutor.strategy.trading_strategy_universe import (
 )
 
 logger = logging.getLogger(__name__)
+
+
+SIMULATED_VAULT_TEST_PRIMARY_CHAIN = ChainId.ethereum
+
+
+def select_simulated_vault_test_primary_chain(
+    rpc_kwargs: dict,
+    vault_specs: list[VaultSpec],
+) -> ChainId:
+    """Choose a stable simulated Lagoon hub for a vault-test batch."""
+
+    assert vault_specs, "A simulated vault test needs at least one vault"
+    if rpc_kwargs.get("json_rpc_ethereum"):
+        return SIMULATED_VAULT_TEST_PRIMARY_CHAIN
+    return ChainId(vault_specs[0].chain_id)
 
 
 @dataclass(slots=True)
@@ -191,6 +211,10 @@ def _create_vault_test_provenance(
     web3config: Web3Config,
     amount: Decimal,
     max_slippage: float,
+    fork_block_source: str | None = None,
+    pinned_fork_blocks: dict[ChainId, int] | None = None,
+    fork_block_target_at: datetime.datetime | None = None,
+    fork_block_reference: str | None = None,
 ) -> dict:
     """Capture source revisions and initial chain heights for a tester run."""
 
@@ -204,7 +228,7 @@ def _create_vault_test_provenance(
             initial_chain_blocks[str(chain_id.value)] = {
                 "error": "Could not capture initial chain block",
             }
-    return {
+    provenance = {
         "schema_version": 2,
         "execution_mode": mode,
         "amount": str(amount),
@@ -214,6 +238,18 @@ def _create_vault_test_provenance(
         "eth_defi_commit": _read_git_commit(eth_defi_root),
         "initial_chain_blocks": initial_chain_blocks,
     }
+    if fork_block_source is not None:
+        provenance["fork_block_source"] = fork_block_source
+    if pinned_fork_blocks is not None:
+        provenance["pinned_fork_blocks"] = {
+            str(chain_id.value): block_number
+            for chain_id, block_number in pinned_fork_blocks.items()
+        }
+    if fork_block_target_at is not None:
+        provenance["fork_block_target_at"] = fork_block_target_at.isoformat()
+    if fork_block_reference:
+        provenance["fork_block_reference"] = fork_block_reference
+    return provenance
 
 
 def load_vault_test_data(
@@ -267,6 +303,8 @@ def create_vault_test_runtime(
     vault_specs: list[VaultSpec],
     data: VaultTestData,
     auto_simulated: bool,
+    simulation_fork_blocks: list[str] | None = None,
+    simulation_fork_block_reference: str | None = None,
 ) -> VaultTestRuntime:
     """Dispatch runtime construction based on the requested execution mode."""
 
@@ -284,6 +322,8 @@ def create_vault_test_runtime(
             amount=amount,
             vault_specs=vault_specs,
             data=data,
+            simulation_fork_blocks=simulation_fork_blocks,
+            simulation_fork_block_reference=simulation_fork_block_reference,
         )
     return _create_real_vault_test_runtime(
         executor_id=executor_id,
@@ -315,17 +355,48 @@ def _create_simulated_vault_test_runtime(
     amount: Decimal,
     vault_specs: list[VaultSpec],
     data: VaultTestData,
+    simulation_fork_blocks: list[str] | None,
+    simulation_fork_block_reference: str | None,
 ) -> VaultTestRuntime:
     """Create the first disposable multichain Anvil generation."""
 
+    primary_chain_id = select_simulated_vault_test_primary_chain(
+        rpc_kwargs,
+        vault_specs,
+    )
+
     # Fork only explicitly requested chains.  This shortens startup and avoids
     # unrelated RPC failures aborting a diagnostic batch.
-    filtered_rpc_kwargs = filter_rpc_kwargs_for_vault_specs(rpc_kwargs, vault_specs)
+    filtered_rpc_kwargs = filter_rpc_kwargs_for_vault_specs(
+        rpc_kwargs,
+        vault_specs,
+        primary_chain_id=primary_chain_id,
+    )
+    explicit_fork_blocks = parse_simulation_fork_blocks(simulation_fork_blocks)
+    selected_at = None
+    if explicit_fork_blocks:
+        validate_simulation_fork_blocks(
+            explicit_fork_blocks,
+            vault_specs,
+            primary_chain_id=primary_chain_id,
+        )
+        pinned_fork_blocks = explicit_fork_blocks
+        fork_block_source = "explicit"
+    else:
+        selected_at = get_last_midnight_utc()
+        pinned_fork_blocks = get_shared_simulation_fork_blocks(
+            vault_specs,
+            rpc_kwargs=filtered_rpc_kwargs,
+            target_at=selected_at,
+            primary_chain_id=primary_chain_id,
+        )
+        fork_block_source = "automatic_midnight"
     simulated_runtime_kwargs = {
         "executor_id": executor_id,
         "rpc_kwargs": filtered_rpc_kwargs,
         "unit_testing": unit_testing,
         "vault_specs": vault_specs,
+        "primary_chain_id": primary_chain_id,
         "vault_universe": data.vault_universe,
         "private_key": private_key or SIMULATED_LAGOON_PRIVATE_KEY,
         "amount": amount,
@@ -335,6 +406,7 @@ def _create_simulated_vault_test_runtime(
         "min_gas_balance": min_gas_balance,
         "max_slippage": max_slippage,
         "token_cache": data.token_cache,
+        "pinned_fork_blocks": pinned_fork_blocks,
     }
     simulated_runtime = start_simulated_vault_runtime_with_replacement(
         generation=1,
@@ -353,6 +425,10 @@ def _create_simulated_vault_test_runtime(
             web3config=simulated_runtime.web3config,
             amount=amount,
             max_slippage=max_slippage,
+            fork_block_source=fork_block_source,
+            pinned_fork_blocks=pinned_fork_blocks,
+            fork_block_target_at=selected_at,
+            fork_block_reference=simulation_fork_block_reference,
         ),
     )
 

--- a/tradeexecutor/cli/vault_trade/simulation.py
+++ b/tradeexecutor/cli/vault_trade/simulation.py
@@ -1,5 +1,6 @@
 """Disposable Anvil infrastructure for ``vault-test-trade --auto-simulated``."""
 
+import calendar
 import datetime
 import json
 import logging
@@ -10,7 +11,9 @@ from decimal import Decimal
 from pathlib import Path
 from typing import Any
 
+from eth_defi.compat import native_datetime_utc_now
 from eth_defi.middleware import ProbablyNodeHasNoBlock
+from eth_defi.provider.multi_provider import create_multi_provider_web3
 from eth_defi.provider.anvil import (
     ArchiveNodeRequired,
     RPCRequestError,
@@ -37,6 +40,7 @@ from tradeexecutor.cli.bootstrap import (
     create_web3_config,
 )
 from tradeexecutor.cli.vault_trade.core import deploy_simulated_lagoon_multichain
+from tradeexecutor.ethereum.web3config import get_chain_slug
 from tradeexecutor.ethereum.token import translate_token_details
 from tradeexecutor.strategy.execution_model import AssetManagementMode
 
@@ -49,6 +53,14 @@ SIMULATED_VAULT_INFRASTRUCTURE_RESTARTS = 1
 
 #: Project cache seeds supplement eth-defi's generic test seeds.
 PROJECT_RPC_CACHE_SEED_DIR = Path(__file__).parents[3] / "tests" / "rpc_cache_seed"
+
+#: Persistent Foundry fork cache for production vault-test-trade experiments.
+VAULT_TEST_RPC_CACHE_DIR = Path("~/.tradingstrategy/vaults/rpc-cache").expanduser()
+
+#: Anvil 1.7.x stores fork ``storage.json`` here regardless of
+#: ``FOUNDRY_RPC_CACHE_DIR``. Keep this explicit until Foundry exposes a
+#: working fork-RPC-cache override.
+DEFAULT_FOUNDRY_RPC_CACHE_DIR = Path.home() / ".foundry" / "cache" / "rpc"
 
 #: These providers cannot supply the historic state required by the simulated
 #: Lagoon balance path. Capture their live tip once per command and retain that
@@ -118,7 +130,15 @@ class SimulatedVaultRuntime:
                     self.generation,
                 )
         finally:
-            self.temporary_deployment_dir.cleanup()
+            try:
+                sync_foundry_rpc_cache_to_vault_cache()
+            except Exception:
+                logger.exception(
+                    "Could not copy Foundry RPC cache after simulation generation %d",
+                    self.generation,
+                )
+            finally:
+                self.temporary_deployment_dir.cleanup()
 
 
 def is_simulated_infrastructure_failure(error: BaseException) -> bool:
@@ -197,26 +217,183 @@ def raise_simulated_vault_attempt_timeout(signum, frame) -> None:
     )
 
 
+def get_simulation_chain_ids(
+    vault_specs: list[VaultSpec],
+    *,
+    primary_chain_id: ChainId,
+) -> set[ChainId]:
+    """Return every chain a simulated batch needs to fork."""
+
+    assert vault_specs, "A simulated vault test needs at least one vault"
+    return {primary_chain_id, *(ChainId(spec.chain_id) for spec in vault_specs)}
+
+
+def parse_simulation_fork_blocks(
+    values: list[str] | None,
+) -> dict[ChainId, int]:
+    """Parse repeatable ``CHAIN_ID:BLOCK_NUMBER`` command-line values."""
+
+    blocks: dict[ChainId, int] = {}
+    for value in values or []:
+        chain_id_text, separator, block_number_text = value.partition(":")
+        if not separator or not chain_id_text or not block_number_text:
+            raise ValueError(
+                "--simulation-fork-block must use CHAIN_ID:BLOCK_NUMBER, "
+                f"got {value!r}"
+            )
+        try:
+            chain_id = ChainId(int(chain_id_text))
+        except ValueError as error:
+            raise ValueError(
+                f"Unknown chain id in --simulation-fork-block: {chain_id_text!r}"
+            ) from error
+        try:
+            block_number = int(block_number_text)
+        except ValueError as error:
+            raise ValueError(
+                f"Invalid block number in --simulation-fork-block: {block_number_text!r}"
+            ) from error
+        if block_number <= 0:
+            raise ValueError(
+                f"--simulation-fork-block must be positive, got {value!r}"
+            )
+        if chain_id in blocks:
+            raise ValueError(
+                f"Duplicate --simulation-fork-block for chain id {chain_id.value}"
+            )
+        blocks[chain_id] = block_number
+    return blocks
+
+
+def validate_simulation_fork_blocks(
+    blocks: dict[ChainId, int],
+    vault_specs: list[VaultSpec],
+    *,
+    primary_chain_id: ChainId,
+) -> None:
+    """Ensure fixed mode defines exactly every chain needed by the batch."""
+
+    selected_chain_ids = get_simulation_chain_ids(
+        vault_specs,
+        primary_chain_id=primary_chain_id,
+    )
+    missing = sorted(selected_chain_ids - blocks.keys(), key=lambda chain_id: chain_id.value)
+    unrelated = sorted(blocks.keys() - selected_chain_ids, key=lambda chain_id: chain_id.value)
+    if missing or unrelated:
+        details = []
+        if missing:
+            details.append(
+                "missing " + ", ".join(str(chain_id.value) for chain_id in missing)
+            )
+        if unrelated:
+            details.append(
+                "unrelated " + ", ".join(str(chain_id.value) for chain_id in unrelated)
+            )
+        raise ValueError(
+            "--simulation-fork-block values must cover exactly the simulated chains: "
+            + "; ".join(details)
+        )
+
+
+def seed_vault_foundry_rpc_cache(cache_dir: Path = VAULT_TEST_RPC_CACHE_DIR) -> None:
+    """Seed both the requested vault cache and Anvil's actual fork cache."""
+
+    seed_default_foundry_rpc_cache(cache_dir)
+    seed_foundry_rpc_cache(PROJECT_RPC_CACHE_SEED_DIR, cache_dir)
+    seed_foundry_rpc_cache(cache_dir, DEFAULT_FOUNDRY_RPC_CACHE_DIR)
+    seed_default_foundry_rpc_cache(DEFAULT_FOUNDRY_RPC_CACHE_DIR)
+    seed_foundry_rpc_cache(PROJECT_RPC_CACHE_SEED_DIR, DEFAULT_FOUNDRY_RPC_CACHE_DIR)
+
+
+def sync_foundry_rpc_cache_to_vault_cache(
+    cache_dir: Path = VAULT_TEST_RPC_CACHE_DIR,
+) -> int:
+    """Persist Anvil's actual fork RPC cache into the vault cache directory."""
+
+    if not DEFAULT_FOUNDRY_RPC_CACHE_DIR.exists():
+        return 0
+    return seed_foundry_rpc_cache(
+        DEFAULT_FOUNDRY_RPC_CACHE_DIR,
+        cache_dir,
+        overwrite=True,
+    )
+
+
+def get_last_midnight_utc(now: datetime.datetime | None = None) -> datetime.datetime:
+    """Return the most recent midnight as a naive UTC datetime."""
+
+    now = now or native_datetime_utc_now()
+    return datetime.datetime.combine(now.date(), datetime.time())
+
+
+def resolve_block_number_at_or_before_timestamp(web3, target_at: datetime.datetime) -> int:
+    """Resolve the latest block whose timestamp is not after ``target_at``."""
+
+    target_timestamp = calendar.timegm(target_at.timetuple())
+    latest = int(web3.eth.block_number)
+    latest_timestamp = int(web3.eth.get_block(latest)["timestamp"])
+    if latest_timestamp <= target_timestamp:
+        return latest
+
+    low = 0
+    high = latest
+    while low < high:
+        middle = (low + high + 1) // 2
+        block_timestamp = int(web3.eth.get_block(middle)["timestamp"])
+        if block_timestamp <= target_timestamp:
+            low = middle
+        else:
+            high = middle - 1
+    return low
+
+
 def get_shared_simulation_fork_blocks(
     vault_specs: list[VaultSpec],
+    rpc_kwargs: dict | None = None,
+    target_at: datetime.datetime | None = None,
+    primary_chain_id: ChainId | None = None,
 ) -> dict[ChainId, int]:
-    """Choose eth-defi's canonical cached fork block where archive history permits.
+    """Choose one fork block per vault chain at the last UTC midnight.
 
-    Monad intentionally has no fixed historical block because its archive state
-    is incomplete. Such chains are captured from the first live generation and
-    still remain pinned for any replacement within that command invocation.
+    Unit tests may omit RPC configuration and use eth-defi's static cached
+    blocks. Command execution always resolves every selected chain dynamically.
     """
 
-    selected_chain_ids = {
-        ChainId(spec.chain_id)
-        for spec in vault_specs
-        if ChainId(spec.chain_id) not in LIVE_TIP_VAULT_TEST_CHAINS
-    }
-    return {
-        chain_id: MIDNIGHT_BLOCKS[chain_id.value]
-        for chain_id in selected_chain_ids
-        if chain_id.value in MIDNIGHT_BLOCKS
-    }
+    fallback_primary_chain_id = primary_chain_id or ChainId(vault_specs[0].chain_id)
+    selected_chain_ids = get_simulation_chain_ids(
+        vault_specs,
+        primary_chain_id=fallback_primary_chain_id,
+    )
+    if rpc_kwargs is None:
+        return {
+            chain_id: MIDNIGHT_BLOCKS[chain_id.value]
+            for chain_id in selected_chain_ids
+            if (
+                chain_id not in LIVE_TIP_VAULT_TEST_CHAINS
+                and chain_id.value in MIDNIGHT_BLOCKS
+            )
+        }
+
+    target_at = target_at or get_last_midnight_utc()
+    selected_fork_blocks: dict[ChainId, int] = {}
+    for chain_id in sorted(selected_chain_ids, key=lambda candidate: candidate.value):
+        rpc_key = f"json_rpc_{get_chain_slug(chain_id)}"
+        configuration_line = rpc_kwargs.get(rpc_key)
+        if not configuration_line:
+            raise RuntimeError(
+                f"Cannot resolve simulated {chain_id.name} fork block for "
+                f"{target_at.isoformat()}: {rpc_key} is not configured"
+            )
+        web3 = create_multi_provider_web3(
+            configuration_line,
+            default_http_timeout=(3.0, 30.0),
+            retries=2,
+        )
+        selected_fork_blocks[chain_id] = resolve_block_number_at_or_before_timestamp(
+            web3,
+            target_at,
+        )
+    return selected_fork_blocks
 
 
 def rotate_simulated_rpc_upstreams(rpc_kwargs: dict) -> None:
@@ -244,6 +421,7 @@ def start_simulated_vault_runtime(  # noqa: PLR0917
     rpc_kwargs: dict,
     unit_testing: bool,
     vault_specs: list[VaultSpec],
+    primary_chain_id: ChainId,
     vault_universe,
     private_key: str,
     amount: Decimal,
@@ -265,20 +443,21 @@ def start_simulated_vault_runtime(  # noqa: PLR0917
     web3config = None
     temporary_deployment_dir = None
     try:
-        # Seed eth-defi's non-destructive Foundry cache before starting the
-        # forks. Replacements share this on-disk cache because they use the
-        # same fixed blocks captured by the first generation.
-        seed_default_foundry_rpc_cache()
-        seed_foundry_rpc_cache(PROJECT_RPC_CACHE_SEED_DIR)
+        # Replacements use the same fixed blocks and share this persistent cache.
+        seed_vault_foundry_rpc_cache()
 
         initial_pinned_fork_blocks = (
-            pinned_fork_blocks or get_shared_simulation_fork_blocks(vault_specs)
+            pinned_fork_blocks
+            or get_shared_simulation_fork_blocks(
+                vault_specs,
+                rpc_kwargs=rpc_kwargs,
+                primary_chain_id=primary_chain_id,
+            )
         )
 
         # Web3Config launches one local Anvil proxy for every selected upstream
         # RPC.  Local RPC retries are disabled; a dead process is replaced by the
         # generation-level retry outside this function.
-        primary_chain_id = ChainId(vault_specs[0].chain_id)
         web3config = create_web3_config(
             **rpc_kwargs,
             unit_testing=unit_testing,
@@ -309,6 +488,7 @@ def start_simulated_vault_runtime(  # noqa: PLR0917
             vault_universe=vault_universe,
             private_key=private_key,
             amount=amount,
+            primary_chain_id=primary_chain_id,
         )
         # Normal bootstrap consumes a deployment file, so write the ephemeral
         # topology in its standard JSON shape rather than adding a special path.
@@ -368,6 +548,10 @@ def start_simulated_vault_runtime(  # noqa: PLR0917
                 logger.exception(
                     "Could not fully clean up a failed simulated vault runtime"
                 )
+        try:
+            sync_foundry_rpc_cache_to_vault_cache()
+        except Exception:
+            logger.exception("Could not copy Foundry RPC cache after setup failure")
         if temporary_deployment_dir is not None:
             temporary_deployment_dir.cleanup()
         raise

--- a/tradeexecutor/cli/vault_trade/state.py
+++ b/tradeexecutor/cli/vault_trade/state.py
@@ -16,6 +16,7 @@ from typing import Any
 
 from eth_defi.abi import ZERO_ADDRESS_STR
 from eth_defi.compat import native_datetime_utc_now
+from eth_defi.utils import get_url_domain
 from eth_defi.vault.base import VaultSpec
 
 from tradeexecutor.state.identifier import (
@@ -90,6 +91,25 @@ def redact_vault_test_error_text(value: object) -> str:
     return _URL_PATTERN.sub("<redacted-url>", str(value))
 
 
+def _redact_vault_test_value(value: Any) -> Any:
+    """Recursively redact text embedded in structured call diagnostics."""
+
+    if isinstance(value, str):
+        return redact_vault_test_error_text(value)
+    if isinstance(value, list):
+        return [_redact_vault_test_value(item) for item in value]
+    if isinstance(value, dict):
+        return {key: _redact_vault_test_value(item) for key, item in value.items()}
+    return value
+
+
+def _get_vault_redemption_preflight(trade) -> dict | None:
+    """Read optional routing diagnostics without serialising mock attributes."""
+
+    value = trade.other_data.get("vault_redemption_preflight")
+    return _redact_vault_test_value(value) if isinstance(value, dict) else None
+
+
 def _serialise_exception_chain(error: BaseException) -> list[dict]:
     """Return the causal exception chain without retaining exception objects."""
 
@@ -124,8 +144,7 @@ def _serialise_vault_test_transactions(
             if trade.trade_id in original_trade_ids:
                 continue
             for transaction in trade.blockchain_transactions:
-                transactions.append(
-                    {
+                transaction_data = {
                         "position_id": position.position_id,
                         "trade_id": trade.trade_id,
                         "chain_id": transaction.chain_id,
@@ -153,7 +172,10 @@ def _serialise_vault_test_transactions(
                         if transaction.stack_trace
                         else None,
                     }
-                )
+                redemption_preflight = _get_vault_redemption_preflight(trade)
+                if redemption_preflight is not None:
+                    transaction_data["vault_redemption_preflight"] = redemption_preflight
+                transactions.append(transaction_data)
     return transactions
 
 
@@ -179,8 +201,7 @@ def _serialise_vault_test_call_context(
                     continue
                 details = transaction.details or {}
                 calldata = details.get("data")
-                calls.append(
-                    {
+                call_data = {
                         "position_id": position.position_id,
                         "trade_id": trade.trade_id,
                         "chain_id": transaction.chain_id,
@@ -205,7 +226,10 @@ def _serialise_vault_test_call_context(
                         if calldata
                         else None,
                     }
-                )
+                redemption_preflight = _get_vault_redemption_preflight(trade)
+                if redemption_preflight is not None:
+                    call_data["vault_redemption_preflight"] = redemption_preflight
+                calls.append(call_data)
     return calls
 
 
@@ -225,6 +249,104 @@ def _capture_chain_blocks(web3config: Any | None) -> dict[str, dict]:
     return blocks
 
 
+def capture_rpc_proxy_failures(
+    web3config: Any | None,
+    *,
+    failed_chain_ids: set[str] | None = None,
+) -> tuple[dict[str, list[str]], list[dict]]:
+    """Capture failed and configured upstream domains from Anvil proxy state."""
+
+    if web3config is None:
+        return {}, []
+
+    failing_domains: dict[str, list[str]] = {}
+    proxy_failures: list[dict] = []
+    failed_chain_ids = failed_chain_ids or set()
+    for chain_id, anvil in getattr(web3config, "anvils", {}).items():
+        chain_key = str(getattr(chain_id, "value", chain_id))
+        provider_failures: list[dict] = []
+        proxy = getattr(anvil, "proxy", None)
+        if proxy is not None:
+            for provider_url, stats in sorted(proxy.get_stats().items()):
+                failure_count = int(getattr(stats, "failure_count", 0) or 0)
+                if failure_count <= 0:
+                    continue
+                provider_domain = get_url_domain(provider_url)
+                recent_errors = []
+                for reply in getattr(stats, "error_replies", [])[-10:]:
+                    timestamp = reply.get("timestamp")
+                    recent_errors.append(
+                        {
+                            "timestamp": timestamp.isoformat()
+                            if hasattr(timestamp, "isoformat")
+                            else redact_vault_test_error_text(timestamp),
+                            "method": reply.get("method"),
+                            "http_status": reply.get("http_status"),
+                            "error": redact_vault_test_error_text(reply.get("error")),
+                        }
+                    )
+                provider_failures.append(
+                    {
+                        "domain": provider_domain,
+                        "request_count": int(getattr(stats, "request_count", 0) or 0),
+                        "observed_failure_count": failure_count,
+                        "method_failure_counts": dict(
+                            getattr(stats, "method_failure_counts", {}) or {}
+                        ),
+                        "recent_errors": recent_errors,
+                    }
+                )
+
+        if not provider_failures and chain_key in failed_chain_ids:
+            seen_domains = set()
+            for upstream_url in getattr(anvil, "upstream_rpc_urls", ()) or ():
+                provider_domain = get_url_domain(upstream_url)
+                if provider_domain in seen_domains:
+                    continue
+                seen_domains.add(provider_domain)
+                provider_failures.append(
+                    {
+                        "domain": provider_domain,
+                        "request_count": 0,
+                        "observed_failure_count": 0,
+                        "method_failure_counts": {},
+                        "recent_errors": [],
+                        "diagnostic": (
+                            "Configured upstream for failed Anvil generation; "
+                            "the RPC proxy recorded no retryable upstream error"
+                        ),
+                    }
+                )
+
+        if provider_failures:
+            failing_domains[chain_key] = [
+                provider["domain"] for provider in provider_failures
+            ]
+            proxy_failures.append(
+                {
+                    "chain_id": chain_key,
+                    "fork_block_number": getattr(anvil, "fork_block_number", None),
+                    "providers": provider_failures,
+                }
+            )
+    return failing_domains, proxy_failures
+
+
+def _merge_failing_upstream_rpc_providers(
+    base: dict[str, list[str]],
+    extra: dict[str, list[str]] | None,
+) -> dict[str, list[str]]:
+    """Merge per-chain provider domains without duplicating entries."""
+
+    merged = {chain_id: list(domains) for chain_id, domains in base.items()}
+    for chain_id, domains in (extra or {}).items():
+        chain_domains = merged.setdefault(chain_id, [])
+        for domain in domains:
+            if domain not in chain_domains:
+                chain_domains.append(domain)
+    return merged
+
+
 def capture_vault_test_error(
     error: BaseException,
     *,
@@ -233,6 +355,8 @@ def capture_vault_test_error(
     web3config: Any | None,
     phase: str,
     capture_chain_blocks: bool = True,
+    extra_failing_upstream_rpc_providers: dict[str, list[str]] | None = None,
+    extra_rpc_proxy_failures: list[dict] | None = None,
 ) -> dict:
     """Create complete, JSON-safe diagnostics for a failed vault-test attempt.
 
@@ -251,7 +375,16 @@ def capture_vault_test_error(
         state,
         original_trade_ids=original_trade_ids,
     )
-    return {
+    failing_upstream_rpc_providers, rpc_proxy_failures = capture_rpc_proxy_failures(
+        web3config
+    )
+    failing_upstream_rpc_providers = _merge_failing_upstream_rpc_providers(
+        failing_upstream_rpc_providers,
+        extra_failing_upstream_rpc_providers,
+    )
+    if extra_rpc_proxy_failures:
+        rpc_proxy_failures = list(extra_rpc_proxy_failures) + rpc_proxy_failures
+    diagnostics = {
         "captured_at": native_datetime_utc_now().isoformat(),
         "phase": phase,
         "exception": exception_chain[0],
@@ -265,6 +398,10 @@ def capture_vault_test_error(
         "transactions": transactions,
         "call_context": call_context,
     }
+    if failing_upstream_rpc_providers:
+        diagnostics["failing_upstream_rpc_providers"] = failing_upstream_rpc_providers
+        diagnostics["rpc_proxy_failures"] = rpc_proxy_failures
+    return diagnostics
 
 
 def classify_vault_test_failure(
@@ -601,30 +738,61 @@ def export_vault_test_report(
 ) -> dict:
     """Build a compact external report without copying unrelated state history."""
 
+    run = _get_latest_vault_test_run(state)
+    run_id = run.get("run_id")
     results = []
     for row in rows:
         vault_id = row["vault id"]
+        row_attempt_id = row.get("attempt")
         matches = [
             candidate
             for candidate in state.portfolio.get_all_positions()
             if candidate.other_data.get("vault_test_attempt", {}).get("vault_id")
             == vault_id
         ]
+        if row_attempt_id:
+            matches = [
+                candidate
+                for candidate in matches
+                if candidate.other_data.get("vault_test_attempt", {}).get("attempt_id")
+                == row_attempt_id
+            ]
+        if run_id:
+            matches = [
+                candidate
+                for candidate in matches
+                if candidate.other_data.get("vault_test_attempt", {})
+                .get("provenance", {})
+                .get("run_id")
+                == run_id
+            ]
         position = max(
             matches, key=lambda candidate: candidate.position_id, default=None
         )
         attempt = position.other_data.get("vault_test_attempt", {}) if position else {}
+        raw_result = attempt.get("result")
+        if raw_result is None and row.get("result") is not None:
+            presentation_result = row["result"]
+        elif raw_result is None:
+            presentation_result = (
+                "success_simulated"
+                if attempt.get("simulated", row.get("mode") == "simulated")
+                else "success_real"
+            )
+        else:
+            presentation_result = raw_result
         results.append(
             {
                 "vault_id": vault_id,
                 "position_id": position.position_id if position else None,
                 "row": row,
                 "attempt": attempt,
+                "result": presentation_result,
             }
         )
     return {
         "schema_version": VAULT_TEST_ATTEMPT_SCHEMA_VERSION,
-        "run": _get_latest_vault_test_run(state),
+        "run": run,
         "results": results,
     }
 

--- a/tradeexecutor/ethereum/vault/vault_routing.py
+++ b/tradeexecutor/ethereum/vault/vault_routing.py
@@ -170,6 +170,47 @@ def reconcile_vault_redemption_amount(
     return onchain_balance
 
 
+def _capture_wrapped_redemption_preflight(
+    transaction: BlockchainTransaction,
+    web3: Web3,
+) -> dict:
+    """Execute the signed Lagoon wrapper as an ``eth_call`` for diagnostics.
+
+    The normal execution path remains authoritative. This call records whether
+    the exact wrapper was already rejected at the pre-broadcast block, without
+    deciding whether the prepared transaction may be broadcast.
+    """
+
+    details = transaction.details or {}
+    call = {
+        "from": transaction.from_address,
+        "to": transaction.contract_address,
+        "data": details.get("data"),
+        "value": details.get("value", 0),
+        "gas": details.get("gas"),
+    }
+    call = {key: value for key, value in call.items() if value is not None}
+    result = {
+        "sender": transaction.from_address,
+        "target": transaction.contract_address,
+        "function_selector": transaction.function_selector,
+        "wrapped_target": transaction.wrapped_target,
+        "wrapped_function_selector": transaction.wrapped_function_selector,
+        "calldata": str(details.get("data")) if details.get("data") else None,
+    }
+    try:
+        pre_broadcast_block_number = int(web3.eth.block_number)
+        result["pre_broadcast_block_number"] = pre_broadcast_block_number
+        output = web3.eth.call(call, block_identifier=pre_broadcast_block_number)
+        result["eth_call_result"] = HexBytes(output).hex()
+    except Exception as error:
+        result["eth_call_error_type"] = (
+            f"{error.__class__.__module__}.{error.__class__.__qualname__}"
+        )
+        result["eth_call_error"] = str(error)
+    return result
+
+
 def convert_vault_flow_analysis(
     analysis: DepositRedeemEventAnalysis,
     *,
@@ -407,8 +448,8 @@ class VaultRouting(RoutingModel):
             # take a positive share amount.
             swap_amount = -trade.planned_quantity
 
-            share_token = target_vault.share_token
-            onchain_balance = share_token.fetch_balance_of(address)
+            onchain_share_token = target_vault.share_token
+            onchain_balance = onchain_share_token.fetch_balance_of(address)
 
             portfolio: Portfolio = state.portfolio
             position = portfolio.get_position_by_id(trade.position_id)
@@ -421,11 +462,39 @@ class VaultRouting(RoutingModel):
                 onchain_balance,
                 position.get_quantity(planned=True),
             )
-            reconciled_amount = reconcile_vault_redemption_amount(
-                swap_amount,
-                onchain_balance,
-                epsilon=self.redeem_epsilon,
+            redemption_preflight = {
+                "position_quantity": str(position.get_quantity()),
+                "position_planned_quantity": str(position.get_quantity(planned=True)),
+                "planned_share_amount": str(swap_amount),
+                "planned_raw_shares": str(
+                    onchain_share_token.convert_to_raw(swap_amount)
+                ),
+                "custody_address": address,
+                "share_token_address": target_vault.share_token.address,
+                "custody_share_balance": str(onchain_balance),
+                "custody_raw_share_balance": str(
+                    onchain_share_token.convert_to_raw(onchain_balance)
+                ),
+                "reconciliation_epsilon": self.redeem_epsilon,
+            }
+            try:
+                reconciled_amount = reconcile_vault_redemption_amount(
+                    swap_amount,
+                    onchain_balance,
+                    epsilon=self.redeem_epsilon,
+                )
+            except Exception as error:
+                redemption_preflight["reconciliation_error_type"] = (
+                    f"{error.__class__.__module__}.{error.__class__.__qualname__}"
+                )
+                redemption_preflight["reconciliation_error"] = str(error)
+                trade.other_data["vault_redemption_preflight"] = redemption_preflight
+                raise
+            redemption_preflight["reconciled_share_amount"] = str(reconciled_amount)
+            redemption_preflight["reconciled_raw_shares"] = str(
+                onchain_share_token.convert_to_raw(reconciled_amount)
             )
+            trade.other_data["vault_redemption_preflight"] = redemption_preflight
             if reconciled_amount < swap_amount:
                 relative_shortfall = (swap_amount - onchain_balance) / swap_amount
                 logger.warning(
@@ -515,6 +584,11 @@ class VaultRouting(RoutingModel):
                 trade.other_data.setdefault("vault_interventions", []).append(
                     intervention.as_dict()
                 )
+            redemption_preflight = trade.other_data.get("vault_redemption_preflight")
+            if redemption_preflight is not None:
+                redemption_preflight["manager_request_raw_shares"] = str(
+                    request.raw_shares
+                )
             is_async = not deposit_manager.has_synchronous_redemption()
             direction = "redeem"
 
@@ -562,6 +636,12 @@ class VaultRouting(RoutingModel):
                 role="vault_request",
                 request_ordinal=ordinal,
             )
+            if direction == "redeem":
+                redemption_preflight = trade.other_data["vault_redemption_preflight"]
+                manager_calls = redemption_preflight.setdefault("manager_calls", [])
+                manager_calls.append(
+                    _capture_wrapped_redemption_preflight(request_tx, tx_builder.web3)
+                )
             txs.append(request_tx)
 
         if not is_async:


### PR DESCRIPTION
## Why

Large simulated vault batches were sensitive to vault ordering, live fork heights and cold archive RPC reads. Failures also lost upstream-provider evidence when Anvil was replaced.

## Lessons learnt

A fixed experiment must include every simulated chain, including Ethereum when it is the Lagoon primary for a Base-only batch. The 2026-08-04 warm-cache run covered 129 unique production vaults with zero `infrastructure_failed` results; it still had two protocol transaction reverts: TAU InfiniFi Pointsmax and Aerodrome USDC.

## Summary

- Make the simulated Lagoon primary explicit and stable.
- Add documented fixed fork blocks, automatic UTC-midnight selection and durable RPC cache synchronisation.
- Persist redacted upstream RPC proxy diagnostics and current-run report provenance.
- Capture wrapped redemption preflight evidence and document the remaining follow-up work.