### PR TITLE
fix: refresh Lagoon guard migration state

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,3 +1,6 @@
 Here are some internal development guides for trade-executor package.
 
 [See the full documentation on the website](https://tradingstrategy.ai/docs/index.html).
+
+For a manual Lagoon `TradingStrategyModuleV0` replacement, see
+[Lagoon guard migration](./lagoon-guard-migration.md).

--- a/docs/lagoon-guard-migration.md
+++ b/docs/lagoon-guard-migration.md
@@ -1,0 +1,55 @@
+# Lagoon guard migration
+
+`lagoon-deploy-vault --guard-only` deploys a replacement
+`TradingStrategyModuleV0` but does not alter the Safe itself. The Safe owners
+must execute the proposed Safe transactions in the deployment artefact before
+the executor can use the replacement module.
+
+## Complete a migration
+
+1. Keep the generated deployment artefact. Its `guard_migration` section
+   contains the old and new guard addresses, the Safe address, and the
+   proposed Safe transactions.
+2. Have the Safe owners execute the proposed transactions.
+3. Set `VAULT_ADAPTER_ADDRESS` to the new guard address in the executor
+   configuration.
+4. Start the executor. It reads the Safe's enabled modules, saves the observed
+   migration status in the strategy state, and then checks that every
+   configured primary and satellite Safe has its configured module enabled.
+
+Do not treat the deployment artefact's
+`enabled_modules_at_deployment` value as confirmation that the migration has
+finished: it is a snapshot taken before the Safe owners execute the upgrade.
+
+## Read the saved state
+
+The primary deployment's `guard_migration` entry stores the live Safe
+observation separately from the deployment instructions:
+
+| Field | Meaning |
+| --- | --- |
+| `enabled_modules_at_deployment` | Historical Safe module snapshot created while deploying the replacement guard. |
+| `proposed_safe_transactions` | Historical transaction plan for Safe owners. |
+| `currently_enabled_modules` | Modules read from the primary Safe at `observed_at`. |
+| `status` | `completed`, `pending`, `both_enabled`, or `no_expected_guard_enabled`. |
+| `manual_intervention_required` | `false` only when the new guard is enabled and the old guard is no longer enabled. |
+| `observed_at` | UTC time of the successful Safe module read. |
+
+`pending` means only the old guard is enabled. `both_enabled` and
+`no_expected_guard_enabled` also need owner intervention. In all three cases,
+use the addresses and transaction plan in the deployment artefact to inspect
+and correct the Safe; do not edit the observed state manually.
+
+If the Safe cannot be read during start-up, the executor logs that the
+migration status could not be refreshed. Resolve the RPC issue before relying
+on the saved observation.
+
+## Start-up safety check
+
+The executor checks `isModuleEnabled(VAULT_ADAPTER_ADDRESS)` on the primary
+Lagoon Safe before it starts execution. It performs the same check for every
+configured satellite Safe. A mismatch stops start-up before trades are sent.
+
+This check is intentionally independent of the migration status: the state is
+an operational record, while module enablement is the live on-chain safety
+condition.

--- a/tests/lagoon/test_lagoon_guard_migration_artifact.py
+++ b/tests/lagoon/test_lagoon_guard_migration_artifact.py
@@ -25,7 +25,6 @@ def test_guard_only_artifacts_include_safe_migration_instructions():
 
     text_payload, json_payload = _augment_guard_only_artifacts(
         deploy_info,
-        vault_adapter_address=old_guard_address,
         text_payload="Deployment summary",
         json_payload={"Trading strategy module": new_guard_address},
     )
@@ -39,5 +38,6 @@ def test_guard_only_artifacts_include_safe_migration_instructions():
     assert instructions["new_guard_address"] == new_guard_address
     assert instructions["safe_address"] == safe_address
     assert instructions["vault_address"] == vault_address
-    assert instructions["safe_transactions"][0]["function"] == "disableModule"
-    assert instructions["safe_transactions"][1]["function"] == "enableModule"
+    assert instructions["enabled_modules_at_deployment"] == [old_guard_address]
+    assert instructions["proposed_safe_transactions"][0]["function"] == "disableModule"
+    assert instructions["proposed_safe_transactions"][1]["function"] == "enableModule"

--- a/tests/test_satellite_preflight.py
+++ b/tests/test_satellite_preflight.py
@@ -12,7 +12,9 @@ production, without needing forks or RPC:
 
 import datetime
 import json
+from decimal import Decimal
 from pathlib import Path
+from unittest.mock import MagicMock
 
 import pytest
 from tradingstrategy.chain import ChainId
@@ -20,9 +22,11 @@ from tradingstrategy.chain import ChainId
 from tradeexecutor.cli.bootstrap import (
     resolve_satellite_modules,
     resolve_deployment_file,
+    refresh_lagoon_guard_migration_state,
     update_strategy_file_deployment_info,
     check_universe_contracts_resolve,
 )
+from tradeexecutor.ethereum.lagoon.execution import LagoonExecution
 from tradeexecutor.state.state import State
 
 
@@ -227,6 +231,145 @@ def test_update_strategy_file_deployment_info_detects_changes(tmp_path: Path):
     assert restored_state.deployment_info.source == "strategy_file"
     assert restored_state.deployment_info.data["deployments"]["base"]["module_address"] == "0xBaseModule"
     assert len(restored_state.deployment_info.modified) == 2
+
+
+def test_refresh_lagoon_guard_migration_state_preserves_live_safe_status(tmp_path: Path):
+    """Lagoon guard migration state tracks an independently executed Safe upgrade.
+
+    1. Load a deployment artefact whose guard migration still shows the old module.
+    2. Read the old module from a mocked live Safe and persist pending status.
+    3. Read the replacement module and persist completed status.
+    4. Reload the unchanged static artefact without reverting the live observation.
+    5. Repeat the refresh without creating a redundant audit entry.
+    """
+    old_module = "0x0000000000000000000000000000000000000001"
+    new_module = "0x0000000000000000000000000000000000000002"
+    safe_address = "0x0000000000000000000000000000000000000003"
+    artifact = tmp_path / "strategy.deployment.json"
+    artifact.write_text(json.dumps({
+        "multichain": True,
+        "deployments": {
+            "hyperliquid": {
+                "safe_address": safe_address,
+                "is_satellite": False,
+                "guard_migration": {
+                    "old_guard_address": old_module,
+                    "new_guard_address": new_module,
+                    "safe_address": safe_address,
+                    "currently_enabled_modules": [old_module],
+                },
+            },
+        },
+    }))
+    state = State()
+
+    # 1. Load the old artefact naming and normalise its historical snapshot.
+    assert update_strategy_file_deployment_info(state, artifact) is True
+    migration = state.deployment_info.data["deployments"]["hyperliquid"]["guard_migration"]
+    assert migration["enabled_modules_at_deployment"] == [old_module]
+
+    # Mock the live Safe because this fast test must not require an RPC connection.
+    vault = MagicMock()
+    vault.safe_address = safe_address
+    vault.safe.retrieve_modules.return_value = [old_module]
+
+    # 2. Persist the pending Safe migration.
+    assert refresh_lagoon_guard_migration_state(state, vault) is True
+    migration = state.deployment_info.data["deployments"]["hyperliquid"]["guard_migration"]
+    assert migration["status"] == "pending"
+    assert migration["manual_intervention_required"] is True
+
+    # 3. Persist the completed Safe migration.
+    vault.safe.retrieve_modules.return_value = [new_module]
+    assert refresh_lagoon_guard_migration_state(state, vault) is True
+    migration = state.deployment_info.data["deployments"]["hyperliquid"]["guard_migration"]
+    assert migration["currently_enabled_modules"] == [new_module]
+    assert migration["status"] == "completed"
+    assert migration["manual_intervention_required"] is False
+    assert len(state.deployment_info.modified) == 3
+
+    # 4. Static instructions must not overwrite the live Safe state.
+    assert update_strategy_file_deployment_info(state, artifact) is False
+    migration = state.deployment_info.data["deployments"]["hyperliquid"]["guard_migration"]
+    assert migration["currently_enabled_modules"] == [new_module]
+
+    # 5. Unchanged on-chain state does not produce duplicate audit entries.
+    assert refresh_lagoon_guard_migration_state(state, vault) is False
+    assert len(state.deployment_info.modified) == 3
+
+
+class _ModuleEnabledCall:
+    """Minimal contract call stub returning the configured Safe module status."""
+
+    def __init__(self, enabled: bool):
+        self.enabled = enabled
+
+    def call(self) -> bool:
+        return self.enabled
+
+
+class _SafeFunctions:
+    """Minimal Safe contract-functions stub."""
+
+    def __init__(self, enabled: bool):
+        self.enabled = enabled
+
+    def isModuleEnabled(self, module_address: str) -> _ModuleEnabledCall:
+        return _ModuleEnabledCall(self.enabled)
+
+
+class _SafeContract:
+    """Minimal Safe contract stub."""
+
+    def __init__(self, enabled: bool):
+        self.functions = _SafeFunctions(enabled)
+
+
+class _Safe:
+    """Minimal Safe API stub."""
+
+    def __init__(self, enabled: bool):
+        self.contract = _SafeContract(enabled)
+
+
+class _ConfiguredSafe:
+    """Safe-only vault stub with the attributes read by Lagoon preflight."""
+
+    def __init__(self, module_address: str, enabled: bool):
+        self.trading_strategy_module_address = module_address
+        self.safe = _Safe(enabled)
+
+
+def test_lagoon_execution_preflight_checks_configured_safe_module():
+    """Lagoon start-up refuses to proceed with disabled primary or satellite modules.
+
+    1. Create a minimal Lagoon execution model with a reachable RPC and no gas threshold.
+    2. Verify start-up preflight accepts enabled configured modules on both Safes.
+    3. Verify it fails clearly when the primary module is disabled.
+    4. Verify it fails clearly when a satellite module is disabled.
+    """
+    # 1. Create a minimal Lagoon execution model with a reachable RPC and no gas threshold.
+    execution_model = object.__new__(LagoonExecution)
+    execution_model.tx_builder = MagicMock()
+    execution_model.tx_builder.web3.eth.block_number = 2
+    execution_model.min_balance_threshold = Decimal(0)
+    module_address = "0x0000000000000000000000000000000000000002"
+    execution_model.vault = _ConfiguredSafe(module_address, enabled=True)
+    execution_model.satellite_vaults = {ChainId.base: _ConfiguredSafe(module_address, enabled=True)}
+
+    # 2. Enabled primary and satellite modules pass the start-up preflight.
+    execution_model.preflight_check()
+
+    # 3. A disabled primary module stops start-up before trading.
+    execution_model.vault = _ConfiguredSafe(module_address, enabled=False)
+    with pytest.raises(AssertionError, match="is not enabled"):
+        execution_model.preflight_check()
+
+    # 4. A disabled satellite module also stops start-up before trading.
+    execution_model.vault = _ConfiguredSafe(module_address, enabled=True)
+    execution_model.satellite_vaults = {ChainId.base: _ConfiguredSafe(module_address, enabled=False)}
+    with pytest.raises(AssertionError, match="satellite Safe"):
+        execution_model.preflight_check()
 
 
 class _FakePair:

--- a/tradeexecutor/cli/bootstrap.py
+++ b/tradeexecutor/cli/bootstrap.py
@@ -71,7 +71,7 @@ from tradeexecutor.ethereum.velvet.vault import VelvetVaultSyncModel
 from tradeexecutor.ethereum.web3config import Web3Config, get_rpc_env_var_name
 from tradeexecutor.monkeypatch.dataclasses_json import patch_dataclasses_json
 from tradeexecutor.state.metadata import Metadata, OnChainData
-from tradeexecutor.state.deployment_info import DeploymentInfo
+from tradeexecutor.state.deployment_info import DeploymentInfo, DeploymentInfoChange
 from tradeexecutor.state.state import State
 from tradeexecutor.state.store import JSONFileStore, SimulateStore
 from tradeexecutor.strategy.default_routing_options import TradeRouting
@@ -476,13 +476,159 @@ def update_strategy_file_deployment_info(
         "safe_salt_nonce": data.get("safe_salt_nonce"),
         "deployments": strip_deployment_state_abi(data.get("deployments") or {}),
     }
+    _normalise_guard_migration_artifact(deployment_data)
     if state.deployment_info is None:
         state.deployment_info = DeploymentInfo()
+    else:
+        _preserve_live_guard_migration_status(
+            state.deployment_info.data,
+            deployment_data,
+        )
 
     return state.deployment_info.update_strategy_file_deployment_data(
         str(deployment_file),
         deployment_data,
     )
+
+
+def _normalise_guard_migration_artifact(deployment_data: dict) -> None:
+    """Mark guard migration data from the deployment artefact as historical.
+
+    The Safe module list and transaction plan are generated before the Safe
+    owners perform the migration.  Older artefacts called these values
+    ``currently_enabled_modules`` and ``safe_transactions``, which falsely
+    suggested that they reflected current chain state.
+    """
+    for deployment in (deployment_data.get("deployments") or {}).values():
+        migration = deployment.get("guard_migration")
+        if not migration:
+            continue
+
+        if "currently_enabled_modules" in migration:
+            migration["enabled_modules_at_deployment"] = migration.pop("currently_enabled_modules")
+        if "safe_transactions" in migration:
+            migration["proposed_safe_transactions"] = migration.pop("safe_transactions")
+
+
+def _normalise_address(address: object) -> str | None:
+    """Return a case-insensitive address comparison key, if valid."""
+    if isinstance(address, str):
+        return address.lower()
+    return None
+
+
+def _preserve_live_guard_migration_status(
+    current_data: dict,
+    deployment_data: dict,
+) -> None:
+    """Keep live Safe observations when refreshing the static deployment artefact.
+
+    The deployment artefact is immutable. Do not overwrite a later chain
+    observation whenever the executor starts.
+    """
+    current_deployments = current_data.get("deployments") or {}
+    deployment_deployments = deployment_data.get("deployments") or {}
+
+    for slug, deployment in deployment_deployments.items():
+        current_deployment = current_deployments.get(slug) or {}
+        current_migration = current_deployment.get("guard_migration") or {}
+        migration = deployment.get("guard_migration") or {}
+
+        # Older state files used this key for a deployment-time snapshot. Only
+        # retain values that this process previously read from the live Safe.
+        if "observed_at" not in current_migration:
+            continue
+
+        current_safe = _normalise_address(current_migration.get("safe_address"))
+        current_new_guard = _normalise_address(current_migration.get("new_guard_address"))
+        safe = _normalise_address(migration.get("safe_address"))
+        new_guard = _normalise_address(migration.get("new_guard_address"))
+        if current_safe != safe or current_new_guard != new_guard:
+            continue
+
+        for key in (
+            "currently_enabled_modules",
+            "status",
+            "manual_intervention_required",
+            "observed_at",
+        ):
+            if key in current_migration:
+                migration[key] = current_migration[key]
+
+
+def refresh_lagoon_guard_migration_state(state: State, vault: LagoonVault) -> bool:
+    """Refresh the primary Lagoon guard migration with the Safe's live modules.
+
+    The deployment artefact records the modules that were enabled while the
+    replacement guard was deployed.  Safe owners execute the module migration
+    separately, so its result needs an on-chain read at executor start-up.
+
+    :return:
+        ``True`` when the persisted state changed.
+    """
+    if state.deployment_info is None:
+        return False
+
+    deployments = state.deployment_info.data.get("deployments") or {}
+    matching_migrations: list[tuple[str, dict]] = []
+    safe_address = _normalise_address(vault.safe_address)
+
+    for slug, deployment in deployments.items():
+        migration = deployment.get("guard_migration")
+        if not migration or deployment.get("is_satellite"):
+            continue
+        if _normalise_address(migration.get("safe_address")) == safe_address:
+            matching_migrations.append((slug, migration))
+
+    if not matching_migrations:
+        return False
+
+    try:
+        modules = list(vault.safe.retrieve_modules())
+    except Exception as e:
+        logger.warning("Could not refresh Lagoon guard migration status for Safe %s: %s", vault.safe_address, e)
+        return False
+
+    normalised_modules = {_normalise_address(module) for module in modules}
+    changed = False
+
+    for slug, migration in matching_migrations:
+        old_guard_address = _normalise_address(migration.get("old_guard_address"))
+        new_guard_address = _normalise_address(migration.get("new_guard_address"))
+        if old_guard_address is None or new_guard_address is None:
+            logger.warning("Skipping incomplete Lagoon guard migration state for %s", slug)
+            continue
+
+        if new_guard_address in normalised_modules and old_guard_address not in normalised_modules:
+            status = "completed"
+        elif old_guard_address in normalised_modules and new_guard_address not in normalised_modules:
+            status = "pending"
+        elif old_guard_address in normalised_modules and new_guard_address in normalised_modules:
+            status = "both_enabled"
+        else:
+            status = "no_expected_guard_enabled"
+
+        manual_intervention_required = status != "completed"
+        updates = {
+            "currently_enabled_modules": modules,
+            "status": status,
+            "manual_intervention_required": manual_intervention_required,
+        }
+        if all(migration.get(key) == value for key, value in updates.items()):
+            continue
+
+        migration.update(updates)
+        migration["observed_at"] = native_datetime_utc_now().isoformat()
+        state.deployment_info.modified.append(
+            DeploymentInfoChange(
+                change_summary_message=(
+                    f"Updated Lagoon guard migration status for {slug} from the live Safe"
+                ),
+            )
+        )
+        changed = True
+
+    return changed
 
 
 def resolve_deployment_file(id: str, state_file: "str | Path | None" = None) -> Path:

--- a/tradeexecutor/cli/commands/lagoon_deploy_vault.py
+++ b/tradeexecutor/cli/commands/lagoon_deploy_vault.py
@@ -511,7 +511,6 @@ def _build_multichain_artifact_payload(
         if chain_configs[slug].guard_only:
             guard_migration = _build_guard_migration_instructions(
                 dep,
-                chain_configs[slug].existing_vault_address or dep.safe_address,
             )
         deployment_data["deployments"][slug] = {
             "vault_address": dep.vault.address if hasattr(dep.vault, "address") else None,
@@ -539,9 +538,9 @@ def _build_multichain_artifact_payload(
             lines.append(f"    New guard address: {guard_migration['new_guard_address']}")
             lines.append(f"    Safe address: {guard_migration['safe_address']}")
             lines.append(f"    Vault address: {guard_migration['vault_address']}")
-            lines.append(f"    Currently enabled Safe modules: {guard_migration['currently_enabled_modules']}")
-            lines.append("    Safe transactions needed:")
-            for tx in guard_migration["safe_transactions"]:
+            lines.append(f"    Enabled Safe modules at deployment: {guard_migration['enabled_modules_at_deployment']}")
+            lines.append("    Proposed Safe transactions:")
+            for tx in guard_migration["proposed_safe_transactions"]:
                 lines.append(f"    {tx['step']}. {tx['call']}")
             lines.append("    Safe ABI needed:")
             lines.extend(f"    {line}" for line in guard_migration["safe_abi"].strip().splitlines())
@@ -552,12 +551,12 @@ def _build_multichain_artifact_payload(
     return "\n".join(lines), deployment_data
 
 
-def _build_guard_migration_instructions(deploy_info, vault_adapter_address: str) -> dict[str, Any]:
+def _build_guard_migration_instructions(deploy_info) -> dict[str, Any]:
     """Build manual Safe migration instructions for guard-only redeploys."""
     mods = deploy_info.safe.retrieve_modules()
     assert len(mods) == 1, f"Expected only one module enabled, got: {mods}"
 
-    old_guard_address = deploy_info.old_trading_strategy_module.address if deploy_info.old_trading_strategy_module else vault_adapter_address
+    old_guard_address = deploy_info.old_trading_strategy_module.address if deploy_info.old_trading_strategy_module else mods[0]
     safe_address = deploy_info.safe.address
 
     transactions = [
@@ -582,8 +581,8 @@ def _build_guard_migration_instructions(deploy_info, vault_adapter_address: str)
         "new_guard_address": deploy_info.trading_strategy_module.address,
         "safe_address": safe_address,
         "vault_address": getattr(deploy_info.vault, "address", None),
-        "currently_enabled_modules": list(mods),
-        "safe_transactions": transactions,
+        "enabled_modules_at_deployment": list(mods),
+        "proposed_safe_transactions": transactions,
         "safe_abi": SAFE_ABI_STR,
     }
 
@@ -596,11 +595,11 @@ def _format_guard_migration_instructions(instructions: dict[str, Any]) -> str:
         f"  New guard address: {instructions['new_guard_address']}",
         f"  Safe address: {instructions['safe_address']}",
         f"  Vault address: {instructions['vault_address']}",
-        f"  Currently enabled Safe modules: {instructions['currently_enabled_modules']}",
-        "  Safe transactions needed:",
+        f"  Enabled Safe modules at deployment: {instructions['enabled_modules_at_deployment']}",
+        "  Proposed Safe transactions:",
     ]
 
-    for tx in instructions["safe_transactions"]:
+    for tx in instructions["proposed_safe_transactions"]:
         lines.append(f"  {tx['step']}. {tx['call']}")
 
     lines.append("  Safe ABI needed:")
@@ -610,13 +609,12 @@ def _format_guard_migration_instructions(instructions: dict[str, Any]) -> str:
 
 def _augment_guard_only_artifacts(
     deploy_info,
-    vault_adapter_address: str,
     *,
     text_payload: str,
     json_payload: dict[str, Any],
 ) -> tuple[str, dict[str, Any]]:
     """Attach Safe migration instructions to guard-only deploy artefacts."""
-    instructions = _build_guard_migration_instructions(deploy_info, vault_adapter_address)
+    instructions = _build_guard_migration_instructions(deploy_info)
     augmented_json = dict(json_payload)
     augmented_json["Guard migration"] = instructions
     augmented_text = text_payload.rstrip() + "\n\n" + _format_guard_migration_instructions(instructions) + "\n"
@@ -632,16 +630,16 @@ def _annotate_single_chain_artifacts(*, text_payload: str, json_payload: dict[st
     return annotated_text, annotated_json
 
 
-def _log_guard_only_details(deploy_info, vault_adapter_address: str, logger) -> None:
+def _log_guard_only_details(deploy_info, logger) -> None:
     """Log manual guard replacement steps for guard-only mode."""
-    instructions = _build_guard_migration_instructions(deploy_info, vault_adapter_address)
+    instructions = _build_guard_migration_instructions(deploy_info)
     logger.info("New guard deployed: %s", instructions["new_guard_address"])
     logger.info("Old guard address: %s", instructions["old_guard_address"])
     logger.info("Safe address: %s", instructions["safe_address"])
     logger.info("Vault address: %s", instructions["vault_address"])
-    logger.info("Currently enabled Safe modules: %s", instructions["currently_enabled_modules"])
-    logger.info("Safe transactions needed:")
-    for tx in instructions["safe_transactions"]:
+    logger.info("Enabled Safe modules at deployment: %s", instructions["enabled_modules_at_deployment"])
+    logger.info("Proposed Safe transactions:")
+    for tx in instructions["proposed_safe_transactions"]:
         logger.info("%d. %s", tx["step"], tx["call"])
     logger.info("Safe ABI needed: %s", instructions["safe_abi"])
 
@@ -1007,7 +1005,6 @@ def lagoon_deploy_vault(
     if guard_only:
         text_payload, json_payload = _augment_guard_only_artifacts(
             deploy_info,
-            vault_adapter_address,
             text_payload=text_payload,
             json_payload=json_payload,
         )
@@ -1041,7 +1038,7 @@ def lagoon_deploy_vault(
     if not guard_only:
         logger.info("Lagoon deployed:\n%s", deploy_info.pformat())
     else:
-        _log_guard_only_details(deploy_info, vault_adapter_address, logger)
+        _log_guard_only_details(deploy_info, logger)
 
 
     # Print deployment guard configuration report
@@ -1235,7 +1232,6 @@ def _deploy_multichain(
             logger.info("Guard migration steps for %s:", slug)
             _log_guard_only_details(
                 dep,
-                configs[slug].existing_vault_address or dep.safe_address,
                 logger,
             )
 

--- a/tradeexecutor/cli/commands/start.py
+++ b/tradeexecutor/cli/commands/start.py
@@ -647,13 +647,15 @@ def start(
         state = loop.init_state()
         deployment_info_updated = update_strategy_file_deployment_info(state, deployment_file)
         if isinstance(sync_model, LagoonVaultSyncModel):
-            deployment_info_updated |= refresh_lagoon_guard_migration_state(state, sync_model.vault)
+            vault = getattr(sync_model, "vault", None)
+            if vault is not None:
+                deployment_info_updated |= refresh_lagoon_guard_migration_state(state, vault)
 
         if deployment_info_updated:
             logger.info("Updated strategy-file deployment information in the state")
             store.sync(state)
 
-        state = loop.setup(state=state)
+        state = loop.setup()
     except Exception as e:
         logger.error("trade-executor crashed on initialisation: %s", e)
         raise e

--- a/tradeexecutor/cli/commands/start.py
+++ b/tradeexecutor/cli/commands/start.py
@@ -23,7 +23,7 @@ from tradingstrategy.timebucket import TimeBucket
 from . import shared_options
 from .app import app
 from ..bootstrap import prepare_executor_id, prepare_cache_and_token_cache, create_web3_config, create_state_store, \
-    create_execution_and_sync_model, resolve_deployment_file, log_multichain_deployment_information, update_strategy_file_deployment_info, create_metadata, create_approval_model, create_client, configure_default_chain
+    create_execution_and_sync_model, resolve_deployment_file, log_multichain_deployment_information, update_strategy_file_deployment_info, refresh_lagoon_guard_migration_state, create_metadata, create_approval_model, create_client, configure_default_chain
 from ...exchange_account.derive import DeriveNetwork
 from ..log import setup_logging, setup_discord_logging, setup_logstash_logging, setup_file_logging, setup_telegram_logging, setup_sentry_logging
 from ..loop import ExecutionLoop
@@ -642,16 +642,21 @@ def start(
         create_charts=mod.create_charts,
     )
 
-    # Crash gracefully at the start up if our main loop cannot set itself up
+    # Crash gracefully at startup if our main loop cannot set itself up
     try:
-        state = loop.setup()
+        state = loop.init_state()
+        deployment_info_updated = update_strategy_file_deployment_info(state, deployment_file)
+        if isinstance(sync_model, LagoonVaultSyncModel):
+            deployment_info_updated |= refresh_lagoon_guard_migration_state(state, sync_model.vault)
+
+        if deployment_info_updated:
+            logger.info("Updated strategy-file deployment information in the state")
+            store.sync(state)
+
+        state = loop.setup(state=state)
     except Exception as e:
         logger.error("trade-executor crashed on initialisation: %s", e)
         raise e
-
-    if update_strategy_file_deployment_info(state, deployment_file):
-        logger.info("Updated strategy-file deployment information in the state")
-        store.sync(state)
 
     if preload_webhook_data:
         if not http_enabled:

--- a/tradeexecutor/cli/loop.py
+++ b/tradeexecutor/cli/loop.py
@@ -1889,7 +1889,7 @@ class ExecutionLoop:
 
         return self.debug_dump_state
 
-    def setup(self, state: State | None = None) -> State:
+    def setup(self) -> State:
         """Set up the main loop of trade executor.
 
         Main entry point to the loop.
@@ -1904,8 +1904,7 @@ class ExecutionLoop:
             Loaded execution state
         """
 
-        if state is None:
-            state = self.init_state()
+        state = self.init_state()
 
         if not self.is_backtest():
             if not self.sync_model.is_ready_for_live_trading(state):

--- a/tradeexecutor/cli/loop.py
+++ b/tradeexecutor/cli/loop.py
@@ -1889,7 +1889,7 @@ class ExecutionLoop:
 
         return self.debug_dump_state
 
-    def setup(self) -> State:
+    def setup(self, state: State | None = None) -> State:
         """Set up the main loop of trade executor.
 
         Main entry point to the loop.
@@ -1904,7 +1904,8 @@ class ExecutionLoop:
             Loaded execution state
         """
 
-        state = self.init_state()
+        if state is None:
+            state = self.init_state()
 
         if not self.is_backtest():
             if not self.sync_model.is_ready_for_live_trading(state):

--- a/tradeexecutor/ethereum/lagoon/execution.py
+++ b/tradeexecutor/ethereum/lagoon/execution.py
@@ -4,7 +4,7 @@ import datetime
 import logging
 from typing import TYPE_CHECKING
 
-from eth_defi.erc_4626.vault_protocol.lagoon.vault import LagoonVault
+from eth_defi.erc_4626.vault_protocol.lagoon.vault import AutomatedSafe, LagoonVault
 from eth_defi.velvet import VelvetVault
 from tradeexecutor.ethereum.ethereum_protocol_adapters import EthereumPairConfigurator
 from tradeexecutor.ethereum.execution import EthereumExecution
@@ -21,6 +21,13 @@ if TYPE_CHECKING:
     from tradeexecutor.testing.hypercore_replay import HypercoreVaultMarketDataSource
 
 logger = logging.getLogger(__name__)
+
+
+def assert_trading_strategy_module_enabled(safe: AutomatedSafe, description: str):
+    """Assert that the configured TradingStrategyModuleV0 is enabled on a Safe."""
+    module_address = safe.trading_strategy_module_address
+    assert module_address, f"Trading strategy module is not configured for {description}"
+    assert safe.safe.contract.functions.isModuleEnabled(module_address).call(), f"Trading strategy module {module_address} is not enabled on {description}"
 
 
 class LagoonExecution(EthereumExecution):
@@ -53,8 +60,15 @@ class LagoonExecution(EthereumExecution):
         :raise ASsertionError:
             Smart contracts not properly configured or not enabled.
         """
-        # Check that the Safe module is enabled
-        assert self.vault.is_trading_strategy_module_enabled(), f"Trading strategy module {self.vault.trading_strategy_module_address} is not enabled on the Lagoon vault {self.vault}"
+        # Check that every Safe has its configured module enabled.
+        assert_trading_strategy_module_enabled(self.vault, f"the Lagoon vault {self.vault}")
+        for chain_id, satellite_vault in self.satellite_vaults.items():
+            assert_trading_strategy_module_enabled(satellite_vault, f"the Lagoon satellite Safe for chain {chain_id}")
+
+    def preflight_check(self):
+        """Check the RPC, gas wallet and configured Safe module at start-up."""
+        super().preflight_check()
+        self.check_valid()
 
     def get_routing_state_details(self) -> RoutingStateDetails:
         details = super().get_routing_state_details()


### PR DESCRIPTION
## Why

The Lagoon guard migration entry stored a deployment-time Safe snapshot under a live-state field. After the Safe upgrade was executed manually, the state could still present the module migration as pending. The configured vault adapter also needed to be checked before execution starts.

## Lessons learnt

Deployment artefacts are historical instructions, while an enabled Safe module is live on-chain state. Keep those facts separate and persist the observation before start-up validation can abort the executor.

## Summary

- Refresh and persist the observed primary Safe guard-migration status before executor setup.
- Rename historical migration fields so they cannot be mistaken for live module state.
- Validate configured primary and satellite Safe modules during Lagoon start-up preflight.
- Correct the migration fallback to use the sole enabled Safe module.
- Document the owner migration workflow, live-state fields, and start-up safety check.
- Preserve the existing CLI start-up interface used by other command paths and test doubles.
