### PR TITLE
feat: recover external Lagoon settlements

### DIFF
--- a/.claude/docs/lagoon-treasury-settlement.md
+++ b/.claude/docs/lagoon-treasury-settlement.md
@@ -97,3 +97,45 @@ When a queue does not settle, inspect:
 Do not post a NAV if frozen positions or stale valuation data make it
 untrustworthy. The frozen-position safety check deliberately precedes the NAV
 transaction.
+
+## External settlement accounting
+
+When Safe owners execute a successful, already-valued `settleDeposit()` call
+outside the executor, the next treasury sync discovers and records the investor
+flow before it reconciles the Safe USDC balance. This is the manual recovery
+procedure after GuardV0 blocks automatic settlement.
+
+The executor creates one reserve `BalanceUpdate` per settlement transaction:
+
+- `cause=deposit_and_redemption`;
+- `quantity = deposited - redeemed` in the reserve stablecoin; and
+- the settlement transaction hash is the idempotency key.
+
+The Safe balance alone is not evidence of an investor flow: trading, bridges
+and external account integrations can change it too. Do not run
+`correct-accounts` to absorb a manual settlement, because that loses the
+investor-flow history used for profitability and equity calculations.
+
+### Confirmation safety
+
+The model scans only through its reorganisation-buffered safe block. Before it
+reconciles Safe USDC, it checks newer blocks for unrecorded Lagoon settlement
+logs. Such a log raises `LagoonUnconfirmedSettlement`; the strategy runner then
+ends the cycle before account checks or `decide_trades()`.
+
+Only mined receipt events are considered, so a dropped or replaced transaction
+does not defer a cycle. The settlement cursor never advances beyond the safe
+block.
+
+### State export
+
+`state.sync.treasury` exposes:
+
+| Field | Meaning |
+|---|---|
+| `pending_deposits` | Underlying waiting in the Lagoon Silo; not portfolio cash. |
+| `pending_redemptions` | Current underlying estimate required for queued redemption shares. |
+| `last_lagoon_settlement_block_scanned` | Highest block with fully processed Lagoon settlement logs. |
+
+`None` means the queue has not been observed. `0.0` means it was observed
+empty. These are snapshots only; receipt events remain the investor-flow source.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 0.2
 
+- Add Lagoon external-settlement recovery: the executor discovers confirmed Safe-governance settlements from Lagoon receipt events before reconciling Safe USDC, records normal investor-flow balance updates idempotently, exports pending queue amounts and defers a trading cycle while a settlement remains inside the confirmation buffer (2026-08-05)
+
 - Fix HyperCore vault deposits whose spot-to-perp CoreWriter action succeeded while the batched perp-to-vault action silently no-op'd: execute and verify the two legs separately, retain recoverable stranded capital in state rather than restoring it to Safe reserve accounting, fail closed across phase-1 broadcast crashes or ambiguous CoreWriter settlement until live Safe/escrow/spot/perp/vault reconciliation proves the destination, and enable default `correct-accounts` recovery of the full perp-to-spot transit amount before any separate spot cleanup (2026-07-30)
 
 - Fix default-on `correct-accounts` cleanup for undersized HyperCore vault positions to redeem directly without deposits or new lock-ups, keep verifiable residuals tracked, supersede stale planned close trades, use a valid live confirmation count, and make `--dry-run` rehearse live preflight, routing, and transaction construction without state writes or broadcasts (2026-07-30)

--- a/docs/plans/lagoon-external-settlement-accounting.md
+++ b/docs/plans/lagoon-external-settlement-accounting.md
@@ -1,0 +1,40 @@
+# Lagoon external settlement accounting
+
+## Objective
+
+Account for a confirmed Lagoon investor settlement even when Safe owners submit
+the settlement transaction. A manual GuardV0 recovery must be recorded before
+the changed Safe USDC balance is used for valuation or trading.
+
+## Implementation
+
+At a reorganisation-buffered safe block, `LagoonVaultSyncModel` scans Lagoon
+`SettleDeposit` and `SettleRedeem` events from the deployment block, or from
+the previous settlement cursor plus one. The dependency scanner reads its range
+in bounded JSON-RPC chunks. It excludes transaction hashes already stored on
+`deposit_and_redemption` balance updates, analyses each new receipt, then
+creates one normal reserve balance update per transaction.
+
+The same in-memory update records the Safe reserve balance at that block, the
+queue snapshots and the new scan cursor. A scan or receipt-analysis failure
+leaves persistent accounting unchanged. The executor broadcast path reuses the
+same receipt-to-event helper.
+
+Before reconciliation, newer blocks are checked for unrecorded settlement logs.
+If one exists, `LagoonUnconfirmedSettlement` ends the strategy cycle before
+trading. The cursor remains below that confirmation buffer.
+
+## State
+
+```python
+pending_deposits: USDollarAmount | None = None
+last_lagoon_settlement_block_scanned: BlockNumber | None = None
+```
+
+`pending_redemptions` already exists. Queue values are export-only snapshots and
+do not form part of cash, NAV or the investor-flow series.
+
+## Test
+
+The Base Anvil test queues 9 USDC, posts NAV, settles through the Safe, then
+verifies recovery, state JSON and a cursor-rewind rescan without duplication.

