### PR TITLE
fix: refresh hot wallet nonces at the start of each live task

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 0.2
 
+- Fix the live executor dying with a permanent `nonce too low` after the asset manager private key is used outside the process, for example a manual Safe multisig settlement. The new `tradeexecutor.ethereum.nonce.refresh_hot_wallet_nonces()` re-reads the onchain nonce for every hot wallet against its own chain at the start of the `live_cycle`, `live_positions` and `live_trigger_checks` scheduled tasks: it adopts an advanced onchain nonce and warns that the key was used elsewhere, and never lowers a counter that is ahead of the chain, which is the normal state while our own transaction is unmined (2026-08-07)
+
 - Add Lagoon external-settlement recovery: the executor discovers confirmed Safe-governance settlements from Lagoon receipt events before reconciling Safe USDC, records normal investor-flow balance updates idempotently, exports pending queue amounts and defers a trading cycle while a settlement remains inside the confirmation buffer (2026-08-05)
 
 - Fix HyperCore vault deposits whose spot-to-perp CoreWriter action succeeded while the batched perp-to-vault action silently no-op'd: execute and verify the two legs separately, retain recoverable stranded capital in state rather than restoring it to Safe reserve accounting, fail closed across phase-1 broadcast crashes or ambiguous CoreWriter settlement until live Safe/escrow/spot/perp/vault reconciliation proves the destination, and enable default `correct-accounts` recovery of the full perp-to-spot transit amount before any separate spot cleanup (2026-07-30)

