### PR TITLE
fix: restore isolated Lagoon test forks

### DIFF
--- a/tests/ethereum/test_cctp_bridge_start.py
+++ b/tests/ethereum/test_cctp_bridge_start.py
@@ -33,8 +33,8 @@ from eth_defi.cctp.constants import CCTP_DOMAIN_ARBITRUM, CCTP_DOMAIN_BASE
 from eth_defi.cctp.receive import prepare_receive_message
 from eth_defi.cctp.testing import craft_cctp_message, forge_attestation, replace_attester_on_fork
 from eth_defi.hotwallet import HotWallet
-from eth_defi.provider.anvil import AnvilLaunch, launch_anvil
-from eth_defi.token import USDC_NATIVE_TOKEN, USDC_WHALE, fetch_erc20_details
+from eth_defi.provider.anvil import AnvilLaunch, fund_erc20_on_anvil, launch_anvil
+from eth_defi.token import USDC_NATIVE_TOKEN, fetch_erc20_details
 from eth_defi.trace import assert_transaction_success_with_explanation
 
 from tradeexecutor.cli.main import app
@@ -51,7 +51,7 @@ pytestmark = pytest.mark.skipif(
 )
 
 #: How much USDC to fund the hot wallet with on Arbitrum
-FUND_AMOUNT = 10_000 * 10**6  # 10,000 USDC
+FUND_AMOUNT = Decimal(10_000)
 
 
 @pytest.fixture()
@@ -71,11 +71,7 @@ def hot_wallet_address(hot_wallet_private_key) -> str:
 def anvil_arbitrum(hot_wallet_address) -> AnvilLaunch:
     """Fork Arbitrum mainnet via Anvil."""
     mainnet_rpc = os.environ["JSON_RPC_ARBITRUM"]
-    arb_usdc_whale = USDC_WHALE[42161]
-    anvil = launch_anvil(
-        mainnet_rpc,
-        unlocked_addresses=[arb_usdc_whale],
-    )
+    anvil = launch_anvil(mainnet_rpc)
     try:
         # Fund hot wallet with ETH and USDC on Arbitrum
         web3 = Web3(HTTPProvider(anvil.json_rpc_url))
@@ -90,10 +86,12 @@ def anvil_arbitrum(hot_wallet_address) -> AnvilLaunch:
         # USDC
         usdc_address = USDC_NATIVE_TOKEN[42161]
         usdc = fetch_erc20_details(web3, usdc_address, chain_id=42161)
-        tx_hash = usdc.contract.functions.transfer(
-            hot_wallet_address, FUND_AMOUNT,
-        ).transact({"from": arb_usdc_whale, "gas": 100_000})
-        assert_transaction_success_with_explanation(web3, tx_hash)
+        fund_erc20_on_anvil(
+            web3,
+            usdc.address,
+            hot_wallet_address,
+            usdc.convert_to_raw(FUND_AMOUNT),
+        )
 
         yield anvil
     finally:

