### PR TITLE
fix: record HyperCore bridge fees accurately

### DIFF
--- a/.claude/docs/hypercore-vault.md
+++ b/.claude/docs/hypercore-vault.md
@@ -112,7 +112,7 @@ Successful live settlement stores cost measurements directly on
 | `bridge_fee_amount` / `bridge_fee_asset` / `bridge_fee_usd` | Measured protocol bridge fee and its USD value. |
 | `account_activation_fee_usd` | Activation provision minus the USDC observed in HyperCore spot. |
 | `hypercore_close_value_loss_usd` | Signed vault-equity decrease less the USDC received and phase-3 headroom retained in spot for a full close. |
-| `hypercore_close_other_loss_usd` | Full-close loss with any included USDC bridge fee removed. |
+| `hypercore_close_other_loss_usd` | State-schema compatibility alias for the full-close loss used by the cost report; the bridge fee is added separately. |
 | `hypercore_close_residual_value_usd` | Vault equity remaining after a full close. |
 | `hypercore_cost_data_complete` | Whether all applicable measurements were captured. |
 
@@ -344,7 +344,7 @@ sequenceDiagram
     Note over R,HC: net arrival reduced by leader performance fee
     R->>Safe: phase 2 — transferUsdClass(perp→spot)
     R->>HC: spot wait — free USDC appeared?
-    R->>Safe: phase 3 — sendAsset(spot→HyperEVM) (minus bridge fee)
+    R->>Safe: phase 3 — sendAsset(spot→HyperEVM) (minus reserved headroom)
     R->>Safe: verify Safe EVM USDC balance increased
     alt all phases verified
         R->>EX: mark_trade_success (executed = net USDC, fee = price slippage)
@@ -419,10 +419,14 @@ Safe's `TradingStrategyModuleV0`:
 - **Multi-node broadcast.** Settlement transactions broadcast through
   `wait_and_broadcast_multiple_nodes` for reliability on HyperEVM.
 - **Bridge fee.** Core→HyperEVM `sendAsset` is not fee-free. Settlement measures
-  a protocol-sized HYPE spot debit, or the USDC debit beyond principal when
-  HYPE is unavailable. Larger, ambiguous balance changes remain unknown. The
-  0.01 USDC phase-3 headroom is residual spot capital, not a fee. Protocol fee
-  mechanics and source links are documented in
+  a protocol-sized HYPE spot debit, or the USDC debit beyond principal when no
+  HYPE debit is observed. The USDC plausibility ceiling is the HYPE-denominated
+  0.05 HYPE ceiling converted at the settlement-time HYPE/USD price. If price
+  telemetry is unavailable, attribution falls back conservatively to the 0.01
+  USDC operational headroom. This headroom is reserved spot capital intended
+  to cover the fee, but it is not itself recorded as the fee and an unusually
+  high base fee can consume or exceed it. Larger, ambiguous balance changes
+  remain unknown. Protocol fee mechanics and source links are documented in
   `eth_defi.hyperliquid.constants.HYPERCORE_BRIDGE_FEE_MARGIN`.
 - **Cost report.** `show-hypercore-rebalance-costs` groups normal successful
   trades by decision-cycle timestamp. Repaired, repair, test, unsuccessful and

--- a/tests/hyperliquid/test_hypercore_activation_cost.py
+++ b/tests/hyperliquid/test_hypercore_activation_cost.py
@@ -75,18 +75,23 @@ def _make_routing_state():
     return rs
 
 
-def test_calculate_hypercore_bridge_fee():
-    """Identify protocol-sized HYPE and USDC fees without attributing unrelated movement.
+def test_calculate_hypercore_bridge_fee() -> None:
+    """Identify protocol-sized HYPE and gas-priced USDC fees without attributing unrelated movement.
 
     1. Measure a small HYPE balance decrease as the bridge fee.
     2. Fall back to the USDC debit beyond principal when HYPE is unchanged.
