### PR TITLE
fix: configure Hypercore dust repair threshold

### DIFF
--- a/.claude/docs/agent-tricks-and-troubleshooting.md
+++ b/.claude/docs/agent-tricks-and-troubleshooting.md
@@ -201,6 +201,77 @@ Claude CLI and Codex CLI (for example, `timeout 900 claude -p ...`). This gives
 a legitimate review enough time to inspect the worktree; it does not override
 the separate one-minute no-output rule for a grounded Claude review.
 
+### Do not mistake an incomplete stream poll for an Opus 5 failure
+
+For `claude -p --output-format stream-json`, an assistant/tool event is not a
+review result. Opus 5 can spend several minutes gathering repository context
+and emit many tool events before it writes the final `result` event. In some
+agent-runner shells, the foreground command wrapper can also return before its
+redirected child has finished writing the JSONL file. Therefore, do **not**
+conclude that Claude "stopped mid-inspection" merely because a short poll has
+no final text, a shell cell reports completion, or the last JSONL line is a
+`thinking`/`tool_use` event.
+
+A Claude review is complete only when its JSONL has a final event with all of:
+
+- `type == "result"`
+- `is_error == false`
+- `stop_reason == "end_turn"`
+- `terminal_reason == "completed"`
+- a non-empty `result`
+
+`rate_limit_event` is telemetry, not necessarily a failure. In particular,
+`status == "allowed"` can appear before a successful final result. Check the
+final `result` event before reporting a rate-limit failure.
+
+Start a long Opus review detached, retain its PID and raw files, then poll the
+process and JSONL rather than repeatedly launching new reviews. `--model opus`
+selects the current Opus alias (currently reported as `claude-opus-5` in the
+result metadata).
+
+```shell
+review_file="/tmp/claude-review-$RANDOM.jsonl"
+review_err="/tmp/claude-review-$RANDOM.err"
+
+nohup timeout 900 claude -p "Review the current uncommitted diff read-only. Do not edit files or run tests. Return findings with file:line references." \
+  --model opus \
+  --output-format stream-json --verbose \
+  --permission-mode dontAsk \
+  --allowedTools "Bash(git status:*),Bash(git diff:*),Bash(sed:*),Bash(rg:*),Bash(grep:*),Bash(ls:*),Read,Grep,Glob" \
+  --no-session-persistence \
+  < /dev/null > "$review_file" 2> "$review_err" &
+review_pid=$!
+echo "Claude review PID: $review_pid"
+```
+
+Poll it from a later command. Do not start another review while the process is
+alive or the JSONL has no terminal `result` event:
+
+```shell
+ps -p "$review_pid" -o pid=,stat=,etime=,cmd=
+wc -c "$review_file" "$review_err"
+tail -n 20 "$review_file"
+
+python3 -c '
+import json
+from pathlib import Path
+
+events = [json.loads(line) for line in Path("'$review_file'").read_text().splitlines()]
+result = next((event for event in reversed(events) if event.get("type") == "result"), None)
+assert result, "Review is still incomplete: no final result event"
+assert not result["is_error"]
+assert result["stop_reason"] == "end_turn"
+assert result["terminal_reason"] == "completed"
+print(result["result"])
+'
+```
+
+If the process has exited and there is no valid final `result`, inspect the raw
+stderr and any `permission_denials` included in a partial result before retrying.
+Only then use a narrower prompt or an inline no-tools review. Re-running an
+unfinished-looking Opus review without this check wastes quota and can create a
+real rate-limit failure.
+
 If a broad review stalls, first verify that basic non-interactive mode and
 read-only Bash tools work before assuming auth is broken:
 

--- a/tests/hyperliquid/test_hypercore_accounting.py
+++ b/tests/hyperliquid/test_hypercore_accounting.py
@@ -9,6 +9,8 @@ Verifies that:
 
 import datetime
 from decimal import Decimal
+from pathlib import Path
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -17,6 +19,7 @@ from eth_defi.compat import native_datetime_utc_now
 from tradingstrategy.chain import ChainId
 
 from tradeexecutor.cli.commands.correct_accounts import _sync_hypercore_vault_positions
