### PR TITLE
fix: Hypercore dust close epsilon is USD, not vault share units

### DIFF
--- a/tests/hyperliquid/test_hypercore_dust_epsilon_units.py
+++ b/tests/hyperliquid/test_hypercore_dust_epsilon_units.py
@@ -1,0 +1,268 @@
+"""Hypercore dust close epsilon must be denominated in USD, not in vault share units.
+
+Regression tests for a defect where a funded Hypercore vault position was silently
+destroyed the moment it was opened.
+
+``get_hyperliquid_vault_close_epsilon()`` returns ``initial_cash * 0.005``, which is a US
+dollar amount, and ``TradingPosition.can_be_closed()`` compared it against
+``get_quantity()``, which is a count of vault *shares*. For vaults whose share price is
+near 1 USD the two coincide and nothing is noticed. For a share priced at 12.78 USD the
+threshold is multiplied by 12.78, and at a 150,000 USD bankroll it becomes 750 shares =
+9,585 USD, so essentially every position the strategy opened in that vault qualified as
+"dust" on arrival.
+
+``Portfolio.close_position()`` is bookkeeping only - it moves the position between
+dictionaries and sells nothing - so the shares vanished with no offsetting cash and no
+realised loss. A 150,000 USD backtest ended at 10,645 USD while its own positions reported
+-1,333 USD realised and +558 USD unrealised: 138,580 USD unaccounted.
+
+The tests drive the real trade path (``State.create_trade`` / ``State.mark_trade_success``),
+because ``mark_trade_success()`` is where the engine consults ``can_be_closed()`` and calls
+``Portfolio.close_position()``. That is exactly the code path that destroyed the positions.
+"""
+
+import datetime
+from decimal import Decimal
+
+import pytest
+
+from tradeexecutor.state.identifier import AssetIdentifier, TradingPairIdentifier, TradingPairKind
+from tradeexecutor.state.portfolio import (
+    CLOSE_POSITION_VALUE_DESTRUCTION_LIMIT_USD,
+    PositionValueDestroyedError,
+)
+from tradeexecutor.state.state import State
+from tradeexecutor.state.trade import TradeType
+from tradeexecutor.strategy.dust import (
+    HYPERLIQUID_VAULT_CLOSE_EPSILON,
+    HYPERLIQUID_VAULT_CLOSE_EPSILON_MAX_USD,
+    configure_hyperliquid_vault_close_epsilon,
+    convert_usd_close_epsilon_to_quantity,
+    get_hyperliquid_vault_close_epsilon,
+)
+
+
+#: Share price of the vault that exposed the defect. pmalt traded around 12.78 USD/share,
+#: far enough from 1.00 that the unit confusion stops being invisible.
+PMALT_SHARE_PRICE = 12.78
+
+#: The position that was destroyed: 701.15 shares bought for 8,963.78 USD.
+PMALT_QUANTITY = Decimal("701.151323")
+
+
+def make_hypercore_pair() -> TradingPairIdentifier:
+    """A Hypercore vault pair.
+
+    ``is_hyperliquid_vault()`` keys off chain 9999, the synthetic chain ID for native
+    Hyperliquid vaults, so the assets must be homed there.
+    """
+    base = AssetIdentifier(
+        chain_id=9999,
+        address="0x4dec0a851849056e259128464ef28ce78afa27f6",
+        token_symbol="pmalt",
+        decimals=6,
+    )
+    quote = AssetIdentifier(
+        chain_id=9999,
+        address="0x0000000000000000000000000000000000000002",
+        token_symbol="USDC",
+        decimals=6,
+    )
+    return TradingPairIdentifier(
+        base=base,
+        quote=quote,
+        pool_address="0x4dec0a851849056e259128464ef28ce78afa27f6",
+        exchange_address="0x0000000000000000000000000000000000000004",
+        internal_id=1,
+        internal_exchange_id=1,
+        fee=0.0,
+        kind=TradingPairKind.vault,
+    )
+
+
+def buy_vault_position(
+    quantity: Decimal,
+    share_price: float = PMALT_SHARE_PRICE,
+    initial_cash: float = 150_000,
+):
+    """Open a Hypercore vault position through the real trade path.
+
+    :return:
+        ``(state, position)``. The position is whichever one the buy landed in - open or,
+        if the engine decided it was dust, closed.
+    """
+    pair = make_hypercore_pair()
+    assert pair.is_hyperliquid_vault(), "Test pair must be recognised as a Hypercore vault"
+
+    state = State()
+    state.portfolio.initialise_reserves(pair.quote, reserve_token_price=1.0)
+    state.portfolio.adjust_reserves(pair.quote, Decimal(str(initial_cash)))
+
+    opened_at = datetime.datetime(2026, 3, 8)
+    position, trade, _created = state.create_trade(
+        strategy_cycle_at=opened_at,
+        pair=pair,
+        quantity=quantity,
+        reserve=None,
+        assumed_price=share_price,
+        trade_type=TradeType.rebalance,
+        reserve_currency=pair.quote,
+        reserve_currency_price=1.0,
+    )
+
+    # The runner stamps the strategy's dust threshold onto open positions every cycle.
+    configure_hyperliquid_vault_close_epsilon([position], initial_cash)
+
+    state.start_execution(opened_at, trade)
+    trade.mark_broadcasted(opened_at)
+    state.mark_trade_success(
+        executed_at=opened_at,
+        trade=trade,
+        executed_price=share_price,
+        executed_amount=quantity,
+        executed_reserve=quantity * Decimal(str(share_price)),
+        lp_fees=0.0,
+        native_token_price=1.0,
+    )
+    position.last_token_price = share_price
+    return state, position
+
+
+def test_epsilon_is_clamped_to_a_usd_ceiling():
+    """A large configured bankroll must not scale the dust threshold into position sizes."""
+    # Unconfigured strategies keep the default safety margin
+    assert get_hyperliquid_vault_close_epsilon(None) == HYPERLIQUID_VAULT_CLOSE_EPSILON
+    assert get_hyperliquid_vault_close_epsilon(0) == HYPERLIQUID_VAULT_CLOSE_EPSILON
+
+    # Small bankrolls scale but never below the floor
+    assert get_hyperliquid_vault_close_epsilon(100) == HYPERLIQUID_VAULT_CLOSE_EPSILON
+
+    # 5,000 * 0.5% = 25 USD, under the ceiling, so the percentage rule still applies
+    assert get_hyperliquid_vault_close_epsilon(5_000) == Decimal("25.000")
+
+    # 150,000 would be 750 USD unclamped - the value that destroyed real positions
+    assert get_hyperliquid_vault_close_epsilon(150_000) == HYPERLIQUID_VAULT_CLOSE_EPSILON_MAX_USD
+    assert get_hyperliquid_vault_close_epsilon(10_000_000) == HYPERLIQUID_VAULT_CLOSE_EPSILON_MAX_USD
+
+
+def test_destruction_limit_sits_above_the_largest_legitimate_dust():
+    """The two thresholds must not contradict each other.
+
+    ``can_be_closed()`` permits closing anything the dust rules call negligible - up to
+    :py:data:`HYPERLIQUID_VAULT_CLOSE_EPSILON_MAX_USD` of value. If the value-destruction
+    guard sat below that, it would raise on closes the engine is supposed to perform, which
+    is exactly what happened in a 150,000 USD backtest: a 31.36 USD residual was dust by the
+    50 USD ceiling but blocked by a 25 USD guard.
+    """
+    assert CLOSE_POSITION_VALUE_DESTRUCTION_LIMIT_USD > float(HYPERLIQUID_VAULT_CLOSE_EPSILON_MAX_USD)
+
+
+def test_usd_epsilon_converts_to_share_units():
+    """The threshold must be divided by the share price before meeting a quantity."""
+    # 50 USD of a 12.78 USD share is ~3.9 shares, not 50
+    converted = convert_usd_close_epsilon_to_quantity(Decimal("50"), PMALT_SHARE_PRICE)
+    assert converted == pytest.approx(Decimal("3.912"), abs=Decimal("0.001"))
+
+    # A ~1 USD share price is where the units coincide, which is why this went unnoticed
+    assert convert_usd_close_epsilon_to_quantity(Decimal("2"), 1.0) == Decimal("2")
+
+    # An unknown price cannot be converted. Falling back to the raw USD number would
+    # reintroduce the defect, so it must collapse to a dust-sized threshold instead.
+    assert convert_usd_close_epsilon_to_quantity(Decimal("750"), None) < Decimal("1")
+    assert convert_usd_close_epsilon_to_quantity(Decimal("750"), 0.0) < Decimal("1")
+
+
+@pytest.mark.parametrize("initial_cash", [25_000, 75_000, 150_000, 1_000_000])
+def test_funded_position_survives_its_own_opening_trade(initial_cash):
+    """The regression: buying a real position must not immediately destroy it.
+
+    701.15 pmalt shares at 12.78 USD is 8,963 USD. Before the fix, at a 150,000 bankroll
+    the dust threshold was 750 *shares*, so ``mark_trade_success()`` closed this position
+    on the same timestamp it was opened, leaving the shares orphaned at zero value.
+    """
+    state, position = buy_vault_position(PMALT_QUANTITY, initial_cash=initial_cash)
+
+    expected_value = float(PMALT_QUANTITY) * PMALT_SHARE_PRICE  # ~8,960 USD
+    assert position.get_quantity() == PMALT_QUANTITY
+    assert position.get_value() == pytest.approx(expected_value, abs=1)
+
+    assert not position.is_closed(), (
+        f"A position worth {position.get_value():,.0f} USD was closed as dust "
+        f"at initial_cash={initial_cash}"
+    )
+    assert not position.can_be_closed()
+    assert position.position_id in state.portfolio.open_positions
+
+    # Equity must reflect the holding, not have silently lost it
+    assert state.portfolio.get_total_equity() == pytest.approx(initial_cash, rel=0.001)
+
+
+def test_genuine_dust_still_closes():
+    """The fix must not strand the withdrawal residual the epsilon exists to absorb.
+
+    ``mark_trade_success()`` auto-closes a dust-sized position on the spot, so the proof is
+    that the position ends up closed. A closed position values at zero, which is why the
+    value is asserted on the trade rather than on the position.
+    """
+    # ~1.50 USD of unredeemable residual, the documented Hypercore withdrawal margin
+    dust_quantity = Decimal("0.117")  # 0.117 * 12.78 = ~1.50 USD
+    _state, position = buy_vault_position(dust_quantity, initial_cash=150_000)
+
+    bought_value = float(dust_quantity) * PMALT_SHARE_PRICE
+    assert bought_value == pytest.approx(1.5, abs=0.05)
+    assert position.is_closed(), "Genuine sub-margin dust should still be closed automatically"
+
+
+def test_close_epsilon_is_expressed_in_share_units():
+    """``get_close_epsilon()`` feeds a quantity comparison, so it must return units."""
+    _state, position = buy_vault_position(PMALT_QUANTITY, initial_cash=150_000)
+
+    epsilon = position.get_close_epsilon()
+
+    # 50 USD ceiling / 12.78 USD per share
+    assert epsilon == pytest.approx(Decimal("3.912"), abs=Decimal("0.001"))
+    # Before the fix this was 750: the raw USD figure used as a share count
+    assert epsilon < Decimal("10")
+
+
+def test_close_position_refuses_to_destroy_value():
+    """A bookkeeping close must not make a funded position disappear."""
+    state, position = buy_vault_position(PMALT_QUANTITY, initial_cash=150_000)
+    equity_before = state.portfolio.get_total_equity()
+
+    with pytest.raises(PositionValueDestroyedError) as exc_info:
+        state.portfolio.close_position(position, datetime.datetime(2026, 3, 8))
+
+    assert "bookkeeping only" in str(exc_info.value)
+    # The position and the equity must survive the refusal
+    assert position.position_id in state.portfolio.open_positions
+    assert not position.is_closed()
+    assert state.portfolio.get_total_equity() == pytest.approx(equity_before)
+
+
+def test_close_position_allows_deliberate_value_destruction():
+    """Accounting corrections, repair tooling and manual operations still force a close."""
+    state, position = buy_vault_position(PMALT_QUANTITY, initial_cash=150_000)
+
+    state.portfolio.close_position(
+        position,
+        datetime.datetime(2026, 3, 8),
+        allow_value_destruction=True,
+    )
+
+    assert position.is_closed()
+    assert position.position_id in state.portfolio.closed_positions
+
+
+def test_close_position_allows_dust():
+    """A position below the value limit closes without opting in."""
+    dust_quantity = Decimal(str(CLOSE_POSITION_VALUE_DESTRUCTION_LIMIT_USD / 2 / PMALT_SHARE_PRICE))
+    state, position = buy_vault_position(dust_quantity, initial_cash=150_000)
+
+    if position.is_closed():
+        # mark_trade_success() already auto-closed it as dust, which is the intended path
+        return
+
+    assert position.get_value() < CLOSE_POSITION_VALUE_DESTRUCTION_LIMIT_USD
+    state.portfolio.close_position(position, datetime.datetime(2026, 3, 8))
+    assert position.is_closed()

