### PR TITLE
fix: scale HyperCore withdrawal safety margin

### DIFF
--- a/.claude/docs/hypercore-vault.md
+++ b/.claude/docs/hypercore-vault.md
@@ -543,9 +543,65 @@ depositing would unnecessarily create a new lock-up. No backend redemption
 minimum has been confirmed; every attempted redemption is verified for actual
 balance movement.
 
+Normal strategy withdrawals reserve `max(0.5% of the available amount, 1.50
+USDC)` for NAV drift between the live read and HyperCore processing. The same
+relative/floor equation is used when a partial reduction is genuinely limited
+by `max_withdrawable`, when constructing a full close from fresh live equity,
+and in normal phase-1 no-op retries. Planning first compares the requested
+amount with the raw live cap; it does not let the safety reserve turn an
+otherwise unconstrained full close into a partial close.
+
+Planning-to-preflight cap drift is a separate decision from the amount left
+below the fresh cap. A normal withdrawal accepts drift up to the same
+relative/floor equation evaluated against the requested amount; larger changes
+still fail rather than silently invalidating same-cycle cash planning. Once
+accepted, execution independently leaves the relative/floor margin below the
+fresh cap. Specialised 3–5 USDC cleanup retains the fixed 1.50 USDC cap-drift
+tolerance while using only 0.10 USDC initial execution headroom, so its small
+headroom cannot accidentally narrow preflight acceptance.
+
+**Production incident (trades #1599–#1605, pmalt and Octavious Maximus,
+2026-08-22/23).** Hyper AI planned pmalt sell #1605 for 6,389.537474 USDC.
+Roughly 15 seconds later, immediately before transaction construction, the
+fresh HyperCore `max_withdrawable` was 6,387.042495 USDC, a 2.494979 USDC
+decrease. The old 1.50 USDC fixed cap-drift tolerance rejected the withdrawal
+before broadcast. The whole batch stopped at its first sequential trade,
+leaving #1605 started without a transaction and the six following trades
+planned.
+
+On restart, new Octavious position #510 still contained planned opening trade
+#1602 but had zero executed quantity. Generic HyperCore dust cleanup used that
+zero as evidence of a completed redemption, then asserted that the opening
+trade was successful while constructing its local repair close. This caused a
+second scheduler crash. There were therefore two independent defects: the
+fixed withdrawal margin did not scale with the amount, and dust cleanup did
+not distinguish an unfinished position from genuine post-redemption dust.
+
+The withdrawal equation now selects the greater of 0.5% of the amount and the
+existing 1.50 USDC floor, then rounds upwards to six-decimal USDC precision.
+For the fresh pmalt cap this yields 31.935213 USDC headroom and a
+6,355.107282 USDC safe request. The accepted cap drift and the headroom below
+the fresh cap are additive: in the percentage regime, realised sell proceeds
+can therefore be roughly 1% below the planned request in the worst case (or up
+to 3.00 USDC below it while both fixed floors apply). That bounded shortfall is
+preferable to aborting the complete sequential batch, while cap drift above its
+configured 0.5%/1.50 USDC tolerance still fails loudly.
+
+Separately, automatic dust cleanup first identifies a dust-sized position and
+then skips it if it has no successful trade or has a planned, started, or
+broadcast trade. The percentage-derived full-close residual is accounted for
+by verified settlement and may exceed the independently capped 50 USDC dust
+threshold; increasing that bookkeeping-only threshold would risk discarding a
+real live position. Settlement stores the observed residual on the closed
+trade, and a later `correct-accounts` run recreates an on-chain residual above
+its default 2 USDC reconciliation threshold as a tracked small position. The
+specialised cleanup ladder can then recover it. These guards are intentionally
+independent: changing the margin cannot make incomplete trade state safe to
+repair, and the state guard cannot prevent stale live withdrawal caps.
+
 Cleanup uses an adaptive initial margin of at most 0.10 USDC instead of the
-normal 1.50 USDC full-close margin, because withholding 1.50 USDC would strand
-a material share of a 3–5 USDC position. The redeem path retries a phase-1
+normal relative/floor full-close margin, because withholding 1.50 USDC would
+strand a material share of a 3–5 USDC position. The redeem path retries a phase-1
 silent no-op with progressively larger 0.25, 0.50, and 1.00 USDC safety
 margins, but only while the resulting redemption remains above the 0.20 USDC
 follow-up phase verification tolerance. The deposit constant is deliberately

--- a/tests/hyperliquid/test_hypercore_accounting.py
+++ b/tests/hyperliquid/test_hypercore_accounting.py
@@ -40,6 +40,7 @@ from tradeexecutor.strategy.account_correction import (
     _build_hypercore_vault_account_checks,
 )
 from tradeexecutor.strategy.dust import (
+    get_hypercore_withdrawal_safety_margin,
     get_close_epsilon_for_pair,
     get_dust_epsilon_for_pair,
     get_hyperliquid_vault_close_epsilon,
@@ -49,6 +50,7 @@ from tradeexecutor.strategy.dust import (
 )
 from tradeexecutor.strategy.execution_model import AssetManagementMode
 from tradeexecutor.strategy.execution_context import unit_test_execution_context
+from tradeexecutor.strategy.pandas_trader.position_manager import PositionManager
 from tradeexecutor.strategy.runner import StrategyRunner
 from tradeexecutor.strategy.sync_model import OnChainBalance
 from tradeexecutor.visual.equity_curve import calculate_compounding_unrealised_trading_profitability
@@ -309,15 +311,13 @@ def test_lockup_func_populates_expires_at():
     2. Run the valuator
     3. Verify other_data contains the ISO string
     """
-    import datetime as dt
-
     position = MagicMock()
     position.is_vault.return_value = True
     position.get_quantity.return_value = Decimal("100.0")
     position.last_token_price = 1.0
     position.other_data = {}
 
-    expires = dt.datetime(2026, 3, 27, 14, 30, 0)
+    expires = datetime.datetime(2026, 3, 27, 14, 30, 0)
 
     def value_func(pair):
         return Decimal("105.0")
@@ -391,10 +391,11 @@ def test_old_bug_equity_squared():
 def test_hypercore_vault_dust_epsilon_covers_safety_margin():
     """Hypercore vault close epsilon is large enough to cover withdrawal safety margin dust.
 
-    HYPERCORE_WITHDRAWAL_SAFETY_MARGIN_RAW (1_500_000 raw = $1.50) is subtracted
-    from live vault equity during full-close withdrawals, leaving ~$1.50 residual
-    in the position.  The close epsilon must exceed this so can_be_closed()
-    recognises the position as effectively closed.
+    The 1.50 USDC fixed safety-margin floor is subtracted from small live vault
+    equities during full-close withdrawals. The default close epsilon must
+    exceed this floor so can_be_closed() recognises the position as effectively
+    closed. Larger percentage-derived headroom is accounted for by verified
+    full-close settlement and must not widen this bookkeeping-only threshold.
 
     1. Build a Hypercore vault pair using create_hypercore_vault_pair().
     2. Verify get_close_epsilon_for_pair() returns the Hypercore-specific epsilon
@@ -470,6 +471,87 @@ def test_hypercore_vault_dust_epsilon_covers_safety_margin():
     )
     assert not non_hypercore_pair.is_hyperliquid_vault()
     assert get_close_epsilon_for_pair(non_hypercore_pair) == DEFAULT_VAULT_EPSILON
+
+
+def test_hypercore_reduction_planning_reserves_relative_margin_with_fixed_floor() -> None:
+    """HyperCore reduction planning keeps relative headroom without weakening small withdrawals.
+
+    1. Build a real state position with enough executed quantity for both reduction scenarios.
+    2. Plan a large cap-bound redemption and verify it retains 0.5% of the live cap.
+    3. Plan a small cap-bound redemption and verify it retains the 1.50 USDC floor.
+    4. Plan an unconstrained full close and verify safety headroom does not make it partial.
+    """
+
+    # 1. Build a real state position with enough executed quantity for both reduction scenarios.
+    reserve_asset = AssetIdentifier(
+        chain_id=ChainId.hypercore.value,
+        address="0xb88339cb7199b77e23db6e890353e22632ba630f",
+        token_symbol="USDC",
+        decimals=6,
+    )
+    pair = create_hypercore_vault_pair(
+        quote=reserve_asset,
+        vault_address="0x1111111111111111111111111111111111111111",
+    )
+    state = State()
+    state.portfolio.initialise_reserves(reserve_asset, reserve_token_price=1.0)
+    state.portfolio.adjust_reserves(reserve_asset, Decimal("10000"), "Initial reserve")
+    position, opening_trade, _created = state.create_trade(
+        strategy_cycle_at=datetime.datetime(2026, 8, 22),
+        pair=pair,
+        quantity=None,
+        reserve=Decimal("7000"),
+        assumed_price=1.0,
+        trade_type=TradeType.rebalance,
+        reserve_currency=reserve_asset,
+        reserve_currency_price=1.0,
+    )
+    opening_trade.mark_success(
+        executed_at=datetime.datetime(2026, 8, 22, 0, 1),
+        executed_price=1.0,
+        executed_quantity=Decimal("7000"),
+        executed_reserve=Decimal("7000"),
+        lp_fees=0,
+        native_token_price=0,
+        force=True,
+    )
+    position.last_token_price = 1.0
+    position_manager = object.__new__(PositionManager)
+
+    # 2. Plan a large cap-bound redemption and verify it retains 0.5% of the live cap.
+    large_cap = Decimal("6389.537474")
+    large_plan = position_manager.prepare_hypercore_position_reduction(
+        position,
+        dollar_delta=-7000,
+        max_redemption=float(large_cap),
+    )
+    large_margin = get_hypercore_withdrawal_safety_margin(large_cap)
+    assert large_margin == Decimal("31.947688")
+    assert large_plan.effective_quantity_delta == pytest.approx(-float(large_cap - large_margin))
+    assert large_plan.redemption_cap_bound is True
+    assert large_plan.treat_as_full_close is False
+
+    # 3. Plan a small cap-bound redemption and verify it retains the 1.50 USDC floor.
+    small_cap = Decimal("100")
+    small_plan = position_manager.prepare_hypercore_position_reduction(
+        position,
+        dollar_delta=-7000,
+        max_redemption=float(small_cap),
+    )
+    assert get_hypercore_withdrawal_safety_margin(small_cap) == Decimal("1.500000")
+    assert small_plan.effective_quantity_delta == pytest.approx(-98.5)
+    assert small_plan.redemption_cap_bound is True
+    assert small_plan.treat_as_full_close is False
+
+    # 4. Plan an unconstrained full close and verify safety headroom does not make it partial.
+    full_close_plan = position_manager.prepare_hypercore_position_reduction(
+        position,
+        dollar_delta=-7000,
+        max_redemption=7000,
+    )
+    assert full_close_plan.effective_quantity_delta == pytest.approx(-7000)
+    assert full_close_plan.redemption_cap_bound is False
+    assert full_close_plan.treat_as_full_close is True
 
 
 def test_repair_hypercore_dust_uses_strategy_close_epsilon():
