### PR TITLE
fix: price HyperEVM transactions dynamically

### DIFF
--- a/.claude/docs/hypercore-vault.md
+++ b/.claude/docs/hypercore-vault.md
@@ -75,7 +75,7 @@ The driver lives in `tradeexecutor/ethereum/vault/hypercore_routing.py`.
 | `HypercoreVaultRoutingState(RoutingState)` | Per-cycle routing state. |
 | `HypercoreWithdrawalVerificationError` | A phase did not reach the expected HyperCore balance within the timeout. |
 | `HypercoreWithdrawalPreflightError` | Live preconditions (lock-up, positive amount, equity or liquidity) failed before broadcasting. |
-| `SettlementBroadcastError` | A settlement transaction failed to broadcast/confirm; carries the partial `BlockchainTransaction`. |
+| `SettlementBroadcastError` | A settlement transaction failed during pricing, signing, broadcast or confirmation; carries the partial `BlockchainTransaction`. |
 
 From eth_defi (`eth_defi.hyperliquid`): `HyperliquidSession` (Info API client),
 `HyperliquidVault` + `VaultInfo` + `VaultFollower` (vault metadata, including
@@ -410,9 +410,30 @@ Safe's `TradingStrategyModuleV0`:
   helpers return `ContractFunction` objects already wrapped for the Safe, so
   the routing signs them directly with the deployer `HotWallet` rather than via
   `LagoonTransactionBuilder` (which would double-wrap them).
-- **Fixed gas pricing.** HyperEVM has no meaningful priority-fee market, so the
-  routing uses fixed `maxFeePerGas` / `maxPriorityFeePerGas` constants instead
-  of per-phase estimation, which previously caused phase failures.
+- **Buffered dynamic gas pricing.** HyperEVM's
+  [JSON-RPC documentation](https://hyperliquid.gitbook.io/hyperliquid-docs/for-developers/hyperevm/json-rpc)
+  defines `eth_gasPrice` as the next small block's base fee. The routing uses
+  four times that live value as
+  `maxFeePerGas`, retaining 4 gwei only as a quiet-period floor. HyperEVM
+  mainnet and testnet are configured as London/EIP-1559 chains in
+  `Web3Config`, preventing Web3's legacy gas-price strategy from adding a
+  conflicting `gasPrice` field while building transactions. HyperEVM
+  currently recommends a zero priority fee and
+  [burns any priority fee paid](https://hyperliquid.gitbook.io/hyperliquid-docs/for-developers/hyperevm),
+  so the routing also uses zero. Assuming the standard EIP-1559 maximum 12.5%
+  per-block increase, four times the base fee covers eleven consecutive maximum
+  increases, or about eleven seconds of HyperEVM small blocks; it does not
+  protect a signed transaction from an indefinitely sustained fee rise.
+  EIP-1559 charges the actual base fee rather than the unused fee cap, although
+  the signing wallet must be able to cover the maximum gas cost. At the
+  incident's 81.88 gwei base fee, a 650k-gas transaction therefore needs
+  capacity for a 0.213 HYPE fee cap. An approval and deposit signed together
+  need about 0.426 HYPE of available balance until the first transaction lands;
+  the routing does not yet preflight this HYPE balance. Never turn the floor
+  back into a ceiling:
+  on 2026-08-23 HyperAI signed at 4 gwei while the observed base fee was
+  81.88 gwei. The transaction could not land at that price and was no longer
+  visible through any configured RPC node when confirmation timed out.
 - **Big blocks guard.** `__init__` asserts the deployer is *not* in big-blocks
   mode (`fetch_using_big_blocks`), which would push txs to the ~1-minute
   mempool instead of ~1 s.

--- a/tests/hyperliquid/test_hypercore_gas_pricing.py
+++ b/tests/hyperliquid/test_hypercore_gas_pricing.py
@@ -1,0 +1,149 @@
+"""Unit tests for buffered HyperEVM transaction gas pricing."""
+
+from unittest.mock import MagicMock, PropertyMock
+
+import pytest
+from eth_account import Account
+
+from eth_defi.hotwallet import HotWallet
+
+from tradeexecutor.ethereum.vault.hypercore_routing import (
+    HYPERCORE_MAX_FEE_BASE_FEE_MULTIPLIER,
+    HYPERCORE_MAX_PRIORITY_FEE_PER_GAS,
+    HYPERCORE_MIN_MAX_FEE_PER_GAS,
+    HypercoreVaultRouting,
+    SettlementBroadcastError,
+    calculate_hypercore_gas_price_suggestion,
+)
+from tradeexecutor.ethereum.web3config import DEFAULT_LONDON_CHAIN_IDS
+from tradingstrategy.chain import ChainId
+
+
+def test_calculate_and_apply_hypercore_gas_price_suggestion() -> None:
+    """Test buffered HyperEVM pricing calculation and signing integration.
+
+    1. Price a transaction during a quiet 0.5 gwei period.
+    2. Check the historical 4 gwei value remains a minimum, not a ceiling.
+    3. Price a transaction using the incident's observed 81.88 gwei base fee.
+    4. Check the fee cap tracks congestion with the configured buffer.
+    5. Sign through the routing helper using a mocked wallet and contract call.
+    6. Check the computed EIP-1559 fields reach the signed transaction.
+    """
+    # 1. Price a transaction during a quiet 0.5 gwei period.
+    quiet_base_fee = 500_000_000
+    quiet = calculate_hypercore_gas_price_suggestion(quiet_base_fee)
+
+    # 2. Check the historical 4 gwei value remains a minimum, not a ceiling.
+    assert quiet.base_fee == quiet_base_fee
+    assert quiet.max_priority_fee_per_gas == HYPERCORE_MAX_PRIORITY_FEE_PER_GAS
+    assert quiet.max_fee_per_gas == HYPERCORE_MIN_MAX_FEE_PER_GAS
+    assert ChainId.hyperliquid.value in DEFAULT_LONDON_CHAIN_IDS
+    assert ChainId.hyperliquid_testnet.value in DEFAULT_LONDON_CHAIN_IDS
+
+    # 3. Price a transaction using the incident's observed 81.88 gwei base fee.
+    congested_base_fee = 81_880_000_000
+    congested = calculate_hypercore_gas_price_suggestion(congested_base_fee)
+
+    # 4. Check the fee cap tracks congestion with the configured buffer.
+    assert congested.base_fee == congested_base_fee
+    assert congested.max_fee_per_gas == (
+        congested_base_fee * HYPERCORE_MAX_FEE_BASE_FEE_MULTIPLIER
+    )
+    assert congested.max_fee_per_gas > congested_base_fee
+
+    # 5. Sign through the routing helper using a mocked wallet and contract call.
+    # Mock the wallet and contract because this unit test checks transaction
+    # plumbing without requiring a private key or live HyperEVM RPC endpoint.
+    routing = object.__new__(HypercoreVaultRouting)
+    routing.chain_id = 999
+    routing.web3 = MagicMock()
+    type(routing.web3.eth).gas_price = PropertyMock(return_value=congested_base_fee)
+    routing.deployer = HotWallet(Account.create())
+    routing.deployer.current_nonce = 7
+    fn = MagicMock()
+    fn.address = "0x" + "56" * 20
+    fn.fn_name = "performCall"
+    fn.build_transaction.side_effect = lambda params: {
+        **params,
+        "to": fn.address,
+        "data": "0x",
+        # Simulate Web3's historical legacy default. The routing must remove it
+        # before asking the real eth-account signer to sign an EIP-1559 tx.
+        "gasPrice": 1_000_000_000,
+    }
+    blockchain_tx = routing._sign_module_call(fn)
+
+    # 6. Check the computed EIP-1559 fields reach the signed transaction.
+    assert blockchain_tx.details["maxFeePerGas"] == congested.max_fee_per_gas
+    assert (
+        blockchain_tx.details["maxPriorityFeePerGas"]
+        == HYPERCORE_MAX_PRIORITY_FEE_PER_GAS
+    )
+    assert "gasPrice" not in blockchain_tx.details
+    assert blockchain_tx.signed_bytes.startswith("0x02")
+    assert blockchain_tx.tx_hash.startswith("0x")
+    assert blockchain_tx.nonce == 7
+    assert blockchain_tx.signed_tx_object is not None
+    assert blockchain_tx.details["function"] == fn.fn_name
+
+
+def test_sign_module_call_preserves_preparation_failures() -> None:
+    """Test pricing and signing failures are preserved before broadcast.
+
+    1. Configure the HyperEVM gas-price RPC read to fail.
+    2. Attempt to build and sign a module transaction.
+    3. Check the failure uses the settlement error path and no transaction is signed.
+    4. Configure the signer to fail after successful live pricing.
+    5. Attempt to build and sign another module transaction.
+    6. Check the signed transaction failure is also persisted as failed.
+    """
+    # 1. Configure the HyperEVM gas-price RPC read to fail.
+    # Mock RPC, contract and signer boundaries because this unit test exercises
+    # local failure persistence without external RPC or private-key access.
+    routing = object.__new__(HypercoreVaultRouting)
+    routing.chain_id = 999
+    routing.web3 = MagicMock()
+    type(routing.web3.eth).gas_price = PropertyMock(
+        side_effect=ConnectionError("HyperEVM RPC unavailable")
+    )
+    routing.deployer = MagicMock()
+    routing.deployer.address = "0x" + "12" * 20
+    fn = MagicMock()
+    fn.address = "0x" + "56" * 20
+    fn.fn_name = "performCall"
+    fn.build_transaction.side_effect = lambda params: dict(params)
+
+    # 2. Attempt to build and sign a module transaction.
+    # 3. Check the failure uses the settlement error path and no transaction is signed.
+    with pytest.raises(
+        SettlementBroadcastError, match="HyperEVM RPC unavailable"
+    ) as exc_info:
+        routing._sign_module_call(fn)
+    routing.deployer.sign_transaction_with_new_nonce.assert_not_called()
+    assert exc_info.value.tx.signed_bytes is None
+    assert exc_info.value.tx.status is False
+    assert exc_info.value.tx.details["function"] == fn.fn_name
+    assert (
+        exc_info.value.tx.revert_reason
+        == "Transaction preparation failed: HyperEVM RPC unavailable"
+    )
+
+    # 4. Configure the signer to fail after successful live pricing.
+    type(routing.web3.eth).gas_price = PropertyMock(return_value=81_880_000_000)
+    signer_unavailable = ValueError("Signer unavailable")
+    routing.deployer.sign_transaction_with_new_nonce.side_effect = signer_unavailable
+
+    # 5. Attempt to build and sign another module transaction.
+    # 6. Check the signed transaction failure is also persisted as failed.
+    with pytest.raises(
+        SettlementBroadcastError, match="Signer unavailable"
+    ) as exc_info:
+        routing._sign_module_call(fn)
+    assert exc_info.value.tx.signed_bytes is None
+    assert exc_info.value.tx.status is False
+    assert exc_info.value.tx.details["function"] == fn.fn_name
+    assert exc_info.value.tx.details["maxFeePerGas"] == 81_880_000_000 * 4
+    assert (
+        exc_info.value.tx.revert_reason
+        == "Transaction preparation failed: Signer unavailable"
+    )

--- a/tradeexecutor/ethereum/vault/hypercore_routing.py
+++ b/tradeexecutor/ethereum/vault/hypercore_routing.py
@@ -278,23 +278,32 @@ RETAIN_RESERVE_ALLOCATION_ON_FAILURE_KEY = "retain_reserve_allocation_on_failure
 #: Background and the 2026-06-13 IKAGI #1022 incident: ``.claude/docs/hypercore-vault.md``.
 HYPERCORE_DEFAULT_PERFORMANCE_FEE = Decimal(str(HYPERLIQUID_VAULT_PERFORMANCE_FEE))
 
-#: Fixed ``maxFeePerGas`` for HyperEVM transactions (in wei).
+#: Minimum ``maxFeePerGas`` for HyperEVM transactions (in wei).
 #:
-#: HyperEVM base fees are typically 0.1–0.5 gwei. Using dynamic
-#: ``estimate_gas_price()`` per phase caused phase 3 of trade #842
-#: (2026-06-04) to get a ``maxFeePerGas`` of 0.66 gwei while the chain
-#: needed ~0.65 gwei effective — the tx eventually landed 18 minutes
-#: later but exceeded the 2-minute confirmation timeout, stranding USDC.
-#:
-#: A fixed 4 gwei is ~20× typical base fee and costs <0.003 HYPE per
-#: 650k-gas transaction — negligible.  Overpayment is refunded by EIP-1559.
-HYPERCORE_FIXED_MAX_FEE_PER_GAS = 4_000_000_000  # 4 gwei
+#: Keep the historical 4 gwei value as a floor for quiet periods. It must not
+#: be used as a ceiling: during the 2026-08-23 HyperAI incident the observed
+#: base fee was already 81.88 gwei, so a transaction capped at 4 gwei could
+#: not enter a block and was no longer visible through any configured RPC node
+#: at timeout.
+HYPERCORE_MIN_MAX_FEE_PER_GAS = 4_000_000_000  # 4 gwei
 
-#: Fixed ``maxPriorityFeePerGas`` for HyperEVM transactions (in wei).
+#: Multiplier applied to HyperEVM's next-small-block base fee.
 #:
-#: HyperEVM does not have a meaningful priority fee market.
-#: A small tip helps with inclusion without overpaying.
-HYPERCORE_FIXED_MAX_PRIORITY_FEE_PER_GAS = 100_000_000  # 0.1 gwei
+#: HyperEVM's ``eth_gasPrice`` reports the base fee for the next small block.
+#: A module transaction can spend several seconds being persisted and handed
+#: to the execution model before broadcast. Four times the observed base fee
+#: absorbs eleven consecutive maximum base-fee increases when HyperEVM follows
+#: the standard EIP-1559 12.5% per-block limit. The unused part of
+#: ``maxFeePerGas`` is not paid.
+HYPERCORE_MAX_FEE_BASE_FEE_MULTIPLIER = 4
+
+#: ``maxPriorityFeePerGas`` for HyperEVM transactions (in wei).
+#:
+#: HyperEVM currently reports zero for ``eth_maxPriorityFeePerGas`` and burns
+#: priority fees. Follow the chain's zero-tip recommendation instead of using
+#: a hard-coded tip.
+#: https://hyperliquid.gitbook.io/hyperliquid-docs/for-developers/hyperevm/json-rpc
+HYPERCORE_MAX_PRIORITY_FEE_PER_GAS = 0
 
 #: Sanity ceiling for attributing a spot HYPE balance change to one bridge.
 #:
@@ -303,6 +312,34 @@ HYPERCORE_FIXED_MAX_PRIORITY_FEE_PER_GAS = 100_000_000  # 0.1 gwei
 #: account activity and is left unknown. USDC fees use this economic ceiling
 #: converted at the observed HYPE/USD price.
 HYPERCORE_MAX_PLAUSIBLE_BRIDGE_FEE_HYPE = Decimal("0.05")
+
+
+def calculate_hypercore_gas_price_suggestion(
+    next_block_base_fee: int,
+) -> GasPriceSuggestion:
+    """Calculate buffered EIP-1559 pricing for a HyperEVM transaction.
+
+    ``eth_gasPrice`` on HyperEVM returns the next small block's base fee. The
+    max fee is deliberately buffered because signing and broadcasting are not
+    adjacent operations in the multi-phase vault execution flow.
+    """
+    assert type(next_block_base_fee) is int, (
+        f"Expected integer base fee, got {type(next_block_base_fee)}"
+    )
+    assert next_block_base_fee >= 0, (
+        f"Base fee cannot be negative: {next_block_base_fee}"
+    )
+
+    max_fee_per_gas = max(
+        HYPERCORE_MIN_MAX_FEE_PER_GAS,
+        next_block_base_fee * HYPERCORE_MAX_FEE_BASE_FEE_MULTIPLIER,
+    )
+    return GasPriceSuggestion(
+        method=GasPriceMethod.london,
+        base_fee=next_block_base_fee,
+        max_priority_fee_per_gas=HYPERCORE_MAX_PRIORITY_FEE_PER_GAS,
+        max_fee_per_gas=max_fee_per_gas,
+    )
 
 
 def usdc_to_raw(amount: Decimal) -> int:
@@ -376,16 +413,16 @@ class HypercoreWithdrawalPreflightError(Exception):
 
 
 class SettlementBroadcastError(Exception):
-    """Raised when a settlement phase transaction fails to broadcast or confirm.
+    """Raised when a settlement transaction fails to price, sign, broadcast or confirm.
 
     Carries the :py:class:`~tradeexecutor.state.blockhain_transaction.BlockchainTransaction`
-    so callers can always append it to the trade for diagnostics, even when the
-    broadcast itself failed.
+    so callers can always append it to the trade for diagnostics. The
+    transaction may be unsigned when preparation failed before broadcast.
     """
 
     def __init__(self, tx: "BlockchainTransaction", cause: Exception):
         super().__init__(str(cause))
-        #: The signed transaction with error info already set.
+        #: The partial or signed transaction with error information already set.
         self.tx = tx
 
 
@@ -574,8 +611,9 @@ class HypercoreVaultRouting(RoutingModel):
         objects already addressed to the module contract. We sign them directly
         with the deployer hot wallet.
 
-        Uses fixed gas pricing to avoid underpricing during multi-phase
-        settlement.  See :py:data:`HYPERCORE_FIXED_MAX_FEE_PER_GAS`.
+        Uses dynamically buffered gas pricing to avoid underpricing during
+        multi-phase settlement. See
+        :py:func:`calculate_hypercore_gas_price_suggestion`.
 
         :param fn:
             Bound ``ContractFunction`` already wrapped through the trading strategy module.
@@ -589,74 +627,64 @@ class HypercoreVaultRouting(RoutingModel):
         :return:
             Signed :py:class:`BlockchainTransaction`.
         """
-        tx_data = fn.build_transaction({
+        function_name = logical_function_name or fn.fn_name
+        tx_params = {
             "chainId": self.chain_id,
             "from": self.deployer.address,
             "gas": gas_limit,
-        })
+        }
 
-        # Use fixed gas pricing to guarantee inclusion during multi-phase
-        # settlement.  Dynamic estimation caused phase 3 tx drops when the
-        # base fee crept above the per-phase estimate between signing and mining.
-        gas_price_suggestion = GasPriceSuggestion(
-            method=GasPriceMethod.london,
-            base_fee=0,
-            max_priority_fee_per_gas=HYPERCORE_FIXED_MAX_PRIORITY_FEE_PER_GAS,
-            max_fee_per_gas=HYPERCORE_FIXED_MAX_FEE_PER_GAS,
-        )
-        apply_gas(tx_data, gas_price_suggestion)
-
-        # Sanity-check: warn if the current base fee exceeds our fixed cap.
-        try:
-            latest_block = self.web3.eth.get_block("latest")
-            current_base_fee = latest_block.get("baseFeePerGas", 0)
-            logger.info(
-                "HyperEVM gas for %s: fixed maxFeePerGas=%d (%.2f gwei), "
-                "fixed maxPriorityFeePerGas=%d (%.2f gwei), "
-                "current baseFee=%d (%.2f gwei)",
-                notes or fn.fn_name,
-                HYPERCORE_FIXED_MAX_FEE_PER_GAS,
-                HYPERCORE_FIXED_MAX_FEE_PER_GAS / 1e9,
-                HYPERCORE_FIXED_MAX_PRIORITY_FEE_PER_GAS,
-                HYPERCORE_FIXED_MAX_PRIORITY_FEE_PER_GAS / 1e9,
-                current_base_fee,
-                current_base_fee / 1e9,
-            )
-            if current_base_fee > HYPERCORE_FIXED_MAX_FEE_PER_GAS:
-                logger.warning(
-                    "HyperEVM base fee %d (%.2f gwei) exceeds fixed maxFeePerGas %d (%.2f gwei). "
-                    "Transaction may not be included. Consider raising HYPERCORE_FIXED_MAX_FEE_PER_GAS.",
-                    current_base_fee,
-                    current_base_fee / 1e9,
-                    HYPERCORE_FIXED_MAX_FEE_PER_GAS,
-                    HYPERCORE_FIXED_MAX_FEE_PER_GAS / 1e9,
-                )
-        except Exception as e:
-            logger.warning("Could not fetch HyperEVM base fee for sanity check: %s", e)
-
-        signed_tx = self.deployer.sign_transaction_with_new_nonce(tx_data)
-        signed_bytes = hexbytes_to_hex_str(signed_tx.rawTransaction)
-
-        # Needed for get_swap_transactions() compatibility.
-        tx_data["function"] = logical_function_name or fn.fn_name
-
-        return BlockchainTransaction(
+        blockchain_tx = BlockchainTransaction(
             type=BlockchainTransactionType.lagoon_vault,
             chain_id=self.chain_id,
             from_address=self.deployer.address,
             contract_address=fn.address,
             function_selector=fn.fn_name,
-            transaction_args=None,
-            args=None,
-            wrapped_args=None,
-            signed_bytes=signed_bytes,
-            signed_tx_object=encode_pickle_over_json(signed_tx),
-            tx_hash=hexbytes_to_hex_str(signed_tx.hash),
-            nonce=signed_tx.nonce,
-            details=tx_data,
+            details={**tx_params, "function": function_name},
             asset_deltas=[],
             notes=notes,
         )
+
+        # HyperEVM defines eth_gasPrice as the next small block's base fee.
+        # Do not fall back to a stale fixed value if this RPC call fails: signing
+        # without a trustworthy current price recreates the dropped transaction
+        # failure this pricing path is meant to prevent.
+        try:
+            next_block_base_fee = self.web3.eth.gas_price
+            gas_price_suggestion = calculate_hypercore_gas_price_suggestion(
+                next_block_base_fee,
+            )
+            tx_data = fn.build_transaction(tx_params)
+            # HyperEVM was historically configured with Web3's legacy gas-price
+            # strategy, which may add gasPrice while filling defaults. Apply our
+            # London fields last so the signer never receives mixed fee styles.
+            apply_gas(tx_data, gas_price_suggestion)
+            blockchain_tx.details = {**tx_data, "function": function_name}
+            signed_tx = self.deployer.sign_transaction_with_new_nonce(tx_data)
+        except Exception as e:
+            # Preserve gas-pricing and signing failures as trade diagnostics so
+            # settlement callers can mark any already-moved USDC as stranded.
+            blockchain_tx.revert_reason = f"Transaction preparation failed: {e}"
+            blockchain_tx.status = False
+            raise SettlementBroadcastError(blockchain_tx, e) from e
+
+        logger.info(
+            "HyperEVM gas for %s: next-block baseFee=%d (%.2f gwei), "
+            "maxFeePerGas=%d (%.2f gwei), maxPriorityFeePerGas=%d (%.2f gwei)",
+            notes or fn.fn_name,
+            next_block_base_fee,
+            next_block_base_fee / 1e9,
+            gas_price_suggestion.max_fee_per_gas,
+            gas_price_suggestion.max_fee_per_gas / 1e9,
+            gas_price_suggestion.max_priority_fee_per_gas,
+            gas_price_suggestion.max_priority_fee_per_gas / 1e9,
+        )
+
+        blockchain_tx.signed_bytes = hexbytes_to_hex_str(signed_tx.rawTransaction)
+        blockchain_tx.signed_tx_object = encode_pickle_over_json(signed_tx)
+        blockchain_tx.tx_hash = hexbytes_to_hex_str(signed_tx.hash)
+        blockchain_tx.nonce = signed_tx.nonce
+        return blockchain_tx
 
     def _get_vault_address(self, trade: TradeExecution) -> str:
         """Extract the Hypercore vault address from the trade pair."""
@@ -2345,8 +2373,8 @@ class HypercoreVaultRouting(RoutingModel):
         :return:
             Tuple of (BlockchainTransaction, receipt dict).
         :raises SettlementBroadcastError:
-            If the broadcast or confirmation fails.  The exception carries
-            the signed ``BlockchainTransaction`` with error info.
+            If transaction preparation, broadcast or confirmation fails. The
+            exception carries the diagnostic ``BlockchainTransaction``.
         """
         fn = build_hypercore_transfer_usd_class_call(
             self.lagoon_vault,
@@ -2396,7 +2424,7 @@ class HypercoreVaultRouting(RoutingModel):
         """Build, sign, and broadcast withdrawal phase 2 (perp -> spot).
 
         :raises SettlementBroadcastError:
-            If the broadcast or confirmation fails.
+            If transaction preparation, broadcast or confirmation fails.
         """
         fn = build_hypercore_transfer_usd_class_call(
             self.lagoon_vault,
@@ -2423,7 +2451,7 @@ class HypercoreVaultRouting(RoutingModel):
         """Build, sign, and broadcast a retry of withdrawal phase 1.
 
         :raises SettlementBroadcastError:
-            If the broadcast or confirmation fails.
+            If transaction preparation, broadcast or confirmation fails.
         """
         fn = build_hypercore_withdraw_from_vault_call(
             self.lagoon_vault,
@@ -2449,7 +2477,7 @@ class HypercoreVaultRouting(RoutingModel):
         """Build, sign, and broadcast withdrawal phase 3 (spot -> EVM).
 
         :raises SettlementBroadcastError:
-            If the broadcast or confirmation fails.
+            If transaction preparation, broadcast or confirmation fails.
         """
         fn = build_hypercore_send_asset_to_evm_call(
             self.lagoon_vault,

--- a/tradeexecutor/ethereum/web3config.py
+++ b/tradeexecutor/ethereum/web3config.py
@@ -36,6 +36,24 @@ SUPPORTED_CHAINS = [
     ChainId.monad,
 ]
 
+#: Chains configured for EIP-1559 transaction defaults when no explicit gas
+#: pricing method is supplied.
+DEFAULT_LONDON_CHAIN_IDS = frozenset(
+    {
+        ChainId.ethereum.value,
+        ChainId.ganache.value,
+        ChainId.avalanche.value,
+        ChainId.polygon.value,
+        ChainId.anvil.value,
+        ChainId.arbitrum.value,
+        ChainId.base.value,
+        ChainId.arbitrum_sepolia.value,
+        ChainId.base_sepolia.value,
+        ChainId.hyperliquid.value,
+        ChainId.hyperliquid_testnet.value,
+    }
+)
+
 #: Override broken slugs in the tradingstrategy library.
 #: ChainId.hyperliquid (999) reports "wanchain testnet" instead of "hyperliquid".
 _CHAIN_SLUG_OVERRIDES: dict[ChainId, str] = {
@@ -307,17 +325,7 @@ class Web3Config:
         chain_id = web3.eth.chain_id
 
         if gas_price_method is None:
-            if chain_id in (
-                ChainId.ethereum.value,
-                ChainId.ganache.value,
-                ChainId.avalanche.value,
-                ChainId.polygon.value,
-                ChainId.anvil.value,
-                ChainId.arbitrum.value,
-                ChainId.base.value,
-                ChainId.arbitrum_sepolia.value,
-                ChainId.base_sepolia.value,
-            ):
+            if chain_id in DEFAULT_LONDON_CHAIN_IDS:
                 # Ethereum supports maxBaseFee method (London hard fork)
                 # Same for Avalanche C-chain https://twitter.com/avalancheavax/status/1389763933448323073
 


### PR DESCRIPTION
## Why

HyperAI signed a HyperEVM settlement transaction with the fixed 4 gwei cap introduced by #1479 while the observed base fee was 81.88 gwei. The transaction could not be included at that price, disappeared from the configured RPC nodes, and crashed the executor after the 15-minute confirmation timeout.

The earlier fix correctly made 4 gwei a safe value for the fee conditions seen at the time, but incorrectly treated it as a permanent ceiling. HyperEVM documents `eth_gasPrice` as the next small block's base fee, so the settlement path needs to derive its cap from that live value and retain 4 gwei only as a floor.

## Lessons learnt

- A fixed cap prevents inconsistent phase-to-phase estimates only while it remains above the base fee; it becomes an absolute inclusion failure when network conditions exceed it.
- HyperEVM is an EIP-1559 chain and should not inherit Web3's legacy gas-price strategy. Otherwise transaction building can add `gasPrice` beside the London fee fields and make signing fail.
- Diagnostic-only transaction metadata must never be passed to `eth-account`, and fee fields must be applied after Web3 fills transaction defaults.
- A large `maxFeePerGas` buffer is a balance requirement, not the amount normally paid. At the incident price, the paired approval and deposit need about 0.426 HYPE of available fee-cap capacity until the first transaction lands.

## Summary

- Price every HyperEVM module transaction with `max(4 gwei, 4 × next-small-block base fee)` and HyperEVM's documented zero priority fee.
- Configure HyperEVM mainnet and testnet as London/EIP-1559 chains.
- Guard gas lookup, transaction building and real signing together; persist a failed partial transaction so mid-settlement callers mark already-moved USDC as stranded instead of crashing the cycle without state diagnostics.
- Add a real `HotWallet` signing regression test that injects a legacy `gasPrice` and proves a clean type-2 transaction is produced.
- Document the buffer window, actual-fee versus fee-cap distinction, wallet balance implications and the 2026-08-23 incident.
- Update the eth-defi submodule for actionable `ConfirmationTimedOut` gas diagnostics.

## Related issues and PRs

- Continues #1479, which introduced the fixed 4 gwei ceiling after an earlier underpriced HyperEVM settlement.
- Depends on tradingstrategy-ai/web3-ethereum-defi#1505 for timeout diagnostics.
