### PR TITLE
fix: correct asset-weight legend yield

### DIFF
--- a/tests/strategy/test_asset_weight_legend.py
+++ b/tests/strategy/test_asset_weight_legend.py
@@ -42,6 +42,7 @@ from tradeexecutor.strategy.chart.asset_weight_legend import (
     add_asset_weight_legend,
     allocation_swatch_data_url,
     calculate_capital_time_allocation_percentages,
+    calculate_end_allocation_percentages,
     merge_asset_weight_legend_entries,
 )
 from tradeexecutor.strategy.chart.vault_legend import get_vault_logo_coverage
@@ -201,6 +202,20 @@ def test_capital_time_allocation_is_weighted_by_time_between_samples() -> None:
     assert allocations == pytest.approx({"Intermittent vault": 100 / 3, "Constant vault": 200 / 3})
 
 
+def test_end_allocation_uses_the_last_chart_sample() -> None:
+    """End allocation is distinct from capital-time allocation."""
+    figure = go.Figure(
+        [
+            go.Scatter(name="Intermittent vault", x=[0, 1, 3], y=[100, 0, 100]),
+            go.Scatter(name="Constant vault", x=[0, 1, 3], y=[100, 100, 100]),
+        ],
+    )
+
+    allocations = calculate_end_allocation_percentages(figure)
+
+    assert allocations == pytest.approx({"Intermittent vault": 50.0, "Constant vault": 50.0})
+
+
 def test_legend_sort_does_not_reorder_chart_traces() -> None:
     """Keep reserve-like entries first while retaining the chart stacking order.
 
@@ -340,8 +355,8 @@ def test_vertical_legend_is_below_the_chart_with_doubled_rows(tmp_path) -> None:
     assert all(annotation.y < 0 for annotation in figure.layout.annotations)
     assert all(annotation.font.size == VERTICAL_HEADER_FONT_SIZE for annotation in figure.layout.annotations[:5])
     assert all(annotation.font.size == VERTICAL_ROW_FONT_SIZE for annotation in figure.layout.annotations[5:])
-    assert figure.layout.annotations[5].text == 'Vault A: <span style="color:#aaa">allocated <span style="color:#ffd700">66.7%</span>, yield <span style="color:#00ff66">12.5%</span></span>'
-    assert figure.layout.annotations[6].text == 'Vault B: <span style="color:#aaa">allocated <span style="color:#ffd700">33.3%</span>, yield <span style="color:#00ff66">-2.5%</span></span>'
+    assert figure.layout.annotations[5].text == 'Vault A: <span style="color:#aaa">avg. allc: <span style="color:#ffd700">66.7%</span>, end allc: <span style="color:#ffd700">66.7%</span>, avg. yield: <span style="color:#00ff66">12.5%</span></span>'
+    assert figure.layout.annotations[6].text == 'Vault B: <span style="color:#aaa">avg. allc: <span style="color:#ffd700">33.3%</span>, end allc: <span style="color:#ffd700">33.3%</span>, avg. yield: <span style="color:#00ff66">-2.5%</span></span>'
     assert all(image.sizex == VERTICAL_ALLOCATION_ICON_WIDTH for image in figure.layout.images if image.x == VERTICAL_ALLOCATION_X)
     assert all(image.sizex == VERTICAL_IDENTITY_ICON_WIDTH for image in figure.layout.images if image.x != VERTICAL_ALLOCATION_X)
     assert {image.x for image in figure.layout.images}.issubset({

--- a/tests/test_multipair.py
+++ b/tests/test_multipair.py
@@ -9,6 +9,29 @@ import pytest
 from tradeexecutor.analysis.multipair import calculate_pair_annualised_average_yield
 
 
+def _make_position(
+    pair,
+    opened_at: datetime.datetime,
+    closed_at: datetime.datetime,
+    trades: list[tuple[datetime.datetime, float, float]],
+):
+    """Create a completed spot/vault position mock with executed cash flows."""
+    position = MagicMock(pair=pair)
+    position.opened_at = opened_at
+    position.closed_at = closed_at
+    position.is_closed.return_value = True
+    position.trades = {}
+    for index, (executed_at, quantity, value) in enumerate(trades):
+        trade = MagicMock()
+        trade.executed_at = executed_at
+        trade.opened_at = executed_at
+        trade.is_success.return_value = True
+        trade.get_position_quantity.return_value = quantity
+        trade.get_value.return_value = value
+        position.trades[index] = trade
+    return position
+
+
 def test_pair_annualised_average_yield_is_weighted_by_capital_and_time() -> None:
     """Annualise a pair's yield without compounding short positions.
 