+from tradeexecutor.cli.commands.repair_hypercore_dust import _apply_strategy_hypercore_close_epsilon
 from tradeexecutor.ethereum.vault.hypercore_valuation import HypercoreVaultPricing, HypercoreVaultValuator
 from tradeexecutor.ethereum.vault.hypercore_vault import create_hypercore_vault_pair
 from tradeexecutor.cli.double_position import check_double_position
@@ -39,6 +42,7 @@ from tradeexecutor.strategy.account_correction import (
 from tradeexecutor.strategy.dust import (
     get_close_epsilon_for_pair,
     get_dust_epsilon_for_pair,
+    get_hyperliquid_vault_close_epsilon,
     HYPERLIQUID_VAULT_CLOSE_EPSILON,
     HYPERLIQUID_VAULT_RELATIVE_EPSILON,
     DEFAULT_VAULT_EPSILON,
@@ -466,6 +470,66 @@ def test_hypercore_vault_dust_epsilon_covers_safety_margin():
     )
     assert not non_hypercore_pair.is_hyperliquid_vault()
     assert get_close_epsilon_for_pair(non_hypercore_pair) == DEFAULT_VAULT_EPSILON
+
+
+def test_repair_hypercore_dust_uses_strategy_close_epsilon():
+    """Repair command applies the strategy capital-derived threshold before checking dust.
+
+    1. Create a Hypercore vault position with a residual above the default threshold.
+    2. Mock loading a strategy module configured with $1,000 initial capital.
+    3. Apply the repair command's strategy configuration helper.
+    4. Verify the position is closeable at the derived $5 threshold.
+    5. Verify no initial cash retains the default threshold.
+    """
+
+    # 1. Create a Hypercore vault position with a residual above the default threshold.
+    quote = AssetIdentifier(
+        chain_id=ChainId.hypercore.value,
+        address="0x0000000000000000000000000000000000000002",
+        token_symbol="USDC",
+        decimals=6,
+    )
+    pair = create_hypercore_vault_pair(
+        quote=quote,
+        vault_address="0x1111111111111111111111111111111111111111",
+    )
+    ts = native_datetime_utc_now()
+    position = TradingPosition(
+        position_id=1,
+        pair=pair,
+        opened_at=ts,
+        last_pricing_at=ts,
+        last_token_price=1.0,
+        last_reserve_price=1.0,
+        reserve_currency=quote,
+    )
+    dummy_trade = MagicMock()
+    dummy_trade.is_spot.return_value = False
+    position.trades[1] = dummy_trade
+    state = MagicMock()
+    state.portfolio.get_open_and_frozen_positions.return_value = [position]
+
+    # 2. Mock strategy loading because only the module's initial cash affects this local repair.
+    strategy_module = SimpleNamespace(initial_cash=1_000)
+
+    # 3. Apply the repair command's strategy configuration helper.
+    with patch(
+        "tradeexecutor.cli.commands.repair_hypercore_dust.read_strategy_module",
+        return_value=strategy_module,
+    ):
+        epsilon = _apply_strategy_hypercore_close_epsilon(
+            state,
+            Path("strategies/hyper-ai.py"),
+            MagicMock(),
+        )
+
+    # 4. Verify the position is closeable at the derived $5 threshold.
+    assert epsilon == Decimal("5.000")
+    with patch.object(position, "get_quantity", return_value=Decimal("3.927094")):
+        assert position.can_be_closed() is True
+
+    # 5. Verify no initial cash retains the default threshold.
+    assert get_hyperliquid_vault_close_epsilon() == HYPERLIQUID_VAULT_CLOSE_EPSILON
 
 
 def test_hypercore_account_check_compares_equity_not_quantity() -> None:

--- a/tradeexecutor/cli/commands/repair_hypercore_dust.py
+++ b/tradeexecutor/cli/commands/repair_hypercore_dust.py
@@ -17,6 +17,8 @@ from ...state.repair import (
     find_hypercore_duplicate_close_candidates,
 )
 from ...state.store import JSONFileStore
+from ...strategy.dust import configure_hyperliquid_vault_close_epsilon
+from ...strategy.strategy_module import read_strategy_module
 
 
 def _count_duplicate_hypercore_groups(state) -> int:
@@ -42,6 +44,32 @@ def _format_candidate_position(position) -> str:
         f"balance_updates={len(position.balance_updates)}, "
         f"trades={len(position.trades)}"
     )