@@ -1137,6 +1219,101 @@ def test_close_hypercore_dust_positions_closes_duplicate_residual_state() -> Non
     assert live_position.position_id in state.portfolio.open_positions
     assert live_position.position_id not in state.portfolio.closed_positions
     assert created_trades[0].trade_type == TradeType.repair
+
+
+def test_close_hypercore_dust_positions_skips_unexecuted_and_planned_positions() -> None:
+    """Dust cleanup must not treat unfinished HyperCore trades as redeemed positions.
+
+    1. Create the Hyper AI crash shape: a new position whose opening trade is still planned.
+    2. Create an executed dust position that also has a started follow-up trade.
+    3. Run dust cleanup and verify neither unfinished position is repaired or closed.
+    """
+
+    # 1. Create the Hyper AI crash shape: a new position whose opening trade is still planned.
+    reserve_asset = AssetIdentifier(
+        chain_id=ChainId.hypercore.value,
+        address="0xb88339cb7199b77e23db6e890353e22632ba630f",
+        token_symbol="USDC",
+        decimals=6,
+    )
+    state = State()
+    state.portfolio.initialise_reserves(reserve_asset, reserve_token_price=1.0)
+    state.portfolio.adjust_reserves(reserve_asset, Decimal("10000"), "Initial reserve")
+    planned_pair = create_hypercore_vault_pair(
+        quote=reserve_asset,
+        vault_address="0x1111111111111111111111111111111111111111",
+        internal_id=1,
+    )
+    planned_position, planned_opening_trade, _created = state.create_trade(
+        strategy_cycle_at=datetime.datetime(2026, 8, 22),
+        pair=planned_pair,
+        quantity=None,
+        reserve=Decimal("3248.872789"),
+        assumed_price=1.0,
+        trade_type=TradeType.rebalance,
+        reserve_currency=reserve_asset,
+        reserve_currency_price=1.0,
+    )
+    assert planned_opening_trade.is_planned()
+    assert planned_position.get_quantity() == 0
+
+    # 2. Create an executed dust position that also has a started follow-up trade.
+    follow_up_pair = create_hypercore_vault_pair(
+        quote=reserve_asset,
+        vault_address="0x2222222222222222222222222222222222222222",
+        internal_id=2,
+    )
+    follow_up_position, successful_opening_trade, _created = state.create_trade(
+        strategy_cycle_at=datetime.datetime(2026, 8, 21),
+        pair=follow_up_pair,
+        quantity=None,
+        reserve=Decimal("1.00"),
+        assumed_price=1.0,
+        trade_type=TradeType.rebalance,
+        reserve_currency=reserve_asset,
+        reserve_currency_price=1.0,
+        flags={TradeFlag.ignore_open},
+    )
+    successful_opening_trade.mark_success(
+        executed_at=datetime.datetime(2026, 8, 21, 0, 1),
+        executed_price=1.0,
+        executed_quantity=Decimal("1.00"),
+        executed_reserve=Decimal("1.00"),
+        lp_fees=0,
+        native_token_price=0,
+        force=True,
+    )
+    _, planned_follow_up_trade, created = state.create_trade(
+        strategy_cycle_at=datetime.datetime(2026, 8, 22),
+        pair=follow_up_pair,
+        quantity=None,
+        reserve=Decimal("25.00"),
+        assumed_price=1.0,
+        trade_type=TradeType.rebalance,
+        reserve_currency=reserve_asset,
+        reserve_currency_price=1.0,
+        position=follow_up_position,
+    )
+    assert created is False
+    state.start_execution(
+        datetime.datetime(2026, 8, 22, 0, 1),
+        planned_follow_up_trade,
+    )
+    assert planned_follow_up_trade.is_started()
+    assert follow_up_position.can_be_closed()
+
+    # 3. Run dust cleanup and verify neither unfinished position is repaired or closed.
+    created_trades = close_hypercore_dust_positions(
+        state.portfolio,
+        now=datetime.datetime(2026, 8, 23),
+    )
+
+    assert created_trades == []
+    assert planned_position.position_id in state.portfolio.open_positions
+    assert follow_up_position.position_id in state.portfolio.open_positions
+    assert state.portfolio.closed_positions == {}
+    assert len(planned_position.trades) == 1
+    assert len(follow_up_position.trades) == 2
 
 
 def test_correct_accounts_closes_phantom_position_from_untracked_withdrawal() -> None:

--- a/tests/hyperliquid/test_hypercore_activation_cost.py
+++ b/tests/hyperliquid/test_hypercore_activation_cost.py
@@ -7,6 +7,7 @@ Verifies that:
 """
 
 import datetime
+import logging
 from decimal import Decimal
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
@@ -14,18 +15,21 @@ from unittest.mock import MagicMock, patch
 import pytest
 from eth_defi.compat import native_datetime_utc_now
 from eth_defi.hyperliquid.api import UserVaultEquity
+from hexbytes import HexBytes
 
 from tradeexecutor.ethereum.vault.hypercore_routing import (
+    HypercoreVaultRouting,
     HypercoreWithdrawalPreflightError,
     calculate_hypercore_bridge_fee,
     compute_spot_to_evm_withdrawal_amount,
     usdc_to_raw,
 )
+from tradeexecutor.state.trade import TradeFlag
+from tradeexecutor.strategy.dust import get_hypercore_withdrawal_safety_margin
+
 
 def _make_routing(simulate=True):
     """Create a HypercoreVaultRouting with mocked dependencies."""
-    from tradeexecutor.ethereum.vault.hypercore_routing import HypercoreVaultRouting
-
     routing = object.__new__(HypercoreVaultRouting)
     routing.web3 = MagicMock()
     routing.lagoon_vault = MagicMock()
@@ -177,8 +181,6 @@ def test_setup_trades_logs_account_mode_without_blocking(caplog):
     2. Simulate an already activated Safe whose Hyperliquid API mode is unified.
     3. Verify setup still builds the trade and logs the observed mode.
     """
-    import logging
-
     routing = _make_routing(simulate=False)
     state = MagicMock()
     trade = _make_trade(planned_reserve=Decimal("25.0"))
@@ -344,7 +346,7 @@ def test_withdrawal_uses_live_equity_on_close():
 
     HyperCore's vaultTransfer silently rejects withdrawals exceeding actual
     equity.  When TradeFlag.close is set, the routing queries live equity via
-    ``userVaultEquities``, subtracts HYPERCORE_WITHDRAWAL_SAFETY_MARGIN_RAW
+    ``userVaultEquities``, subtracts max(0.5% of live equity, 1.50 USDC)
     to avoid NAV drift rejections, and uses that as the withdrawal amount.
 
     1. Create a sell trade with TradeFlag.close and planned_reserve slightly
@@ -353,9 +355,6 @@ def test_withdrawal_uses_live_equity_on_close():
     3. Verify the withdrawal tx is built with live equity minus safety margin.
     4. Verify the safe amount is stored in ``trade.other_data`` for settlement.
     """
-    from tradeexecutor.state.trade import TradeFlag
-    from tradeexecutor.ethereum.vault.hypercore_routing import HYPERCORE_WITHDRAWAL_SAFETY_MARGIN_RAW
-
     routing = _make_routing(simulate=False)
     trade = _make_trade(planned_reserve=Decimal("7.129505"), is_buy=False)
     trade.pair.pool_address = "0x4dec0a851849056e259128464ef28ce78afa27f6"
@@ -370,7 +369,7 @@ def test_withdrawal_uses_live_equity_on_close():
         locked_until=datetime.datetime(2020, 1, 1),
     )
     live_raw = 7_128_756
-    expected_withdrawal_raw = live_raw - HYPERCORE_WITHDRAWAL_SAFETY_MARGIN_RAW
+    expected_withdrawal_raw = live_raw - usdc_to_raw(get_hypercore_withdrawal_safety_margin(live_equity.equity))
 
     # 2. Mock the equity fetch and tx building.
     with patch("tradeexecutor.ethereum.vault.hypercore_routing.fetch_user_vault_equity", return_value=live_equity):
@@ -406,9 +405,6 @@ def test_withdrawal_logs_large_equity_mismatch_but_uses_live_amount(caplog):
     3. Verify the withdrawal still uses live equity minus safety margin.
     4. Verify the warning is logged so the operator can inspect the drift.
     """