@@ -19,10 +42,18 @@ def test_pair_annualised_average_yield_is_weighted_by_capital_and_time() -> None
     # 1. Create two positions with different principal and holding periods.
     pair = MagicMock()
     pair.is_cctp_bridge.return_value = False
-    first_position = MagicMock(pair=pair)
-    first_position.get_value_at_open.return_value = 100.0
-    second_position = MagicMock(pair=pair)
-    second_position.get_value_at_open.return_value = 200.0
+    first_position = _make_position(
+        pair,
+        datetime.datetime(2025, 1, 1),
+        datetime.datetime(2025, 1, 11),
+        [(datetime.datetime(2025, 1, 1), 100.0, 100.0)],
+    )
+    second_position = _make_position(
+        pair,
+        datetime.datetime(2025, 1, 1),
+        datetime.datetime(2025, 1, 21),
+        [(datetime.datetime(2025, 1, 1), 200.0, 200.0)],
+    )
     portfolio = MagicMock()
     portfolio.get_all_positions.return_value = [first_position, second_position]
 
@@ -40,3 +71,33 @@ def test_pair_annualised_average_yield_is_weighted_by_capital_and_time() -> None
 
     # 3. Check the money-time-weighted annualised yield.
     assert yield_percent == pytest.approx(3.65)
+
+
+def test_pair_annualised_average_yield_includes_position_adjustments() -> None:
+    """Include later capital additions in the annualisation denominator."""
+    pair = MagicMock()
+    pair.is_cctp_bridge.return_value = False
+    position = _make_position(
+        pair,
+        datetime.datetime(2025, 1, 1),
+        datetime.datetime(2025, 1, 21),
+        [
+            (datetime.datetime(2025, 1, 1), 100.0, 100.0),
+            (datetime.datetime(2025, 1, 11), 100.0, 100.0),
+        ],
+    )
+    portfolio = MagicMock()
+    portfolio.get_all_positions.return_value = [position]
+
+    with patch(
+        "tradeexecutor.analysis.multipair.calculate_pnl_generic",
+        return_value=SimpleNamespace(profit_usd=20.0),
+    ):
+        yield_percent = calculate_pair_annualised_average_yield(
+            pair,
+            portfolio,
+            datetime.datetime(2026, 1, 1),
+        )
+
+    # $100 is exposed for ten days and $200 for the next ten days.
+    assert yield_percent == pytest.approx(20 / 3_000 * 365)