--- a/tests/ethereum/test_hot_wallet_nonce_refresh.py
+++ b/tests/ethereum/test_hot_wallet_nonce_refresh.py
@@ -1,0 +1,143 @@
+"""Hot wallet nonce refresh tests.
+
+The executor keeps the hot wallet nonce in an in-memory counter that is read
+from the chain only once at startup. If the same private key is used outside the
+executor process, for example a manual Safe multisig transaction or an operator
+running a CLI command, the counter falls behind the chain and every transaction
+the executor signs afterwards is permanently rejected with ``nonce too low``.
+
+:py:func:`~tradeexecutor.ethereum.nonce.refresh_hot_wallet_nonces` is called at
+the start of every scheduled live task to correct this before anything is signed.
+"""
+
+import pytest
+from eth_defi.hotwallet import HotWallet
+from eth_defi.provider.anvil import AnvilLaunch, launch_anvil
+from eth_defi.provider.multi_provider import create_multi_provider_web3
+from eth_defi.trace import assert_transaction_success_with_explanation
+from tradingstrategy.chain import ChainId
+from web3 import Web3
+
+from tradeexecutor.ethereum.nonce import refresh_hot_wallet_nonces
+from tradeexecutor.ethereum.web3config import Web3Config
+
+ZERO_ADDRESS = "0x0000000000000000000000000000000000000000"
+
+
+@pytest.fixture()
+def anvil() -> AnvilLaunch:
+    """Local test chain."""
+    anvil = launch_anvil()
+    try:
+        yield anvil
+    finally:
+        anvil.close()
+
+
+@pytest.fixture()
+def web3(anvil: AnvilLaunch) -> Web3:
+    """Web3 connection to the local test chain."""
+    return create_multi_provider_web3(anvil.json_rpc_url)
+
+
+@pytest.fixture()
+def hot_wallet(web3: Web3) -> HotWallet:
+    """Funded hot wallet with an unsynced nonce counter."""
+    return HotWallet.create_for_testing(web3)
+
+
+@pytest.fixture()
+def web3config(web3: Web3) -> Web3Config:
+    """Web3Config holding the single test chain connection."""
+    config = Web3Config()
+    config.connections[ChainId.anvil] = web3
+    config.set_default_chain(ChainId.anvil)
+    return config
+
+
+def _broadcast_outside_the_counter(web3: Web3, hot_wallet: HotWallet):
+    """Spend a nonce without touching the hot wallet's in-memory counter.
+
+    Simulates the private key being used by another process, a manual Safe
+    transaction or a CLI command while the executor is running.
+    """
+    tx = {
+        "from": hot_wallet.address,
+        "to": ZERO_ADDRESS,
+        "value": 1,
+        "gas": 100_000,
+        "gasPrice": web3.eth.gas_price,
+        "chainId": web3.eth.chain_id,
+        # Read straight from the chain, bypassing HotWallet.allocate_nonce()
+        "nonce": web3.eth.get_transaction_count(hot_wallet.address),
+    }
+    signed = hot_wallet.account.sign_transaction(tx)
+    tx_hash = web3.eth.send_raw_transaction(signed.raw_transaction)
+    assert_transaction_success_with_explanation(web3, tx_hash)
+
+
+def test_refresh_hot_wallet_nonces_adopts_external_nonce(
+    web3: Web3,
+    web3config: Web3Config,
+    hot_wallet: HotWallet,
+):
+    """Refreshing adopts a nonce burned outside the trade executor.
+
+    This is the failure that took the hyper-ai executor down: a manual Safe
+    settlement spent the next nonce, the executor kept its stale counter and
+    every NAV update it signed afterwards was rejected as ``nonce too low``.
+
+    1. Initialise the counter from the chain through the refresh helper.
+    2. Spend a nonce outside the counter, as an external process would.
+    3. Refresh again and confirm the counter adopted the on-chain nonce.
+    """
+
+    # 1. Initialise the counter from the chain through the refresh helper.
+    # create_for_testing() has already synced it, so clear it first to cover
+    # the unsynced startup path as well.
+    hot_wallet.current_nonce = None
+    result = refresh_hot_wallet_nonces(web3config, {ChainId.anvil: hot_wallet}, context="unit_test")
+    assert result == {ChainId.anvil: 0}
+    assert hot_wallet.current_nonce == 0
+
+    # 2. Spend a nonce outside the counter, as an external process would
+    _broadcast_outside_the_counter(web3, hot_wallet)
+    assert hot_wallet.current_nonce == 0, "External use must not touch the in-memory counter"
+    assert web3.eth.get_transaction_count(hot_wallet.address) == 1
+
+    # 3. Refresh again and confirm the counter adopted the on-chain nonce
+    result = refresh_hot_wallet_nonces(web3config, {ChainId.anvil: hot_wallet}, context="unit_test")
+    assert result == {ChainId.anvil: 1}
+    assert hot_wallet.current_nonce == 1
+
+
+def test_refresh_hot_wallet_nonces_never_rewinds_counter(
+    web3: Web3,
+    web3config: Web3Config,
+    hot_wallet: HotWallet,
+):
+    """Refreshing does not rewind a counter that is ahead of the chain.
+
+    A local counter ahead of the chain is the normal state while our own
+    transaction is broadcast but not yet mined. Rewinding it would hand the same
+    nonce out twice and cause a collision, so the counter must be left alone.
+
+    1. Initialise the counter from the chain.
+    2. Allocate a nonce locally without broadcasting anything.
+    3. Refresh and confirm the counter was not lowered back to the chain value.
+    """
+
+    # 1. Initialise the counter from the chain
+    refresh_hot_wallet_nonces(web3config, {ChainId.anvil: hot_wallet}, context="unit_test")
+    assert hot_wallet.current_nonce == 0
+
+    # 2. Allocate a nonce locally without broadcasting anything
+    allocated = hot_wallet.allocate_nonce()
+    assert allocated == 0
+    assert hot_wallet.current_nonce == 1
+    assert web3.eth.get_transaction_count(hot_wallet.address) == 0
+
+    # 3. Refresh and confirm the counter was not lowered back to the chain value
+    result = refresh_hot_wallet_nonces(web3config, {ChainId.anvil: hot_wallet}, context="unit_test")
+    assert result == {ChainId.anvil: 1}
+    assert hot_wallet.current_nonce == 1

--- a/tradeexecutor/cli/loop.py
+++ b/tradeexecutor/cli/loop.py
@@ -21,10 +21,12 @@ import pandas as pd
 from apscheduler.events import EVENT_JOB_ERROR, EVENT_JOB_MAX_INSTANCES, EVENT_JOB_MISSED
 
 from tradingstrategy.candle import GroupedCandleUniverse