-    from tradeexecutor.state.trade import TradeFlag
-    from tradeexecutor.ethereum.vault.hypercore_routing import HYPERCORE_WITHDRAWAL_SAFETY_MARGIN_RAW
-
     routing = _make_routing(simulate=False)
     trade = _make_trade(planned_reserve=Decimal("100.0"), is_buy=False)
     trade.pair.pool_address = "0x1111111111111111111111111111111111111111"
@@ -422,7 +418,7 @@ def test_withdrawal_logs_large_equity_mismatch_but_uses_live_amount(caplog):
         equity=Decimal("90.0"),
         locked_until=datetime.datetime(2020, 1, 1),
     )
-    expected_withdrawal_raw = 90_000_000 - HYPERCORE_WITHDRAWAL_SAFETY_MARGIN_RAW
+    expected_withdrawal_raw = 90_000_000 - usdc_to_raw(get_hypercore_withdrawal_safety_margin(live_equity.equity))
 
     # Step 2: Mock the live equity so the drift warning path is exercised.
     with caplog.at_level("WARNING"):
@@ -490,8 +486,6 @@ def test_live_withdrawal_preflight_blocks_requests_above_max_withdrawable():
     2. Mock Hyperliquid to report an expired lock-up and a smaller ``max_withdrawable``.
     3. Verify the preflight raises before any withdrawal can be broadcast.
     """
-    from tradeexecutor.ethereum.vault.hypercore_routing import HypercoreWithdrawalPreflightError
-
     routing = _make_routing(simulate=False)
     trade = _make_trade(planned_reserve=Decimal("25.0"), is_buy=False)
 
@@ -545,8 +539,53 @@ def test_live_withdrawal_preflight_caps_normal_max_withdrawable_drift_with_safet
                     vault_address="0xVAULT",
                 )
 
-    assert effective_raw == 3_471_605_878
-    assert trade.other_data["hypercore_capped_withdrawal_raw"] == 3_471_605_878
+    assert effective_raw == 3_455_740_348
+    assert trade.other_data["hypercore_capped_withdrawal_raw"] == 3_455_740_348
+
+
+def test_live_withdrawal_preflight_caps_hyper_ai_relative_drift_incident():
+    """The Hyper AI pmalt drift is accepted by relative headroom and capped safely.
+
+    HyperCore native vault state is unavailable to EVM integration fixtures,
+    so only its equity and vault-info API responses are mocked; the real
+    routing preflight and margin calculation are exercised.
+
+    1. Recreate trade #1605 whose requested redemption exceeded the fresh cap by 2.494979 USDC.
+    2. Mock the unlocked HyperCore equity and execution-time max-withdrawable response.
+    3. Verify the 0.5% margin accepts the drift and caps below the fresh amount.
+    """
+    routing = _make_routing(simulate=False)
+    trade = _make_trade(planned_reserve=Decimal("6389.537474"), is_buy=False)
+    unlocked_equity = UserVaultEquity(
+        vault_address="0xVAULT",
+        equity=Decimal("6398.397264"),
+        locked_until=native_datetime_utc_now() - datetime.timedelta(days=1),
+    )
+
+    # 1. Recreate trade #1605 whose request exceeded the fresh cap by 2.494979 USDC.
+    requested_raw = 6_389_537_474
+
+    # 2. Mock the unlocked HyperCore equity and execution-time max-withdrawable response.
+    with (
+        patch(
+            "tradeexecutor.ethereum.vault.hypercore_routing.HyperliquidVault.fetch_info",
+            return_value=SimpleNamespace(max_withdrawable=Decimal("6387.042495")),
+        ),
+        patch(
+            "tradeexecutor.ethereum.vault.hypercore_routing.fetch_user_vault_equity",
+            return_value=unlocked_equity,
+        ),
+        patch.object(routing, "_get_session", return_value=routing._session),
+    ):
+        effective_raw = routing._check_live_withdrawal_preconditions(
+            trade=trade,
+            requested_raw=requested_raw,
+            vault_address="0xVAULT",
+        )
+
+    # 3. Verify the 0.5% margin accepts the drift and caps below the fresh amount.
+    assert effective_raw == 6_355_107_282
+    assert trade.other_data["hypercore_capped_withdrawal_raw"] == 6_355_107_282
 
 
 def test_live_withdrawal_preflight_blocks_cap_below_safety_margin():
@@ -595,10 +634,6 @@ def test_settlement_second_buy_no_activation_cost(
     "hypercore_activation_cost_raw" in other_data.  Settlement must
     treat activation_cost as 0 and deposit the full planned amount.
     """
-    import datetime
-    from eth_defi.hyperliquid.api import UserVaultEquity
-    from hexbytes import HexBytes
-
     routing = _make_routing(simulate=False)
 
     # Second buy: no activation cost in other_data