-    3. Reject a large HYPE balance movement as ambiguous account activity.
+    3. Accept HYPE bridge fees up to the 0.05 HYPE ceiling and reject larger movements.
+    4. Record the high-base-fee debit from live trade #1598 only with price telemetry.
+    5. Reject a larger unrelated USDC debit.
     """
+    hype_usd_price = 72.3535
+
     # 1. Measure a small HYPE balance decrease as the bridge fee.
     assert calculate_hypercore_bridge_fee(
         {"HYPE": Decimal("1"), "USDC": Decimal("10.01")},
         {"HYPE": Decimal("0.9999"), "USDC": Decimal("0.01")},
         Decimal("10"),
+        hype_usd_price,
     ) == (Decimal("0.0001"), "HYPE")
 
     # 2. Fall back to the USDC debit beyond principal when HYPE is unchanged.
@@ -94,13 +99,43 @@ def test_calculate_hypercore_bridge_fee():
         {"HYPE": Decimal("0"), "USDC": Decimal("10.01")},
         {"HYPE": Decimal("0"), "USDC": Decimal("0.009")},
         Decimal("10"),
+        None,
     ) == (Decimal("0.001"), "USDC")
 
-    # 3. Reject a large HYPE balance movement as ambiguous account activity.
+    # 3. Accept HYPE bridge fees up to the 0.05 HYPE ceiling and reject larger movements.
     assert calculate_hypercore_bridge_fee(
         {"HYPE": Decimal("1"), "USDC": Decimal("10.01")},
-        {"HYPE": Decimal("0.5"), "USDC": Decimal("0.01")},
+        {"HYPE": Decimal("0.95"), "USDC": Decimal("0.01")},
         Decimal("10"),
+        hype_usd_price,
+    ) == (Decimal("0.05"), "HYPE")
+    assert calculate_hypercore_bridge_fee(
+        {"HYPE": Decimal("1"), "USDC": Decimal("10.01")},
+        {"HYPE": Decimal("0.9499"), "USDC": Decimal("0.01")},
+        Decimal("10"),
+        hype_usd_price,
+    ) is None
+
+    # 4. Record the high-base-fee debit from live trade #1598 only with price telemetry.
+    assert calculate_hypercore_bridge_fee(
+        {"USDC": Decimal("4452.945985")},
+        {"USDC": Decimal("0.1552")},
+        Decimal("4452.773475"),
+        hype_usd_price,
+    ) == (Decimal("0.017310"), "USDC")
+    assert calculate_hypercore_bridge_fee(
+        {"USDC": Decimal("4452.945985")},
+        {"USDC": Decimal("0.1552")},
+        Decimal("4452.773475"),
+        None,
+    ) is None
+
+    # 5. Reject a larger unrelated USDC debit.
+    assert calculate_hypercore_bridge_fee(
+        {"USDC": Decimal("4456.945985")},
+        {"USDC": Decimal("0.1552")},
+        Decimal("4452.773475"),
+        hype_usd_price,
     ) is None
 
 
@@ -712,8 +747,10 @@ def test_settlement_second_buy_no_activation_cost(
 @patch("tradeexecutor.ethereum.vault.hypercore_routing.get_block_timestamp")
 @patch("tradeexecutor.ethereum.vault.hypercore_routing.fetch_user_vault_equity")
 def test_settlement_uses_capped_withdrawal_amount(
-    mock_fetch_equity, mock_block_ts, mock_report_failure,
-):
+    mock_fetch_equity: MagicMock,
+    mock_block_ts: MagicMock,
+    mock_report_failure: MagicMock,
+) -> None:
     """Withdrawal settlement uses the capped live-equity amount from phase 1.
 
     When phase 1 stored a ``hypercore_capped_withdrawal_raw`` in