+
+
+def _apply_strategy_hypercore_close_epsilon(
+    state,
+    strategy_file: Path | None,
+    logger,
+):
+    """Apply a strategy module's Hypercore dust threshold before repairing state."""
+
+    if strategy_file is None:
+        logger.info(
+            "No strategy file supplied; using persisted Hypercore close thresholds or the 2.00 default"
+        )
+        return None
+
+    strategy_module = read_strategy_module(strategy_file)
+    epsilon = configure_hyperliquid_vault_close_epsilon(
+        state.portfolio.get_open_and_frozen_positions(),
+        strategy_module.initial_cash,
+    )
+    logger.info(
+        "Applied Hypercore vault close epsilon %s from strategy module %s",
+        epsilon,
+        strategy_file,
+    )
+    return epsilon
 
 
 @app.command()
@@ -70,7 +98,8 @@ def repair_hypercore_dust(
 
     This command is intentionally local-state only. It does not attempt any
     on-chain execution; instead it creates repair trades for Hypercore vault
-    positions that are already within the configured close epsilon.
+    positions that are already within the configured close epsilon. When a
+    strategy file is supplied, its initial cash determines the threshold.
 
     Duplicate Hypercore positions are diagnosed before and after cleanup so
     operators can see whether stale dust residuals were removed or whether a
@@ -95,6 +124,8 @@ def repair_hypercore_dust(
         backup_suffix="repair-hypercore-dust-backup",
         unit_testing=unit_testing,
     )
+
+    _apply_strategy_hypercore_close_epsilon(state, strategy_file, logger)
 
     duplicate_group_count_before = _count_duplicate_hypercore_groups(state)
     if duplicate_group_count_before:

--- a/tradeexecutor/state/position.py
+++ b/tradeexecutor/state/position.py
@@ -315,6 +315,12 @@ class TradingPosition(GenericPosition):
     #: Misc bag of data, not often needed
     other_data: PositionOtherData = field(default_factory=dict)
 
+    #: Strategy-specific dust threshold for a Hypercore vault position.
+    #:
+    #: Stored on the position because state-level settlement and account checks
+    #: need the same threshold without access to the active strategy module.
+    hyperliquid_vault_close_epsilon: Decimal | None = None
+
     #: Position was produced by a fork-only vault-test-trade simulation.
     #:
     #: Such positions are retained as closed diagnostics but are not live assets.
@@ -444,6 +450,13 @@ class TradingPosition(GenericPosition):
         See :py:meth:`mark_down`.
         """
         return self.other_data.get("marked_down_at") is not None
+
+    def get_close_epsilon(self) -> Decimal:
+        """Get the quantity threshold below which this position is closed."""
+        return get_close_epsilon_for_pair(
+            self.pair,
+            hyperliquid_vault_close_epsilon=self.hyperliquid_vault_close_epsilon,
+        )
 
     def has_automatic_close(self) -> bool:
         """This position has stop loss/take profit set."""
@@ -1365,7 +1378,7 @@ class TradingPosition(GenericPosition):
 
         - It has planned trades taking the position to zero
         """
-        epsilon = get_close_epsilon_for_pair(self.pair)
+        epsilon = self.get_close_epsilon()
         # A small live residual alone is not enough here. Hypercore vaults in
         # particular can keep dust in the position because the protocol refuses
         # exact full withdrawals when NAV moves between planning and execution.
@@ -1389,15 +1402,7 @@ class TradingPosition(GenericPosition):
             # Already closed
             return False
 
-        if self.is_vault():
-            # Morpho Spark USDC workaround.
-            # The vault maxRedeem() returns an amount of shares that has a rounding error.
-            # Thus we are left we one share token that cannot be redeemed.
-            # See estimate_4626_deposit() for details.
-            epsilon = get_close_epsilon_for_pair(self.pair)
-        else:
-            # Try to get sane default epsilon
-            epsilon = get_close_epsilon_for_pair(self.pair)
+        epsilon = self.get_close_epsilon()
 
         quantity = self.get_quantity()
 

--- a/tradeexecutor/state/position.py
+++ b/tradeexecutor/state/position.py
@@ -317,8 +317,11 @@ class TradingPosition(GenericPosition):
 
     #: Strategy-specific dust threshold for a Hypercore vault position.
     #:
-    #: Stored on the position because state-level settlement and account checks
-    #: need the same threshold without access to the active strategy module.
+    #: Stored on the position so state-level settlement can use the same
+    #: threshold without access to the active strategy module.
+    #:
+    #: TODO: Migrate account correction and close-planning paths that still use
+    #: pair-only thresholds to this persisted value.
     hyperliquid_vault_close_epsilon: Decimal | None = None
 
     #: Position was produced by a fork-only vault-test-trade simulation.

--- a/tradeexecutor/strategy/dust.py
+++ b/tradeexecutor/strategy/dust.py
@@ -5,6 +5,7 @@ a lot of trades may end up having rounding artifacts.
 We need to deal with these rounding artifacts by checking for "dust".
 
 """
+from collections.abc import Iterable
 from _decimal import Decimal
 from decimal import Decimal
 
@@ -64,6 +65,8 @@ HYPERCORE_SMALL_POSITION_CLEANUP_PENDING_REDEEM = (
     "hypercore_small_position_cleanup_pending_redeem"
 )
 
+HYPERLIQUID_VAULT_CLOSE_EPSILON_CAPITAL_PCT = Decimal("0.005")
+
 #: Hypercore vault equities fluctuate every block due to active trading
 #: inside the vault, and live cycles can spend a long time in sequential
 #: settlement before the final accounting read happens.
@@ -100,7 +103,33 @@ def get_dust_epsilon_for_pair(pair: TradingPairIdentifier) -> Decimal:
     return get_dust_epsilon_for_asset(pair.base)
 
 
-def get_close_epsilon_for_pair(pair: TradingPairIdentifier) -> Decimal:
+def get_hyperliquid_vault_close_epsilon(initial_cash: float | None = None) -> Decimal:
+    """Get a Hypercore vault close epsilon from a strategy module's initial cash.
+
+    A strategy with initial cash uses 0.5% of that value. Strategies without
+    configured initial cash retain the default close epsilon.
+    """
+    if initial_cash is None or initial_cash <= 0:
+        return HYPERLIQUID_VAULT_CLOSE_EPSILON
+    return Decimal(str(initial_cash)) * HYPERLIQUID_VAULT_CLOSE_EPSILON_CAPITAL_PCT
+
+
+def configure_hyperliquid_vault_close_epsilon(
+    positions: Iterable,
+    initial_cash: float | None = None,
+) -> Decimal:
+    """Apply the strategy-specific close epsilon to Hypercore positions."""
+    epsilon = get_hyperliquid_vault_close_epsilon(initial_cash)
+    for position in positions:
+        if position.pair.is_hyperliquid_vault():
+            position.hyperliquid_vault_close_epsilon = epsilon
+    return epsilon
+
+
+def get_close_epsilon_for_pair(
+    pair: TradingPairIdentifier,
+    hyperliquid_vault_close_epsilon: Decimal | None = None,
+) -> Decimal:
     """Get the close threshold for a trading pair.
 
     - Currently same as dust epsilon
@@ -128,7 +157,7 @@ def get_close_epsilon_for_pair(pair: TradingPairIdentifier) -> Decimal:
     if pair.is_credit_supply():
         return COLLATERAL_EPSILON
     elif pair.is_hyperliquid_vault():
-        return HYPERLIQUID_VAULT_CLOSE_EPSILON
+        return hyperliquid_vault_close_epsilon or HYPERLIQUID_VAULT_CLOSE_EPSILON
     elif pair.is_vault():
         return DEFAULT_VAULT_EPSILON
 

--- a/tradeexecutor/strategy/dust.py
+++ b/tradeexecutor/strategy/dust.py
@@ -109,6 +109,9 @@ def get_hyperliquid_vault_close_epsilon(initial_cash: float | None = None) -> De
     A strategy with initial cash uses 0.5% of that value. Strategies without
     configured initial cash retain the default close epsilon.
     """
+    # TODO: Clamp the percentage-derived threshold between the default safety
+    # margin floor and a safe absolute maximum. initial_cash is a backtest input
+    # and can differ materially from live strategy equity.
     if initial_cash is None or initial_cash <= 0:
         return HYPERLIQUID_VAULT_CLOSE_EPSILON
     return Decimal(str(initial_cash)) * HYPERLIQUID_VAULT_CLOSE_EPSILON_CAPITAL_PCT

--- a/tradeexecutor/strategy/runner.py
+++ b/tradeexecutor/strategy/runner.py
@@ -28,6 +28,7 @@ from tradeexecutor.statistics.statistics_table import StatisticsTable
 from tradeexecutor.strategy.account_correction import check_accounts, UnexpectedAccountingCorrectionIssue
 from tradeexecutor.strategy.approval import ApprovalModel
 from tradeexecutor.strategy.cycle import CycleDuration
+from tradeexecutor.strategy.dust import configure_hyperliquid_vault_close_epsilon
 from tradeexecutor.strategy.execution_context import ExecutionContext, ExecutionMode
 from tradeexecutor.strategy.execution_model import ExecutionModel
 from tradeexecutor.strategy.generic.generic_pricing_model import GenericPricing
@@ -679,6 +680,8 @@ class StrategyRunner(abc.ABC):
         - Call after we have stored the execution state in the database
         """
 
+        self.configure_hyperliquid_vault_close_epsilon(state)
+
         # We cannot call account check right after the trades,
         # as meny low quality nodes might still report old token balances
         # from eth_call
@@ -713,6 +716,14 @@ class StrategyRunner(abc.ABC):
                 end_block=end_block,
                 cycle=cycle,
             )
