### PR TITLE
fix: make Lagoon manual settlement self-configuring

### DIFF
--- a/.claude/docs/lagoon-treasury-settlement.md
+++ b/.claude/docs/lagoon-treasury-settlement.md
@@ -73,38 +73,27 @@ execution intentionally bypasses the asset-manager policy.
 Use `lagoon-manual-settle` before proposing the direct Safe transaction:
 
 ```shell
-trade-executor lagoon-manual-settle \
-    --vault-address "$VAULT_ADDRESS" \
-    --chain-name hyperliquid \
-    --json-rpc-hyperliquid "$JSON_RPC_HYPERLIQUID"
+trade-executor lagoon-manual-settle
 ```
 
-For Lagoon versions that expose `newTotalAssets()`, the command reads the
-submitted, not-yet-settled raw NAV on-chain and refuses a conflicting
-`--new-total-assets` value. If the deployed ABI lacks this getter, provide the
-exact raw `_newTotalAssets` from the GuardV0 manual-settlement alert:
-
-```shell
-trade-executor lagoon-manual-settle \
-    --vault-address "$VAULT_ADDRESS" \
-    --chain-name hyperliquid \
-    --new-total-assets 32602857313 \
-    --json-rpc-hyperliquid "$JSON_RPC_HYPERLIQUID"
-```
-
-Lagoon uses its maximum `uint256` value to mark that no NAV is pending; the
-command treats this sentinel as unavailable and requires the alert value.
+The command uses the same `STRATEGY_FILE`, `STATE_FILE`, `VAULT_ADDRESS` and
+`JSON_RPC_*` environment configuration as the executor. No command-line
+parameters are needed. It reads the submitted, not-yet-settled raw NAV from
+`newTotalAssets()` where available. For Lagoon versions without that getter it
+recovers the value from the contract's `NewTotalAssetsUpdated` and
+`TotalAssetsUpdated` events. The event scan starts at the vault deployment
+block and uses the shared chunked JSON-RPC or Hypersync reader.
 
 Do not substitute the current `totalAssets()` value. The command reads the
 current deposit and redemption queues and the Safe balance on-chain, then
 selects `settleDeposit` for a deposit queue (which may also settle redemptions)
-or `settleRedeem` for a redemption-only queue. It prints the version-specific
-ABI and fields to enter manually in Safe Transaction Builder. They are not an
-importable Builder batch file. It uses `eth_estimateGas` with the Safe as the
-sender to check the direct vault target call. A successful estimate only shows
-that call did not revert at the reported block; it does not validate the NAV or
-Safe signatures, owner policy or guards. It does not sign, post NAV, create a
-Safe proposal or broadcast any transaction.
+or `settleRedeem` for a redemption-only queue. It prints step-by-step Gnosis
+Safe setup instructions, including the Safe, target, operation, ABI, input and
+calldata. It uses `eth_estimateGas` with the Safe as the sender to check the
+direct vault target call. A successful estimate only shows that call did not
+revert at the reported block; it does not validate the NAV or Safe signatures,
+owner policy or guards. It does not sign, post NAV, create a Safe proposal or
+broadcast any transaction.
 
 ## Frontend metadata
 

--- a/tests/lagoon/test_lagoon_manual_settle.py
+++ b/tests/lagoon/test_lagoon_manual_settle.py
@@ -2,9 +2,11 @@
 
 import os
 from decimal import Decimal
+from types import SimpleNamespace
 
 import pytest
 from eth_typing import HexAddress
+from hexbytes import HexBytes
 from web3 import Web3
 
 from eth_defi.abi import encode_function_call
@@ -13,7 +15,8 @@ from eth_defi.hotwallet import HotWallet
 from eth_defi.token import TokenDetails
 from eth_defi.trace import assert_transaction_success_with_explanation
 
-from tradeexecutor.cli.commands.lagoon_manual_settle import _build_settlement_call, inspect_manual_lagoon_settlement
+import tradeexecutor.cli.commands.lagoon_manual_settle as manual_settle
+from tradeexecutor.cli.commands.lagoon_manual_settle import _build_settlement_call, format_manual_settlement_instructions, inspect_manual_lagoon_settlement
 
 
 JSON_RPC_BASE = os.environ.get("JSON_RPC_BASE")