@@ -727,22 +764,26 @@ def test_settlement_uses_capped_withdrawal_amount(
     2. Set ``hypercore_capped_withdrawal_raw`` in ``trade.other_data``.
     3. Mock all settlement phases to succeed with the capped amount.
     4. Verify phases 2-3 receive the capped raw amount.
-    5. Verify no ``report_failure`` call (trade succeeds).
+    5. Verify the observed USDC bridge fee remains separate from full-close loss.
+    6. Verify no ``report_failure`` call (trade succeeds).
     """
+    # 1. Create a closing sell whose planned reserve exceeds live equity.
     routing = _make_routing(simulate=False)
     capped_raw = 7_128_756  # Live equity at phase 1 build time
-    planned_raw = 7_129_505  # Original planned_reserve (slightly higher)
 
     trade = _make_trade(planned_reserve=Decimal("7.129505"), is_buy=False)
+    trade.closing = True
     trade.pair.pool_address = "0x4dec0a851849056e259128464ef28ce78afa27f6"
-    # Phase 1 stored the capped amount
+
+    # 2. Store the amount capped by phase 1.
     trade.other_data = {"hypercore_capped_withdrawal_raw": capped_raw}
     trade.blockchain_transactions = [MagicMock(tx_hash="0xaa")]
 
     state = MagicMock()
     mock_block_ts.return_value = datetime.datetime(2025, 1, 1)
 
-    # Phase 1 receipt: success
+    # 3. Mock each settlement phase and balance observation. The spot snapshots
+    # model the reserved 0.01 USDC being consumed entirely as the bridge fee.
     receipts = {HexBytes("0xaa"): {"status": 1, "blockNumber": 100}}
 
     # Equity snapshots (before / after withdrawal)
@@ -765,36 +806,21 @@ def test_settlement_uses_capped_withdrawal_amount(
     phase3_tx = MagicMock(tx_hash="0xcc")
     phase3_receipt = {"status": 1, "blockNumber": 102}
 
-    captured_phase2_raw = []
-    captured_phase3_raw = []
+    captured_phase2_raw: list[int] = []
+    captured_phase3_raw: list[int] = []
 
-    def mock_phase2(raw):
+    def mock_phase2(raw: int) -> tuple[MagicMock, dict[str, int]]:
         captured_phase2_raw.append(raw)
         return (phase2_tx, phase2_receipt)
 
-    def mock_phase3(raw):
+    def mock_phase3(raw: int) -> tuple[MagicMock, dict[str, int]]:
         captured_phase3_raw.append(raw)
         return (phase3_tx, phase3_receipt)
 
-    # Mock the polling functions to return the capped amount
+    # HyperCore polling returns the capped amount; EVM receives the
+    # headroom-adjusted bridge principal.
     perp_balance = Decimal("7.128756")
     spot_balance = Decimal("7.128756")
-
-    with (
-        patch.object(routing, "_fetch_safe_evm_usdc_balance", return_value=19_000_000),
-        patch.object(routing, "_fetch_safe_perp_withdrawable_balance", return_value=Decimal("0")),
-        patch.object(routing, "_fetch_safe_spot_free_usdc_balance", return_value=Decimal("0")),
-        patch.object(routing, "_wait_for_perp_withdrawable_balance", return_value=perp_balance),
-        patch.object(routing, "_wait_for_spot_free_usdc_balance", return_value=spot_balance),
-        patch.object(routing, "_wait_for_usdc_arrival", return_value=capped_raw),
-        patch.object(routing, "_broadcast_withdrawal_phase2", side_effect=mock_phase2),
-        patch.object(routing, "_broadcast_withdrawal_phase3", side_effect=mock_phase3),
-    ):
-        routing._settle_withdrawal(
-            routing.web3, state, trade, receipts,
-            stop_on_execution_failure=False,
-        )
-
     phase3_expected_raw = usdc_to_raw(
         compute_spot_to_evm_withdrawal_amount(
             spot_balance=spot_balance,
@@ -802,15 +828,50 @@ def test_settlement_uses_capped_withdrawal_amount(
         )
     )
 
+    with (
+        patch.object(routing, "_fetch_safe_evm_usdc_balance", return_value=19_000_000),
+        patch.object(routing, "_fetch_safe_perp_withdrawable_balance", return_value=Decimal("0")),
+        patch.object(routing, "_fetch_safe_spot_free_usdc_balance", return_value=Decimal("0")),
+        patch.object(routing, "_wait_for_perp_withdrawable_balance", return_value=perp_balance),
+        patch.object(routing, "_wait_for_spot_free_usdc_balance", return_value=spot_balance),
+        patch.object(routing, "_wait_for_usdc_arrival", return_value=phase3_expected_raw),
+        patch.object(routing, "_broadcast_withdrawal_phase2", side_effect=mock_phase2),
+        patch.object(routing, "_broadcast_withdrawal_phase3", side_effect=mock_phase3),
+        patch.object(
+            routing,
+            "_fetch_safe_spot_free_balances",
+            side_effect=[
+                {"USDC": spot_balance},
+                {"USDC": Decimal(0)},
+            ],
+        ),
+        # Fix the conversion rate so the observed USDC debit is classified
+        # against the deterministic 0.05 HYPE economic ceiling.
+        patch.object(routing, "_fetch_hype_usd_price", return_value=72.3535),
+    ):
+        routing._settle_withdrawal(
+            routing.web3, state, trade, receipts,
+            stop_on_execution_failure=False,
+        )
+
     # 4. Verify phase 2 used the capped amount and phase 3 reserved bridge-fee headroom.
     assert captured_phase2_raw == [capped_raw], (
         f"Phase 2 should use capped amount {capped_raw}, got {captured_phase2_raw}"
     )
     assert captured_phase3_raw == [phase3_expected_raw], (
-        f"Phase 3 should use fee-adjusted amount {phase3_expected_raw}, got {captured_phase3_raw}"
+        f"Phase 3 should use headroom-adjusted amount {phase3_expected_raw}, got {captured_phase3_raw}"
     )
 
-    # 5. Trade succeeded — no failure reported.
+    # 5. Persist the USDC debit beyond principal as a fee separate from close loss.
+    assert trade.bridge_input_amount == Decimal("7.118756")
+    assert trade.bridge_output_amount == Decimal("7.118756")
+    assert trade.bridge_fee_amount == Decimal("0.01")
+    assert trade.bridge_fee_asset == "USDC"
+    assert trade.bridge_fee_usd == pytest.approx(0.01)
+    assert trade.hypercore_close_value_loss_usd == pytest.approx(0)
+    assert trade.hypercore_close_other_loss_usd == pytest.approx(0)
+
+    # 6. Trade succeeded — no failure reported.
     state.mark_trade_success.assert_called_once()
     mock_report_failure.assert_not_called()
 

--- a/tradeexecutor/ethereum/vault/hypercore_routing.py
+++ b/tradeexecutor/ethereum/vault/hypercore_routing.py
@@ -298,10 +298,11 @@ HYPERCORE_FIXED_MAX_PRIORITY_FEE_PER_GAS = 100_000_000  # 0.1 gwei
 
 #: Sanity ceiling for attributing a spot HYPE balance change to one bridge.
 #:
-#: The protocol fee is 200k HyperEVM gas and is normally far below this.
-#: A larger change is more likely unrelated account activity and is left
-#: unknown instead of being reported as an exact rebalance cost.
-HYPERCORE_MAX_PLAUSIBLE_BRIDGE_FEE_HYPE = Decimal("0.01")
+#: The protocol fee is 200k HyperEVM gas. At that gas amount, this ceiling
+#: corresponds to a 250 gwei base fee. A larger change is more likely unrelated
+#: account activity and is left unknown. USDC fees use this economic ceiling
+#: converted at the observed HYPE/USD price.
+HYPERCORE_MAX_PLAUSIBLE_BRIDGE_FEE_HYPE = Decimal("0.05")
 
 
 def usdc_to_raw(amount: Decimal) -> int:
@@ -318,12 +319,20 @@ def calculate_hypercore_bridge_fee(
     spot_before: dict[str, Decimal],
     spot_after: dict[str, Decimal],
     usdc_principal: Decimal,
+    hype_usd_price: float | None,
 ) -> tuple[Decimal, str] | None:
     """Calculate a plausible observed HyperCore-to-HyperEVM bridge fee.
 
-    HyperCore pays the fee in HYPE when available and otherwise in USDC.
+    Prefer an observed HYPE debit. If HYPE is unchanged, attribute the USDC
+    debit beyond the bridge principal instead. A USDC fee has the same economic
+    value as the HYPE-denominated gas charge, so its plausibility ceiling must
+    scale with HYPE/USD. The fixed 0.01 USDC operational headroom is not a fee
+    ceiling: trade #1598 paid 0.01731 USDC when the next HyperEVM block base fee
+    rose to 1.196 gwei.
+
     Balance changes outside protocol-sized bounds are ambiguous and remain
-    unknown.
+    unknown. If HYPE/USD telemetry is unavailable, retain the legacy 0.01 USDC
+    ceiling so ordinary fees are still captured conservatively.
     """
     hype_decrease = (
         spot_before.get("HYPE", Decimal(0))
@@ -339,7 +348,14 @@ def calculate_hypercore_bridge_fee(
         - spot_after.get("USDC", Decimal(0))
         - usdc_principal
     )
-    if Decimal(0) <= usdc_fee <= HYPERCORE_BRIDGE_FEE_MARGIN:
+    max_plausible_usdc_fee = HYPERCORE_BRIDGE_FEE_MARGIN
+    if hype_usd_price is not None:
+        max_plausible_usdc_fee = max(
+            max_plausible_usdc_fee,
+            HYPERCORE_MAX_PLAUSIBLE_BRIDGE_FEE_HYPE
+            * Decimal(str(hype_usd_price)),
+        )
+    if Decimal(0) <= usdc_fee <= max_plausible_usdc_fee:
         return usdc_fee, "USDC"
     return None
 
@@ -3722,9 +3738,13 @@ class HypercoreVaultRouting(RoutingModel):
         executed_price = float(executed_reserve / abs(executed_amount)) if executed_amount else 1.0
 
         if not self.simulate:
-            # The phase-3 bridge fee is paid from HyperCore spot HYPE when the
-            # account has HYPE available. Measure the balance delta instead of
-            # treating the safety headroom as a fee.
+            gas_cost = self._get_trade_gas_cost(trade)
+            hype_usd_price = self._fetch_hype_usd_price()
+
+            # Measure the phase-3 fee from the spot balance delta instead of
+            # treating the reserved safety headroom as a fee. Prefer a HYPE
+            # debit; when HYPE is unchanged, use the USDC debit beyond the
+            # requested bridge principal.
             trade.bridge_input_amount = phase3_withdraw_amount
             trade.bridge_output_amount = executed_reserve
             trade.bridge_fee_amount = None
@@ -3735,14 +3755,13 @@ class HypercoreVaultRouting(RoutingModel):
                     bridge_spot_before,
                     bridge_spot_after,
                     phase3_withdraw_amount,
+                    hype_usd_price,
                 )
                 if observed_bridge_fee is not None:
                     trade.bridge_fee_amount, trade.bridge_fee_asset = observed_bridge_fee
                     if trade.bridge_fee_asset == "USDC":
                         trade.bridge_fee_usd = float(trade.bridge_fee_amount)
 
-            gas_cost = self._get_trade_gas_cost(trade)
-            hype_usd_price = self._fetch_hype_usd_price()
             if trade.bridge_fee_asset == "HYPE" and hype_usd_price is not None:
                 trade.bridge_fee_usd = float(trade.bridge_fee_amount * Decimal(str(hype_usd_price)))
 
@@ -3751,6 +3770,9 @@ class HypercoreVaultRouting(RoutingModel):
                 and vault_equity_before_phase1_snapshot is not None
                 and remaining_equity is not None
             ):
+                # expected_raw was re-anchored to the actual perp arrival before
+                # phase 2. Principal plus reserved headroom therefore reconstructs
+                # the vault withdrawal independently of the phase-3 bridge fee.
                 close_value_loss = (
                     vault_equity_before_phase1_snapshot
                     - remaining_equity
@@ -3759,13 +3781,11 @@ class HypercoreVaultRouting(RoutingModel):
                 )
                 trade.hypercore_close_value_loss_usd = float(close_value_loss)
                 trade.hypercore_close_residual_value_usd = float(remaining_equity)
-                # A USDC bridge fee is part of the redeemed-vault shortfall.
-                # A HYPE fee is paid from the separate spot HYPE balance and
-                # must remain separate so the report includes it once.
-                if trade.bridge_fee_asset == "USDC" and trade.bridge_fee_usd is not None:
-                    trade.hypercore_close_other_loss_usd = float(close_value_loss) - trade.bridge_fee_usd
-                elif trade.bridge_fee_asset == "HYPE":
-                    trade.hypercore_close_other_loss_usd = float(close_value_loss)
+                # The bridge fee is measured from the separate spot balance
+                # delta. The close-loss formula already removes reserved USDC
+                # headroom, so it does not contain either USDC or HYPE bridge
+                # fees. Keep the full loss as the report's other-loss component.
+                trade.hypercore_close_other_loss_usd = float(close_value_loss)
 
             trade.hypercore_cost_data_complete = (
                 gas_cost is not None

--- a/tradeexecutor/state/trade.py
+++ b/tradeexecutor/state/trade.py
@@ -645,14 +645,14 @@ class TradeExecution:
     #: Economic value lost while fully closing a HyperCore vault position.
     #:
     #: This is the signed value ``equity before - equity after - USDC received
-    #: on HyperEVM - USDC bridge headroom left in spot``. A USDC bridge fee is
-    #: included in this amount, while a HYPE bridge fee is separate because it
-    #: leaves the Safe's HYPE balance. It is recorded only for a full close.
+    #: on HyperEVM - USDC bridge headroom left in spot``. Bridge fees are
+    #: measured separately from the HyperCore spot balance delta and are not
+    #: included in this amount. It is recorded only for a full close.
     hypercore_close_value_loss_usd: float | None = None
 
-    #: Full-close value loss excluding any bridge fee already included in it.
+    #: State-schema compatibility alias for ``hypercore_close_value_loss_usd``.
     #:
-    #: Reporting adds this field and ``bridge_fee_usd`` exactly once.
+    #: The cost report adds this field and ``bridge_fee_usd`` exactly once.
     hypercore_close_other_loss_usd: float | None = None
 
     #: HyperCore vault equity left after a full close, in USD/USDC.


### PR DESCRIPTION
## Why

HyperCore's Core-to-HyperEVM `sendAsset` fee is based on 200,000 gas at the next HyperEVM block's base gas price. Live trade #1598 paid 0.01731 USDC, above the legacy 0.01 USDC attribution ceiling, so the cost was left unknown. Full-close reporting could also subtract an observed USDC bridge fee from a loss calculation that already excluded it.

## Lessons learnt

Operational fee headroom and an observed bridge fee are distinct values. Because phase 2 re-anchors the expected amount to the actual perp arrival, principal plus reserved headroom reconstructs the vault withdrawal independently of the phase-3 bridge fee. This means close loss excludes the bridge fee whether it is paid in HYPE or USDC.

A HYPE-denominated plausibility ceiling is more stable than a fixed USDC ceiling. Converting 0.05 HYPE at the settlement-time HYPE/USD price accommodates varying base fees while retaining the conservative 0.01 USDC fallback when price telemetry is unavailable.

## Summary

- Measure HYPE or excess-USDC spot debits as the Core-to-HyperEVM bridge fee.
- Raise the attribution ceiling to 0.05 HYPE and convert it to USDC using the observed HYPE/USD price.
- Record full-close loss separately from the bridge fee without double-subtracting it.
- Preserve the existing close-loss reporting field as a documented state-schema compatibility alias.
- Cover the ceiling boundaries, the live #1598 fee, missing price telemetry, and full-close accounting in focused tests.