+
+    def configure_hyperliquid_vault_close_epsilon(self, state: State):
+        """Apply this strategy module's Hypercore dust threshold to its positions."""
+        initial_cash = self.parameters.get("initial_cash") if self.parameters else None
+        configure_hyperliquid_vault_close_epsilon(
+            state.portfolio.get_open_and_frozen_positions(),
+            initial_cash,
+        )
 
     def _has_open_hypercore_vault_positions(self, state: State) -> bool:
         """Check if the portfolio currently has any live Hypercore vault positions.
@@ -821,6 +832,8 @@ class StrategyRunner(abc.ABC):
         assert isinstance(universe, StrategyExecutionUniverse)
 
         assert isinstance(strategy_cycle_timestamp, datetime.datetime)
+
+        self.configure_hyperliquid_vault_close_epsilon(state)
 
         if cycle_duration not in (CycleDuration.cycle_unknown, CycleDuration.cycle_1s, None) and not allow_unaligned_strategy_cycle_timestamp:
             assert strategy_cycle_timestamp.second == 0, f"Cycle duration {cycle_duration}: Does not look like a cycle timestamp: {strategy_cycle_timestamp}, should be even minutes"
@@ -943,6 +956,8 @@ class StrategyRunner(abc.ABC):
                         trade_set.add(t)
 
                     # logger.info("decide_trades() returned %d trades", len(rebalance_trades))
+
+                self.configure_hyperliquid_vault_close_epsilon(state)
 
                 new_position_ids = set(state.portfolio.open_positions.keys())
                 if old_position_ids != new_position_ids and len(trade_set) == 0:


### PR DESCRIPTION
## Why

Hypercore redemptions can leave a residual larger than the generic 2.00 close threshold when live equity moves. The repair command also ignored the strategy capital, so it could leave that residual open.

## Lessons learnt

The Hypercore close threshold is used by state-level settlement and repair routines, so it must be persisted on positions. Standalone repair tooling must load the strategy configuration explicitly.

## Summary

- Derive Hypercore vault close epsilon as 0.5% of strategy initial cash, otherwise retain 2.00.
- Persist the threshold during runner ticks and use it in position closing checks.
- Apply the same threshold in `repair-hypercore-dust` and add regression coverage.