--- a/tests/lagoon/test_lagoon_deposit.py
+++ b/tests/lagoon/test_lagoon_deposit.py
@@ -1,5 +1,6 @@
 """Test Lagoon vault deposits/redemptions are correctly performed."""
 import datetime
+import json
 import os
 from decimal import Decimal
 from unittest.mock import Mock
@@ -9,6 +10,7 @@ from eth_typing import HexAddress
 from web3 import Web3
 
 from eth_defi.hotwallet import HotWallet
+from eth_defi.safe.simulate import simulate_safe_execution_anvil
 from eth_defi.erc_4626.vault_protocol.lagoon.deployment import LagoonAutomatedDeployment
 from eth_defi.token import TokenDetails, fetch_erc20_details
 from eth_defi.trace import assert_transaction_success_with_explanation
@@ -18,6 +20,7 @@ from tradeexecutor.ethereum.lagoon.vault import (
     LagoonVaultSyncModel,
 )
 from tradeexecutor.state.portfolio import ReserveMissing
+from tradeexecutor.state.balance_update import BalanceUpdateCause
 from tradeexecutor.state.state import State
 from tradeexecutor.statistics.core import calculate_statistics
 from tradeexecutor.strategy.execution_context import ExecutionMode
@@ -72,9 +75,12 @@ def test_lagoon_treasury_initialise(
     cycle = native_datetime_utc_now()
     events = sync_model.sync_treasury(cycle, state)
     assert len(events) == 0
-    assert treasury.last_block_scanned is None
-    assert treasury.last_updated_at is None
-    assert treasury.last_cycle_at is None
+    assert treasury.last_block_scanned is not None
+    assert treasury.last_updated_at is not None
+    assert treasury.last_cycle_at == cycle
+    assert treasury.last_lagoon_settlement_block_scanned == treasury.last_block_scanned
+    assert treasury.pending_deposits == pytest.approx(0)
+    assert treasury.pending_redemptions == pytest.approx(0)
     assert len(treasury.balance_update_refs) == 0
     assert len(reserve_position.balance_updates) == 0
 
@@ -162,6 +168,74 @@ def test_lagoon_sync_deposit(
     )
     assert statistics.portfolio.share_price_usd == pytest.approx(1.0)
     assert statistics.portfolio.share_count == Decimal(9)
+
+
+def test_lagoon_recovers_external_safe_settlement(
+    web3: Web3,
+    automated_lagoon_vault: LagoonAutomatedDeployment,
+    base_usdc_token: TokenDetails,
+    vault_strategy_universe: TradingStrategyUniverse,
+    depositor: HexAddress,
+    asset_manager: HotWallet,
+) -> None:
+    """Recover a Lagoon settlement sent directly by the Safe on an Anvil fork.
+
+    1. Initialise treasury state and establish an empty confirmed settlement cursor.
+    2. Queue an investor deposit, post its NAV, then settle it directly as the Safe.
+    3. Run the executor's next treasury sync and verify it creates one investor-flow event.
+    4. Rewind the cursor and verify transaction-hash recovery is idempotent.
+    """
+    vault = automated_lagoon_vault.vault
+    state = State()
+    sync_model = LagoonVaultSyncModel(vault=vault, hot_wallet=asset_manager)
+    sync_model.sync_initial(
+        state,
+        reserve_asset=vault_strategy_universe.get_reserve_asset(),
+        reserve_token_price=1.0,
+    )
+
+    # 1. Establish the confirmed scan cursor before the external settlement.
+    assert sync_model.sync_treasury(native_datetime_utc_now(), state, post_valuation=False) == []
+    cursor_before = state.sync.treasury.last_lagoon_settlement_block_scanned
+    assert cursor_before is not None
+
+    # 2. Queue and externally settle 9 USDC without the executor broadcast path.
+    amount = Decimal(9)
+    tx_hash = base_usdc_token.approve(vault.address, amount).transact({"from": depositor})
+    assert_transaction_success_with_explanation(web3, tx_hash)
+    tx_hash = vault.request_deposit(depositor, base_usdc_token.convert_to_raw(amount)).transact({"from": depositor})
+    assert_transaction_success_with_explanation(web3, tx_hash)
+    tx_hash = vault.post_new_valuation(Decimal(0)).transact({"from": asset_manager.address})
+    assert_transaction_success_with_explanation(web3, tx_hash)
+    external_settlement = simulate_safe_execution_anvil(
+        web3,
+        vault.safe_address,
+        vault.vault_contract.functions.settleDeposit(0),
+    )
+    assert_transaction_success_with_explanation(web3, external_settlement)
+
+    # 3. The executor discovers the Safe transaction and records its flow.
+    events = sync_model.sync_treasury(native_datetime_utc_now(), state, post_valuation=False)
+    assert len(events) == 1
+    event = events[0]
+    assert event.tx_hash == external_settlement.hex()
+    assert event.cause == BalanceUpdateCause.deposit_and_redemption
+    assert event.quantity == amount
+    assert event.strategy_cycle_included_at == event.block_mined_at
+    assert state.portfolio.get_cash() == amount
+    assert len(state.sync.treasury.balance_update_refs) == 1
+    assert state.sync.treasury.pending_deposits == pytest.approx(0)
+    assert state.sync.treasury.last_lagoon_settlement_block_scanned >= event.block_number
+    assert state.sync.treasury.last_lagoon_settlement_block_scanned > cursor_before
+    exported_treasury = json.loads(state.to_json_safe())["sync"]["treasury"]
+    assert exported_treasury["pending_deposits"] == pytest.approx(0)
+    assert exported_treasury["pending_redemptions"] == pytest.approx(0)
+    assert exported_treasury["last_lagoon_settlement_block_scanned"] >= event.block_number
+
+    # 4. An unset legacy cursor rescans from deployment without duplication.
+    state.sync.treasury.last_lagoon_settlement_block_scanned = None
+    assert sync_model.sync_treasury(native_datetime_utc_now(), state, post_valuation=False) == []
+    assert len(state.portfolio.get_default_reserve_position().balance_updates) == 1
 
 
 def test_lagoon_sync_treasury_marks_noop_startup_sync(

--- a/tradeexecutor/ethereum/lagoon/vault.py
+++ b/tradeexecutor/ethereum/lagoon/vault.py
@@ -18,6 +18,8 @@ from eth_defi.compat import native_datetime_utc_fromtimestamp, native_datetime_u
 from eth_defi.confirmation import wait_and_broadcast_multiple_nodes_mev_blocker
 from eth_defi.erc_4626.vault_protocol.lagoon.analysis import \
     analyse_vault_flow_in_settlement
+from eth_defi.erc_4626.vault_protocol.lagoon.settlement import \
+    fetch_lagoon_settlements
 from eth_defi.erc_4626.vault_protocol.lagoon.vault import (
     DEFAULT_LAGOON_POST_VALUATION_GAS, DEFAULT_LAGOON_SETTLE_GAS, LagoonVault)
 from eth_defi.hotwallet import HotWallet
@@ -29,6 +31,7 @@ from eth_defi.revert_reason import extract_revert_data
 from eth_defi.token import fetch_erc20_details
 from eth_defi.trace import assert_transaction_success_with_explanation
 from eth_typing import BlockIdentifier, HexAddress
+from hexbytes import HexBytes
 from tradingstrategy.chain import ChainId
 
 from tradeexecutor.ethereum.address_sync_model import AddressSyncModel
@@ -43,11 +46,20 @@ from tradeexecutor.state.types import (BlockNumber, JSONHexAddress, Percent,
                                        USDollarPrice)
 from tradeexecutor.strategy.interest import sync_interests
 from tradeexecutor.strategy.pricing_model import PricingModel
-from tradeexecutor.strategy.sync_model import OnChainBalance
+from tradeexecutor.strategy.sync_model import OnChainBalance, UnconfirmedTreasurySync
 from tradeexecutor.strategy.trading_strategy_universe import \
     TradingStrategyUniverse
 
 logger = logging.getLogger(__name__)
+
+
+class LagoonUnconfirmedSettlement(UnconfirmedTreasurySync):
+    """Lagoon settlement state cannot be synchronised safely."""
+
+
+def _normalise_tx_hash(tx_hash: str | HexBytes) -> str:
+    """Return a stable lower-case transaction hash for state deduplication."""
+    return HexBytes(tx_hash).hex().lower()
 
 
 def _load_lagoon_guard_v0_error_selectors() -> dict[str, bytes]:
@@ -571,18 +583,226 @@ class LagoonVaultSyncModel(AddressSyncModel):
         else:
             return state.portfolio.get_net_asset_value(include_interest=True)
 
+    def _fetch_lagoon_queue_amounts(
+        self,
+        block_number: int,
+    ) -> tuple[Decimal, Decimal]:
+        """Read aggregate investor queue amounts at one explicit block."""
+        flow_manager = self.vault.get_flow_manager()
+        return (
+            flow_manager.fetch_pending_deposit(block_number),
+            flow_manager.calculate_underlying_needed_for_redemptions(block_number),
+        )
+
+    def _get_recorded_lagoon_settlement_hashes(self, reserve_position) -> set[str]:
+        """Return settlement transaction hashes already represented in state."""
+        hashes = set()
+        for event in reserve_position.get_balance_update_events():
+            if event.cause != BalanceUpdateCause.deposit_and_redemption:
+                continue
+            if event.tx_hash is None:
+                raise RuntimeError(
+                    "Cannot initialise Lagoon settlement recovery because reserve "
+                    f"balance update #{event.balance_update_id} at block "
+                    f"{event.block_number} has no transaction hash"
+                )
+            hashes.add(_normalise_tx_hash(event.tx_hash))
+        return hashes
+
+    def _fetch_lagoon_settlements(
+        self,
+        start_block: int,
+        end_block: int,
+    ) -> list:
+        """Read Lagoon settlement logs without using Hypersync against Anvil."""
+        return fetch_lagoon_settlements(
+            vault=self.vault,
+            start_block=start_block,
+            end_block=end_block,
+            use_hypersync=False if self.anvil else None,
+        )
+
+    def _probe_unconfirmed_lagoon_settlements(
+        self,
+        *,
+        safe_sync_block: int,
+        recorded_hashes: set[str],
+    ) -> None:
+        """Defer a cycle when a newer external Lagoon settlement exists."""
+        tip = self.web3.eth.block_number
+        if tip < safe_sync_block:
+            raise LagoonUnconfirmedSettlement(
+                f"Lagoon RPC tip {tip:,} is behind safe sync block {safe_sync_block:,}"
+            )
+        if tip == safe_sync_block:
+            return
+
+        try:
+            unsettled = self._fetch_lagoon_settlements(safe_sync_block + 1, tip)
+        except Exception as e:
+            raise LagoonUnconfirmedSettlement(
+                "Cannot prove Lagoon's unconfirmed block range has no settlement"
+            ) from e
+
+        unknown_hashes = {
+            _normalise_tx_hash(row.tx_hash)
+            for row in unsettled
+            if _normalise_tx_hash(row.tx_hash) not in recorded_hashes
+        }
+        if unknown_hashes:
+            raise LagoonUnconfirmedSettlement(
+                "Lagoon settlement(s) are inside the confirmation buffer: "
+                + ", ".join(sorted(unknown_hashes))
+            )
+
+    def _discover_lagoon_settlements(
+        self,
+        *,
+        state: State,
+        reserve_position,
+        safe_sync_block: int,
+    ) -> list:
+        """Analyse confirmed, unrecorded Lagoon settlements without state mutation."""
+        treasury = state.sync.treasury
+        deployment_block = state.sync.deployment.block_number
+        assert deployment_block is not None, "Lagoon deployment block missing; run trade-executor init"
+
+        recorded_hashes = self._get_recorded_lagoon_settlement_hashes(reserve_position)
+        previous_cursor = treasury.last_lagoon_settlement_block_scanned
+        if previous_cursor is not None and safe_sync_block < previous_cursor:
+            raise LagoonUnconfirmedSettlement(
+                f"Lagoon safe sync block {safe_sync_block:,} is behind settlement cursor {previous_cursor:,}"
+            )
+
+        self._probe_unconfirmed_lagoon_settlements(
+            safe_sync_block=safe_sync_block,
+            recorded_hashes=recorded_hashes,
+        )
+
+        start_block = deployment_block if previous_cursor is None else previous_cursor + 1
+        if start_block > safe_sync_block:
+            return []
+
+        rows = self._fetch_lagoon_settlements(start_block, safe_sync_block)
+        tx_hashes = {
+            _normalise_tx_hash(row.tx_hash)
+            for row in rows
+            if _normalise_tx_hash(row.tx_hash) not in recorded_hashes
+        }
+        tx_receipts = [
+            (tx_hash, self.web3.eth.get_transaction_receipt(HexBytes(tx_hash)))
+            for tx_hash in tx_hashes
+        ]
+        tx_receipts.sort(
+            key=lambda item: (item[1]["blockNumber"], item[1]["transactionIndex"])
+        )
+        return [
+            analyse_vault_flow_in_settlement(self.vault, HexBytes(tx_hash))
+            for tx_hash, _receipt in tx_receipts
+        ]
+
+    def _create_lagoon_settlement_event(
+        self,
+        *,
+        event_id: int,
+        reserve_position,
+        reserve_asset: AssetIdentifier,
+        analysis,
+        old_balance: Decimal,
+        origin: str,
+    ) -> BalanceUpdate:
+        """Build one persistent reserve event from a verified Lagoon receipt."""
+        delta = analysis.get_underlying_diff()
+        other_data = analysis.get_serialiable_diagnostics_data()
+        other_data["settlement_origin"] = origin
+
+        return BalanceUpdate(
+            balance_update_id=event_id,
+            position_type=BalanceUpdatePositionType.reserve,
+            cause=BalanceUpdateCause.deposit_and_redemption,
+            asset=reserve_position.asset,
+            block_mined_at=analysis.timestamp,
+            strategy_cycle_included_at=analysis.timestamp,
+            chain_id=reserve_asset.chain_id,
+            old_balance=old_balance,
+            quantity=delta,
+            owner_address=None,
+            tx_hash=_normalise_tx_hash(analysis.tx_hash),
+            log_index=None,
+            position_id=None,
+            usd_value=float(delta),
+            notes=f"Lagoon reserve update at tx {analysis.tx_hash.hex()}, block {analysis.block_number:,}",
+            block_number=analysis.block_number,
+            other_data=other_data,
+        )
+
+    def _commit_confirmed_lagoon_settlements(
+        self,
+        *,
+        state: State,
+        reserve_position,
+        reserve_asset: AssetIdentifier,
+        analyses: list,
+        safe_sync_block: int,
+        reserve_balance: Decimal,
+        pending_deposits: Decimal,
+        pending_redemptions: Decimal,
+        share_count: Decimal,
+        strategy_cycle_ts: datetime.datetime,
+    ) -> list[BalanceUpdate]:
+        """Apply analysed settlement flows and one Safe/queue snapshot."""
+        treasury = state.sync.treasury
+        next_event_id = state.portfolio.next_balance_update_id
+        old_balance = reserve_position.quantity
+        events = []
+        for analysis in analyses:
+            event = self._create_lagoon_settlement_event(
+                event_id=next_event_id,
+                reserve_position=reserve_position,
+                reserve_asset=reserve_asset,
+                analysis=analysis,
+                old_balance=old_balance,
+                origin="discovered_by_scan",
+            )
+            events.append(event)
+            next_event_id += 1
+            old_balance += event.quantity
+
+        for event in events:
+            reserve_position.add_balance_update_event(event)
+            treasury.balance_update_refs.append(BalanceEventRef.from_balance_update_event(event))
+        state.portfolio.next_balance_update_id = next_event_id
+        reserve_position.quantity = reserve_balance
+        reserve_position.reserve_token_price = 1.0
+        reserve_position.last_pricing_at = native_datetime_utc_now()
+        reserve_position.last_sync_at = native_datetime_utc_now()
+        treasury.last_lagoon_settlement_block_scanned = safe_sync_block
+        treasury.last_block_scanned = safe_sync_block
+        treasury.last_updated_at = native_datetime_utc_now()
+        treasury.last_cycle_at = strategy_cycle_ts
+        treasury.pending_deposits = float(pending_deposits)
+        treasury.pending_redemptions = float(pending_redemptions)
+        treasury.share_count = share_count
+        treasury.balance_update_refs.sort(
+            key=lambda ref: (ref.strategy_cycle_included_at or datetime.datetime.min, ref.balance_event_id)
+        )
+        return events
+
     def _mark_treasury_sync_completed(
         self,
         treasury_sync,
         strategy_cycle_ts: datetime.datetime,
         block_number: int,
+        pending_deposits: Decimal | None = None,
         pending_redemptions: Decimal | None = None,
         share_count: Decimal | None = None,
     ) -> None:
-        """Mark Lagoon treasury as synced even when no settlement was needed."""
+        """Mark one consistent Lagoon treasury/queue snapshot as complete."""
         treasury_sync.last_updated_at = native_datetime_utc_now()
         treasury_sync.last_cycle_at = strategy_cycle_ts
         treasury_sync.last_block_scanned = block_number
+        if pending_deposits is not None:
+            treasury_sync.pending_deposits = float(pending_deposits)
         if pending_redemptions is not None:
             treasury_sync.pending_redemptions = float(pending_redemptions)
         if share_count is not None:
@@ -847,47 +1067,53 @@ class LagoonVaultSyncModel(AddressSyncModel):
             chain_id=reserve_asset.chain_id,
         )
 
+        # Freeze all accounting reads at one reorganisation-buffered block.
+        # Discover investor flows before Safe-balance reconciliation so a direct
+        # Safe settlement cannot be silently treated as strategy PnL.
+        safe_sync_block = self.get_safe_latest_block()
+        if end_block is not None:
+            safe_sync_block = min(safe_sync_block, end_block)
+
+        analyses = self._discover_lagoon_settlements(
+            state=state,
+            reserve_position=reserve_position,
+            safe_sync_block=safe_sync_block,
+        )
+        pending_deposits, pending_redemptions = self._fetch_lagoon_queue_amounts(safe_sync_block)
+        share_count = vault.fetch_total_supply(safe_sync_block)
+        onchain_balance = reserve_token.fetch_balance_of(
+            self.get_token_storage_address(),
+            block_identifier=safe_sync_block,
+        )
+        recovered_events = self._commit_confirmed_lagoon_settlements(
+            state=state,
+            reserve_position=reserve_position,
+            reserve_asset=reserve_asset,
+            analyses=analyses,
+            safe_sync_block=safe_sync_block,
+            reserve_balance=onchain_balance,
+            pending_deposits=pending_deposits,
+            pending_redemptions=pending_redemptions,
+            share_count=share_count,
+            strategy_cycle_ts=strategy_cycle_ts,
+        )
+        if analyses:
+            logger.info(
+                "Recovered %d Lagoon settlement transaction(s) through block %d",
+                len(analyses),
+                safe_sync_block,
+            )
+
         self._check_frozen_positions_for_settlement(
             state,
             post_valuation=post_valuation,
         )
 
-        # Reconcile reserves from on-chain before calculating NAV.
-        #
-        # Exchange account positions (e.g. GMX) transfer USDC from the Safe
-        # via sendTokens() in multicall — outside the trade engine.
-        # This means reserve_position.quantity can be stale: it still
-        # reflects the pre-transfer balance while the USDC has already
-        # left the Safe.
-        #
-        # The exchange account value function (e.g. create_gmx_account_value_func)
-        # only returns capital locked in exchange positions, NOT free USDC
-        # in the Safe — so the Safe's actual USDC balance is the correct
-        # reserve component for NAV.  Without this reconciliation,
-        # calculate_valuation() double-counts the transferred USDC
-        # (once in stale reserves, once in the exchange account position),
-        # inflating the NAV and mispricing deposits.
-        #
-        # See README-GMX-Lagoon.md for the full token flow.
-        block_number = self.get_safe_latest_block()
-        onchain_balance = reserve_token.fetch_balance_of(
-            self.get_token_storage_address(),
-            block_identifier=block_number,
-        )
-        if reserve_position.quantity != onchain_balance:
-            logger.warning(
-                "Reserve balance mismatch: portfolio=%s, on-chain=%s. "
-                "Updating to on-chain value before NAV calculation.",
-                reserve_position.quantity,
-                onchain_balance,
-            )
-            reserve_position.quantity = onchain_balance
-
-        valuation = self.calculate_valuation(state, block_number=block_number)
+        valuation = self.calculate_valuation(state, block_number=safe_sync_block)
 
         if not post_valuation:
             logger.warning("LagoonVaultSyncModel.sync_treasury() called with post_valuation=False")
-            return []
+            return recovered_events
 
         if self.disable_broadcast:
             # GuardV0 requires a current NAV before settlement. Consequently,
@@ -897,11 +1123,11 @@ class LagoonVaultSyncModel(AddressSyncModel):
             logger.info(
                 "Lagoon treasury broadcasting disabled: not posting NAV or settling the investor queue"
             )
-            return []
+            return recovered_events
 
         assert self.hot_wallet, "asset_manager HotWallet needed in order to sync Lagoon vault"
 
-        old_balance = reserve_token.fetch_balance_of(self.get_token_storage_address())
+        old_balance = reserve_position.quantity
 
         # NAV must be fresh on every requested post-valuation cycle. GuardV0
         # decides investor settlement separately and never suppresses this tx.
@@ -1024,10 +1250,11 @@ class LagoonVaultSyncModel(AddressSyncModel):
                 treasury_sync=treasury_sync,
                 strategy_cycle_ts=strategy_cycle_ts,
                 block_number=nav_block_number,
+                pending_deposits=flow_manager.fetch_pending_deposit(metadata_block_number),
                 pending_redemptions=pending_redemptions,
                 share_count=share_count,
             )
