### PR TITLE
fix: handle temporary vault locks and same-candle PnL

### DIFF
--- a/tests/mainnet_fork/test_lagoon_vault_from_bridge.py
+++ b/tests/mainnet_fork/test_lagoon_vault_from_bridge.py
@@ -1039,6 +1039,8 @@ def test_multiple_base_vault_positions_share_one_bridge(
     assert bridge_position.bridge_capital_allocated > 0
 
     # 6. Close IPOR Fusion USDC (Z).
+    # IPOR Fusion locks a new deposit for one hour before redemption.
+    mine(base_web3, increase_timestamp=3600)
     allocation_before_z_close = bridge_position.bridge_capital_allocated
     _execute_vault_sell(
         base_web3=base_web3,

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -34,6 +34,7 @@ from tradeexecutor.statistics.core import calculate_statistics, update_statistic
 from tradeexecutor.statistics.statistics_table import \
     serialise_live_long_short_stats, serialise_long_short_stats_as_json_table
 from tradeexecutor.strategy.execution_context import ExecutionMode
+from tradeexecutor.strategy.pnl import calculate_pnl
 from tradeexecutor.strategy.trade_pricing import TradePricing
 from tradeexecutor.strategy.valuation import revalue_state
 from tradeexecutor.testing.unit_test_trader import UnitTestTrader
@@ -1753,8 +1754,6 @@ def test_share_price_profit_partial_sell(usdc, weth_usdc, start_ts: datetime.dat
 
 def test_share_price_profit_matches_traditional(usdc, weth_usdc, start_ts: datetime.datetime):
     """Verify share price profit matches traditional calculation for simple case."""
-    from tradeexecutor.strategy.pnl import calculate_pnl
-
     state = State()
     state.update_reserves([ReservePosition(usdc, Decimal(10000), start_ts, 1.0, start_ts)])
     trader = UnitTestTrader(state, lp_fees=0, price_impact=1)
@@ -1770,6 +1769,41 @@ def test_share_price_profit_matches_traditional(usdc, weth_usdc, start_ts: datet
     # Both should show same profit percentage
     assert share_data.profit_pct == pytest.approx(traditional_data.profit_pct, rel=0.01)
     assert share_data.profit_usd == pytest.approx(traditional_data.profit_usd, rel=0.01)
+
+
+def test_profit_calculation_allows_zero_duration_closed_position(usdc, weth_usdc, start_ts: datetime.datetime):
+    """Same-candle backtest closures have PnL but no meaningful annualised return.
+
+    1. Create and close a spot position using the unit-test trader.
+    2. Set the close timestamp equal to its opening timestamp, as daily backtests can do.
+    3. Calculate traditional, annualised, and share-price PnL values.
+    4. Verify the zero duration is retained and annualised PnL is not fabricated.
+    """
+
+    # 1. Create and close a spot position using the unit-test trader.
+    state = State()
+    state.update_reserves([ReservePosition(usdc, Decimal(10_000), start_ts, 1.0, start_ts)])
+    trader = UnitTestTrader(state, lp_fees=0, price_impact=1)
+    position, _ = trader.buy(weth_usdc, Decimal("1"), 1_000.0)
+    position, _ = trader.sell(weth_usdc, Decimal("1"), 1_000.0)
+
+    # 2. Set the close timestamp equal to its opening timestamp, as daily backtests can do.
+    position.closed_at = position.opened_at
+
+    # 3. Calculate traditional, annualised, and share-price PnL values.
+    traditional_pnl = calculate_pnl(position)
+    annualised_pnl = position.calculate_total_profit_percent_annualised(
+        end_at=position.closed_at,
+        calculation_method="cumulative",
+    )
+    share_price_pnl = position.get_share_price_profit()
+
+    # 4. Verify the zero duration is retained and annualised PnL is not fabricated.
+    assert traditional_pnl.duration == datetime.timedelta(0)
+    assert traditional_pnl.profit_pct == pytest.approx(0)
+    assert traditional_pnl.profit_pct_annualised == pytest.approx(0)
+    assert annualised_pnl == pytest.approx(0)
+    assert share_price_pnl.duration == datetime.timedelta(0)
 
 
 def test_position_statistics_includes_share_price(usdc, weth_usdc, start_ts: datetime.datetime):

--- a/tradeexecutor/state/position.py
+++ b/tradeexecutor/state/position.py
@@ -1763,7 +1763,10 @@ class TradingPosition(GenericPosition):
         if self.is_closed():
             assert end_at, "Position is still open, but no end date given"
 
-        duration = (end_at - self.opened_at)
+        duration = end_at - self.opened_at
+        assert duration >= datetime.timedelta(0), f"Position {self} has a negative duration: {duration}"
+        if duration == datetime.timedelta(0):
+            return 0.0
         annual_periods = datetime.timedelta(days=365) / duration
         profit = self.get_total_profit_percent(calculation_method=calculation_method, end_at=end_at)
 

--- a/tradeexecutor/strategy/pnl.py
+++ b/tradeexecutor/strategy/pnl.py
@@ -139,20 +139,25 @@ def calculate_pnl(
 
     unrealised_pnl = (mark_price * float(position.get_quantity())) - cumulative_cost
 
-    duration = (end_at - position.opened_at)
-    assert duration > datetime.timedelta(0), f"Position {position} has a negative duration: {duration}, opened at {position.opened_at}, closed at {end_at}"
-    annualised_periods = datetime.timedelta(days=365) / duration
+    duration = end_at - position.opened_at
+    assert duration >= datetime.timedelta(0), f"Position {position} has a negative duration: {duration}, opened at {position.opened_at}, closed at {end_at}"
     profit_usd = realised_pnl_total + unrealised_pnl
     profit_pct = (profit_usd / cumulative_value) if cumulative_value else 0
 
-    try:
-        profit_pct_annualised = (1 + profit_pct) ** annualised_periods - 1
-    except OverflowError as e:
-        # If we make a very short position (few hours) and make gains like 4%,
-        # Python floating point will overflow when calculating annualised profit.
-        profit_pct_annualised = math.copysign(max_annualised_profit, profit_pct)
-    except Exception as e:
-        raise RuntimeError(f"Failed to annualise profit_pct {profit_pct} for position {position} with duration {duration}, periods {annualised_periods}") from e
+    if duration == datetime.timedelta(0):
+        # Daily backtests can open and close a position on the same candle.
+        # Annualised return is undefined in that case, so do not fabricate one.
+        profit_pct_annualised = 0.0
+    else:
+        annualised_periods = datetime.timedelta(days=365) / duration
+        try:
+            profit_pct_annualised = (1 + profit_pct) ** annualised_periods - 1
+        except OverflowError as e:
+            # If we make a very short position (few hours) and make gains like 4%,
+            # Python floating point will overflow when calculating annualised profit.
+            profit_pct_annualised = math.copysign(max_annualised_profit, profit_pct)
+        except Exception as e:
+            raise RuntimeError(f"Failed to annualise profit_pct {profit_pct} for position {position} with duration {duration}, periods {annualised_periods}") from e
 
     return ProfitData(
         profit_pct=profit_pct,
@@ -286,8 +291,8 @@ def calculate_share_price_pnl(
         profit_usd = total_sold - total_invested
 
     duration = end_at - position.opened_at
-    assert duration > datetime.timedelta(0), \
-        f"Position {position} has non-positive duration: {duration}"
+    assert duration >= datetime.timedelta(0), \
+        f"Position {position} has a negative duration: {duration}"
 
     return PositionInternalSharePriceData(
         initial_share_price=initial_share_price,


### PR DESCRIPTION
## Why

The Base IPOR Fusion fork test redeemed a newly deposited vault position before its one-hour lockup elapsed. The Hyperliquid waterfall notebook can open and close a position on one daily candle, where annualised PnL is undefined.

## Lessons learnt

Fork tests must model protocol time locks explicitly. Same-timestamp backtest closures are valid data, but annualised returns must not be fabricated from a zero duration.

## Summary

- Advance the Base fork past the IPOR redemption lockup before closing the shared-bridge position.
- Preserve same-candle PnL while reporting zero annualised return.
- Add focused zero-duration PnL coverage.