@@ -33,6 +36,7 @@ def test_inspect_manual_lagoon_settlement(
     2. Inspect its live queue and construct the direct Safe settlement calldata.
     3. Verify gas estimation accepts the direct vault target call from the Safe.
     4. Verify the ABI encodes a non-zero raw NAV.
+    5. Verify the printed instructions contain all Safe transaction inputs.
     """
     vault = automated_lagoon_vault.vault
     amount = Decimal(9)
@@ -43,20 +47,21 @@ def test_inspect_manual_lagoon_settlement(
     tx_hash = vault.request_deposit(depositor, base_usdc_token.convert_to_raw(amount)).transact({"from": depositor})
     assert_transaction_success_with_explanation(web3, tx_hash)
     valuation = Decimal(0)
+    settlement_scan_start_block = web3.eth.block_number
     tx_hash = vault.post_new_valuation(valuation).transact({"from": asset_manager.address})
     assert_transaction_success_with_explanation(web3, tx_hash)
 
     # 2. Inspect its live queue and construct the direct Safe settlement calldata.
     new_total_assets_raw = base_usdc_token.convert_to_raw(valuation)
-    report = inspect_manual_lagoon_settlement(vault, new_total_assets_raw=new_total_assets_raw)
+    report = inspect_manual_lagoon_settlement(vault, settlement_scan_start_block)
 
     # 3. Verify gas estimation accepts the direct vault target call from the Safe.
     assert Decimal(report["pending_deposit"]) == amount
     assert Decimal(report["pending_redemption_shares"]) == 0
     assert report["safe"] == vault.safe_address
     assert report["settlement_abi"]["name"] == "settleDeposit"
-    assert report["pending_new_total_assets_raw"] is None
     assert report["new_total_assets_raw"] == new_total_assets_raw
+    assert report["new_total_assets_source"] == "NewTotalAssetsUpdated/TotalAssetsUpdated events"
     assert report["gnosis_safe_transaction_fields"]["to"] == vault.address
     assert report["gnosis_safe_transaction_fields"]["contractInputsValues"]["_newTotalAssets"] == str(new_total_assets_raw)
     assert report["target_call_simulation"]["succeeds"] is True, report["target_call_simulation"]
@@ -64,3 +69,65 @@ def test_inspect_manual_lagoon_settlement(
     # 4. Verify the ABI encodes a non-zero raw NAV.
     _, non_zero_settle_call = _build_settlement_call(vault, "settleDeposit", 1)
     assert Web3.to_hex(encode_function_call(non_zero_settle_call)).endswith("1".zfill(64))
+
+    # 5. Verify the printed instructions contain all Safe transaction inputs.
+    instructions = format_manual_settlement_instructions(report)
+    assert f"Open Safe {vault.safe_address}" in instructions
+    assert f"Set the target contract to {vault.address}" in instructions
+    assert '"_newTotalAssets":"0"' in instructions
+    assert report["gnosis_safe_transaction_fields"]["data"] in instructions
+
+
+def test_fetch_pending_new_total_assets_from_events(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Recover pending NAV safely when the Lagoon ABI has no getter.
+
+    1. Mock the shared event reader because this test targets event ordering without an RPC scan.
+    2. Recover a non-zero pending NAV from its event.
+    3. Confirm a later settlement event and the Lagoon sentinel both clear it.
+    """
+    new_nav_topic = Web3.keccak(text="NewTotalAssetsUpdated(uint256)")
+    settled_nav_topic = Web3.keccak(text="TotalAssetsUpdated(uint256)")
+    vault = SimpleNamespace(
+        address="0x0000000000000000000000000000000000000001",
+        vault_contract=SimpleNamespace(abi=[]),
+        web3=object(),
+    )
+
+    # 1. Mock the shared event reader because this test targets event ordering without an RPC scan.
+    monkeypatch.setattr(manual_settle, "is_anvil", lambda _web3: False)
+
+    def make_log(topic: HexBytes, value: int, block_number: int) -> dict:
+        return {
+            "topics": [topic],
+            "data": HexBytes(value.to_bytes(32, byteorder="big")),
+            "blockNumber": block_number,
+            "logIndex": 0,
+        }
+
+    # 2. Recover a non-zero pending NAV from its event.
+    monkeypatch.setattr(
+        manual_settle,
+        "fetch_vault_settlement_logs",
+        lambda **_kwargs: [make_log(new_nav_topic, 123_456_789, 10)],
+    )
+    assert manual_settle._fetch_pending_new_total_assets(vault, 1, 10) == (
+        123_456_789,
+        "NewTotalAssetsUpdated/TotalAssetsUpdated events",
+    )
+
+    # 3. Confirm a later settlement event and the Lagoon sentinel both clear it.
+    monkeypatch.setattr(
+        manual_settle,
+        "fetch_vault_settlement_logs",
+        lambda **_kwargs: [
+            make_log(new_nav_topic, 123_456_789, 10),
+            make_log(settled_nav_topic, 123_456_789, 11),
+        ],
+    )
+    assert manual_settle._fetch_pending_new_total_assets(vault, 1, 11)[0] is None
+    monkeypatch.setattr(
+        manual_settle,
+        "fetch_vault_settlement_logs",
+        lambda **_kwargs: [make_log(new_nav_topic, manual_settle.NO_PENDING_NAV, 12)],
+    )
+    assert manual_settle._fetch_pending_new_total_assets(vault, 1, 12)[0] is None

--- a/tradeexecutor/cli/commands/lagoon_manual_settle.py
+++ b/tradeexecutor/cli/commands/lagoon_manual_settle.py
@@ -1,17 +1,22 @@
 """Inspect and simulate a manual Lagoon Safe settlement."""
 
 import json
+from pathlib import Path
 from typing import Any
 
 import typer
+from hexbytes import HexBytes
 from web3 import Web3
 
 from eth_defi.abi import encode_function_call
-from tradeexecutor.cli.bootstrap import create_web3_config
+from eth_defi.erc_4626.settlement_events import fetch_vault_settlement_logs
+from eth_defi.provider.anvil import is_anvil
+from tradeexecutor.cli.bootstrap import configure_default_chain, create_web3_config, prepare_executor_id
 from tradeexecutor.cli.commands import shared_options
 from tradeexecutor.cli.commands.app import app
-from tradeexecutor.cli.commands.lagoon_utils import load_lagoon_vault
+from tradeexecutor.cli.commands.lagoon_utils import load_lagoon_vault, resolve_state_store
 from tradeexecutor.cli.log import setup_logging
+from tradeexecutor.strategy.strategy_module import read_strategy_module
 
 
 NO_PENDING_NAV = 2**256 - 1
@@ -30,8 +35,8 @@ def _build_settlement_call(vault, function_name: str, new_total_assets_raw: int 
 
     if new_total_assets_raw is None:
         raise RuntimeError(
-            f"Vault {vault.address} needs _newTotalAssets for {function_name}, but its ABI has no readable newTotalAssets() value. "
-            "Pass --new-total-assets from the GuardV0 manual-settlement alert."
+            f"Vault {vault.address} needs _newTotalAssets for {function_name}, but no pending valuation was found on-chain. "
+            "Run a normal Lagoon treasury sync to post a fresh valuation before preparing manual settlement."
         )
     assert len(inputs) == 1 and inputs[0]["type"] == "uint256", (
         f"Unexpected {function_name} ABI for {vault.address}: {abi}"
@@ -39,24 +44,42 @@ def _build_settlement_call(vault, function_name: str, new_total_assets_raw: int 
     return abi, getattr(vault.vault_contract.functions, function_name)(new_total_assets_raw)
 
 
-def _fetch_pending_new_total_assets(vault, block_number: int) -> int | None:
-    """Read the valuation waiting to be settled, if this Lagoon version exposes it."""
+def _fetch_pending_new_total_assets(vault, deployment_block: int, block_number: int) -> tuple[int | None, str]:
+    """Read the valuation waiting to be settled from contract state or events."""
     has_getter = any(
         item.get("type") == "function" and item.get("name") == "newTotalAssets" and not item["inputs"]
         for item in vault.vault_contract.abi
     )
-    if not has_getter:
-        return None
-    new_total_assets = vault.vault_contract.functions.newTotalAssets().call(block_identifier=block_number)
-    return None if new_total_assets == NO_PENDING_NAV else new_total_assets
+    if has_getter:
+        new_total_assets = vault.vault_contract.functions.newTotalAssets().call(block_identifier=block_number)
+        value = None if new_total_assets == NO_PENDING_NAV else new_total_assets
+        return value, "newTotalAssets()"
+
+    new_nav_topic = Web3.keccak(text="NewTotalAssetsUpdated(uint256)")
+    settled_nav_topic = Web3.keccak(text="TotalAssetsUpdated(uint256)")
+    logs = fetch_vault_settlement_logs(
+        web3=vault.web3,
+        address=vault.address,
+        topic0_list=[Web3.to_hex(new_nav_topic), Web3.to_hex(settled_nav_topic)],
+        start_block=deployment_block,
+        end_block=block_number,
+        use_hypersync=False if is_anvil(vault.web3) else None,
+    )
+    pending_new_total_assets = None
+    for log in sorted(logs, key=lambda item: (item["blockNumber"], item["logIndex"])):
+        if HexBytes(log["topics"][0]) == new_nav_topic:
+            value = int.from_bytes(HexBytes(log["data"]), byteorder="big")
+            pending_new_total_assets = None if value == NO_PENDING_NAV else value
+        else:
+            pending_new_total_assets = None
+    return pending_new_total_assets, "NewTotalAssetsUpdated/TotalAssetsUpdated events"
 
 
-def inspect_manual_lagoon_settlement(vault, new_total_assets_raw: int | None = None) -> dict[str, Any]:
+def inspect_manual_lagoon_settlement(vault, deployment_block: int) -> dict[str, Any]:
     """Read one on-chain Lagoon queue snapshot and simulate Safe settlement.
 
-    The tool reads the pending ``newTotalAssets`` value where the deployed ABI
-    exposes it. Otherwise the caller must supply the exact raw value from the
-    executor's GuardV0 manual-settlement alert. It never calculates or posts a
+    The tool reads the pending ``newTotalAssets`` value from the deployed
+    contract getter or its valuation events. It never calculates or posts a
     valuation.
     """
     web3: Web3 = vault.web3
@@ -70,16 +93,7 @@ def inspect_manual_lagoon_settlement(vault, new_total_assets_raw: int | None = N
     safe_address = Web3.to_checksum_address(vault.safe_address)
     safe_balance = denomination_token.fetch_balance_of(safe_address, block_identifier=block_number)
 
-    if new_total_assets_raw is not None:
-        assert new_total_assets_raw >= 0, "new_total_assets_raw cannot be negative"
-    pending_new_total_assets_raw = _fetch_pending_new_total_assets(vault, block_number)
-    if new_total_assets_raw is None:
-        new_total_assets_raw = pending_new_total_assets_raw
-    elif pending_new_total_assets_raw is not None and new_total_assets_raw != pending_new_total_assets_raw:
-        raise RuntimeError(
-            f"--new-total-assets ({new_total_assets_raw}) does not match the on-chain newTotalAssets() "
-            f"value ({pending_new_total_assets_raw}) at block {block_number}"
-        )
+    new_total_assets_raw, new_total_assets_source = _fetch_pending_new_total_assets(vault, deployment_block, block_number)
     if pending_deposit > 0:
         function_name = "settleDeposit"
     elif pending_redemption_shares > 0:
@@ -142,9 +156,8 @@ def inspect_manual_lagoon_settlement(vault, new_total_assets_raw: int | None = N
             "decimals": denomination_token.decimals,
         },
         "onchain_nav": str(onchain_nav),
-        "pending_new_total_assets_raw": pending_new_total_assets_raw,
         "new_total_assets_raw": new_total_assets_raw,
-        "new_total_assets_source": "on-chain newTotalAssets()" if pending_new_total_assets_raw is not None else "command input; copy the exact raw value from the GuardV0 manual-settlement alert",
+        "new_total_assets_source": new_total_assets_source,
         "pending_deposit": str(pending_deposit),
         "pending_redemption_shares": str(pending_redemption_shares),
         "safe_balance": str(safe_balance),
@@ -161,37 +174,88 @@ def inspect_manual_lagoon_settlement(vault, new_total_assets_raw: int | None = N
     }
 
 
+def format_manual_settlement_instructions(report: dict[str, Any]) -> str:
+    """Format operator instructions for a direct Gnosis Safe transaction."""
+    if not report["settlement_required"]:
+        return (
+            "No manual Lagoon settlement is needed.\n"
+            f"Vault: {report['vault']}\n"
+            f"Pending deposits: {report['pending_deposit']}\n"
+            f"Pending redemption shares: {report['pending_redemption_shares']}"
+        )
+
+    transaction = report["gnosis_safe_transaction_fields"]
+    method = transaction["contractMethod"]["name"]
+    inputs = transaction["contractInputsValues"]
+    simulation = report["target_call_simulation"]
+    lines = [
+        "Manual Lagoon settlement via Gnosis Safe",
+        "",
+        f"Queue at block: {report['block_number']}",
+        f"Pending deposits: {report['pending_deposit']} {report['denomination_token']['symbol']}",
+        f"Pending redemption shares: {report['pending_redemption_shares']}",
+        f"Safe balance: {report['safe_balance']} {report['denomination_token']['symbol']}",
+        "",
+        "Set up the Safe transaction:",
+        f"1. Open Safe {report['safe']} on chain {report['chain_id']}.",
+        "2. Create a new Contract interaction transaction.",
+        f"3. Set the target contract to {transaction['to']}.",
+        "4. Set value to 0 and operation to Call (0).",
+        f"5. Paste this ABI: {json.dumps([report['settlement_abi']], separators=(',', ':'))}",
+        f"6. Select {method} and enter: {json.dumps(inputs, separators=(',', ':'))}.",
+        f"7. Confirm the calldata is {transaction['data']}.",
+        "8. Re-simulate in Safe, collect the required signatures, then execute.",
+        "",
+        f"Direct target-call simulation succeeds: {simulation['succeeds']}",
+    ]
+    if simulation.get("estimated_gas") is not None:
+        lines.append(f"Estimated target-call gas: {simulation['estimated_gas']}")
+    if simulation.get("error"):
+        lines.append(f"Simulation error: {simulation['error']}")
+    lines.extend((
+        "",
+        "This preflight does not validate the NAV, Safe signatures, owner policy or Safe guards.",
+        "Do not execute if the Safe simulation differs from these values.",
+    ))
+    return "\n".join(lines)
+
+
 @app.command()
-@shared_options.with_json_rpc_options(include_chain_name=True)
+@shared_options.with_json_rpc_options()
 def lagoon_manual_settle(
-    vault_address: str = shared_options.required_option(shared_options.vault_address),
-    new_total_assets: int | None = typer.Option(None, "--new-total-assets", envvar="NEW_TOTAL_ASSETS", help="Exact raw NAV if this Lagoon version does not expose newTotalAssets()"),
+    id: str = shared_options.id,
+    strategy_file: Path = shared_options.strategy_file,
+    state_file: Path | None = shared_options.state_file,
+    vault_address: str | None = shared_options.vault_address,
     log_level: str = shared_options.log_level,
-    chain_name: str | None = shared_options.chain_name,
     rpc_kwargs: dict | None = None,
 ):
-    """Display and safely simulate the required direct Safe settlement transaction.
+    """Print instructions for the required direct Safe settlement transaction.
 
     This is a read-only operational tool for a GuardV0-capped Lagoon queue.
     It does not post a valuation, create a Safe transaction, or broadcast one.
-    The command reads ``newTotalAssets()`` when available; otherwise pass
-    ``--new-total-assets`` from the GuardV0 manual-settlement alert. The
-    estimate checks only the direct vault call with the Safe as sender.
+    It reads all configuration from the normal executor environment and state.
     """
+    id = prepare_executor_id(id, strategy_file)
     setup_logging(log_level=log_level)
-    # The shared decorator filters rpc_kwargs to chain_name before this command
-    # is called, leaving a single connection when --chain-name is supplied.
+    mod = read_strategy_module(strategy_file)
     web3config = create_web3_config(**rpc_kwargs)
     if not web3config.has_any_connection():
         raise RuntimeError("Pass a JSON-RPC connection for the Lagoon vault chain")
-    if len(web3config.connections) != 1:
-        raise RuntimeError("Pass exactly one JSON-RPC connection or select one with --chain-name")
 
-    web3config.choose_single_chain()
+    configure_default_chain(web3config, mod)
     try:
+        state_path, store = resolve_state_store(id, state_file)
+        assert not store.is_pristine(), f"Strategy state file does not exist: {state_path}"
+        state = store.load()
+        deployment = state.sync.deployment
+        vault_address = vault_address or deployment.address
+        assert vault_address, "Lagoon vault address is missing from VAULT_ADDRESS and strategy state"
+        deployment_block = deployment.block_number
+        assert deployment_block is not None, "Lagoon deployment block is missing from strategy state"
         vault = load_lagoon_vault(web3config.get_default(), vault_address)
-        report = inspect_manual_lagoon_settlement(vault, new_total_assets)
-        typer.echo(json.dumps(report, indent=2))
+        report = inspect_manual_lagoon_settlement(vault, deployment_block)
+        typer.echo(format_manual_settlement_instructions(report))
     finally:
         web3config.close()
 


### PR DESCRIPTION
## Why

The manual settlement command must run like the other executor commands: configuration comes from the normal strategy environment and state, and the operator should not copy vault addresses, chain selection or raw NAV values onto the command line.

## Lessons learnt

Older Lagoon ABIs do not expose `newTotalAssets()`, but the pending valuation is still recoverable from ordered `NewTotalAssetsUpdated` and `TotalAssetsUpdated` contract events. The normal settlement cursor is not a NAV-event cursor, so the lookup must start from the deployment block and use the shared chunked JSON-RPC or Hypersync reader.

## Summary

- Make `trade-executor lagoon-manual-settle` resolve its chain, state and vault from standard executor configuration.
- Recover the exact pending NAV entirely from on-chain contract state or events.
- Print step-by-step Gnosis Safe setup instructions with ABI, input and calldata.
- Cover event fallback, ordering, sentinel handling, instruction output and live target-call simulation.