@@ -694,12 +729,6 @@ def test_settlement_uses_capped_withdrawal_amount(
     4. Verify phases 2-3 receive the capped raw amount.
     5. Verify no ``report_failure`` call (trade succeeds).
     """
-    import datetime
-    import logging
-    from decimal import Decimal
-    from eth_defi.hyperliquid.api import UserVaultEquity
-    from hexbytes import HexBytes
-
     routing = _make_routing(simulate=False)
     capped_raw = 7_128_756  # Live equity at phase 1 build time
     planned_raw = 7_129_505  # Original planned_reserve (slightly higher)
@@ -994,8 +1023,6 @@ def test_settlement_uses_capped_deposit_and_refunds_reserve(
     3. Verify phase 2 uses capped amount, mark_trade_success uses correct values.
     4. Verify reserve refund of 20 USDC.
     """
-    from hexbytes import HexBytes
-
     routing = _make_routing(simulate=False)
 
     trade = _make_trade(planned_reserve=Decimal("100.0"))
@@ -1090,8 +1117,6 @@ def test_settlement_capped_deposit_with_activation_cost(
     3. Verify phase 2 uses capped amount, executed_reserve includes activation.
     4. Verify reserve refund of 3 USDC.
     """
-    from hexbytes import HexBytes
-
     routing = _make_routing(simulate=False)
 
     trade = _make_trade(planned_reserve=Decimal("100.0"))
@@ -1188,8 +1213,6 @@ def test_settlement_capped_deposit_refunds_bridge_not_reserves(
     3. Verify refund goes to bridge_position.adjust_bridge_capital_allocated,
        NOT to state.portfolio.adjust_reserves.
     """
-    from hexbytes import HexBytes
-
     routing = _make_routing(simulate=False)
 
     trade = _make_trade(planned_reserve=Decimal("100.0"))

--- a/tests/hyperliquid/test_hypercore_small_position_cleanup.py
+++ b/tests/hyperliquid/test_hypercore_small_position_cleanup.py
@@ -11,9 +11,11 @@ from tradingstrategy.chain import ChainId
 from tradeexecutor.ethereum.vault.hypercore_routing import (
     HYPERCORE_SMALL_POSITION_CLEANUP_INITIAL_SAFETY_MARGIN_RAW,
     HYPERCORE_SMALL_POSITION_CLEANUP_RETRY_SAFETY_MARGINS_RAW,
+    HYPERCORE_WITHDRAWAL_PREFLIGHT_CAP_TOLERANCE_FLOOR_RAW,
     HYPERCORE_WITHDRAWAL_SAFETY_MARGIN_RAW,
     HypercoreWithdrawalPreflightError,
     HypercoreVaultRouting,
+    usdc_to_raw,
 )
 from tradeexecutor.ethereum.vault.hypercore_small_position_cleanup import (
     HYPERCORE_SMALL_POSITION_MINIMUM_REDEEMABLE_EQUITY,
@@ -31,6 +33,7 @@ from tradeexecutor.state.state import State
 from tradeexecutor.state.trade import TradeType
 from tradeexecutor.strategy.dust import (
     HYPERCORE_SMALL_POSITION_CLEANUP_PENDING_REDEEM,
+    get_hypercore_withdrawal_safety_margin,
 )
 
 
@@ -280,13 +283,13 @@ def test_cleanup_uses_strategy_minimum_allocation_and_pending_marker():
     assert pending_candidates[0].is_pending_cleanup is True
 
 
-def test_cleanup_uses_progressively_larger_silent_noop_retry_margins():
+def test_cleanup_uses_progressively_larger_silent_noop_retry_margins() -> None:
     """A cleanup close receives an adaptive retry ladder without a deposit floor.
 
     1. Create the normal and cleanup trade markers used by the HyperCore router.
     2. Ask the routing helper for their silent-no-op retry margins.
-    3. Verify cleanup starts with a small adaptive margin and accepts a positive sub-5 retry.
-    4. Verify only cleanup closes receive the progressively larger retry ladder.
+    3. Verify cleanup separates its cap-drift tolerance from its small execution margin.
+    4. Verify normal retries derive the configured margin and cleanup uses its retry ladder.
     """
 
     # 1. Create the normal and cleanup trade markers used by the HyperCore router.
@@ -295,14 +298,18 @@ def test_cleanup_uses_progressively_larger_silent_noop_retry_margins():
     cleanup_trade = SimpleNamespace(other_data={"hypercore_small_position_cleanup": True})
 
     # 2. Ask the routing helper for their silent-no-op retry margins.
-    normal_margins = routing._get_phase1_noop_retry_safety_margins(normal_trade)
-    cleanup_margins = routing._get_phase1_noop_retry_safety_margins(cleanup_trade)
+    normal_margins = routing._get_phase1_noop_retry_safety_margins(normal_trade, 1_000_000_000)
+    cleanup_margins = routing._get_phase1_noop_retry_safety_margins(cleanup_trade, 1_000_000_000)
 
-    # 3. Verify cleanup starts with a small adaptive margin and accepts a positive sub-5 retry.
+    # 3. Verify cleanup separates its cap-drift tolerance from its small execution margin.
     assert routing._get_full_close_safety_margin_raw(
         cleanup_trade,
         3_450_000,
     ) == HYPERCORE_SMALL_POSITION_CLEANUP_INITIAL_SAFETY_MARGIN_RAW
+    assert routing._get_withdrawal_cap_drift_tolerance_raw(
+        cleanup_trade,
+        3_450_000,
+    ) == HYPERCORE_WITHDRAWAL_PREFLIGHT_CAP_TOLERANCE_FLOOR_RAW
     with pytest.raises(
         HypercoreWithdrawalPreflightError,
         match="required to verify every withdrawal phase",
@@ -332,8 +339,11 @@ def test_cleanup_uses_progressively_larger_silent_noop_retry_margins():
         safety_margin_raw=1_000_000,
     ) is None
 
-    # 4. Verify only cleanup closes receive the progressively larger retry ladder.
-    assert normal_margins == (HYPERCORE_WITHDRAWAL_SAFETY_MARGIN_RAW,)
+    # 4. Verify normal retries derive the configured margin and cleanup uses its retry ladder.
+    expected_normal_margin = usdc_to_raw(
+        get_hypercore_withdrawal_safety_margin(Decimal("1000"))
+    )
+    assert normal_margins == (expected_normal_margin,)
     assert cleanup_margins == HYPERCORE_SMALL_POSITION_CLEANUP_RETRY_SAFETY_MARGINS_RAW
 
 

--- a/tests/test_rebalance.py
+++ b/tests/test_rebalance.py
@@ -2118,8 +2118,8 @@ def test_alpha_model_caps_profitable_hypercore_sell_before_trade_generation(
     """Check Hypercore sell sizing uses live position price and capped quantity before trade creation.
 
     1. Create a profitable Hypercore position whose marked value is above its stored quantity.
-    2. Cap redemption below the requested sell so the alpha model must recompute the effective sell.
-    3. Verify the signal stores the capped marked-value delta, while the sell trade stores the smaller released cash amount.
+    2. Cap redemption below the requested sell so the alpha model must reserve safety headroom and recompute the effective sell.
+    3. Verify the signal and sell trade use the safety-adjusted cap rather than the raw live cap.
     """
     state = State()
     hypercore_vault_pair = _create_hypercore_position_for_rebalance_test(state, start_ts, usdc)
@@ -2156,7 +2156,7 @@ def test_alpha_model_caps_profitable_hypercore_sell_before_trade_generation(
     alpha_model.update_old_weights(state.portfolio, ignore_credit=False)
     alpha_model.calculate_target_positions(position_manager, investable_equity=20.0)
 
-    # 2. Cap redemption below the requested sell so the alpha model must recompute the effective sell.
+    # 2. Cap redemption below the requested sell so the alpha model must reserve safety headroom and recompute the effective sell.
     trades = alpha_model.generate_rebalance_trades_and_triggers(
         position_manager,
         min_trade_threshold=0.01,
@@ -2167,13 +2167,13 @@ def test_alpha_model_caps_profitable_hypercore_sell_before_trade_generation(
     signal = alpha_model.get_signal_by_pair(hypercore_vault_pair)
     assert signal is not None
 
-    # 3. Verify the signal stores the capped marked-value delta, while the sell trade stores the smaller released cash amount.
-    assert signal.position_adjust_usd == pytest.approx(-10.0)
-    assert signal.position_adjust_quantity == pytest.approx(-5.0)
+    # 3. Verify the signal and sell trade use the safety-adjusted cap rather than the raw live cap.
+    assert signal.position_adjust_usd == pytest.approx(-8.5)
+    assert signal.position_adjust_quantity == pytest.approx(-4.25)
     assert len(trades) == 1
     assert trades[0].is_sell()
-    assert trades[0].planned_quantity == Decimal("-5")
-    assert trades[0].planned_reserve == Decimal("10")
+    assert trades[0].planned_quantity == Decimal("-4.25")
+    assert trades[0].planned_reserve == Decimal("8.50")
     assert trades[0].planned_price == pytest.approx(2.0)
 
 
@@ -2270,8 +2270,8 @@ def test_alpha_model_converts_loss_making_hypercore_usd_cap_to_quantity(
     """Check Hypercore USD redemption cap is converted to vault units when share price is below 1.
 
     1. Create a loss-making Hypercore position with share price below 1.
-    2. Cap the redemption in USD below the requested sell.
-    3. Verify capped USD is converted to a larger vault-unit quantity.
+    2. Cap the redemption in USD below the requested sell and reserve safety headroom.
+    3. Verify safety-adjusted USD is converted to the corresponding vault-unit quantity.
     """
     state = State()
     hypercore_vault_pair = _create_hypercore_position_for_rebalance_test(
@@ -2313,7 +2313,7 @@ def test_alpha_model_converts_loss_making_hypercore_usd_cap_to_quantity(
     alpha_model.update_old_weights(state.portfolio, ignore_credit=False)
     alpha_model.calculate_target_positions(position_manager, investable_equity=20.0)
 
-    # 2. Cap the redemption in USD below the requested sell.
+    # 2. Cap the redemption in USD below the requested sell and reserve safety headroom.
     trades = alpha_model.generate_rebalance_trades_and_triggers(
         position_manager,
         min_trade_threshold=0.01,
@@ -2324,13 +2324,13 @@ def test_alpha_model_converts_loss_making_hypercore_usd_cap_to_quantity(
     signal = alpha_model.get_signal_by_pair(hypercore_vault_pair)
     assert signal is not None
 
-    # 3. Verify capped USD is converted to a larger vault-unit quantity.
-    assert signal.position_adjust_usd == pytest.approx(-10.0)
-    assert signal.position_adjust_quantity == pytest.approx(-20.0)
+    # 3. Verify safety-adjusted USD is converted to the corresponding vault-unit quantity.
+    assert signal.position_adjust_usd == pytest.approx(-8.5)
+    assert signal.position_adjust_quantity == pytest.approx(-17.0)
     assert len(trades) == 1
     assert trades[0].is_sell()
-    assert trades[0].planned_quantity == Decimal("-20")
-    assert trades[0].planned_reserve == Decimal("10.0")
+    assert trades[0].planned_quantity == Decimal("-17")
+    assert trades[0].planned_reserve == Decimal("8.50")
     assert trades[0].planned_price == pytest.approx(0.5)
 
 
@@ -2344,7 +2344,7 @@ def test_alpha_model_skips_hypercore_sell_below_threshold_after_capping(
     """Check Hypercore sell thresholds are evaluated after the live redemption cap is applied.
 
     1. Create a profitable Hypercore position whose requested marked-value reduction is large.
-    2. Cap the redeemable quantity so the effective sell becomes smaller than the sell threshold.
+    2. Apply safety headroom to the redeemable cap so the effective sell becomes smaller than the sell threshold.
     3. Verify the alpha model skips the trade instead of emitting a dust Hypercore withdrawal.
     """
     state = State()
@@ -2382,7 +2382,7 @@ def test_alpha_model_skips_hypercore_sell_below_threshold_after_capping(
     alpha_model.update_old_weights(state.portfolio, ignore_credit=False)
     alpha_model.calculate_target_positions(position_manager, investable_equity=20.0)
 
-    # 2. Cap the redeemable quantity so the effective sell becomes smaller than the sell threshold.
+    # 2. Apply safety headroom to the redeemable cap so the effective sell becomes smaller than the sell threshold.
     trades = alpha_model.generate_rebalance_trades_and_triggers(
         position_manager,
         min_trade_threshold=0.01,
@@ -2395,8 +2395,8 @@ def test_alpha_model_skips_hypercore_sell_below_threshold_after_capping(
 
     # 3. Verify the alpha model skips the trade instead of emitting a dust Hypercore withdrawal.
     assert trades == []
-    assert signal.position_adjust_usd == pytest.approx(-2.0)
-    assert signal.position_adjust_quantity == pytest.approx(-1.0)
+    assert signal.position_adjust_usd == pytest.approx(-0.5)
+    assert signal.position_adjust_quantity == pytest.approx(-0.25)
     assert TradingPairSignalFlags.individual_trade_size_too_small in signal.flags
 
 
@@ -2482,8 +2482,8 @@ def test_alpha_model_uses_capped_hypercore_cash_release_for_buy_checks(
     """Check same-cycle cash planning uses capped Hypercore cash release, not marked value reduction.
 
     1. Create a profitable Hypercore position and a second buy signal competing for the released cash.
-    2. Cap the Hypercore sell so its released cash is smaller than the buy that follows in the same cycle.
-    3. Verify check_enough_cash() fails against the capped planned reserve instead of the larger marked-value reduction.
+    2. Apply safety headroom to the Hypercore cap so its released cash is smaller than the buy that follows in the same cycle.
+    3. Verify check_enough_cash() fails against the safety-adjusted reserve instead of the larger marked-value reduction.
     """
     state = State()
     hypercore_vault_pair = _create_hypercore_position_for_rebalance_test(state, start_ts, usdc)
@@ -2521,7 +2521,7 @@ def test_alpha_model_uses_capped_hypercore_cash_release_for_buy_checks(
     alpha_model.update_old_weights(state.portfolio, ignore_credit=False)
     alpha_model.calculate_target_positions(position_manager, investable_equity=45.0)
 
-    # 2. Cap the Hypercore sell so its released cash is smaller than the buy that follows in the same cycle.
+    # 2. Apply safety headroom to the Hypercore cap so its released cash is smaller than the buy that follows in the same cycle.
     trades = alpha_model.generate_rebalance_trades_and_triggers(
         position_manager,
         min_trade_threshold=0.01,
@@ -2532,8 +2532,8 @@ def test_alpha_model_uses_capped_hypercore_cash_release_for_buy_checks(
     hypercore_sell = next(t for t in trades if t.pair == hypercore_vault_pair)
     aave_buy = next(t for t in trades if t.pair == aave_usdc)
 
-    # 3. Verify check_enough_cash() fails against the capped planned reserve instead of the larger marked-value reduction.
-    assert hypercore_sell.planned_reserve == Decimal("10")
+    # 3. Verify check_enough_cash() fails against the safety-adjusted reserve instead of the larger marked-value reduction.
+    assert hypercore_sell.planned_reserve == Decimal("8.50")
     assert aave_buy.planned_reserve == Decimal("15")
     with pytest.raises(NotEnoughCasForBuys):
         position_manager.check_enough_cash(trades)

--- a/tradeexecutor/ethereum/vault/hypercore_dust_claim.py
+++ b/tradeexecutor/ethereum/vault/hypercore_dust_claim.py
@@ -38,7 +38,6 @@ from tradeexecutor.ethereum.vault.hypercore_routing import (
     HYPERCORE_FOLLOW_UP_PHASE_TOLERANCE_RAW,
     HYPERCORE_MULTICALL_GAS,
     HYPERCORE_WITHDRAWAL_PHASE1_RETRY_ATTEMPTS,
-    HYPERCORE_WITHDRAWAL_SAFETY_MARGIN_RAW,
     raw_to_usdc,
     usdc_to_raw,
 )
@@ -58,6 +57,7 @@ from tradeexecutor.state.balance_update import (
     BalanceUpdatePositionType,
 )
 from tradeexecutor.state.sync import BalanceEventRef
+from tradeexecutor.strategy.dust import get_hypercore_withdrawal_safety_margin
 from tradeexecutor.utils.blockchain import get_block_timestamp
 
 logger = logging.getLogger(__name__)
@@ -291,9 +291,10 @@ def _classify_candidate(
         )
 
     requested_amount = min(equity.equity, max_withdrawable)
+    safety_margin = get_hypercore_withdrawal_safety_margin(requested_amount)
     safe_raw_claim_amount = (
         context.reserve_token.convert_to_raw(requested_amount)
-        - HYPERCORE_WITHDRAWAL_SAFETY_MARGIN_RAW
+        - context.reserve_token.convert_to_raw(safety_margin)
     )
     if safe_raw_claim_amount <= 0:
         return HypercoreDustCandidate(
@@ -527,9 +528,8 @@ def _get_phase1_noop_retry_raw(
     ``MINIMUM_VAULT_DEPOSIT`` is deliberately irrelevant because the
     withdrawal encoder does not apply it.
     """
-    retry_raw = (
-        usdc_to_raw(current_vault_equity) - HYPERCORE_WITHDRAWAL_SAFETY_MARGIN_RAW
-    )
+    safety_margin = get_hypercore_withdrawal_safety_margin(current_vault_equity)
+    retry_raw = usdc_to_raw(current_vault_equity - safety_margin)
     if retry_raw <= HYPERCORE_FOLLOW_UP_PHASE_TOLERANCE_RAW:
         return None
     if retry_raw >= previous_raw:

--- a/tradeexecutor/ethereum/vault/hypercore_routing.py
+++ b/tradeexecutor/ethereum/vault/hypercore_routing.py
@@ -130,9 +130,11 @@ from eth_defi.compat import native_datetime_utc_now
 from tradeexecutor.ethereum.tx import TransactionBuilder
 from tradeexecutor.state.identifier import TradingPairIdentifier, AssetIdentifier
 from tradeexecutor.strategy.dust import (
+    HYPERCORE_WITHDRAWAL_SAFETY_MARGIN_FLOOR,
     HYPERCORE_SMALL_POSITION_CLEANUP_CLOSE_EPSILON,
     HYPERCORE_SMALL_POSITION_CLEANUP_PENDING_REDEEM,
     get_close_epsilon_for_pair,
+    get_hypercore_withdrawal_safety_margin,
 )
 from tradingstrategy.pair import PandasPairUniverse
 
@@ -155,11 +157,11 @@ USDC_DECIMALS = 6
 #: (from trade creation) and the live vault equity (at execution time) must
 #: agree within this tolerance.  If live equity is below this fraction of
 #: the planned amount, something is seriously wrong (wrong vault, corrupted
-#: state, major vault event) and we abort rather than risk a bad withdrawal.
+#: state, major vault event), so emit a prominent warning while continuing
+#: with authoritative live equity to avoid freezing a legitimate close.
 HYPERCORE_LIKELY_CLOSE_TOLERANCE = 0.975
 
-#: Safety margin (raw USDC, 6 decimals) subtracted from live vault equity
-#: when building full-close withdrawals.
+#: Fixed safety-margin floor in raw 6-decimal USDC.
 #:
 #: HyperCore's ``vaultTransfer`` silently rejects withdrawals that exceed
 #: actual equity — the EVM tx succeeds but zero USDC moves.  Between the
@@ -167,48 +169,54 @@ HYPERCORE_LIKELY_CLOSE_TOLERANCE = 0.975
 #: action, the vault NAV can fluctuate (fees, PnL, mark-to-market).  The
 #: API may also round the equity string upward vs. the on-chain value.
 #:
-#: $1.50 (1 500 000 raw) covers larger observed drift for volatile vaults.
-#: The original $0.01 margin was too tight, and even the later $0.10 margin
-#: proved insufficient for some live withdrawals when vault share price moved
-#: between the API read and HyperCore processing the queued action.
+#: The effective margin is ``max(0.5% of the available amount, $1.50)``. The
+#: percentage scales protection for larger volatile-vault withdrawals, while
+#: this floor retains the proven headroom for small withdrawals.
 #:
-#: This may leave up to ~$1.50 in the vault. The withdrawal encoder does not
-#: apply ``MINIMUM_VAULT_DEPOSIT``, so a later cleanup pass may attempt the
-#: remaining positive amount. Final residual dust is handled in accounting.
-HYPERCORE_WITHDRAWAL_SAFETY_MARGIN_RAW = 1_500_000
+#: This deliberately leaves the calculated headroom in the vault. Verified
+#: full-close settlement records the residual while closing the original
+#: position. A later account reconciliation recreates a residual above its
+#: dust threshold as a tracked small position for cleanup; a materially short
+#: withdrawal remains open immediately.
+HYPERCORE_WITHDRAWAL_SAFETY_MARGIN_FLOOR_RAW = int(
+    HYPERCORE_WITHDRAWAL_SAFETY_MARGIN_FLOOR * 10**USDC_DECIMALS
+)
+
+#: Deprecated compatibility alias used by existing floor-focused tests and
+#: external tooling. New withdrawal code calculates the effective margin.
+HYPERCORE_WITHDRAWAL_SAFETY_MARGIN_RAW = (
+    HYPERCORE_WITHDRAWAL_SAFETY_MARGIN_FLOOR_RAW
+)
+
+#: Floor for acceptable planning-to-preflight cap drift in raw USDC.
+#:
+#: This controls whether execution may resize a stale planned request; it is
+#: deliberately a separate concept from the headroom left below the fresh cap.
+#: Normal withdrawals scale this tolerance with the requested amount, while
+#: specialised 3–5 USDC cleanup trades retain this 1.50 USDC tolerance even
+#: though their execution headroom starts at only 0.10 USDC. Drift above the
+#: configured tolerance still fails loudly to protect same-cycle cash planning.
+HYPERCORE_WITHDRAWAL_PREFLIGHT_CAP_TOLERANCE_FLOOR_RAW = (
+    HYPERCORE_WITHDRAWAL_SAFETY_MARGIN_FLOOR_RAW
+)
 
 #: Initial full-close margin used only by ``correct-accounts`` small-position
-#: cleanup. Withholding the normal 1.50 USDC margin from a 3–5 USDC position
-#: would strand a material share of the capital. Cleanup starts with 0.10 USDC
-#: and falls back to its larger silent-no-op retry ladder if live NAV moves by
-#: more than this before HyperCore processes the action.
+#: cleanup. Withholding the normal relative/floor margin from a 3–5 USDC
+#: position would strand a material share of the capital. Cleanup starts with
+#: 0.10 USDC and falls back to its larger silent-no-op retry ladder if live NAV
+#: moves by more than this before HyperCore processes the action.
 HYPERCORE_SMALL_POSITION_CLEANUP_INITIAL_SAFETY_MARGIN_RAW = 100_000
 
 #: A HyperCore small-position cleanup retries a silent phase-1 no-op with
 #: increasingly conservative safety margins.  This is deliberately scoped to
 #: the correct-accounts clean-up marker: normal strategy rebalances retain
-#: their single 1.50 USDC retry margin and fail loudly after a repeat no-op.
+#: their single relative/floor retry margin and fail loudly after a repeat
+#: no-op.
 HYPERCORE_SMALL_POSITION_CLEANUP_RETRY_SAFETY_MARGINS_RAW = (
     250_000,
     500_000,
     1_000_000,
 )
-
-#: Normal live preflight cap drift tolerance (raw USDC, 6 decimals).
-#:
-#: Incident reference:
-#:
-#: - HyperAI crashed on 2026-04-15 during trade #336, Jay Pennie.
-#: - The requested withdrawal can be based on a live planning snapshot a few
-#:   seconds older than the preflight snapshot.
-#: - Active vault NAV can move enough in that interval to change the reported
-#:   cap by dollars, not merely by a few raw units.
-#:
-#: This is deliberately separate from the execution safety margin below: it
-#: controls the maximum planning-to-execution drift we accept, not the amount
-#: left behind once the action is queued. Larger gaps still indicate a material
-#: liquidity change that must not silently alter same-cycle cash planning.
-HYPERCORE_WITHDRAWAL_PREFLIGHT_CAP_TOLERANCE_RAW = 1_500_000
 
 #: Number of phase-1 retry attempts after HyperCore silently no-ops a
 #: ``vaultTransfer`` withdrawal.
@@ -832,8 +840,8 @@ class HypercoreVaultRouting(RoutingModel):
         #    due to fees, PnL, and mark-to-market during the ~2-5 s between
         #    reading the API and HyperCore processing the queued action.
         #    Small-position cleanup uses a smaller adaptive margin so the
-        #    generic 1.50 USDC margin does not strand a material share of a
-        #    3–5 USDC position. Its settlement path has larger automatic
+        #    normal relative/floor margin does not strand a material share of
+        #    a 3–5 USDC position. Its settlement path has larger automatic
         #    retries if the first attempt silently no-ops.
         safety_margin_raw = self._get_full_close_safety_margin_raw(trade, live_raw)
         safe_raw = live_raw - safety_margin_raw
@@ -866,7 +874,8 @@ class HypercoreVaultRouting(RoutingModel):
     ) -> int:
         """Return the NAV-drift margin for a full-close redemption.
 
-        Normal strategy withdrawals retain the proven 1.50 USDC margin.
+        Normal strategy withdrawals use max(0.5% of the available amount,
+        1.50 USDC).
         ``correct-accounts`` cleanup uses a fixed 0.10 USDC margin and rejects
         amounts that cannot produce verifiable movement in every later phase.
         ``MINIMUM_VAULT_DEPOSIT`` is deliberately irrelevant because the
@@ -880,7 +889,28 @@ class HypercoreVaultRouting(RoutingModel):
                     "USDC is required to verify every withdrawal phase"
                 )
             return HYPERCORE_SMALL_POSITION_CLEANUP_INITIAL_SAFETY_MARGIN_RAW
-        return HYPERCORE_WITHDRAWAL_SAFETY_MARGIN_RAW
+        return usdc_to_raw(
+            get_hypercore_withdrawal_safety_margin(raw_to_usdc(available_raw))
+        )
+
+    def _get_withdrawal_cap_drift_tolerance_raw(
+        self,
+        trade: TradeExecution,
+        requested_raw: int,
+    ) -> int:
+        """Return allowed drift between planned and fresh withdrawal caps.
+
+        The cap-drift tolerance decides whether resizing a stale request is
+        acceptable; it does not decide how much headroom to leave below the
+        fresh cap. Normal withdrawals use the same 0.5%/1.50 USDC equation so
+        the pmalt 2.494979 USDC movement is recoverable, but cleanup retains a
+        fixed 1.50 USDC tolerance independently of its 0.10 USDC headroom.
+        """
+        if trade.other_data.get("hypercore_small_position_cleanup"):
+            return HYPERCORE_WITHDRAWAL_PREFLIGHT_CAP_TOLERANCE_FLOOR_RAW
+        return usdc_to_raw(
+            get_hypercore_withdrawal_safety_margin(raw_to_usdc(requested_raw))
+        )
 
     def _check_live_withdrawal_preconditions(
         self,
@@ -898,7 +928,7 @@ class HypercoreVaultRouting(RoutingModel):
         :return:
             Raw USDC amount to use for the withdrawal. This is normally the
             requested amount, but can be capped to the live max-withdrawable
-            when the over-request is only dust-sized.
+            when the over-request is within the configured NAV-drift tolerance.
         """
         session = self._get_session()
         vault = HyperliquidVault(session=session, vault_address=vault_address)
@@ -943,17 +973,23 @@ class HypercoreVaultRouting(RoutingModel):
         effective_requested_raw = requested_raw
         if requested_raw > max_withdrawable_raw:
             # HyperCore reports the live withdrawal cap in USDC decimals.
-            # Between trade planning and setup_trades() this can move by tiny
-            # raw amounts because vault equity and max_withdrawable are live
-            # HyperCore values, while the trade was planned from state/pricing
-            # snapshots taken slightly earlier.
+            # Between trade planning and setup_trades() this can move because
+            # vault equity and max_withdrawable are live HyperCore values,
+            # while the trade was planned from state/pricing snapshots taken
+            # slightly earlier.
             overshoot_raw = requested_raw - max_withdrawable_raw
-            if overshoot_raw <= HYPERCORE_WITHDRAWAL_PREFLIGHT_CAP_TOLERANCE_RAW:
+            cap_drift_tolerance_raw = self._get_withdrawal_cap_drift_tolerance_raw(
+                trade,
+                requested_raw,
+            )
+            if overshoot_raw <= cap_drift_tolerance_raw:
                 # A strict abort here is worse than a normal live-NAV cap
                 # because sequential execution stops at the first exception.
                 # Do not request the exact fresh cap: it may move again before
                 # HyperCore processes the queued vaultTransfer and then silently
-                # no-op. Leave the same safety margin used by this full close.
+                # no-op. Headroom is calculated separately from the fresh cap;
+                # cleanup trades therefore keep their specialised 0.10 USDC
+                # execution margin without narrowing cap-drift tolerance.
                 safety_margin_raw = self._get_full_close_safety_margin_raw(
                     trade,
                     max_withdrawable_raw,
@@ -1473,7 +1509,7 @@ class HypercoreVaultRouting(RoutingModel):
         self,
         current_vault_equity: Decimal,
         previous_raw: int,
-        safety_margin_raw: int = HYPERCORE_WITHDRAWAL_SAFETY_MARGIN_RAW,
+        safety_margin_raw: int,
     ) -> int | None:
         """Return a smaller phase-1 retry amount after a suspected silent no-op.
 
@@ -1520,12 +1556,14 @@ class HypercoreVaultRouting(RoutingModel):
     def _get_phase1_noop_retry_safety_margins(
         self,
         trade: TradeExecution,
+        available_raw: int,
     ) -> tuple[int, ...]:
         """Get phase-1 retry margins for a normal or cleanup withdrawal."""
 
         if trade.other_data.get("hypercore_small_position_cleanup"):
             return HYPERCORE_SMALL_POSITION_CLEANUP_RETRY_SAFETY_MARGINS_RAW
-        return (HYPERCORE_WITHDRAWAL_SAFETY_MARGIN_RAW,) * HYPERCORE_WITHDRAWAL_PHASE1_RETRY_ATTEMPTS
+        margin_raw = self._get_full_close_safety_margin_raw(trade, available_raw)
+        return (margin_raw,) * HYPERCORE_WITHDRAWAL_PHASE1_RETRY_ATTEMPTS
 
     def _wait_for_spot_free_usdc_balance(
         self,
@@ -3164,13 +3202,16 @@ class HypercoreVaultRouting(RoutingModel):
                         perp_balance,
                     )
                 else:
-                    retry_margins = self._get_phase1_noop_retry_safety_margins(trade)
+                    if current_vault_equity is None:
+                        retry_margins = ()
+                    else:
+                        retry_margins = self._get_phase1_noop_retry_safety_margins(
+                            trade,
+                            usdc_to_raw(current_vault_equity),
+                        )
                     retry_succeeded = False
                     last_retry_wait_error: HypercoreWithdrawalVerificationError | None = None
                     for retry_number, retry_safety_margin_raw in enumerate(retry_margins, start=1):
-                        if current_vault_equity is None:
-                            break
-
                         retry_raw = self._get_phase1_noop_retry_raw(
                             current_vault_equity=current_vault_equity,
                             previous_raw=expected_raw,

--- a/tradeexecutor/ethereum/vault/hypercore_small_position_cleanup.py
+++ b/tradeexecutor/ethereum/vault/hypercore_small_position_cleanup.py
@@ -14,7 +14,7 @@ no-ops. ``MINIMUM_VAULT_DEPOSIT`` is enforced by the deposit encoder; the
 withdrawal encoder has no equivalent client-side check. The cleaner therefore
 never tops up a position it is trying to close. Settlement checks detect a
 backend no-op. Cleanup uses an adaptive 0.10 USDC initial margin instead of the
-normal 1.50 USDC close margin, so almost all of a small position is recovered.
+normal relative/floor close margin, so almost all of a small position is recovered.
 If too little remains to verify all withdrawal phases, the position is closed
 locally as protocol dust. If a routed trade fails, the updated state is saved
 and the normal failed-trade repair flow takes over.

--- a/tradeexecutor/state/position.py
+++ b/tradeexecutor/state/position.py
@@ -461,11 +461,11 @@ class TradingPosition(GenericPosition):
         Always returned in **base token units**, because every caller compares it against
         :py:meth:`get_quantity`.
 
-        The Hypercore vault threshold is configured in US dollars (it models an absolute
-        withdrawal safety margin), so it is converted to share units at the position's mark
-        price. Without that conversion the threshold is silently multiplied by the share
-        price, and any position smaller than that is closed as dust the moment it opens -
-        destroying the shares, because
+        The Hypercore vault threshold is configured in US dollars. It covers small residuals
+        while remaining capped independently of the relative withdrawal safety margin, so it
+        is converted to share units at the position's mark price. Without that conversion the
+        threshold is silently multiplied by the share price, and any position smaller than
+        that is closed as dust the moment it opens - destroying the shares, because
         :py:meth:`tradeexecutor.state.portfolio.Portfolio.close_position` is bookkeeping only.
         """
         epsilon = get_close_epsilon_for_pair(

--- a/tradeexecutor/state/repair.py
+++ b/tradeexecutor/state/repair.py
@@ -24,15 +24,12 @@ import logging
 from dataclasses import dataclass
 from decimal import Decimal
 from itertools import chain
-from typing import List, TypedDict
-
 from eth_defi.compat import native_datetime_utc_now
 
 from tradeexecutor.state.portfolio import Portfolio
 from tradeexecutor.state.position import TradingPosition
 from tradeexecutor.state.state import State
 from tradeexecutor.state.trade import TradeExecution, TradeType, TradeStatus, TradeFlag
-from eth_defi.compat import native_datetime_utc_now
 
 logger = logging.getLogger(__name__)
 
@@ -53,18 +50,18 @@ class RepairResult:
     """
 
     #: How many frozen positions we encountered
-    frozen_positions: List[TradingPosition]
+    frozen_positions: list[TradingPosition]
 
     #: What positions we managed to unfreeze
-    unfrozen_positions: List[TradingPosition]
+    unfrozen_positions: list[TradingPosition]
 
     #: Individual trades that needed repair or were deliberately deferred for
     #: live reconciliation. Deferred HyperCore deposits must not be mistaken
     #: for completed accounting repairs.
-    trades_needing_repair: List[TradeExecution]
+    trades_needing_repair: list[TradeExecution]
 
     #: New trades we made to fix the accounting
-    new_trades: List[TradeExecution]
+    new_trades: list[TradeExecution]
 
 
 @dataclass(slots=True)
@@ -538,7 +535,7 @@ def close_position_with_empty_trade(portfolio: Portfolio, p: TradingPosition) ->
 def close_hypercore_dust_positions(
     portfolio: Portfolio,
     now: datetime.datetime | None = None,
-) -> List[TradeExecution]:
+) -> list[TradeExecution]:
     """Close Hypercore vault dust positions with repair trades.
 
     Hypercore full withdrawals intentionally leave a small residual balance
@@ -548,15 +545,16 @@ def close_hypercore_dust_positions(
     still meaningful live positions.
 
     1. Scan open and frozen positions for Hypercore vault entries.
-    2. Identify positions that are already within the close epsilon.
-    3. Close each dust position locally with a zero-quantity repair trade.
+    2. Skip positions with no successful trade or any unfinished trade.
+    3. Identify positions that are already within the close epsilon.
+    4. Close each dust position locally with a zero-quantity repair trade.
 
     :return:
         Repair trades created for the auto-closed dust positions.
     """
 
     now = now or native_datetime_utc_now()
-    created_trades: List[TradeExecution] = []
+    created_trades: list[TradeExecution] = []
 
     positions = list(chain(
         portfolio.open_positions.values(),
@@ -568,6 +566,25 @@ def close_hypercore_dust_positions(
             continue
 
         if not position.can_be_closed():
+            continue
+
+        # Hyper AI position #510 had only planned opening trade #1602 after a
+        # previous sequential batch aborted. Its zero quantity was unfinished
+        # state, not post-withdrawal dust, and repairing it caused the 2026-08-23
+        # scheduler crash. Check this only after identifying a dust-sized
+        # position so healthy positions with queued trades do not emit warnings.
+        has_successful_trade = position.has_executed_trades()
+        has_unfinished_trade = (
+            position.has_planned_trades() or position.has_unexecuted_trades()
+        )
+        if not has_successful_trade or has_unfinished_trade:
+            logger.warning(
+                "Skipping Hypercore dust cleanup for unfinished position %s: "
+                "successful trade=%s, unfinished trade=%s",
+                position,
+                has_successful_trade,
+                has_unfinished_trade,
+            )
             continue
 
         if position.is_frozen():
@@ -590,7 +607,7 @@ def close_hypercore_dust_positions(
     return created_trades
 
 
-def find_trades_to_be_repaired(state: State) -> List[TradeExecution]:
+def find_trades_to_be_repaired(state: State) -> list[TradeExecution]:
     trades_to_be_repaired = []
     # Closed trades do not need attention
     for p in chain(state.portfolio.open_positions.values(), state.portfolio.frozen_positions.values()):
@@ -606,7 +623,7 @@ def find_trades_to_be_repaired(state: State) -> List[TradeExecution]:
     return trades_to_be_repaired
 
 
-def reconfirm_trade(reconfirming_needed_trades: List[TradeExecution]):
+def reconfirm_trade(reconfirming_needed_trades: list[TradeExecution]):
 
     raise NotImplementedError("Unfinished")
 

--- a/tradeexecutor/strategy/account_correction.py
+++ b/tradeexecutor/strategy/account_correction.py
@@ -1180,12 +1180,11 @@ def create_missing_vault_positions(
         # Dust-level equity with no open position: write it off, the same way
         # leftover spot dust is ignored once a position has been closed.
         #
-        # Hypercore vault withdrawals cannot fully exit. The protocol refuses
-        # exact full withdrawals when NAV moves between planning and execution,
-        # so a small residual (the withdrawal safety margin, ~1.5 USDC) is left
-        # behind on-chain. The original position is already marked closed at
-        # exit, because the close epsilon (HYPERLIQUID_VAULT_CLOSE_EPSILON)
-        # tolerates this residual in can_be_closed().
+        # Hypercore vault withdrawals cannot safely request exact live equity.
+        # Normal full closes leave max(0.5% of live equity, 1.50 USDC) on-chain
+        # because NAV can move before HyperCore processes the queued action.
+        # Verified settlement records that residual and closes the original
+        # state position independently of this reconciliation threshold.
         #
         # We must NOT manufacture a closed "dust" position for the residual
         # here. This function runs on every correct-accounts cycle and the
@@ -1194,6 +1193,10 @@ def create_missing_vault_positions(
         # the hyper-ai closed-positions list with hundreds of zero-quantity
         # positions. Other trading pairs simply leave such sub-dust balances
         # written off; do the same for Hypercore vaults and just skip it.
+        # A percentage-derived residual above the default 2 USDC threshold is
+        # deliberately recreated as a tracked position below, allowing the
+        # specialised small-position cleanup path to recover it instead of
+        # silently discarding economically meaningful vault shares.
         # Use <= so the threshold matches can_be_closed(), which treats a
         # residual of exactly the close epsilon as closeable dust.
         dust_epsilon = get_close_epsilon_for_pair(pair)

--- a/tradeexecutor/strategy/dust.py
+++ b/tradeexecutor/strategy/dust.py
@@ -6,8 +6,7 @@ We need to deal with these rounding artifacts by checking for "dust".
 
 """
 from collections.abc import Iterable
-from _decimal import Decimal
-from decimal import Decimal
+from decimal import Decimal, ROUND_CEILING
 
 from tradeexecutor.state.identifier import TradingPairIdentifier, AssetIdentifier
 from tradeexecutor.state.types import Percent, USDollarPrice
@@ -46,13 +45,15 @@ DEFAULT_VAULT_EPSILON = Decimal(10 ** -6)
 #: Incident reference:
 #:
 #: - HyperAI trade #326, Super Moon, on 2026-04-15 withdrew successfully.
-#: - Routing used the live full-close safety margin of 1.5 USDC.
+#: - Routing used the live full-close safety-margin floor of 1.5 USDC.
 #: - The position then remained open with 1.500000 quantity because this close
 #:   epsilon was still 0.20 USDC from an older safety-margin setting.
 #:
-#: Keep this above HYPERCORE_WITHDRAWAL_SAFETY_MARGIN_RAW = 1_500_000 raw
-#: ($1.50 in 6-decimal USDC) so can_be_closed() recognises the intentional
-#: residual as dust and the runner can auto-close it before account checks.
+#: Keep this above the fixed 1.50 USDC withdrawal-margin floor so
+#: can_be_closed() recognises small intentional residuals as dust and the
+#: runner can auto-close them before account checks. Percentage-derived
+#: headroom above this threshold is handled by verified full-close settlement,
+#: not by widening this bookkeeping-only dust threshold.
 #:
 #: .. warning::
 #:
@@ -78,17 +79,93 @@ HYPERLIQUID_VAULT_CLOSE_EPSILON_CAPITAL_PCT = Decimal("0.005")
 
 #: Absolute ceiling, in US dollars, for the capital-scaled Hypercore close epsilon.
 #:
-#: Hypercore withdrawal dust is caused by an *absolute* safety margin of ~1.50 USDC
-#: subtracted from live equity, so it does not grow with the strategy. Scaling the
-#: threshold by ``initial_cash`` was intended to give larger strategies a little more
-#: slack, but without a ceiling a 150,000 USD strategy gets a 750 USD "dust" threshold -
-#: five hundred times the residual it is supposed to absorb, and comfortably large enough
-#: to swallow a real position.
+#: This threshold was originally scaled with ``initial_cash`` to cover withdrawal
+#: headroom, but without a ceiling a 150,000 USD strategy gets a 750 USD "dust"
+#: threshold, comfortably large enough to swallow a real position. Normal withdrawals
+#: now use a separate relative/floor margin; any residual above this close-epsilon cap
+#: must remain tracked for another redemption instead of being written off as dust.
 #:
-#: 50 USD is ~33x the observed withdrawal margin and far below any position this strategy
-#: family opens, so it keeps the intended slack without letting the threshold reach
-#: economically meaningful sizes.
+#: 50 USD covers the 31.94 USDC margin from the 2026-08-22 pmalt incident. It
+#: is not intended to cover every percentage-derived margin: full-close
+#: settlement records a verified larger residual while closing the state
+#: position, whereas writing off an arbitrary live position as dust would lose
+#: its shares from bookkeeping.
 HYPERLIQUID_VAULT_CLOSE_EPSILON_MAX_USD = Decimal("50.00")
+
+#: Minimum NAV-drift headroom left when withdrawing from a HyperCore vault.
+HYPERCORE_WITHDRAWAL_SAFETY_MARGIN_FLOOR = Decimal("1.50")
+
+#: Relative NAV-drift headroom left when withdrawing from a HyperCore vault.
+#:
+#: HyperCore processes ``vaultTransfer`` asynchronously after the equity read,
+#: so larger withdrawals need more headroom than the fixed floor provides.
+HYPERCORE_WITHDRAWAL_SAFETY_MARGIN_PCT = Decimal("0.005")
+
+#: HyperCore USDC precision used when rounding a safety margin upwards.
+HYPERCORE_USDC_QUANTUM = Decimal("0.000001")
+
+
+def get_hypercore_withdrawal_safety_margin(amount: Decimal) -> Decimal:
+    """Calculate HyperCore withdrawal headroom as ``max(0.5% × amount, 1.50 USDC)``.
+
+    The relative term was introduced after the 2026-08-22 Hyper AI incident.
+    Rebalance trade #1605 planned a 6,389.537474 USDC pmalt redemption using a
+    live ``max_withdrawable`` snapshot. Roughly 15 seconds later, immediately
+    before transaction construction, HyperCore reported only 6,387.042495
+    USDC withdrawable. The 2.494979 USDC movement exceeded the old fixed 1.50
+    USDC tolerance, so preflight aborted before broadcasting anything.
+
+    The 1.50 USDC floor is retained from earlier 2026-04-15 Hyper AI
+    incidents: trade #336 established that a tiny fixed preflight tolerance
+    was insufficient, while trade #326 showed that the intentional residual
+    must remain within the default close epsilon for small withdrawals.
+
+    Because the seven-trade rebalance had already been persisted, trade #1605
+    remained started without transactions and trades #1599–#1604 remained
+    planned. On the next start, the planned-only Octavious opening trade #1602
+    had zero executed quantity. Automatic dust cleanup mistook that unfinished
+    position for a redeemed residual and crashed while asserting that its
+    opening trade had succeeded. Dust cleanup now independently guards against
+    unfinished positions; this margin prevents the original stale-cap failure.
+
+    A fixed margin does not scale with a vault position: 1.50 USDC is generous
+    for a small withdrawal but only 0.023% of the failed pmalt request. The
+    0.5% term gives larger, actively traded vaults proportionate protection
+    against fees, PnL and mark-to-market changes between the API read and
+    asynchronous ``vaultTransfer`` processing. The fixed floor retains the
+    proven minimum protection for withdrawals below 300 USDC, where 0.5%
+    would otherwise be less than 1.50 USDC.
+
+    The result is rounded upwards to the next raw USDC unit. Rounding down
+    would make the actual headroom smaller than the configured equation and
+    could reintroduce a one-unit over-withdrawal no-op at the boundary.
+
+    :param amount:
+        Withdrawal amount or live withdrawable cap in human-readable USDC.
+    :return:
+        Safety margin in human-readable USDC with six-decimal precision.
+    """
+    assert isinstance(amount, Decimal), (
+        f"HyperCore withdrawal amount must be Decimal, got {type(amount)}"
+    )
+    assert amount >= 0, f"HyperCore withdrawal amount cannot be negative: {amount}"
+
+    # Relative side of the equation: the failed pmalt withdrawal would reserve
+    # 31.947688 USDC instead of the old, insufficient 1.50 USDC fixed amount.
+    relative_margin = amount * HYPERCORE_WITHDRAWAL_SAFETY_MARGIN_PCT
+
+    # Fixed-floor side of the equation: for amounts below 300 USDC, 0.5% is
+    # smaller than 1.50 USDC, so retain the safety level proven by earlier
+    # small-withdrawal incidents.
+    safety_margin = max(
+        relative_margin,
+        HYPERCORE_WITHDRAWAL_SAFETY_MARGIN_FLOOR,
+    )
+
+    # HyperCore USDC has six decimals. Always round the chosen margin upwards
+    # so integer conversion cannot weaken the threshold by one raw unit.
+    return safety_margin.quantize(HYPERCORE_USDC_QUANTUM, rounding=ROUND_CEILING)
+
 
 #: Hypercore vault equities fluctuate every block due to active trading
 #: inside the vault, and live cycles can spend a long time in sequential

--- a/tradeexecutor/strategy/pandas_trader/position_manager.py
+++ b/tradeexecutor/strategy/pandas_trader/position_manager.py
@@ -27,7 +27,10 @@ from tradeexecutor.state.position import TradingPosition, TriggerPriceUpdate
 from tradeexecutor.state.state import State
 from tradeexecutor.state.trade import TradeType, TradeExecution, TradeFlag, TradeStatus
 from tradeexecutor.state.types import USDollarAmount, Percent, LeverageMultiplier, USDollarPrice
-from tradeexecutor.strategy.dust import get_close_epsilon_for_pair
+from tradeexecutor.strategy.dust import (
+    get_close_epsilon_for_pair,
+    get_hypercore_withdrawal_safety_margin,
+)
 from tradeexecutor.strategy.pricing_model import PricingModel
 from tradeexecutor.strategy.trading_strategy_universe import translate_trading_pair, TradingStrategyUniverse
 from tradeexecutor.utils.leverage_calculations import LeverageEstimate
@@ -1681,9 +1684,17 @@ class PositionManager:
         redemption_cap_bound = False
 
         if max_redemption is not None:
-            max_redeemable_quantity = Decimal(str(max_redemption)) / current_price
+            max_redemption_decimal = Decimal(str(max_redemption))
+            max_redeemable_quantity = max_redemption_decimal / current_price
             if effective_quantity > max_redeemable_quantity:
-                effective_quantity = max_redeemable_quantity
+                safety_margin = get_hypercore_withdrawal_safety_margin(
+                    max_redemption_decimal
+                )
+                safe_max_redemption = max(
+                    Decimal(0),
+                    max_redemption_decimal - safety_margin,
+                )
+                effective_quantity = safe_max_redemption / current_price
                 redemption_cap_bound = True
 
         remaining_quantity = max(Decimal(0), available_quantity - effective_quantity)


### PR DESCRIPTION
## Why

Hyper AI's seven-trade rebalance crashed when pmalt's live `max_withdrawable` fell by 2.494979 USDC between planning and preflight, exceeding the fixed 1.50 USDC tolerance. On restart, dust cleanup then crashed on planned-only Octavious trade #1602 because zero executed quantity was mistaken for a completed redemption.

## Lessons learnt

A fixed withdrawal allowance does not scale with actively traded vault positions. Planning-to-preflight drift tolerance and execution headroom are related numerically but protect different invariants and must remain separate. Sequential batches also persist legitimate unfinished position state, which must never be interpreted as redeemed dust. Percentage-sized residuals above reconciliation dust must remain recoverable through tracked small-position cleanup.

## Summary

- Reserve `max(0.5% of the relevant withdrawal amount, 1.50 USDC)`, rounded upwards to raw USDC precision, in cap-bound planning, full-close execution, normal retries, and dust claims.
- Preserve unconstrained full-close semantics by deciding whether the raw redemption cap binds before applying safety headroom.
- Keep planning-to-preflight drift tolerance separate from fresh-cap execution headroom, including the specialised cleanup tolerances.
- Skip automatic dust repair for dust-sized positions without a successful trade or with planned, started, or broadcast trades.
- Keep the bookkeeping-only close epsilon capped and document how reconciliation recreates larger residuals for specialised cleanup.
- Add real-state planning and repair regressions, mock only unavailable HyperCore boundaries, and document the production incident and recovery invariants.