-            return []
+            return recovered_events
 
         # Only the successful guarded or unlimited preflight path reaches this
         # point; all cap and cooldown reverts were handled without gas spend.
@@ -1089,34 +1316,21 @@ class LagoonVaultSyncModel(AddressSyncModel):
         event_id = portfolio.next_balance_update_id
         portfolio.next_balance_update_id += 1
 
-        # Include our valuation in the other_data diangnostics
-        other_data = analysis.get_serialiable_diagnostics_data()
-        other_data["valuation"] = valuation
         valuation_with_deposits = valuation + float(delta)
-        other_data["valuation_with_deposits"] = valuation_with_deposits
-
         share_count = vault.fetch_total_supply(analysis.block_number)
-        other_data["share_count"] = share_count
-
-        evt = BalanceUpdate(
-            balance_update_id=event_id,
-            position_type=BalanceUpdatePositionType.reserve,
-            cause=BalanceUpdateCause.deposit_and_redemption,
-            asset=reserve_position.asset,
-            block_mined_at=analysis.timestamp,
-            strategy_cycle_included_at=strategy_cycle_ts,
-            chain_id=reserve_asset.chain_id,
+        pending_deposits, pending_redemptions = self._fetch_lagoon_queue_amounts(analysis.block_number)
+        evt = self._create_lagoon_settlement_event(
+            event_id=event_id,
+            reserve_position=reserve_position,
+            reserve_asset=reserve_asset,
+            analysis=analysis,
             old_balance=old_balance,
-            quantity=delta,
-            owner_address=None,
-            tx_hash=analysis.tx_hash.hex(),
-            log_index=None,
-            position_id=None,
-            usd_value=float(delta),  # Assume stablecoin
-            notes=f"Lagoon reserve update at tx {analysis.tx_hash.hex()}, block {analysis.block_number:,}",
-            block_number=analysis.block_number,
-            other_data=other_data,
+            origin="executor_broadcast",
         )
+        assert evt.other_data is not None
+        evt.other_data["valuation"] = valuation
+        evt.other_data["valuation_with_deposits"] = valuation_with_deposits
+        evt.other_data["share_count"] = share_count
 
         # Update reserve position mutable value
         reserve_position.reserve_token_price = float(1)
@@ -1128,18 +1342,27 @@ class LagoonVaultSyncModel(AddressSyncModel):
         # Add in the event cross reference list
         ref = BalanceEventRef.from_balance_update_event(evt)
         treasury_sync.balance_update_refs.append(ref)
+        treasury_sync.balance_update_refs.sort(
+            key=lambda item: (item.strategy_cycle_included_at or datetime.datetime.min, item.balance_event_id)
+        )
         treasury_sync.last_block_scanned = analysis.block_number
         treasury_sync.last_updated_at = native_datetime_utc_now()
         treasury_sync.last_cycle_at = strategy_cycle_ts
-        treasury_sync.pending_redemptions = float(analysis.pending_redemptions_underlying)
+        treasury_sync.pending_deposits = float(pending_deposits)
+        treasury_sync.pending_redemptions = float(pending_redemptions)
         treasury_sync.share_count = share_count
+        treasury_sync.last_lagoon_settlement_block_scanned = max(
+            treasury_sync.last_lagoon_settlement_block_scanned or analysis.block_number,
+            analysis.block_number,
+        )
 
         logger.info(
             f"Lagoon settlements done, the last block is now {treasury_sync.last_block_scanned:,}\n"
             f"Safe address: {vault.safe_address}, vault address: {vault.vault_address}, silo address: {vault.silo_address}\n"
             f"Settled {analysis.get_underlying_diff()} USD\n"
             f"Non-deposit valuation is {valuation:,.2f} USD, with-deposit valuation is {valuation_with_deposits:,.2f} USD\n"
-            f"Pending redemptions {analysis.pending_redemptions_underlying} USD\n"
+            f"Pending deposits {pending_deposits} USD\n"
+            f"Pending redemptions {pending_redemptions} USD\n"
             f"Share count {share_count} {vault.share_token.symbol}"
         )
-        return [evt]
+        return recovered_events + [evt]

--- a/tradeexecutor/state/sync.py
+++ b/tradeexecutor/state/sync.py
@@ -166,6 +166,19 @@ class Treasury:
     #:
     pending_redemptions: Optional[USDollarAmount] = None
 
+    #: How much underlying-token deposits are waiting in the investor queue.
+    #:
+    #: For Lagoon based vaults this is the pending Silo balance observed at
+    #: ``last_block_scanned``. It is outside the Safe and never forms part of
+    #: portfolio cash or NAV.
+    pending_deposits: USDollarAmount | None = None
+
+    #: Highest block whose Lagoon settlement logs were completely processed.
+    #:
+    #: This is independent from ``last_block_scanned`` because a queue snapshot
+    #: may advance on a NAV-only cycle.
+    last_lagoon_settlement_block_scanned: BlockNumber | None = None
+
     #: Number of issued shares.
     #:
     #: For Lagoon based vaults, needed to calcualte share price.
@@ -247,4 +260,3 @@ class Sync:
     def is_initialised(self) -> bool:
         """Have we scanned the initial deployment event for the sync model."""
         return self.deployment.block_number is not None
-

--- a/tradeexecutor/strategy/runner.py
+++ b/tradeexecutor/strategy/runner.py
@@ -36,7 +36,7 @@ from tradeexecutor.strategy.generic.generic_valuation import GenericValuation
 from tradeexecutor.strategy.pandas_trader.indicator import CreateIndicatorsProtocol
 from tradeexecutor.strategy.pandas_trader.strategy_input import StrategyInputIndicators
 from tradeexecutor.strategy.parameters import StrategyParameters
-from tradeexecutor.strategy.sync_model import SyncModel
+from tradeexecutor.strategy.sync_model import SyncModel, UnconfirmedTreasurySync
 from tradeexecutor.strategy.run_state import RunState
 from tradeexecutor.strategy.output import output_positions, DISCORD_BREAK_CHAR, output_trades
 from tradeexecutor.strategy.pandas_trader.position_manager import PositionManager
@@ -852,16 +852,21 @@ class StrategyRunner(abc.ABC):
                 self.revalue_state(strategy_cycle_timestamp, state, valuation_model)
 
             # Watch incoming deposits
-            with self.timed_task_context_manager("sync_portfolio"):
-                self.sync_portfolio(
-                    strategy_cycle_timestamp,
-                    universe,
-                    state,
-                    debug_details,
-                    end_block,
-                    long_short_metrics_latest=long_short_metrics_latest,
-                    post_valuation=True,
-                )
+            try:
+                with self.timed_task_context_manager("sync_portfolio"):
+                    self.sync_portfolio(
+                        strategy_cycle_timestamp,
+                        universe,
+                        state,
+                        debug_details,
+                        end_block,
+                        long_short_metrics_latest=long_short_metrics_latest,
+                        post_valuation=True,
+                    )
+            except UnconfirmedTreasurySync as e:
+                logger.warning("Deferring strategy cycle because treasury sync is unconfirmed: %s", e)
+                debug_details["treasury_sync_deferred"] = str(e)
+                return debug_details
 
             # Resolve any pending async vault settlements (Ostium V1.5, ERC-7540 Lagoon).
             # Polymorphic: live execution models poll the on-chain deposit manager,

--- a/tradeexecutor/strategy/sync_model.py
+++ b/tradeexecutor/strategy/sync_model.py
@@ -29,6 +29,10 @@ from eth_defi.compat import native_datetime_utc_now
 SyncMethodV0 = Callable[[Portfolio, datetime.datetime, List[AssetIdentifier]], List[ReserveUpdateEvent]]
 
 
+class UnconfirmedTreasurySync(Exception):
+    """Treasury data is not final enough to make a trading decision this cycle."""
+
+
 @dataclass
 class OnChainBalance:
     """Describe on-chain token position.


### PR DESCRIPTION
## Why

GuardV0 can require Safe owners to settle a Lagoon queue manually. Without receipt recovery, the next executor cycle absorbs the Safe USDC movement into reserve reconciliation and loses the investor-flow record.

## Lessons learnt

A Safe balance delta is not a reliable investor-flow signal. Receipt-derived Lagoon settlement events, a separate confirmed scan cursor, and a confirmation-range guard preserve accounting while avoiding trades against an unconfirmed reserve balance.

## Summary

- Recover confirmed externally settled Lagoon deposit/redemption receipts before Safe reconciliation.
- Export pending deposit and redemption queue snapshots with the settlement scan cursor.
- Defer a strategy cycle when a newer unrecorded settlement is inside the confirmation buffer.
- Add Base Anvil coverage for direct Safe settlement, state export and deployment-backfill idempotency.
- Document the manual GuardV0 recovery flow and accounting model.