--- a/tradeexecutor/analysis/multipair.py
+++ b/tradeexecutor/analysis/multipair.py
@@ -80,10 +80,11 @@ def calculate_pair_annualised_average_yield(
 ) -> float:
     """Calculate the capital- and time-weighted annualised yield for a pair.
 
-    This uses total PnL divided by the sum of each position's opening USD value
-    multiplied by its holding period. It is a simple annualised rate, avoiding
-    the unrealistic compounding caused by annualising individual short-lived
-    positions.
+    This uses total PnL divided by the capital-time exposure of every position.
+    Position adjustments are included as cash flows: a later buy increases the
+    denominator from its execution time and a sell reduces it. This avoids
+    inflating the displayed yield for rebalanced positions whose final PnL
+    reflects capital added after the first opening trade.
 
     :return:
         Annualised average yield as a decimal fraction, where ``0.05`` is 5%.
@@ -95,19 +96,61 @@ def calculate_pair_annualised_average_yield(
     total_capital_days = 0.0
     for position in (position for position in portfolio.get_all_positions() if position.pair == pair):
         profit_data = calculate_pnl_generic(position, end_at=end_at)
-        duration = profit_data.duration
-        capital_at_open = float(position.get_value_at_open())
-        duration_days = duration.total_seconds() / datetime.timedelta(days=1).total_seconds()
-        if capital_at_open <= 0 or duration_days <= 0:
+        capital_days = _calculate_position_capital_days(position, end_at)
+        if capital_days <= 0:
             continue
 
         total_profit_usd += float(profit_data.profit_usd)
-        total_capital_days += capital_at_open * duration_days
+        total_capital_days += capital_days
 
     if total_capital_days == 0:
         return 0.0
 
     return total_profit_usd / total_capital_days * 365
+
+
+def _calculate_position_capital_days(
+    position,
+    end_at: datetime.datetime,
+) -> float:
+    """Calculate capital-time exposure for a position with cash flows.
+
+    Cost basis is increased for every successful buy and reduced
+    proportionally for every successful sell. Integrating that basis between
+    trade executions gives the capital-days used to annualise aggregate PnL.
+    """
+    position_end_at = position.closed_at if position.is_closed() else end_at
+    current_cost_basis = 0.0
+    current_quantity = 0.0
+    capital_days = 0.0
+    last_timestamp = position.opened_at
+
+    for trade in sorted(position.trades.values(), key=lambda trade: trade.executed_at or trade.opened_at):
+        if not trade.is_success():
+            continue
+
+        timestamp = trade.executed_at or trade.opened_at
+        assert timestamp is not None, f"Successful trade missing execution timestamp: {trade}"
+        assert timestamp >= last_timestamp, f"Trade timestamps out of order for {position}: {trade}"
+
+        duration_days = (timestamp - last_timestamp).total_seconds() / datetime.timedelta(days=1).total_seconds()
+        capital_days += current_cost_basis * duration_days
+
+        quantity_change = float(trade.get_position_quantity())
+        trade_value = float(trade.get_value())
+        if quantity_change > 0:
+            current_cost_basis += trade_value
+            current_quantity += quantity_change
+        elif quantity_change < 0 and current_quantity > 0:
+            sold_fraction = min(abs(quantity_change) / current_quantity, 1.0)
+            current_cost_basis *= 1 - sold_fraction
+            current_quantity += quantity_change
+
+        last_timestamp = timestamp
+
+    duration_days = (position_end_at - last_timestamp).total_seconds() / datetime.timedelta(days=1).total_seconds()
+    capital_days += current_cost_basis * duration_days
+    return capital_days
 
 
 def analyse_multipair(

--- a/tradeexecutor/strategy/chart/asset_weight_legend.py
+++ b/tradeexecutor/strategy/chart/asset_weight_legend.py
@@ -407,6 +407,27 @@ def calculate_capital_time_allocation_percentages(figure: Figure) -> dict[str, f
     }
 
 
+def calculate_end_allocation_percentages(figure: Figure) -> dict[str, float]:
+    """Calculate each trace's allocation at the final chart timestamp.
+
+    This complements :py:func:`calculate_capital_time_allocation_percentages`:
+    the former describes the end-of-backtest portfolio while the latter
+    describes the average capital committed over the entire chart.
+    """
+    end_values = {
+        trace.name: float(np.nan_to_num(np.asarray(trace.y, dtype=float), nan=0.0, posinf=0.0, neginf=0.0)[-1])
+        for trace in figure.data
+        if trace.name and trace.y is not None and len(trace.y) > 0
+    }
+    total_end_value = sum(end_values.values())
+    if total_end_value <= 0:
+        return {}
+    return {
+        name: value / total_end_value * 100
+        for name, value in end_values.items()
+    }
+
+
 def add_asset_weight_legend(
     figure: Figure,
     entries: Iterable[AssetWeightLegendEntry],
@@ -442,6 +463,7 @@ def add_asset_weight_legend(
 
     merged_entries = merge_asset_weight_legend_entries(entries)
     capital_time_allocations = calculate_capital_time_allocation_percentages(figure)
+    end_allocations = calculate_end_allocation_percentages(figure)
     entries_by_label: dict[str, list[AssetWeightLegendEntry]] = {}
     for entry in merged_entries:
         entries_by_label.setdefault(entry.label, []).append(entry)
@@ -619,8 +641,9 @@ def add_asset_weight_legend(
             text=(
                 (
                     f'{trace.name}: <span style="color:#aaa">'
-                    f'allocated <span style="color:#ffd700">{capital_time_allocations[trace.name]:.1f}%</span>, '
-                    f'yield <span style="color:#00ff66">{entry.annualised_yield_percent if entry else 0.0:.1f}%</span></span>'
+                    f'avg. allc: <span style="color:#ffd700">{capital_time_allocations[trace.name]:.1f}%</span>, '
+                    f'end allc: <span style="color:#ffd700">{end_allocations.get(trace.name, 0.0):.1f}%</span>, '
+                    f'avg. yield: <span style="color:#00ff66">{entry.annualised_yield_percent if entry else 0.0:.1f}%</span></span>'
                 )
                 if legend_layout == "vertical" and trace.name in capital_time_allocations
                 else (


### PR DESCRIPTION
## Summary

- calculate annualised pair yield using cashflow-aware capital-time exposure
- distinguish average allocation from end allocation in the compressed asset-weight legend
- relabel the legend fields to make their time basis explicit