+from tradingstrategy.chain import ChainId
 from tradingstrategy.client import BaseClient
 from tradingstrategy.timebucket import TimeBucket
 
 from tradeexecutor.analysis.pair import display_strategy_universe
+from tradeexecutor.ethereum.nonce import refresh_hot_wallet_nonces
 from tradeexecutor.cli.watchdog import create_watchdog_registry, register_worker, mark_alive, start_background_watchdog, \
     WatchdogMode
 from tradeexecutor.state.metadata import Metadata
@@ -722,6 +724,53 @@ class ExecutionLoop:
         # Assume universe stays static between cycles
         # for hourly revaluations
         return universe
+
+    def refresh_nonces(self, context: str):
+        """Re-read hot wallet nonces from the chain before a scheduled task signs anything.
+
+        The in-memory nonce counter desynchronises whenever the same private key
+        is used outside this process, for example a manual Safe transaction or an
+        operator running a CLI command against a live strategy. Refreshing at the
+        start of every scheduled task means the counter is corrected before any
+        transaction is signed, instead of the executor signing with a spent nonce
+        and getting a permanent ``nonce too low`` rejection.
+
+        Does nothing for execution models without a hot wallet, such as
+        backtesting and dummy execution.
+
+        See :py:func:`tradeexecutor.ethereum.nonce.refresh_hot_wallet_nonces`.
+
+        :param context:
+            Name of the scheduled task, included in the log messages.
+        """
+
+        web3config = getattr(self.execution_model, "web3config", None)
+        if web3config is None:
+            return
+
+        hot_wallet = self.sync_model.get_hot_wallet()
+        if hot_wallet is None:
+            return
+
+        # The wallet's nonce counter belongs to the chain its transaction builder
+        # signs for. Satellite chain wallets are created and synced per trade in
+        # GenericRouting.setup_trades() and are not tracked here.
+        tx_builder = getattr(self.execution_model, "tx_builder", None)
+        tx_builder_chain_id = getattr(tx_builder, "chain_id", None)
+        if isinstance(tx_builder_chain_id, int):
+            chain_id = ChainId(tx_builder_chain_id)
+        else:
+            chain_id = web3config.default_chain_id
+
+        if chain_id is None:
+            logger.warning("Cannot refresh hot wallet %s nonce (%s): chain id unknown", hot_wallet.address, context)
+            return
+
+        refresh_hot_wallet_nonces(
+            web3config,
+            {chain_id: hot_wallet},
+            context=context,
+        )
 
     def update_position_valuations(
             self,
@@ -1502,6 +1551,10 @@ class ExecutionLoop:
             nonlocal universe
             try:
 
+                # Correct the hot wallet nonce counter before we sign any trade,
+                # in case the private key was used outside this process
+                self.refresh_nonces("live_cycle")
+
                 extra_debug_data = {}
 
                 # Wall clock time
@@ -1640,6 +1693,10 @@ class ExecutionLoop:
             try:
                 ts = native_datetime_utc_now()
 
+                # Post-valuation settlement below broadcasts an on-chain NAV update,
+                # so correct the nonce counter before anything is signed
+                self.refresh_nonces("live_positions")
+
                 # Post-valuation settlement runs automatically for all Lagoon-style
                 # vaults (async deposits) — no environment variable to misconfigure
                 # between deployments. It reconciles reserve cash from on-chain before
@@ -1716,6 +1773,10 @@ class ExecutionLoop:
 
             try:
                 ts = native_datetime_utc_now()
+
+                # Stop loss and take profit triggers may execute trades
+                self.refresh_nonces("live_trigger_checks")
+
                 self.check_position_triggers(ts, state, universe)
             except Exception as e:
                 die(e)

--- a/tradeexecutor/ethereum/nonce.py
+++ b/tradeexecutor/ethereum/nonce.py
@@ -1,0 +1,273 @@
+"""Hot wallet nonce maintenance for the live trading loop.
+
+:py:class:`eth_defi.hotwallet.HotWallet` tracks the transaction nonce in an
+in-memory counter that is normally read from the blockchain only once, when
+the executor starts. Every transaction the executor signs afterwards increments
+that counter locally.
+
+The counter silently desynchronises whenever the same private key is used
+outside the executor process, for example
+
+- a manual Safe multisig transaction executed by the asset manager key,
+- an operator running a CLI command such as ``correct-accounts`` or
+  ``lagoon-redeem`` against a live strategy,
+- a recovery script broadcasting from the same key.
+
+Once the on-chain nonce has moved past the local counter, every transaction the
+executor signs is rejected with ``nonce too low`` and can never be broadcast,
+because the nonce is permanently spent. This module re-reads the on-chain nonce
+at the start of each scheduled live task so that the desynchronisation is
+corrected before anything is signed, and so that the operator gets a warning in
+the logs telling them the key was used elsewhere.
+
+See :py:func:`refresh_hot_wallet_nonces`.
+"""
+
+import logging
+
+from eth_defi.hotwallet import HotWallet
+from tradingstrategy.chain import ChainId
+
+from tradeexecutor.ethereum.web3config import Web3Config
+
+logger = logging.getLogger(__name__)
+
+
+def refresh_hot_wallet_nonces(
+    web3config: Web3Config,
+    wallets: dict[ChainId, HotWallet],
+    *,
+    context: str = "",
+) -> dict[ChainId, int]:
+    """Re-read the on-chain nonce for every hot wallet we hold.
+
+    Each wallet is refreshed against the JSON-RPC connection of its own chain,
+    because a :py:class:`~eth_defi.hotwallet.HotWallet` instance carries a
+    single nonce counter that is only meaningful for one chain. Passing a wallet
+    under the wrong chain id would corrupt its counter, so the caller owns the
+    chain to wallet mapping.
+
+    Logging follows the on-chain movement:
+
+    - The nonce advanced since we last looked, meaning the private key was used
+      outside this process: log a ``WARNING`` and adopt the on-chain value.
+
+    - The local counter is ahead of the chain: log at ``DEBUG``. This is the
+      normal state while a broadcast transaction is still unmined. The counter
+      is deliberately left alone, because
+      :py:meth:`eth_defi.hotwallet.HotWallet.sync_nonce` never lowers it and
+      rewinding into a pending transaction's nonce would cause a collision.
+
+    - Nothing changed: log at ``DEBUG``.
+
+    Example:
+
+    .. code-block:: python
+
+        refresh_hot_wallet_nonces(
+            web3config,
+            {ChainId.hyperliquid: hot_wallet},
+            context="live_cycle",
+        )
+
+    .. rubric:: Where this is called
+
+    The only production caller is
+    :py:meth:`tradeexecutor.cli.loop.ExecutionLoop.refresh_nonces`, which
+    resolves the persistent hot wallet from
+    :py:meth:`tradeexecutor.strategy.sync_model.SyncModel.get_hot_wallet` and the
+    chain from ``execution_model.tx_builder.chain_id``, then calls this function
+    with a single entry mapping.
+
+    ``refresh_nonces()`` runs at the start of all three scheduled live tasks in
+    :py:meth:`tradeexecutor.cli.loop.ExecutionLoop.run_live`, each passing its
+    own ``context`` so the log line names the task that triggered the refresh:
+
+    - ``live_cycle`` — the strategy cycle, which signs trades.
+
+    - ``live_positions`` — the statistics refresh, which also posts the on-chain
+      NAV update and settles the vault for Lagoon-style strategies. This runs on
+      ``stats_refresh_frequency``, independently of the strategy cycle, and is
+      the task that failed in the incident below.
+
+    - ``live_trigger_checks`` — stop loss and take profit checks, which may
+      execute trades.
+
+    All three run on the same single-threaded APScheduler executor
+    (``ThreadPoolExecutor(1)``), so they are serialised and a refresh can never
+    race a signing operation in another task.
+
+    Cost is one ``eth_getTransactionCount`` per wallet per task invocation, plus
+    a second one via ``sync_nonce()`` only when the nonce actually moved.
+
+    .. rubric:: Incident this was written for
+
+    On 2026-08-06 the ``hyper-ai`` Lagoon strategy on HyperEVM (chain 999) died
+    and stayed down. Sequence of events:
+
+    - The asset manager hot wallet ``0x005B8d2FF173C8bCc980F275884B1E717082F10C``
+      is one of six owners of the vault Safe
+      ``0xa8F8DEbb722c6174B814b432169BF569603F673F``, which has a signing
+      threshold of four.
+
+    - At 10:50:40 UTC a 4-of-6 Safe ``execTransaction`` calling
+      ``settleDeposit(27169.177262)`` on the Lagoon vault
+      ``0xC723aDd84EE4646044ff28e552808E0a3ac48b54`` was executed with that hot
+      wallet as the submitting owner, in transaction ``0xad73384d…`` at block
+      42,453,420. This was an operator action through the Safe UI, not the
+      executor: the executor's own Lagoon transactions go through the
+      TradingStrategyModule, never through ``execTransaction``. It consumed
+      wallet nonce 2546.
+
+    - The executor never noticed. ``LagoonVaultSyncModel`` inherits the empty
+      :py:meth:`tradeexecutor.strategy.sync_model.SyncModel.resync_nonce`, so the
+      "make sure our hot wallet nonce is up to date" call in
+      :py:class:`tradeexecutor.strategy.runner.StrategyRunner` was a no-op and
+      the counter had not been read from the chain since process startup.
+
+    - At 12:00:14 UTC the ``live_positions`` task signed
+      ``updateNewTotalAssets(32500.498565)`` with the stale nonce 2546 and the
+      chain replied ``nonce too low: next nonce 2547, tx nonce 2546``. The nonce
+      was permanently spent, so no amount of rebroadcasting could ever succeed.
+
+    - ``eth_defi.confirmation.wait_and_broadcast_multiple_nodes_mev_blocker()``
+      treated it as retryable and re-sent the identical signed bytes across three
+      RPC providers for ten minutes before raising ``ConfirmationTimedOut``,
+      which escaped as ``LiveSchedulingTaskFailed`` and terminated the executor.
+
+    Refreshing at the start of each task means the counter would have been
+    corrected to 2547 before the NAV update was signed.
+
+    .. rubric:: Known gaps
+
+    This function narrows the failure window, it does not close it. Do not treat
+    it as a complete fix.
+
+    - **The race window remains.** An external transaction can land between the
+      refresh and the signing that follows it. The durable fix is to treat
+      ``chain_nonce > tx.nonce`` as a non-retryable condition in
+      ``eth_defi.confirmation.wait_and_broadcast_multiple_nodes_mev_blocker()``
+      and have the caller re-sync, re-sign and retry once, rather than
+      rebroadcasting bytes that can never be accepted.
+
+    - **A counter that is ahead of the chain cannot be repaired here.**
+      :py:meth:`eth_defi.hotwallet.HotWallet.sync_nonce` refuses to lower
+      ``current_nonce``, which is what makes this function safe to call
+      repeatedly, but it also means a gap is permanent for the life of the
+      process. Gaps arise when a signed transaction is discarded without being
+      broadcast, for example when
+      :py:meth:`tradeexecutor.ethereum.vault.hypercore_routing.HypercoreVaultRouting.setup_trades`
+      signs approve and deposit transactions per trade in a loop and a later
+      trade raises. Repairing that needs a separate, explicit reset that is
+      allowed to lower the counter, gated on having no unmined transactions of
+      our own.
+
+    - **Satellite chain wallets are not covered.** Transactions on non-primary
+      chains use throwaway :py:class:`~eth_defi.hotwallet.HotWallet` objects
+      created and synced per trade in
+      :py:meth:`tradeexecutor.strategy.generic.generic_router.GenericRouting.setup_trades`,
+      which are discarded when the transaction builder is restored. There is no
+      registry of them to refresh. Related:
+      ``HypercoreVaultRouting.deployer`` is rebound to whichever wallet the
+      routing state last held and is never restored, so on a multichain
+      deployment it can end up pointing at a satellite wallet that this function
+      does not reach. The ``wallets`` argument is a mapping specifically so that
+      persistent per-chain wallets can be passed here without changing the
+      signature, should they be introduced.
+
+    - **Pending transactions are invisible.** The nonce is read at the ``latest``
+      block, not ``pending``, so our own broadcast but unmined transactions do
+      not count. This is exactly why the counter must never be lowered.
+
+    :param web3config:
+        Web3 connections for all configured chains.
+
+        Used to look up the JSON-RPC connection for each wallet's chain.
+
+    :param wallets:
+        Chain id to hot wallet mapping.
+
+        Every wallet is refreshed against the connection of the chain it is
+        keyed under. Chains that have no configured connection are skipped
+        with a warning.
+
+    :return:
+        Chain id to the nonce the wallet will use for its next transaction,
+        after the refresh.
+
+        Chains that were skipped are absent from the result.
+    """
+
+    assert isinstance(web3config, Web3Config), f"Expected Web3Config, got {type(web3config)}"
+    assert isinstance(wallets, dict), f"Expected dict, got {type(wallets)}"
+
+    suffix = f" ({context})" if context else ""
+    result: dict[ChainId, int] = {}
+
+    for chain_id, hot_wallet in wallets.items():
+        assert isinstance(chain_id, ChainId), f"Expected ChainId key, got {type(chain_id)}"
+        assert isinstance(hot_wallet, HotWallet), f"Expected HotWallet value, got {type(hot_wallet)}"
+
+        try:
+            web3 = web3config.get_connection(chain_id)
+        except KeyError:
+            logger.warning(
+                "Cannot refresh hot wallet %s nonce%s: no JSON-RPC connection configured for chain %s",
+                hot_wallet.address,
+                suffix,
+                chain_id.name,
+            )
+            continue
+
+        local_nonce = hot_wallet.current_nonce
+        onchain_nonce = web3.eth.get_transaction_count(hot_wallet.address)
+
+        if local_nonce is None:
+            # First sync for this wallet, nothing to compare against
+            hot_wallet.sync_nonce(web3)
+            logger.debug(
+                "Hot wallet %s nonce initialised to %d on chain %s%s",
+                hot_wallet.address,
+                hot_wallet.current_nonce,
+                chain_id.name,
+                suffix,
+            )
+        elif onchain_nonce > local_nonce:
+            # The key was used outside the trade executor and burned nonces we
+            # do not know about. Adopt the chain value before we sign anything,
+            # otherwise every transaction we sign is rejected as "nonce too low".
+            hot_wallet.sync_nonce(web3)
+            logger.warning(
+                "Hot wallet %s nonce advanced outside the trade executor on chain %s%s: was %d, now %d. "
+                "The private key has been used by another process, a manual Safe transaction or a CLI command.",
+                hot_wallet.address,
+                chain_id.name,
+                suffix,
+                local_nonce,
+                hot_wallet.current_nonce,
+            )
+        elif onchain_nonce < local_nonce:
+            # Normal while our own transaction is broadcast but not yet mined.
+            # Also happens when a signed transaction was discarded, which leaves
+            # a permanent gap that this function cannot repair.
+            logger.debug(
+                "Hot wallet %s local nonce %d is ahead of chain nonce %d on chain %s%s, "
+                "leaving the counter untouched",
+                hot_wallet.address,
+                local_nonce,
+                onchain_nonce,
+                chain_id.name,
+                suffix,
+            )
+        else:
+            logger.debug(
+                "Hot wallet %s nonce unchanged at %d on chain %s%s",
+                hot_wallet.address,
+                local_nonce,
+                chain_id.name,
+                suffix,
+            )
+
+        result[chain_id] = hot_wallet.current_nonce
+
+    return result


### PR DESCRIPTION
## Why

On 2026-08-06 the `hyper-ai` Lagoon strategy on HyperEVM died and stayed down for a day with a permanent `nonce too low: next nonce 2547, tx nonce 2546`.

Onchain forensics established the cause:

- The asset manager hot wallet `0x005B8d2FF173C8bCc980F275884B1E717082F10C` is one of six owners of the vault Safe `0xa8F8DEbb722c6174B814b432169BF569603F673F`, threshold four.
- At 10:50:40 UTC a 4-of-6 Safe `execTransaction` calling `settleDeposit(27169.177262)` on the Lagoon vault `0xC723aDd84EE4646044ff28e552808E0a3ac48b54` was executed with that hot wallet as the submitting owner — transaction `0xad73384d…`, block 42,453,420. This was an operator action through the Safe UI, not the executor: the executor's own Lagoon transactions go through the TradingStrategyModule and never emit `execTransaction`. It consumed wallet nonce 2546.
- The executor never noticed. `LagoonVaultSyncModel` inherits the empty `SyncModel.resync_nonce()`, so the "make sure our hot wallet nonce is up to date" call in `StrategyRunner` is a no-op for Lagoon strategies and the counter had not been read from the chain since process startup.
- At 12:00:14 UTC the `live_positions` task signed `updateNewTotalAssets(32500.498565)` with the stale nonce 2546. The nonce was permanently spent, so no rebroadcast could ever succeed.
- `wait_and_broadcast_multiple_nodes_mev_blocker()` treated it as retryable and re-sent identical signed bytes across three RPC providers for ten minutes before raising `ConfirmationTimedOut`, which escaped as `LiveSchedulingTaskFailed` and terminated the executor.

The executor's own log corroborates the external settlement: `Recovered 1 Lagoon settlement transaction(s) through block 42457659`.

## Lessons learnt

- An in-memory nonce counter that is chain-synced only at startup is a liability whenever the key is also a Safe owner. Operators legitimately use that key through the Safe UI, and the executor has no way to observe it.
- `resync_nonce()` already existed for exactly this scenario, but the base implementation is an empty method and only `HotWalletSyncModel` and `EnzymeVaultSyncModel` override it. An abstract-by-convention hook that silently does nothing is worse than no hook, because the call site reads as protected when it is not.
- Nonce posting and settlement do not only happen on the strategy cycle. `live_positions` broadcasts the onchain NAV update on `stats_refresh_frequency`, independently of `live_cycle`, so a cycle-only fix would have been unreliable. The refresh belongs on every scheduled task that can sign.
- A `HotWallet` carries one nonce counter, so it is only meaningful for one chain. Refreshing a single wallet against several chains would settle on the maximum across them and create a permanent gap. The chain to wallet mapping has to be owned by the caller.
- `sync_nonce()` refusing to lower the counter is what makes repeated refreshing safe against lagging load-balanced RPCs and against our own unmined transactions. The same property means it cannot repair a counter that is ahead of the chain.
- `nonce too low` is not a transient RPC condition when the chain nonce is ahead of the transaction nonce. Classifying it as retryable turned a one-nonce desync into ten minutes of futile rebroadcasting and then a process exit.

## Summary

- New `tradeexecutor/ethereum/nonce.py` with `refresh_hot_wallet_nonces(web3config, wallets, context=...)`. It refreshes each hot wallet against the JSON-RPC connection of its own chain, warns when the onchain nonce has advanced past the local counter and adopts it, logs at debug when the counter is ahead of the chain or unchanged, and skips chains with no configured connection. Returns the resulting nonce per chain.
- The function docstring documents where and how it is called, the incident above, and the known gaps that remain: the race window between refresh and signing, the inability to repair a counter that is ahead of the chain, satellite chain wallets not being covered, and pending transactions being invisible because the nonce is read at `latest`.
- New `ExecutionLoop.refresh_nonces(context)` in `tradeexecutor/cli/loop.py`, which resolves the persistent hot wallet from the sync model and the chain from the transaction builder, and no-ops for execution models without a hot wallet.
- Called at the start of `live_cycle`, `live_positions` and `live_trigger_checks`, each tagged with its own context so the log names the task that triggered the refresh.
- New `tests/ethereum/test_hot_wallet_nonce_refresh.py`: one test reproducing the incident by spending a nonce outside the counter and confirming the refresh adopts it, and one confirming the refresh never rewinds a counter that is ahead of the chain.
- Changelog entry.

The `wallets` argument is a mapping rather than a single wallet so that persistent per-chain wallets can be passed without changing the signature, should they replace the throwaway satellite wallets created per trade in `GenericRouting.setup_trades()`.

Follow-up, not in this PR: treat `chain_nonce > tx.nonce` as non-retryable in `eth_defi.confirmation.wait_and_broadcast_multiple_nodes_mev_blocker()` and have the Lagoon settle path re-sync, re-sign and retry once. That closes the residual race this PR only narrows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
