### PR TITLE
fix: only defer explicit vault windows

### DIFF
--- a/tests/backtest/test_phase_aware_backtest.py
+++ b/tests/backtest/test_phase_aware_backtest.py
@@ -237,7 +237,12 @@ def _phase_aware_decide_trades(
     venue_value_before = queue_venue_redeemable(state.portfolio, venue_pair_ids)
     raw_cash_before = state.portfolio.get_cash()
 
-    alpha_model = PhaseAwareAlphaModel(timestamp, cycle=input.cycle, venue_pair_ids=venue_pair_ids)
+    alpha_model = PhaseAwareAlphaModel(
+        timestamp,
+        cycle=input.cycle,
+        venue_pair_ids=venue_pair_ids,
+        window_gated_pair_ids={TARGET_INTERNAL_ID},
+    )
     # Default: only the window-gated target. The venue is never signalled -> excluded from candidates.
     if signal_fn is not None:
         scores = signal_fn(input.cycle)

--- a/tests/units_tests/test_phase_aware_alpha_model.py
+++ b/tests/units_tests/test_phase_aware_alpha_model.py
@@ -194,7 +194,12 @@ def test_apply_parks_closed_window_and_zeros_adjust():
     other_data = OtherData()
     signal = _make_signal(_make_pair(101), 1000.0)
     pm = _make_pm(other_data, open_pairs=set())  # 101 closed
-    alpha = PhaseAwareAlphaModel(datetime.datetime(2024, 1, 1), cycle=5, venue_pair_ids={999})
+    alpha = PhaseAwareAlphaModel(
+        datetime.datetime(2024, 1, 1),
+        cycle=5,
+        venue_pair_ids={999},
+        window_gated_pair_ids={101},
+    )
     alpha.signals = {101: signal}
 
     # 1-2. Park before generation - the deferred buy is zeroed out.
@@ -210,6 +215,47 @@ def test_apply_parks_closed_window_and_zeros_adjust():
     assert open_events[101].cycle == 5
 
 
+def test_apply_does_not_park_closed_vault_without_explicit_window_gate():
+    """A closed synchronous vault is skipped normally, not held in the queue.
+
+    A zero-capacity ERC-4626 vault may report ``can_deposit=False`` permanently.
+    It is not safe to assume that it has a future deposit window unless the
+    strategy explicitly configured it as one.
+    """
+    other_data = OtherData()
+    signal = _make_signal(_make_pair(101), 1000.0)
+    pm = _make_pm(other_data, open_pairs=set())
+    alpha = PhaseAwareAlphaModel(
+        datetime.datetime(2024, 1, 1),
+        cycle=5,
+        venue_pair_ids={999},
+    )
+    alpha.signals = {101: signal}
+
+    alpha.apply_phase_aware_intent(pm)
+
+    assert signal.position_adjust_usd == pytest.approx(1000.0)
+    assert TradingPairSignalFlags.parked_in_queue_vault not in signal.flags
+    assert read_open_park_events(other_data) == {}
+
+
+def test_apply_closes_legacy_park_for_vault_without_window_gate():
+    """Release a legacy queue reservation when its window-gate permission is removed."""
+    other_data = OtherData()
+    append_queue_event(other_data, QueueVaultEvent(EVENT_PARK, 101, 1000.0, 1))
+    pm = _make_pm(other_data, open_pairs=set())
+    alpha = PhaseAwareAlphaModel(
+        datetime.datetime(2024, 1, 2),
+        cycle=2,
+        venue_pair_ids={999},
+    )
+    alpha.signals = {101: _make_signal(_make_pair(101), 1000.0)}
+
+    alpha.apply_phase_aware_intent(pm)
+
+    assert read_open_park_events(other_data) == {}
+
+
 def test_promote_finalised_only_when_buy_emits():
     """A promotion is logged/flagged only once the deposit trade actually emits.
 
@@ -222,7 +268,12 @@ def test_promote_finalised_only_when_buy_emits():
     pair = _make_pair(101)
     signal = _make_signal(pair, 1200.0)
     pm = _make_pm(other_data, open_pairs={101})  # A open
-    alpha = PhaseAwareAlphaModel(datetime.datetime(2024, 1, 2), cycle=2, venue_pair_ids={999})
+    alpha = PhaseAwareAlphaModel(
+        datetime.datetime(2024, 1, 2),
+        cycle=2,
+        venue_pair_ids={999},
+        window_gated_pair_ids={101},
+    )
     alpha.signals = {101: signal}
 
     # 1-2. apply marks the candidate but does not promote yet.
@@ -248,7 +299,12 @@ def test_promote_candidate_stays_open_when_buy_suppressed():
     append_queue_event(other_data, QueueVaultEvent(EVENT_PARK, 101, 1000.0, 1))
     signal = _make_signal(_make_pair(101), 1200.0)
     pm = _make_pm(other_data, open_pairs={101})
-    alpha = PhaseAwareAlphaModel(datetime.datetime(2024, 1, 2), cycle=2, venue_pair_ids={999})
+    alpha = PhaseAwareAlphaModel(
+        datetime.datetime(2024, 1, 2),
+        cycle=2,
+        venue_pair_ids={999},
+        window_gated_pair_ids={101},
+    )
     alpha.signals = {101: signal}
     alpha.apply_phase_aware_intent(pm)
 
@@ -267,7 +323,12 @@ def test_stale_close_when_no_longer_targeted():
     other_data = OtherData()
     append_queue_event(other_data, QueueVaultEvent(EVENT_PARK, 202, 2000.0, 1))
     pm = _make_pm(other_data, open_pairs=set())
-    alpha = PhaseAwareAlphaModel(datetime.datetime(2024, 1, 2), cycle=2, venue_pair_ids={999})
+    alpha = PhaseAwareAlphaModel(
+        datetime.datetime(2024, 1, 2),
+        cycle=2,
+        venue_pair_ids={999},
+        window_gated_pair_ids={202},
+    )
     alpha.signals = {}  # B no longer targeted
 
     alpha.apply_phase_aware_intent(pm)
@@ -284,7 +345,12 @@ def test_settlement_pending_park_stays_open():
     append_queue_event(other_data, QueueVaultEvent(EVENT_PARK, 101, 1000.0, 1))
     signal = _make_signal(_make_pair(101), 0.0, carry_forward=True)
     pm = _make_pm(other_data, open_pairs=set())
-    alpha = PhaseAwareAlphaModel(datetime.datetime(2024, 1, 2), cycle=2, venue_pair_ids={999})
+    alpha = PhaseAwareAlphaModel(
+        datetime.datetime(2024, 1, 2),
+        cycle=2,
+        venue_pair_ids={999},
+        window_gated_pair_ids={101},
+    )
     alpha.signals = {101: signal}
 
     alpha.apply_phase_aware_intent(pm)
@@ -301,7 +367,12 @@ def test_still_closed_reparks_and_stays_open():
     append_queue_event(other_data, QueueVaultEvent(EVENT_PARK, 101, 1000.0, 1))
     signal = _make_signal(_make_pair(101), 1100.0)
     pm = _make_pm(other_data, open_pairs=set())  # still closed
-    alpha = PhaseAwareAlphaModel(datetime.datetime(2024, 1, 2), cycle=2, venue_pair_ids={999})
+    alpha = PhaseAwareAlphaModel(
+        datetime.datetime(2024, 1, 2),
+        cycle=2,
+        venue_pair_ids={999},
+        window_gated_pair_ids={101},
+    )
     alpha.signals = {101: signal}
 
     alpha.apply_phase_aware_intent(pm)
@@ -347,7 +418,12 @@ def test_repark_same_amount_does_not_duplicate_event():
     append_queue_event(other_data, QueueVaultEvent(EVENT_PARK, 101, 1000.0, 1))
     signal = _make_signal(_make_pair(101), 1000.0)
     pm = _make_pm(other_data, open_pairs=set())  # still closed
-    alpha = PhaseAwareAlphaModel(datetime.datetime(2024, 1, 2), cycle=2, venue_pair_ids={999})
+    alpha = PhaseAwareAlphaModel(
+        datetime.datetime(2024, 1, 2),
+        cycle=2,
+        venue_pair_ids={999},
+        window_gated_pair_ids={101},
+    )
     alpha.signals = {101: signal}
 
     # 1-2. Re-parked (still parked) but no duplicate event appended.
@@ -429,7 +505,12 @@ def test_park_dominant_cancels_cycle_via_min_trade_gate():
     dominant = _make_signal(_make_pair(101), 1000.0)  # closed-window deposit, will be parked
     tiny = _make_signal(_make_pair(202), 5.0)  # open, below the gate threshold
     pm = _make_pm(other_data, open_pairs={202})  # 101 closed, 202 open
-    alpha = PhaseAwareAlphaModel(datetime.datetime(2024, 1, 1), cycle=1, venue_pair_ids={999})
+    alpha = PhaseAwareAlphaModel(
+        datetime.datetime(2024, 1, 1),
+        cycle=1,
+        venue_pair_ids={999},
+        window_gated_pair_ids={101},
+    )
     alpha.signals = {101: dominant, 202: tiny}
 
     # 2. Park the dominant deposit (window closed) -> its adjustment is zeroed before generation.

--- a/tradeexecutor/strategy/phase_aware.py
+++ b/tradeexecutor/strategy/phase_aware.py
@@ -287,15 +287,16 @@ def read_open_redeem_block_events(other_data: OtherData) -> dict[int, QueueVault
 
 
 class PhaseAwareAlphaModel(AlphaModel):
-    """AlphaModel that defers window-closed vault deposits into a yield-bearing queue venue.
+    """AlphaModel that defers explicitly window-gated deposits into a queue venue.
 
-    Instead of *skipping* a vault whose deposit window is closed, it **defers** the
-    buy and logs a durable park event, so the capital waits in the queue venue and
-    is deposited on a later cycle once the window opens. It reuses the overridable
-    hooks extracted from :py:class:`AlphaModel` in PR-0 and the queue-venue helpers
-    in this module. It is orthogonal to the allocation method (works with any
-    ``normalise_weights`` variant): the phase-aware pass operates on ``self.signals``
-    after targets are computed, whatever produced them.
+    Instead of *skipping* an explicitly configured window-gated vault whose deposit
+    window is closed, it **defers** the buy and logs a durable park event, so the
+    capital waits in the queue venue and is deposited on a later cycle once the
+    window opens. Other closed vaults retain the base model's skip behaviour. It
+    reuses the overridable hooks extracted from :py:class:`AlphaModel` in PR-0 and
+    the queue-venue helpers in this module. It is orthogonal to the allocation
+    method (works with any ``normalise_weights`` variant): the phase-aware pass
+    operates on ``self.signals`` after targets are computed, whatever produced them.
 
     Cross-chain deposits compose with no phase-aware-specific code: a promoted buy into a
     satellite-chain vault is funded through the existing CCTP planner, provided the queue venue
@@ -339,6 +340,7 @@ class PhaseAwareAlphaModel(AlphaModel):
         *,
         cycle: int | None = None,
         venue_pair_ids: set | None = None,
+        window_gated_pair_ids: set | None = None,
         **kwargs,
     ):
         """
@@ -355,12 +357,19 @@ class PhaseAwareAlphaModel(AlphaModel):
             :py:func:`queue_vault_pair_ids`). Used to (a) add their redeemable value
             to the same-cycle cash budget and (b) exclude them from old-weight
             accounting.