--- a/tradeexecutor/cli/commands/correct_accounts.py
+++ b/tradeexecutor/cli/commands/correct_accounts.py
@@ -201,7 +201,9 @@ def _sync_hypercore_vault_positions(
                 native_token_price=0.0,
                 force=True,
             )
-            state.portfolio.close_position(position, valued_at)
+            # Accounting correction: the onchain balance is gone, so the book-close is the
+            # intended outcome and the offsetting correction is recorded separately.
+            state.portfolio.close_position(position, valued_at, allow_value_destruction=True)
 
             logger.info(
                 "Closed phantom vault position %d with repair trade %d",

--- a/tradeexecutor/cli/vault_trade/state.py
+++ b/tradeexecutor/cli/vault_trade/state.py
@@ -727,8 +727,9 @@ def record_attempt_result(
     position.other_data["vault_test_attempt"] = attempt
 
     # Diagnostic positions never represent live holdings, so close them at the
-    # same timestamp at which they were created.
-    state.portfolio.close_position(position, now)
+    # same timestamp at which they were created. Deliberate book-close: a test-trade
+    # position may still carry a nominal valuation and holds nothing real.
+    state.portfolio.close_position(position, now, allow_value_destruction=True)
     return position
 
 
@@ -870,7 +871,8 @@ def close_simulated_positions(
             if outcome_data:
                 attempt["outcome_data"] = outcome_data
         if position.is_open():
-            state.portfolio.close_position(position, now)
+            # Deliberate book-close of a diagnostic test-trade position.
+            state.portfolio.close_position(position, now, allow_value_destruction=True)
 
 
 def merge_simulated_attempt(

--- a/tradeexecutor/state/portfolio.py
+++ b/tradeexecutor/state/portfolio.py
@@ -28,6 +28,36 @@ from eth_defi.compat import native_datetime_utc_now
 logger = logging.getLogger(__name__)
 
 
+#: How much value, in US dollars, a position may still hold when it is book-closed.
+#:
+#: :py:meth:`Portfolio.close_position` only moves a position between dictionaries; it does
+#: not sell anything. Closing a position that still holds value therefore removes the
+#: holding from the portfolio with no offsetting cash and no realised loss - equity simply
+#: drops and the position reports a profit of zero.
+#:
+#: Every legitimate automatic close happens either after a sell has taken the quantity to
+#: (near) zero, or on a position the dust rules consider negligible. This limit must
+#: therefore sit **above the largest legitimate dust threshold** - otherwise it blocks the
+#: very closes :py:meth:`TradingPosition.can_be_closed` is designed to allow - and far below
+#: any real position, so a mis-scaled threshold cannot quietly delete one.
+#:
+#: The binding constraint is
+#: :py:data:`tradeexecutor.strategy.dust.HYPERLIQUID_VAULT_CLOSE_EPSILON_MAX_USD` (50 USD),
+#: the most a Hypercore residual can be worth and still count as dust. 100 USD leaves a
+#: clear margin above it while still catching the failure this guard exists for: a 8,963 USD
+#: position closed as "dust" because a USD threshold was compared against a share count.
+CLOSE_POSITION_VALUE_DESTRUCTION_LIMIT_USD = 100.0
+
+
+class PositionValueDestroyedError(Exception):
+    """A bookkeeping close would have made a funded position disappear.
+
+    Raised by :py:meth:`Portfolio.close_position` when the position still holds more than
+    :py:data:`CLOSE_POSITION_VALUE_DESTRUCTION_LIMIT_USD` and the caller has not opted in
+    to value destruction.
+    """
+
+
 class NotEnoughMoney(Exception):
     """We try to allocate reserve for a buy trade, but do not have cash."""
 
@@ -944,6 +974,7 @@ class Portfolio:
         self,
         position: TradingPosition,
         executed_at: datetime.datetime,
+        allow_value_destruction: bool = False,
     ):
         """Move a position from open positions to closed ones.
 
@@ -954,7 +985,8 @@ class Portfolio:
         .. code-block:: python
 
             p = state.portfolio.open_positions[11]
-            state.portfolio.close_position(p, native_datetime_utc_now())
+            # A manual console close is deliberate, so opt in to value destruction
+            state.portfolio.close_position(p, native_datetime_utc_now(), allow_value_destruction=True)
             print("Left open")
             for p in state.portfolio.open_positions.values():
                 print(p)
@@ -966,9 +998,26 @@ class Portfolio:
         :param executed_at:
             Wall clock time
 
+        :param allow_value_destruction:
+            Permit closing a position that still holds material value.
+
+            This method is bookkeeping only - it moves the position between dictionaries and
+            sells nothing - so closing a funded position makes its holdings disappear from
+            the portfolio without any offsetting cash or realised loss. Deliberate callers
+            (accounting corrections, manual console operations, repair tooling) pass ``True``.
+            Automatic paths leave it ``False`` so a mis-scaled dust threshold cannot quietly
+            delete a live position.
+
+        :raise PositionValueDestroyedError:
+            If the position still holds more than
+            :py:data:`CLOSE_POSITION_VALUE_DESTRUCTION_LIMIT_USD` and
+            ``allow_value_destruction`` is not set.
         """
 
         assert position.position_id in self.open_positions, f"Not in open positions: {position}"
+
+        if not allow_value_destruction:
+            self._check_close_does_not_destroy_value(position)
 
         # Move position to closed
         logger.info("Marking position to closed: %s at %s", position, executed_at)
@@ -977,6 +1026,43 @@ class Portfolio:
         self.closed_positions[position.position_id] = position
 
         assert position.is_closed()
+
+    def _check_close_does_not_destroy_value(self, position: TradingPosition):
+        """Refuse to book-close a position that still holds material value.
+
+        Position types whose close semantics legitimately leave a non-zero valuation are
+        exempt:
+
+        - CCTP bridge positions close on *available* bridge capital while raw quantity can
+          stay positive (see :py:meth:`TradingPosition.can_be_closed`).
+        - Credit supply and leveraged positions are valued through their loans, where a
+          residual accrued-interest valuation at close time is normal.
+        """
+        if position.is_credit_supply() or position.pair.is_cctp_bridge():
+            return
+
+        try:
+            remaining_value = position.get_value()
+        except Exception:
+            # Valuation is best-effort here: a position we cannot value is not evidence of
+            # value destruction, and this check must never mask the original failure.
+            return
+
+        if remaining_value is None or remaining_value <= CLOSE_POSITION_VALUE_DESTRUCTION_LIMIT_USD:
+            return
+
+        raise PositionValueDestroyedError(
+            f"Refusing to close position {position} as it still holds "
+            f"{remaining_value:,.2f} USD ({position.get_quantity()} units at "
+            f"{position.last_token_price}), above the "
+            f"{CLOSE_POSITION_VALUE_DESTRUCTION_LIMIT_USD} USD limit.\n"
+            f"close_position() is bookkeeping only and does not sell anything, so this would "
+            f"remove the holding from the portfolio without any offsetting cash or realised "
+            f"loss.\n"
+            f"If the position was meant to be closed by trading, the sell did not execute. "
+            f"If the close is deliberate (accounting correction, manual operation, repair), "
+            f"pass allow_value_destruction=True."
+        )
 
     def adjust_reserves(
         self,

--- a/tradeexecutor/state/position.py
+++ b/tradeexecutor/state/position.py
@@ -30,6 +30,7 @@ from tradeexecutor.state.types import USDollarAmount, BPS, USDollarPrice, Percen
 from tradeexecutor.state.valuation import ValuationUpdate
 from tradeexecutor.strategy.dust import (
     HYPERCORE_SMALL_POSITION_CLEANUP_PENDING_REDEEM,
+    convert_usd_close_epsilon_to_quantity,
     get_close_epsilon_for_pair,
     get_dust_epsilon_for_pair,
 )
@@ -455,11 +456,31 @@ class TradingPosition(GenericPosition):
         return self.other_data.get("marked_down_at") is not None
 
     def get_close_epsilon(self) -> Decimal:
-        """Get the quantity threshold below which this position is closed."""
-        return get_close_epsilon_for_pair(
+        """Get the quantity threshold below which this position is closed.
+
+        Always returned in **base token units**, because every caller compares it against
+        :py:meth:`get_quantity`.
+
+        The Hypercore vault threshold is configured in US dollars (it models an absolute
+        withdrawal safety margin), so it is converted to share units at the position's mark
+        price. Without that conversion the threshold is silently multiplied by the share
+        price, and any position smaller than that is closed as dust the moment it opens -
+        destroying the shares, because
+        :py:meth:`tradeexecutor.state.portfolio.Portfolio.close_position` is bookkeeping only.
+        """
+        epsilon = get_close_epsilon_for_pair(
             self.pair,
             hyperliquid_vault_close_epsilon=self.hyperliquid_vault_close_epsilon,
         )
+
+        if self.pair.is_hyperliquid_vault():
+            price = self.last_token_price
+            if not price and self.has_executed_trades():
+                # Not revalued yet - the opening price is the best mark available.
+                price = self.get_opening_price()
+            epsilon = convert_usd_close_epsilon_to_quantity(epsilon, price)
+
+        return epsilon
 
     def has_automatic_close(self) -> bool:
         """This position has stop loss/take profit set."""

--- a/tradeexecutor/state/repair.py
+++ b/tradeexecutor/state/repair.py
@@ -342,7 +342,8 @@ def close_hypercore_duplicate_clone(
     )
     clone_position.other_data["closed_duplicate_survivor_position_id"] = survivor_position.position_id
     clone_position.other_data["hypercore_duplicate_close_reason"] = candidate.close_reason
-    portfolio.close_position(clone_position, now)
+    # Repair tooling: the duplicate position is being removed on purpose.
+    portfolio.close_position(clone_position, now, allow_value_destruction=True)
     logger.info(
         "Closed Hypercore duplicate clone position #%d with repair trade #%d and kept survivor #%d for vault %s at %s",
         clone_position.position_id,
@@ -522,7 +523,9 @@ def close_position_with_empty_trade(portfolio: Portfolio, p: TradingPosition) ->
     opening_trade.add_note(f"Repaired at {now.strftime('%Y-%m-%d %H:%M')}, by #{c.trade_id}")
     c.add_note(f"Repairing to close the position, full position size gone missing")
 
-    portfolio.close_position(position, native_datetime_utc_now())
+    # Repair tooling: the whole position size has gone missing onchain, and the repair
+    # trade above books the loss.
+    portfolio.close_position(position, native_datetime_utc_now(), allow_value_destruction=True)
 
     # The position is now cleared
     assert p.is_closed()

--- a/tradeexecutor/strategy/dust.py
+++ b/tradeexecutor/strategy/dust.py
@@ -10,7 +10,7 @@ from _decimal import Decimal
 from decimal import Decimal
 
 from tradeexecutor.state.identifier import TradingPairIdentifier, AssetIdentifier
-from tradeexecutor.state.types import Percent
+from tradeexecutor.state.types import Percent, USDollarPrice
 from tradeexecutor.utils.accuracy import COLLATERAL_EPSILON
 
 #: The absolute number of tokens we consider the value to be zero
@@ -53,6 +53,15 @@ DEFAULT_VAULT_EPSILON = Decimal(10 ** -6)
 #: Keep this above HYPERCORE_WITHDRAWAL_SAFETY_MARGIN_RAW = 1_500_000 raw
 #: ($1.50 in 6-decimal USDC) so can_be_closed() recognises the intentional
 #: residual as dust and the runner can auto-close it before account checks.
+#:
+#: .. warning::
+#:
+#:     This threshold is denominated in **US dollars**, not in vault share units.
+#:     Callers comparing it against a position quantity must convert it first with
+#:     :py:func:`convert_usd_close_epsilon_to_quantity`. For vaults whose share price is
+#:     near 1 USD the two happen to coincide, which is why the distinction went unnoticed;
+#:     for a share priced at 12.78 USD, treating "2.00" as share units makes the dust
+#:     threshold 25.56 USD instead of 2.00 USD.
 HYPERLIQUID_VAULT_CLOSE_EPSILON = Decimal("2.00")
 
 #: A HyperCore small-position cleanup residual above this amount can still
@@ -66,6 +75,20 @@ HYPERCORE_SMALL_POSITION_CLEANUP_PENDING_REDEEM = (
 )
 
 HYPERLIQUID_VAULT_CLOSE_EPSILON_CAPITAL_PCT = Decimal("0.005")
+
+#: Absolute ceiling, in US dollars, for the capital-scaled Hypercore close epsilon.
+#:
+#: Hypercore withdrawal dust is caused by an *absolute* safety margin of ~1.50 USDC
+#: subtracted from live equity, so it does not grow with the strategy. Scaling the
+#: threshold by ``initial_cash`` was intended to give larger strategies a little more
+#: slack, but without a ceiling a 150,000 USD strategy gets a 750 USD "dust" threshold -
+#: five hundred times the residual it is supposed to absorb, and comfortably large enough
+#: to swallow a real position.
+#:
+#: 50 USD is ~33x the observed withdrawal margin and far below any position this strategy
+#: family opens, so it keeps the intended slack without letting the threshold reach
+#: economically meaningful sizes.
+HYPERLIQUID_VAULT_CLOSE_EPSILON_MAX_USD = Decimal("50.00")
 
 #: Hypercore vault equities fluctuate every block due to active trading
 #: inside the vault, and live cycles can spend a long time in sequential
@@ -104,17 +127,56 @@ def get_dust_epsilon_for_pair(pair: TradingPairIdentifier) -> Decimal:
 
 
 def get_hyperliquid_vault_close_epsilon(initial_cash: float | None = None) -> Decimal:
-    """Get a Hypercore vault close epsilon from a strategy module's initial cash.
+    """Get a Hypercore vault close epsilon, in **US dollars**, from a strategy's initial cash.
 
-    A strategy with initial cash uses 0.5% of that value. Strategies without
-    configured initial cash retain the default close epsilon.
+    A strategy with initial cash uses 0.5% of that value, clamped between the default
+    safety-margin floor and :py:data:`HYPERLIQUID_VAULT_CLOSE_EPSILON_MAX_USD`. Strategies
+    without configured initial cash retain the default close epsilon.
+
+    ``initial_cash`` is a strategy-module input and can differ materially from live
+    strategy equity, so the clamp is what stops a large configured bankroll turning the
+    dust threshold into a real position size.
+
+    :return:
+        Dust threshold in US dollars. Convert with
+        :py:func:`convert_usd_close_epsilon_to_quantity` before comparing to a quantity.
     """
-    # TODO: Clamp the percentage-derived threshold between the default safety
-    # margin floor and a safe absolute maximum. initial_cash is a backtest input
-    # and can differ materially from live strategy equity.
     if initial_cash is None or initial_cash <= 0:
         return HYPERLIQUID_VAULT_CLOSE_EPSILON
-    return Decimal(str(initial_cash)) * HYPERLIQUID_VAULT_CLOSE_EPSILON_CAPITAL_PCT
+
+    scaled = Decimal(str(initial_cash)) * HYPERLIQUID_VAULT_CLOSE_EPSILON_CAPITAL_PCT
+    return min(max(scaled, HYPERLIQUID_VAULT_CLOSE_EPSILON), HYPERLIQUID_VAULT_CLOSE_EPSILON_MAX_USD)
+
+
+def convert_usd_close_epsilon_to_quantity(
+    epsilon_usd: Decimal,
+    price: USDollarPrice | None,
+) -> Decimal:
+    """Convert a USD-denominated close epsilon into base token units.
+
+    :py:meth:`TradingPosition.can_be_closed` compares the close epsilon against a position
+    *quantity*, so a USD threshold has to be divided by the share price first. Skipping the
+    conversion silently scales the threshold by the share price: at a 12.78 USD share price
+    a 750 USD threshold becomes 750 *shares* worth 9,585 USD, and any position below that
+    is written off as dust the moment it is opened.
+
+    :param epsilon_usd:
+        Dust threshold in US dollars.
+
+    :param price:
+        Current mark price of one base token, in US dollars.
+
+    :return:
+        Dust threshold in base token units.
+
+        When the price is unknown or non-positive the conversion is impossible, and this
+        falls back to :py:data:`DEFAULT_VAULT_EPSILON` rather than to the unconverted USD
+        figure. Leaving a dust position open is recoverable on a later cycle; closing a
+        funded position is not.
+    """
+    if not price or price <= 0:
+        return DEFAULT_VAULT_EPSILON
+    return epsilon_usd / Decimal(str(price))
 
 
 def configure_hyperliquid_vault_close_epsilon(


### PR DESCRIPTION
A 150,000 USD backtest ended at **10,645 USD** while its own positions reported **-1,333 USD realised** and **+558 USD unrealised**. Every position was healthy. 138,580 USD had simply left the accounting.

## Root cause

`get_hyperliquid_vault_close_epsilon()` returns `initial_cash * 0.005` — a **US dollar** amount. `TradingPosition.can_be_closed()` compared it against `get_quantity()` — a count of **vault shares**.

For vaults priced near 1 USD/share the two coincide, which is why this was invisible. The default `2.00` is documented against a "$1.50 in 6-decimal USDC" withdrawal margin, so it was always meant as dollars.

pmalt trades at 12.78 USD/share. At a 150,000 bankroll the threshold became **750 shares = 9,585 USD**. `mark_trade_success()` consults `can_be_closed()` immediately after a buy settles, so **34 freshly opened positions worth 111,120 USD were book-closed as "dust" on the timestamp they were opened**. `Portfolio.close_position()` is bookkeeping only and sells nothing, so the shares were orphaned at zero value with realised P&L of 0.

The percentage scaling is what turned a latent unit confusion into value destruction that grows with bankroll:

| Bankroll | Threshold | As pmalt value | Effect |
|---|---:|---:|---|
| 25,000 | 125 shares | 1,598 USD | below typical trade size — rarely bites |
| 150,000 | 750 shares | 9,585 USD | catches almost every entry |

That is why 25,000 USD strategies reconcile to ~0.3% while 150,000 USD ones lost 92%.

**This is not backtest-only.** The same path drives live dust auto-close via `close_hypercore_dust_positions()` in the runner.

## Changes

**1. Denominate the epsilon in USD and convert before comparing**

- `convert_usd_close_epsilon_to_quantity()` divides the USD threshold by the mark price
- `TradingPosition.get_close_epsilon()` applies it for Hypercore pairs, so all existing quantity comparisons stay correct
- On unknown price the conversion falls back to a **dust-sized** threshold, never the raw USD figure — leaving dust open is recoverable, closing a funded position is not

**2. Clamp the capital-scaled threshold to 50 USD**

Closes the TODO the function already carried. Hypercore withdrawal dust comes from an *absolute* ~1.50 USD safety margin, so it does not grow with the strategy.

**3. Refuse to book-close a position still holding value**

`close_position(..., allow_value_destruction=False)` raises `PositionValueDestroyedError` above 100 USD. CCTP bridge and credit positions are exempt — their close semantics legitimately leave a non-zero valuation. Accounting correction, repair tooling and manual vault operations opt in explicitly.

The 100 USD guard must stay **above** the 50 USD dust ceiling or it blocks closes the dust rules are designed to allow. An end-to-end backtest caught exactly that with a 31.36 USD residual; the invariant is now asserted in a test.

## Tests

`tests/hyperliquid/test_hypercore_dust_epsilon_units.py` — 12 tests driving the real `create_trade` → `mark_trade_success` path, which is where the destruction happened.

Verified they catch the defect: re-simulating the bug (disabling the conversion and the clamp) fails 6 of them. The bankroll parametrisation encodes the observed pattern — 25,000 and 75,000 survive even unfixed, 150,000 does not.

## Verification

Same 150,000 USD configuration, before and after:

| | Before | After |
|---|---:|---:|
| Final equity | 10,645 USD | **163,634 USD** |
| Unexplained vs `initial + realised + unrealised - fees` | -91.88% | **+0.77%** |
| Positions closed with cash out and no cash in | 34 (111,120 USD) | **0** |
| Control configuration residual | -5.83% | **-0.14%** |

Regression suites: `tests/hyperliquid/` 166 passed / 20 skipped. `tests/backtest/` 199 passed / 39 skipped / 22 errors — **identical to the clean-master baseline** (the 22 are pre-existing, missing dataset API key).

## Deliberately not included

Three related items change search-harness behaviour and deserve separate review:

- `perform_optimisation(ignore_wallet_errors=True)` scores crashed backtests as zeros, so an unrunnable configuration ranks last instead of being reported
- `GridSearchResult` metrics are quantised by quantstats `.round(2)`, making Calmar a coarse search objective
- The grid-search cache key covers only searched parameters, so changing an unsearched one silently serves stale results — fixing it would invalidate every existing cache

🤖 Generated with [Claude Code](https://claude.com/claude-code)