### PR TITLE
fix: add Safe builder details to Lagoon alerts

### DIFF
--- a/.claude/docs/lagoon-treasury-settlement.md
+++ b/.claude/docs/lagoon-treasury-settlement.md
@@ -58,6 +58,11 @@ module addresses, the pending queue sizes, exact gross flow and configured cap.
 The NAV update has succeeded, but the queues and Guard cooldown timestamp are
 unchanged.
 
+The alert also gives a Gnosis Safe Transaction Builder-ready `settleDeposit`
+ABI, specifies the Safe, vault target, zero value and call operation, and logs
+the raw `_newTotalAssets` value. Safe owners must use that exact raw value for
+the just-posted NAV when calling the vault directly.
+
 `lagoon-settle` is not the recovery mechanism for this case because it uses the
 same asset-manager module and will be rejected by GuardV0. The Safe owners must
 submit the deliberate direct Safe settlement transaction. Direct governance

--- a/tests/lagoon/test_lagoon_guard_settlement.py
+++ b/tests/lagoon/test_lagoon_guard_settlement.py
@@ -19,7 +19,10 @@ from eth_defi.trace import assert_transaction_success_with_explanation
 from tradingstrategy.chain import ChainId
 
 from tradeexecutor.cli.bootstrap import create_metadata
-from tradeexecutor.ethereum.lagoon.vault import LagoonVaultSyncModel
+from tradeexecutor.ethereum.lagoon.vault import (
+    LAGOON_SETTLE_DEPOSIT_SAFE_TRANSACTION_BUILDER_ABI,
+    LagoonVaultSyncModel,
+)
 from tradeexecutor.monkeypatch.dataclasses_json import patch_dataclasses_json
 from tradeexecutor.state.state import State
 from tradeexecutor.strategy.execution_model import AssetManagementMode
@@ -210,3 +213,6 @@ def test_lagoon_guard_posts_nav_but_defers_oversized_flow_to_safe(
     assert "cap=10" in caplog.text
     assert vault.address in caplog.text
     assert vault.safe_address in caplog.text
+    assert f"safe_address={vault.safe_address}" in caplog.text
+    assert LAGOON_SETTLE_DEPOSIT_SAFE_TRANSACTION_BUILDER_ABI in caplog.text
+    assert f"_newTotalAssets={base_usdc_token.convert_to_raw(Decimal(5))}" in caplog.text

--- a/tradeexecutor/ethereum/lagoon/vault.py
+++ b/tradeexecutor/ethereum/lagoon/vault.py
@@ -92,6 +92,14 @@ LAGOON_SETTLEMENT_COOLDOWN_ACTIVE_SELECTOR = LAGOON_GUARD_V0_ERROR_SELECTORS[
     "LagoonSettlementCooldownActive"
 ]
 
+# Paste this into Gnosis Safe Transaction Builder for a direct v0.5 Lagoon
+# settlement. The Safe must call the vault directly, rather than the guarded
+# TradingStrategyModuleV0.
+LAGOON_SETTLE_DEPOSIT_SAFE_TRANSACTION_BUILDER_ABI = (
+    '[{"inputs":[{"internalType":"uint256","name":"_newTotalAssets","type":"uint256"}],'
+    '"name":"settleDeposit","outputs":[],"stateMutability":"nonpayable","type":"function"}]'
+)
+
 # TradingStrategyModuleV0 releases predating the GuardV0 safety configuration getter.
 LAGOON_UNLIMITED_LEGACY_MODULE_VERSIONS = frozenset({
     "v0.1.0",
@@ -988,6 +996,7 @@ class LagoonVaultSyncModel(AddressSyncModel):
     def _log_manual_lagoon_settlement_required(
         self,
         preflight: LagoonSettlementPreflight,
+        new_total_assets_raw: int,
     ) -> None:
         """Tell the operator to settle an oversized GuardV0 queue through Safe governance."""
         assert preflight.actual_amount_raw is not None
@@ -995,9 +1004,10 @@ class LagoonVaultSyncModel(AddressSyncModel):
         underlying_token = self.vault.underlying_token
         logger.error(
             "Lagoon automated settlement skipped: direct Safe-governance settlement required. "
-            "chain=%d vault=%s safe=%s module=%s pending_deposit=%s %s "
+            "chain=%d vault=%s safe_address=%s module=%s pending_deposit=%s %s "
             "pending_redemption_shares_raw=%d gross_flow=%s %s (%d raw) cap=%s %s (%d raw). "
-            "NAV update succeeded and both queues remain pending.",
+            "NAV update succeeded and both queues remain pending. Gnosis Safe Transaction Builder: "
+            "Safe=%s, to=%s, value=0, operation=0, ABI=%s, _newTotalAssets=%d.",
             self.chain_id.value,
             self.vault.address,
             self.vault.safe_address,
@@ -1011,6 +1021,10 @@ class LagoonVaultSyncModel(AddressSyncModel):
             underlying_token.convert_to_decimals(preflight.max_amount_raw),
             underlying_token.symbol,
             preflight.max_amount_raw,
+            self.vault.safe_address,
+            self.vault.address,
+            LAGOON_SETTLE_DEPOSIT_SAFE_TRANSACTION_BUILDER_ABI,
+            new_total_assets_raw,
         )
 
     def sync_treasury(
@@ -1229,7 +1243,10 @@ class LagoonVaultSyncModel(AddressSyncModel):
             if preflight.manual_settlement_required:
                 # Gross flow is above the GuardV0 cap. The Safe, rather than
                 # the guarded asset manager, must deliberately settle it.
-                self._log_manual_lagoon_settlement_required(preflight)
+                self._log_manual_lagoon_settlement_required(
+                    preflight,
+                    reserve_token.convert_to_raw(valuation_decimal),
+                )
             elif preflight.next_settlement_timestamp is not None:
                 # Gross flow is within the cap, but a previous non-zero
                 # settlement started GuardV0's cooldown.


### PR DESCRIPTION
## Why

GuardV0-cap breaches require a deliberate Safe-governance settlement. The existing alert did not provide copyable Transaction Builder ABI or a clearly labelled Safe address, making recovery unnecessarily error-prone.

## Lessons learnt

A direct Lagoon `settleDeposit(uint256)` call must use the exact raw NAV that was just posted; displaying the ABI alone is insufficient for Safe owners to construct the transaction safely.

## Summary

- Add Safe Transaction Builder fields, ABI and raw NAV argument to the manual-settlement alert.
- Assert the alert payload in GuardV0 coverage.
- Document the manual recovery inputs.