--- a/tests/lagoon/conftest.py
+++ b/tests/lagoon/conftest.py
@@ -8,7 +8,9 @@ Explore the static deployment which we fork from the Base mainnet:
 - Safe contract: https://basescan.org/address/0x20415f3Ec0FEA974548184bdD6e67575D128953F#readProxyContract
 - Roles: https://app.safe.global/apps/open?safe=base:0x20415f3Ec0FEA974548184bdD6e67575D128953F&appUrl=https%3A%2F%2Fzodiac.gnosisguild.org%2F
 """
+import logging
 import os
+import time
 from decimal import Decimal
 
 import pytest
@@ -19,10 +21,8 @@ from web3 import Web3
 from eth_defi.hotwallet import HotWallet
 from eth_defi.erc_4626.vault_protocol.lagoon.deployment import deploy_automated_lagoon_vault, LagoonDeploymentParameters, LagoonAutomatedDeployment
 from eth_defi.erc_4626.vault_protocol.lagoon.vault import LagoonVault
-from eth_defi.provider.anvil import AnvilLaunch
+from eth_defi.provider.anvil import AnvilLaunch, fork_network_anvil
 from eth_defi.provider.multi_provider import create_multi_provider_web3
-from eth_defi.testing.anvil_fork_pool import AnvilForkPool
-from eth_defi.testing.evm_snapshot_fixture import evm_snapshot_revert
 from eth_defi.testing.fork_blocks import BASE_MIDNIGHT_BLOCK
 from eth_defi.token import TokenDetails, fetch_erc20_details, USDC_NATIVE_TOKEN
 from eth_defi.trace import assert_transaction_success_with_explanation
@@ -53,6 +53,8 @@ CI = os.environ.get("CI", None) is not None
 
 pytestmark = pytest.mark.skipif(not JSON_RPC_BASE, reason="No JSON_RPC_BASE environment variable")
 
+logger = logging.getLogger(__name__)
+
 
 @pytest.fixture()
 def usdc_holder() -> HexAddress:
@@ -61,28 +63,38 @@ def usdc_holder() -> HexAddress:
 
 
 @pytest.fixture()
-def anvil_base_fork(anvil_fork_pool: AnvilForkPool, usdc_holder: HexAddress) -> AnvilLaunch:
-    """Reuse and reset the cached canonical Base fork for Lagoon tests.
+def anvil_base_fork(usdc_holder: HexAddress) -> AnvilLaunch:
+    """Create an isolated fork of Base at the cached canonical block.
 
-    The per-test EVM snapshot/revert preserves deployment and transaction
-    isolation while the pooled Anvil process retains its warmed storage cache.
-
-    :return:
-        Shared Anvil fork at :data:`BASE_MIDNIGHT_BLOCK`.
+    :return: JSON-RPC URL for Web3
     """
     rpc_url = os.environ.get("JSON_RPC_BASE") or JSON_RPC_BASE
     assert rpc_url, "JSON_RPC_BASE not set"
-    launch = anvil_fork_pool.get_launch(
-        rpc_url,
-        BASE_MIDNIGHT_BLOCK,
-        unlocked_addresses=[usdc_holder],
-    )
-    snapshot = evm_snapshot_revert(launch)
-    next(snapshot)
+
+    launch = None
+    for attempt in range(3):
+        try:
+            launch = fork_network_anvil(
+                rpc_url,
+                unlocked_addresses=[usdc_holder],
+                fork_block_number=BASE_MIDNIGHT_BLOCK,
+            )
+            break
+        except AssertionError:
+            if attempt == 2:
+                raise
+            logger.warning(
+                "Retrying Lagoon Base fork startup after failed Anvil launch, attempt %d/3",
+                attempt + 2,
+            )
+            time.sleep(2 * (attempt + 1))
+
+    assert launch is not None
     try:
         yield launch
     finally:
-        next(snapshot, None)
+        # Wind down Anvil process after the test is complete
+        launch.close()
 
 
 @pytest.fixture()


### PR DESCRIPTION
## Why

PR #1626 changed the deployment-heavy Lagoon tests from one Anvil fork per test to a shared fork reset with snapshots. The shared process becomes unresponsive after several complete Safe, Lagoon and Guard deployments: two CI attempts and a CI-like local module run all produced localhost read timeouts during fixture setup, followed by an `evm_revert` timeout.

## Lessons learnt

The Anvil fork pool's liveness probe protects the boundary between tests, but cannot recover a process that wedges midway through a state-heavy deployment. Snapshot/revert pooling remains useful for read-only or proven-light mutation suites; full Lagoon deployment tests need process isolation. A fixed fork block and graceful shutdown still preserve Foundry's on-disk RPC cache benefits.

## Summary

- Restore a dedicated Base Anvil fork for every Lagoon deposit test.
- Retain the fixed canonical Base block and bounded three-attempt launch retry.
- Close each fork gracefully after the test so Foundry can persist its RPC cache.
- Preserve all other cache, submodule and ERC-4626 pooling changes from PR #1626.

## Unrelated test fixes for CI green

- Fund the CCTP bridge test wallet directly through Anvil instead of relying on a mutable Arbitrum mainnet USDC holder whose balance has fallen below the test amount.
- Convert the human-readable funding amount through the token metadata instead of hard-coding USDC decimals.

## Related issues and PRs

- #1626
- #1628