+
+        :param window_gated_pair_ids:
+            Internal ids of vaults whose closed deposit windows are expected to reopen.
+            Only these pairs may use the park -> deposit-on-open flow. A synchronous
+            vault that reports deposits closed or zero capacity must fall through to
+            the normal skipped-buy path instead of reserving queue capital indefinitely.
         """
         super().__init__(timestamp=timestamp, **kwargs)
         # This subclass is intentionally not slotted, so instances get a __dict__
         # for these transient per-cycle attributes (not part of the serialised state).
         self.phase_aware_cycle = cycle
         self.venue_pair_ids: set = set(venue_pair_ids) if venue_pair_ids else set()
+        self.window_gated_pair_ids: set = set(window_gated_pair_ids) if window_gated_pair_ids else set()
         #: Vaults with an open park event whose window opened and stayed targeted this
         #: cycle. The promote event is finalised in
         #: :py:meth:`reconcile_phase_aware_events`, only once the deposit trade has
@@ -430,9 +439,16 @@ class PhaseAwareAlphaModel(AlphaModel):
         open_events = read_open_park_events(other_data)
         self._promote_candidates = set()
 
-        # 1. Park every fresh positive deposit whose window is closed.
+        # 1. Park only explicitly window-gated vaults whose window is closed.
+        #
+        # ``can_deposit()`` may be false for permanent or capacity-related reasons
+        # (e.g. an ERC-4626 vault reporting ``maxDeposit == 0``). Such a vault does
+        # not have a known future opening and must use AlphaModel's ordinary
+        # skipped-buy path, not reserve capital in the queue venue.
         for vault_id, signal in self.signals.items():
             if signal.carry_forward_position or signal.position_adjust_usd <= 0:
+                continue
+            if vault_id not in self.window_gated_pair_ids:
                 continue
             if pricing_model.can_deposit(self.timestamp, signal.pair):
                 if vault_id in open_events:
@@ -442,6 +458,11 @@ class PhaseAwareAlphaModel(AlphaModel):
 
         # 2. Stale-close open park events whose vault is no longer a live parked deposit.
         for vault_id in open_events:
+            if vault_id not in self.window_gated_pair_ids:
+                # Release a legacy park for a vault that is no longer explicitly
+                # eligible for deferred deposit handling.
+                self._log_phase_aware_event(other_data, EVENT_CLOSE, vault_id, 0.0)
+                continue
             if vault_id in self._promote_candidates:
                 continue
             signal = self.signals.get(vault_id)


### PR DESCRIPTION
## Summary

- restrict queue parking to vaults explicitly configured with a reopening deposit window
- release legacy park events for vaults no longer eligible for deferred deposits
- retain the normal skipped-buy path for closed synchronous or zero-capacity vaults