### PR TITLE
fix: handle HyperCore full-close residuals

### DIFF
--- a/.claude/docs/alpha-model.md
+++ b/.claude/docs/alpha-model.md
@@ -157,22 +157,24 @@ pinned) are documented in `vault-deposit-redeem.md`.
 against the portfolio and emits trades, applying gates in this order:
 
 1. **Whole-portfolio gate** — if the largest single adjustment is below
-   `min_trade_threshold`, the entire rebalance is skipped (flag
-   `max_adjust_too_small`). All-or-nothing, because dropping only some legs
-   would break the sells-fund-buys pairing.
+   `min_trade_threshold`, the rebalance is skipped (flag
+   `max_adjust_too_small`) except for full-close intents. In that exception
+   only full closes are emitted; every unrelated adjustment is cleared.
 2. **Same-cycle cash caps** — the always-on **async cap** (queued ERC-7540 /
    Ostium redemptions pay out later, so buys are scaled to the cash that
    actually arrives; flag `capped_by_pending_settlement_cash`) and the
    **opt-in sync cap** (`cap_buys_to_sync_cash=True`: sells dropped by the
    min-trade gate free no cash either, so buys are scaled to the sells that
-   actually execute; flag `capped_by_sync_cash`). Opt-in rules and the worked
+   actually execute; flag `capped_by_sync_cash`). A softband-bypassed full
+   close is excluded from that opt-in cap's assumed funding. Opt-in rules and the worked
    hyper-ai example live in `vault-deposit-redeem.md`.
 3. **Per-signal gates** — problematic/frozen pairs, buys whose vault deposit
-   window is closed (`cannot_deposit`), sells below
-   `sell_rebalance_min_threshold` or below the pair dust epsilon
+   window is closed (`cannot_deposit`), partial sells below
+   `sell_rebalance_min_threshold` or sells below the pair dust epsilon
    (`individual_trade_size_too_small` / `individual_trade_quantity_too_small`),
    positions with a pending vault settlement (`settlement_pending`), and
-   positions not yet redeemable (`cannot_redeem`).
+   positions not yet redeemable (`cannot_redeem`). A full-close intent bypasses
+   only the individual sell softband; all other gates still apply.
 4. **Emission** — position closes for signals under
    `close_position_weight_epsilon`, adjust trades for the rest, plus optional
    stop-loss/take-profit triggers. Trades are returned sorted by

--- a/.claude/docs/hypercore-vault.md
+++ b/.claude/docs/hypercore-vault.md
@@ -96,6 +96,9 @@ the contract between `setup_trades()` and `settle_trade()`:
 | `hypercore_deposit_capital_at_risk` | during phase-1 preparation, persisted immediately before broadcast | Conservative checkpoint for USDC a node may already have accepted from the Safe. It blocks generic failed-buy refunds after a crash or indeterminate broadcast until live reconciliation. |
 | `hypercore_capped_deposit_raw` | deposit preflight | Deposit capped to actual Safe EVM USDC balance. |
 | `hypercore_capped_withdrawal_raw` | withdrawal preflight / retry | Withdrawal capped to live vault equity minus safety margin. |
+| `hypercore_accepted_residual_writeoff_usd` / `_at` / `_reason` | verified close or local dust cleanup | Audit record for equity intentionally removed from local tracking. |
+| `hypercore_close_residual_status` / `_value_usd` / `_observed_at` | verified full-close settlement | Whether the live residual was accepted or needs another close attempt. |
+| `hypercore_close_residual_first_seen_at` / `_retry_count` | residual above 5 USDC | Retry diagnostics; log an escalation after three verified incomplete closes. |
 | `hypercore_stranded_usdc` | on failure | Records USDC stranded mid-pipeline (perp/spot) for operator recovery and retains its reserve allocation. |
 | `hypercore_failure_diagnosis` | on failure | Full diagnostic snapshot string. |
 
@@ -115,6 +118,9 @@ Successful live settlement stores cost measurements directly on
 | `hypercore_close_other_loss_usd` | State-schema compatibility alias for the full-close loss used by the cost report; the bridge fee is added separately. |
 | `hypercore_close_residual_value_usd` | Vault equity remaining after a full close. |
 | `hypercore_cost_data_complete` | Whether all applicable measurements were captured. |
+
+For a verified full close, `trade.other_data["hypercore_accepted_residual_writeoff_usd"]`
+duplicates the accepted residual amount for the settlement audit trail.
 
 HyperEVM-to-HyperCore deposits have no protocol bridge fee and record an
 explicit zero after successful verification. Their observed spot increase is
@@ -614,15 +620,15 @@ configured 0.5%/1.50 USDC tolerance still fails loudly.
 
 Separately, automatic dust cleanup first identifies a dust-sized position and
 then skips it if it has no successful trade or has a planned, started, or
-broadcast trade. The percentage-derived full-close residual is accounted for
-by verified settlement and may exceed the independently capped 50 USDC dust
-threshold; increasing that bookkeeping-only threshold would risk discarding a
-real live position. Settlement stores the observed residual on the closed
-trade, and a later `correct-accounts` run recreates an on-chain residual above
-its default 2 USDC reconciliation threshold as a tracked small position. The
-specialised cleanup ladder can then recover it. These guards are intentionally
-independent: changing the margin cannot make incomplete trade state safe to
-repair, and the state guard cannot prevent stale live withdrawal caps.
+broadcast trade. Verified settlement may accept a residual of up to 5 USDC
+after a full close; this is distinct from the 2 USDC transaction-dust rule and
+never widens the close threshold for a fresh position. `correct-accounts`
+ignores untracked HyperCore equity at or below 5 USDC, since it cannot safely
+distinguish a retained account-scoped residual from an external micro-deposit.
+Larger residuals remain tracked for another normal close attempt. These guards
+are intentionally independent: changing the margin cannot make incomplete
+trade state safe to repair, and the state guard cannot prevent stale live
+withdrawal caps.
 
 Cleanup uses an adaptive initial margin of at most 0.10 USDC instead of the
 normal relative/floor full-close margin, because withholding 1.50 USDC would

--- a/docs/plans/hypercore-full-close-residual-cleanup.md
+++ b/docs/plans/hypercore-full-close-residual-cleanup.md
@@ -1,0 +1,65 @@
+# HyperCore full-close residual handling
+
+## Status
+
+Implemented on 2026-08-24.
+
+## Decision
+
+Use the normal alpha cycle to retry incomplete HyperCore closes. An open
+zero-target position is already durable retry state, so a separate scheduler
+would duplicate transaction persistence, nonce serialisation, and unfinished
+trade safeguards.
+
+## Behaviour
+
+- A full-close intent is an existing position with a reducing signal and a
+  target below `close_position_weight_epsilon`.
+- Full closes bypass only the portfolio and individual rebalance softbands.
+  Problematic pairs, frozen positions, lockups, pending settlement, redemption
+  limits, quantity dust, and routing preflight checks still apply.
+- If the whole rebalance is below the portfolio threshold, only full-close
+  intents are emitted; unrelated small adjustments remain skipped.
+- With `cap_buys_to_sync_cash` enabled, a softband-bypassed close contributes
+  no assumed cash to same-cycle buys. Only settled USDC is available on a later
+  cycle. Strategies without that optional cash guard retain their existing
+  marked-value financing behaviour.
+- HyperCore's accepted residual is exactly 5 USD. This is separate from the
+  2 USD transaction-dust threshold and is always converted to vault shares
+  before a quantity comparison.
+
+## Residual lifecycle
+
+| Observation after a closing withdrawal | State action |
+| --- | --- |
+| Verified residual `<= 5 USD` | Close the ledger position, credit only received USDC, and record accepted-residual metadata. |
+| Verified residual `> 5 USD` | Book only proven redemption, keep the position open, and retry on the next normal alpha cycle. |
+| Residual unavailable | Preserve the normal successful-close result. The post-withdrawal equity read is diagnostic and must not turn a verified EVM withdrawal into a phantom open position. |
+
+The 5 USD boundary applies only to a verified close residual in state
+settlement. Ordinary close planning and fresh positions retain the narrower
+2 USD transaction-dust threshold. `correct-accounts` ignores any untracked
+HyperCore vault balance at or below 5 USD, because it cannot safely distinguish
+an external micro-deposit from an account-scoped retained residual.
+
+Reattaching residual equity to a later new deposit remains deliberate operator
+recovery work; this change does not invent a synthetic reserve credit or balance
+update for it.
+
+## Operations
+
+No recurring cleanup job or external cron process is configured. The existing
+manual `correct-accounts` and HyperCore dust-repair commands remain recovery
+tools and must be run with the live executor stopped.
+
+Escalate after three successful close attempts still verify more than 5 USD
+remaining. Lockups, unavailable redemption capacity, pending settlement, and
+unroutable pairs are deferrals, not write-off conditions.
+
+## Verification
+
+- Full-close softband bypass and non-bypass partial reduction tests.
+- Same-cycle cash-cap test proving bypassed proceeds do not fund buys.
+- USD-to-share dust conversion tests at non-unit share prices.
+- Verified 5 USD residual versus fresh small-deposit tests.
+- Correct-accounts regression test preventing residual recreation.

--- a/tests/hyperliquid/test_correct_accounts_vault_dust_writeoff.py
+++ b/tests/hyperliquid/test_correct_accounts_vault_dust_writeoff.py
@@ -25,8 +25,9 @@ from unittest.mock import MagicMock, patch
 from tradeexecutor.ethereum.vault.hypercore_vault import create_hypercore_vault_pair
 from tradeexecutor.state.identifier import AssetIdentifier
 from tradeexecutor.state.state import State
+from tradeexecutor.state.trade import TradeType
 from tradeexecutor.strategy.account_correction import create_missing_vault_positions
-from tradeexecutor.strategy.dust import HYPERLIQUID_VAULT_CLOSE_EPSILON
+from tradeexecutor.strategy.dust import HYPERCORE_ACCEPTED_RESIDUAL_USD, HYPERLIQUID_VAULT_CLOSE_EPSILON
 
 
 def _build_state_and_universe() -> tuple[State, MagicMock, object]:
@@ -133,3 +134,83 @@ def test_vault_real_equity_still_opens_position():
     assert len(created_trades) == 1
     assert len(state.portfolio.open_positions) == 1
     assert len(state.portfolio.closed_positions) == 0
+
+
+def test_accepted_residual_is_not_recreated_by_correct_accounts():
+    """A verified accepted residual remains written off during account correction.
+
+    1. Create and locally close a Hypercore position with a recorded three USD accepted residual.
+    2. Run missing-position discovery against the same three USD on-chain equity.
+    3. Verify correct-accounts does not recreate the residual as a funded position.
+    """
+    # 1. A closed position retains the routing/repair accepted-residual record.
+    state, strategy_universe, pair = _build_state_and_universe()
+    position, trade, _created = state.create_trade(
+        strategy_cycle_at=datetime.datetime(2026, 8, 24),
+        pair=pair,
+        quantity=None,
+        reserve=Decimal("3"),
+        assumed_price=1.0,
+        trade_type=TradeType.rebalance,
+        reserve_currency=pair.quote,
+        reserve_currency_price=1.0,
+    )
+    trade.mark_success(
+        executed_at=datetime.datetime(2026, 8, 24),
+        executed_price=1.0,
+        executed_quantity=Decimal("3"),
+        executed_reserve=Decimal("3"),
+        lp_fees=0,
+        native_token_price=0,
+        force=True,
+    )
+    position.other_data["hypercore_accepted_residual_writeoff_usd"] = "3"
+    state.portfolio.close_position(
+        position,
+        datetime.datetime(2026, 8, 24),
+        allow_value_destruction=True,
+    )
+
+    # 2. Correct-accounts sees the account-scoped vault residual after the close.
+    with patch(
+        "tradeexecutor.strategy.account_correction.translate_trading_pair",
+        return_value=pair,
+    ):
+        created_trades = create_missing_vault_positions(
+            strategy_universe=strategy_universe,
+            state=state,
+            strategy_cycle_at=datetime.datetime(2026, 8, 25),
+            vault_value_func=lambda p: Decimal("3"),
+        )
+
+    # 3. Matching residual equity remains intentionally untracked.
+    assert created_trades == []
+    assert state.portfolio.open_positions == {}
+    assert len(state.portfolio.closed_positions) == 1
+
+
+def test_five_usd_residual_is_written_off_without_historical_state():
+    """The accepted-residual policy must not depend on matching an old closed position.
+
+    1. Build a fresh state with no historical positions.
+    2. Discover a five USD HyperCore vault balance.
+    3. Verify correct-accounts treats it as the global retained-residual minimum.
+    """
+    # 1. No historical write-off record is needed.
+    state, strategy_universe, pair = _build_state_and_universe()
+
+    # 2. Correct-accounts discovers an account-scoped residual.
+    with patch(
+        "tradeexecutor.strategy.account_correction.translate_trading_pair",
+        return_value=pair,
+    ):
+        created_trades = create_missing_vault_positions(
+            strategy_universe=strategy_universe,
+            state=state,
+            strategy_cycle_at=datetime.datetime(2026, 8, 25),
+            vault_value_func=lambda p: HYPERCORE_ACCEPTED_RESIDUAL_USD,
+        )
+
+    # 3. The operational boundary prevents another phantom position.
+    assert created_trades == []
+    assert state.portfolio.open_positions == {}

--- a/tests/hyperliquid/test_hypercore_accounting.py
+++ b/tests/hyperliquid/test_hypercore_accounting.py
@@ -9,8 +9,6 @@ Verifies that:
 
 import datetime
 from decimal import Decimal
-from pathlib import Path
-from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -19,7 +17,6 @@ from eth_defi.compat import native_datetime_utc_now
 from tradingstrategy.chain import ChainId
 
 from tradeexecutor.cli.commands.correct_accounts import _sync_hypercore_vault_positions
-from tradeexecutor.cli.commands.repair_hypercore_dust import _apply_strategy_hypercore_close_epsilon
 from tradeexecutor.ethereum.vault.hypercore_valuation import HypercoreVaultPricing, HypercoreVaultValuator
 from tradeexecutor.ethereum.vault.hypercore_vault import create_hypercore_vault_pair
 from tradeexecutor.cli.double_position import check_double_position
@@ -43,15 +40,12 @@ from tradeexecutor.strategy.dust import (
     get_hypercore_withdrawal_safety_margin,
     get_close_epsilon_for_pair,
     get_dust_epsilon_for_pair,
-    get_hyperliquid_vault_close_epsilon,
     HYPERLIQUID_VAULT_CLOSE_EPSILON,
     HYPERLIQUID_VAULT_RELATIVE_EPSILON,
     DEFAULT_VAULT_EPSILON,
 )
 from tradeexecutor.strategy.execution_model import AssetManagementMode
-from tradeexecutor.strategy.execution_context import unit_test_execution_context
 from tradeexecutor.strategy.pandas_trader.position_manager import PositionManager
-from tradeexecutor.strategy.runner import StrategyRunner
 from tradeexecutor.strategy.sync_model import OnChainBalance
 from tradeexecutor.visual.equity_curve import calculate_compounding_unrealised_trading_profitability
 
@@ -554,66 +548,6 @@ def test_hypercore_reduction_planning_reserves_relative_margin_with_fixed_floor(
     assert full_close_plan.treat_as_full_close is True
 
 
-def test_repair_hypercore_dust_uses_strategy_close_epsilon():
-    """Repair command applies the strategy capital-derived threshold before checking dust.
-
-    1. Create a Hypercore vault position with a residual above the default threshold.
-    2. Mock loading a strategy module configured with $1,000 initial capital.
-    3. Apply the repair command's strategy configuration helper.
-    4. Verify the position is closeable at the derived $5 threshold.
-    5. Verify no initial cash retains the default threshold.
-    """
-
-    # 1. Create a Hypercore vault position with a residual above the default threshold.
-    quote = AssetIdentifier(
-        chain_id=ChainId.hypercore.value,
-        address="0x0000000000000000000000000000000000000002",
-        token_symbol="USDC",
-        decimals=6,
-    )
-    pair = create_hypercore_vault_pair(
-        quote=quote,
-        vault_address="0x1111111111111111111111111111111111111111",
-    )
-    ts = native_datetime_utc_now()
-    position = TradingPosition(
-        position_id=1,
-        pair=pair,
-        opened_at=ts,
-        last_pricing_at=ts,
-        last_token_price=1.0,
-        last_reserve_price=1.0,
-        reserve_currency=quote,
-    )
-    dummy_trade = MagicMock()
-    dummy_trade.is_spot.return_value = False
-    position.trades[1] = dummy_trade
-    state = MagicMock()
-    state.portfolio.get_open_and_frozen_positions.return_value = [position]
-
-    # 2. Mock strategy loading because only the module's initial cash affects this local repair.
-    strategy_module = SimpleNamespace(initial_cash=1_000)
-
-    # 3. Apply the repair command's strategy configuration helper.
-    with patch(
-        "tradeexecutor.cli.commands.repair_hypercore_dust.read_strategy_module",
-        return_value=strategy_module,
-    ):
-        epsilon = _apply_strategy_hypercore_close_epsilon(
-            state,
-            Path("strategies/hyper-ai.py"),
-            MagicMock(),
-        )
-
-    # 4. Verify the position is closeable at the derived $5 threshold.
-    assert epsilon == Decimal("5.000")
-    with patch.object(position, "get_quantity", return_value=Decimal("3.927094")):
-        assert position.can_be_closed() is True
-
-    # 5. Verify no initial cash retains the default threshold.
-    assert get_hyperliquid_vault_close_epsilon() == HYPERLIQUID_VAULT_CLOSE_EPSILON
-
-
 def test_hypercore_account_check_compares_equity_not_quantity() -> None:
     """Test Hypercore account checks compare expected equity against live equity.
 
@@ -690,125 +624,6 @@ def test_hypercore_account_check_compares_equity_not_quantity() -> None:
     assert correction.relative_epsilon == HYPERLIQUID_VAULT_RELATIVE_EPSILON
     assert correction.usd_value == 0.0
     assert correction.mismatch is False
-
-
-def test_post_trade_hypercore_revaluation_runs_only_for_open_hypercore_positions() -> None:
-    """Revalue Hypercore positions immediately before post-trade account checks.
-
-    1. Build a minimal runner with one open Hypercore vault position and one non-Hypercore position.
-    2. Run the post-trade Hypercore refresh helper and verify only the Hypercore position is revalued.
-    3. Leave only a frozen Hypercore vault position and verify the helper still performs the refresh.
-    4. Remove all Hypercore positions and verify the helper skips the extra valuation pass entirely.
-    """
-
-    class DummyRunner(StrategyRunner):
-        """Minimal runner used to exercise post-trade Hypercore revaluation."""
-
-        def pretick_check(self, ts: datetime.datetime, universe) -> None:
-            return None
-
-    # 1. Build a minimal runner with one open Hypercore vault position and one non-Hypercore position.
-    runner = DummyRunner(
-        timed_task_context_manager=MagicMock(),
-        execution_model=MagicMock(),
-        approval_model=MagicMock(),
-        valuation_model_factory=MagicMock(),
-        sync_model=None,
-        pricing_model_factory=MagicMock(),
-        execution_context=unit_test_execution_context,
-    )
-
-    reserve_asset = AssetIdentifier(
-        chain_id=999,
-        address="0xb88339cb7199b77e23db6e890353e22632ba630f",
-        token_symbol="USDC",
-        decimals=6,
-    )
-    hypercore_pair = create_hypercore_vault_pair(
-        quote=reserve_asset,
-        vault_address="0x1111111111111111111111111111111111111111",
-    )
-    spot_pair = TradingPairIdentifier(
-        base=AssetIdentifier(
-            chain_id=1,
-            address="0x0000000000000000000000000000000000000001",
-            token_symbol="WETH",
-            decimals=18,
-        ),
-        quote=AssetIdentifier(
-            chain_id=1,
-            address="0x0000000000000000000000000000000000000002",
-            token_symbol="USDC",
-            decimals=6,
-        ),
-        pool_address="0x0000000000000000000000000000000000000003",
-        exchange_address="0x0000000000000000000000000000000000000004",
-        internal_id=2,
-        internal_exchange_id=2,
-        fee=0.003,
-    )
-
-    hypercore_position = MagicMock()
-    hypercore_position.pair = hypercore_pair
-    frozen_hypercore_position = MagicMock()
-    frozen_hypercore_position.pair = hypercore_pair
-    spot_position = MagicMock()
-    spot_position.pair = spot_pair
-
-    state = MagicMock()
-    state.portfolio.open_positions = {
-        1: hypercore_position,
-        2: spot_position,
-    }
-    state.portfolio.get_open_and_frozen_positions.return_value = [
-        hypercore_position,
-        spot_position,
-    ]
-
-    valuation_model = MagicMock()
-    universe = MagicMock()
-    runner.setup_routing_context = MagicMock(
-        return_value=MagicMock(valuation_model=valuation_model),
-    )
-
-    # 2. Run the post-trade Hypercore refresh helper and verify only the Hypercore position is revalued.
-    runner._revalue_open_hypercore_positions_before_post_trade_account_check(
-        universe,
-        state,
-    )
-
-    assert valuation_model.call_count == 1
-    assert valuation_model.call_args[0][1] is hypercore_position
-
-    # 3. Leave only a frozen Hypercore position and verify the helper still refreshes it.
-    valuation_model.reset_mock()
-    runner.setup_routing_context.reset_mock()
-    state.portfolio.open_positions = {2: spot_position}
-    state.portfolio.get_open_and_frozen_positions.return_value = [
-        spot_position,
-        frozen_hypercore_position,
-    ]
-
-    runner._revalue_open_hypercore_positions_before_post_trade_account_check(
-        universe,
-        state,
-    )
-
-    assert valuation_model.call_count == 1
-    assert valuation_model.call_args[0][1] is frozen_hypercore_position
-
-    # 4. Remove all Hypercore positions and verify the helper skips the extra valuation pass entirely.
-    valuation_model.reset_mock()
-    runner.setup_routing_context.reset_mock()
-    state.portfolio.get_open_and_frozen_positions.return_value = [spot_position]
-
-    runner._revalue_open_hypercore_positions_before_post_trade_account_check(
-        universe,
-        state,
-    )
-
-    valuation_model.assert_not_called()
-    runner.setup_routing_context.assert_not_called()
 
 
 def test_hypercore_dust_position_is_reused_without_planned_close() -> None:

--- a/tests/hyperliquid/test_hypercore_dual_chain.py
+++ b/tests/hyperliquid/test_hypercore_dual_chain.py
@@ -14,6 +14,7 @@ import pytest
 
 from eth_defi.hyperliquid.api import UserVaultEquity
 from hexbytes import HexBytes
+from tradeexecutor.strategy.dust import HYPERCORE_CLOSE_RESIDUAL_STATUS_PENDING_RETRY
 
 
 VAULT_ADDR = "0xdfc24b077bc1425ad1dea75bcb6f8158e10df303"
@@ -1021,7 +1022,11 @@ def test_full_close_uses_observed_gross_decrease_when_phase1_under_redeems(
     trade.closing = True
     state = MagicMock()
     state.portfolio.get_position_by_id.return_value.get_quantity.return_value = Decimal("65")
-    state.portfolio.find_position_for_trade.return_value.get_quantity.return_value = Decimal("65")
+    position = state.portfolio.find_position_for_trade.return_value
+    position.get_quantity.return_value = Decimal("65")
+    position.get_close_epsilon.return_value = Decimal("2")
+    position.position_id = 1
+    position.other_data = {}
     mock_block_ts.return_value = datetime.datetime(2025, 1, 1)
     mock_fetch_equity.side_effect = [
         _make_equity(Decimal("1000.0")),
@@ -1069,6 +1074,8 @@ def test_full_close_uses_observed_gross_decrease_when_phase1_under_redeems(
     assert success_kwargs["executed_amount"] == Decimal("-50")
     assert success_kwargs["executed_reserve"] == Decimal("109.99")
     assert success_kwargs["executed_price"] == pytest.approx(109.99 / 50)
+    assert position.other_data["hypercore_close_residual_status"] == HYPERCORE_CLOSE_RESIDUAL_STATUS_PENDING_RETRY
+    assert position.other_data["hypercore_close_residual_retry_count"] == 1
 
 
 @patch("tradeexecutor.ethereum.vault.hypercore_routing.report_failure")

--- a/tests/hyperliquid/test_hypercore_dust_epsilon_units.py
+++ b/tests/hyperliquid/test_hypercore_dust_epsilon_units.py
@@ -3,8 +3,8 @@
 Regression tests for a defect where a funded Hypercore vault position was silently
 destroyed the moment it was opened.
 
-``get_hyperliquid_vault_close_epsilon()`` returns ``initial_cash * 0.005``, which is a US
-dollar amount, and ``TradingPosition.can_be_closed()`` compared it against
+The HyperCore accepted-residual boundary is a US dollar amount, and an earlier
+``TradingPosition.can_be_closed()`` implementation compared it against
 ``get_quantity()``, which is a count of vault *shares*. For vaults whose share price is
 near 1 USD the two coincide and nothing is noticed. For a share priced at 12.78 USD the
 threshold is multiplied by 12.78, and at a 150,000 USD bankroll it becomes 750 shares =
@@ -31,14 +31,14 @@ from tradeexecutor.state.portfolio import (
     CLOSE_POSITION_VALUE_DESTRUCTION_LIMIT_USD,
     PositionValueDestroyedError,
 )
+from tradeexecutor.state.repair import close_hypercore_dust_positions
 from tradeexecutor.state.state import State
 from tradeexecutor.state.trade import TradeType
 from tradeexecutor.strategy.dust import (
     HYPERLIQUID_VAULT_CLOSE_EPSILON,
-    HYPERLIQUID_VAULT_CLOSE_EPSILON_MAX_USD,
-    configure_hyperliquid_vault_close_epsilon,
+    HYPERCORE_ACCEPTED_RESIDUAL_USD,
+    HYPERCORE_CLOSE_RESIDUAL_STATUS_ACCEPTED,
     convert_usd_close_epsilon_to_quantity,
-    get_hyperliquid_vault_close_epsilon,
 )
 
 
@@ -110,9 +110,6 @@ def buy_vault_position(
         reserve_currency_price=1.0,
     )
 
-    # The runner stamps the strategy's dust threshold onto open positions every cycle.
-    configure_hyperliquid_vault_close_epsilon([position], initial_cash)
-
     state.start_execution(opened_at, trade)
     trade.mark_broadcasted(opened_at)
     state.mark_trade_success(
@@ -128,33 +125,26 @@ def buy_vault_position(
     return state, position
 
 
-def test_epsilon_is_clamped_to_a_usd_ceiling():
-    """A large configured bankroll must not scale the dust threshold into position sizes."""
-    # Unconfigured strategies keep the default safety margin
-    assert get_hyperliquid_vault_close_epsilon(None) == HYPERLIQUID_VAULT_CLOSE_EPSILON
-    assert get_hyperliquid_vault_close_epsilon(0) == HYPERLIQUID_VAULT_CLOSE_EPSILON
+def test_hypercore_residual_boundaries_are_fixed():
+    """HyperCore policy must keep transaction dust and accepted residuals distinct.
 
-    # Small bankrolls scale but never below the floor
-    assert get_hyperliquid_vault_close_epsilon(100) == HYPERLIQUID_VAULT_CLOSE_EPSILON
-
-    # 5,000 * 0.5% = 25 USD, under the ceiling, so the percentage rule still applies
-    assert get_hyperliquid_vault_close_epsilon(5_000) == Decimal("25.000")
-
-    # 150,000 would be 750 USD unclamped - the value that destroyed real positions
-    assert get_hyperliquid_vault_close_epsilon(150_000) == HYPERLIQUID_VAULT_CLOSE_EPSILON_MAX_USD
-    assert get_hyperliquid_vault_close_epsilon(10_000_000) == HYPERLIQUID_VAULT_CLOSE_EPSILON_MAX_USD
+    1. Read the two constants used for the two accounting decisions.
+    2. Verify transaction dust remains below the accepted residual boundary.
+    """
+    # 1-2. Neither boundary depends on strategy capital.
+    assert HYPERLIQUID_VAULT_CLOSE_EPSILON == Decimal("2.00")
+    assert HYPERCORE_ACCEPTED_RESIDUAL_USD == Decimal("5.00")
 
 
 def test_destruction_limit_sits_above_the_largest_legitimate_dust():
     """The two thresholds must not contradict each other.
 
-    ``can_be_closed()`` permits closing anything the dust rules call negligible - up to
-    :py:data:`HYPERLIQUID_VAULT_CLOSE_EPSILON_MAX_USD` of value. If the value-destruction
-    guard sat below that, it would raise on closes the engine is supposed to perform, which
-    is exactly what happened in a 150,000 USD backtest: a 31.36 USD residual was dust by the
-    50 USD ceiling but blocked by a 25 USD guard.
+    A freshly verified accepted residual can be worth up to
+    :py:data:`HYPERCORE_ACCEPTED_RESIDUAL_USD`. If the value-destruction
+    guard sat below that, it would raise on a local close the engine is supposed to
+    perform.
     """
-    assert CLOSE_POSITION_VALUE_DESTRUCTION_LIMIT_USD > float(HYPERLIQUID_VAULT_CLOSE_EPSILON_MAX_USD)
+    assert CLOSE_POSITION_VALUE_DESTRUCTION_LIMIT_USD > float(HYPERCORE_ACCEPTED_RESIDUAL_USD)
 
 
 def test_usd_epsilon_converts_to_share_units():
@@ -213,16 +203,45 @@ def test_genuine_dust_still_closes():
     assert position.is_closed(), "Genuine sub-margin dust should still be closed automatically"
 
 
+def test_verified_five_usd_residual_closes_but_new_deposit_does_not():
+    """The accepted-residual boundary must not close a fresh small deposit.
+
+    1. Open a three USD Hypercore position, which is above transaction dust but below five USD.
+    2. Verify it remains open until a fresh residual observation records it as accepted.
+    3. Run local dust repair and verify it closes only with that verified marker.
+    """
+    state, position = buy_vault_position(Decimal("0.235"), initial_cash=150_000)
+
+    # 1-2. A new 3 USD deposit is live equity, not an accepted withdrawal residual.
+    assert position.get_value() == pytest.approx(3.0, abs=0.05)
+    assert not position.can_be_closed()
+    assert not position.is_closed()
+
+    # 3. The routing/runner fresh observation authorises the five USD write-off boundary.
+    position.other_data["hypercore_close_residual_status"] = HYPERCORE_CLOSE_RESIDUAL_STATUS_ACCEPTED
+    residual_value = position.get_value(include_interest=False)
+    trades = close_hypercore_dust_positions(
+        state.portfolio,
+        now=datetime.datetime(2026, 8, 24),
+    )
+    assert len(trades) == 1
+    assert position.is_closed()
+    assert position.other_data["hypercore_accepted_residual_writeoff_usd"] == str(residual_value)
+
+
 def test_close_epsilon_is_expressed_in_share_units():
     """``get_close_epsilon()`` feeds a quantity comparison, so it must return units."""
     _state, position = buy_vault_position(PMALT_QUANTITY, initial_cash=150_000)
 
     epsilon = position.get_close_epsilon()
 
-    # 50 USD ceiling / 12.78 USD per share
-    assert epsilon == pytest.approx(Decimal("3.912"), abs=Decimal("0.001"))
-    # Before the fix this was 750: the raw USD figure used as a share count
-    assert epsilon < Decimal("10")
+    # 2 USD transaction dust / 12.78 USD per share
+    assert epsilon == pytest.approx(Decimal("0.156"), abs=Decimal("0.001"))
+    # This must stay a small share quantity, never a raw USD amount.
+    assert epsilon < Decimal("1")
+
+    position.other_data["hypercore_close_residual_status"] = HYPERCORE_CLOSE_RESIDUAL_STATUS_ACCEPTED
+    assert position.get_close_epsilon() == pytest.approx(Decimal("0.391"), abs=Decimal("0.001"))
 
 
 def test_close_position_refuses_to_destroy_value():

--- a/tests/test_rebalance.py
+++ b/tests/test_rebalance.py
@@ -2400,18 +2400,95 @@ def test_alpha_model_skips_hypercore_sell_below_threshold_after_capping(
     assert TradingPairSignalFlags.individual_trade_size_too_small in signal.flags
 
 
-def test_alpha_model_skips_hypercore_sell_below_quantity_dust(
+def test_alpha_model_full_close_bypasses_hypercore_rebalance_softbands(
+    start_ts: datetime.datetime,
+    strategy_universe: TradingStrategyUniverse,
+    pricing_model: BacktestPricing,
+    usdc: AssetIdentifier,
+    weth_usdc: TradingPairIdentifier,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Check a small zero-target Hypercore position closes despite rebalance softbands.
+
+    1. Create a 4 USD Hypercore position, give it a zero target, and add a 4 USD buy.
+    2. Use 75 USD portfolio and individual sell softbands that would suppress both adjustments.
+    3. Verify only the full close is generated and records the explicit bypass diagnostic.
+    """
+    state = State()
+    hypercore_vault_pair = _create_hypercore_position_for_rebalance_test(
+        state,
+        start_ts,
+        usdc,
+        last_token_price=2.0,
+        reserve_amount=Decimal(2),
+    )
+
+    # 1. A zero signal produces full-close intent for the existing position.
+    position_manager = PositionManager(
+        start_ts + datetime.timedelta(days=1),
+        strategy_universe.data_universe,
+        state,
+        pricing_model,
+    )
+    _patch_hypercore_pricing(monkeypatch, pricing_model, hypercore_vault_pair)
+    monkeypatch.setattr(
+        pricing_model,
+        "check_redemption",
+        lambda ts, pair, **kwargs: RedemptionCheckResult(
+            timestamp=ts,
+            stage=kwargs["stage"],
+            can_redeem=True,
+            pair_ticker=pair.get_ticker(),
+            vault_address=pair.pool_address,
+            safe_address="0x0000000000000000000000000000000000000abc",
+            max_withdrawable=None,
+            max_redemption=None,
+            message="Hypercore sell is redeemable",
+        ),
+    )
+    alpha_model = AlphaModel(timestamp=position_manager.timestamp)
+    alpha_model.set_signal(hypercore_vault_pair, 0.0)
+    alpha_model.set_signal(weth_usdc, 1.0)
+    alpha_model.select_top_signals(count=5)
+    alpha_model.assign_weights(method=weight_passthrouh)
+    alpha_model.normalise_weights(max_weight=1.0)
+    alpha_model.update_old_weights(state.portfolio, ignore_credit=False)
+    alpha_model.calculate_target_positions(position_manager, investable_equity=4.0)
+
+    # 2. The close is smaller than both softbands and the portfolio-wide threshold.
+    trades = alpha_model.generate_rebalance_trades_and_triggers(
+        position_manager,
+        min_trade_threshold=75.0,
+        individual_rebalance_min_threshold=75.0,
+        sell_rebalance_min_threshold=75.0,
+    )
+    signal = alpha_model.get_signal_by_pair(hypercore_vault_pair)
+    buy_signal = alpha_model.get_signal_by_pair(weth_usdc)
+    assert signal is not None
+    assert buy_signal is not None
+
+    # 3. Full-close intent bypasses the softbands; the unrelated buy stays suppressed.
+    assert len(trades) == 1
+    assert trades[0].is_sell()
+    assert TradingPairSignalFlags.full_close_softband_bypassed in signal.flags
+    assert signal.other_data["full_close_softband_bypassed"] is True
+    assert buy_signal.position_adjust_ignored is True
+    assert buy_signal.position_adjust_usd == 0.0
+    assert buy_signal.position_adjust_quantity == 0.0
+
+
+def test_alpha_model_compares_hypercore_sell_dust_in_share_units(
     start_ts: datetime.datetime,
     strategy_universe: TradingStrategyUniverse,
     pricing_model: BacktestPricing,
     usdc: AssetIdentifier,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Check Hypercore sell quantity dust is skipped even when its USD value passes trade thresholds.
+    """Check Hypercore sell dust converts its USD boundary to vault share units.
 
     1. Create a high-share-price Hypercore position that needs a small rebalance sell.
-    2. Keep the USD sell above the configured sell threshold but the vault quantity below dust epsilon.
-    3. Verify the alpha model skips the trade before low-level trade creation rejects it.
+    2. Keep the USD sell above the configured sell threshold and above the converted share dust boundary.
+    3. Verify the alpha model creates the reduction instead of treating USD as a share quantity.
     """
     state = State()
     hypercore_vault_pair = _create_hypercore_position_for_rebalance_test(
@@ -2453,7 +2530,7 @@ def test_alpha_model_skips_hypercore_sell_below_quantity_dust(
     alpha_model.update_old_weights(state.portfolio, ignore_credit=False)
     alpha_model.calculate_target_positions(position_manager, investable_equity=2958.0)
 
-    # 2. Keep the USD sell above the configured sell threshold but the vault quantity below dust epsilon.
+    # 2. At 60 USD/share, a 2 USD dust boundary is only 0.033 shares, not 2 shares.
     trades = alpha_model.generate_rebalance_trades_and_triggers(
         position_manager,
         min_trade_threshold=0.01,
@@ -2464,11 +2541,12 @@ def test_alpha_model_skips_hypercore_sell_below_quantity_dust(
     signal = alpha_model.get_signal_by_pair(hypercore_vault_pair)
     assert signal is not None
 
-    # 3. Verify the alpha model skips the trade before low-level trade creation rejects it.
-    assert trades == []
+    # 3. Verify the valid 0.7-share reduction is not skipped as dust.
+    assert len(trades) == 1
+    assert trades[0].is_sell()
     assert signal.position_adjust_usd == pytest.approx(-42.0)
     assert signal.position_adjust_quantity == pytest.approx(-0.7)
-    assert TradingPairSignalFlags.individual_trade_quantity_too_small in signal.flags
+    assert TradingPairSignalFlags.individual_trade_quantity_too_small not in signal.flags
 
 
 def test_alpha_model_uses_capped_hypercore_cash_release_for_buy_checks(

--- a/tests/units_tests/test_alpha_model_sync_cash_cap.py
+++ b/tests/units_tests/test_alpha_model_sync_cash_cap.py
@@ -289,6 +289,57 @@ def test_sync_cash_cap_threshold_semantics_match_generator():
     assert buy2.position_adjust_usd == pytest.approx(16.0)  # 10 cash + 6 sell; the 4 trim excluded
 
 
+def test_sync_cash_cap_does_not_spend_softband_bypassed_full_close_proceeds():
+    """A softband-bypassed full close executes but does not fund a same-cycle buy.
+
+    1. Create a 25 USD zero-target sell below a 50 USD sell softband and a 60 USD buy.
+    2. Classify the sell as a full close and run the synchronous cash cap with 10 USD cash.
+    3. Verify the buy is limited to the known cash, while a similarly sized partial trim remains skipped.
+    """
+    # 1. A zero target is full-close intent; the same notional with a positive target is a trim.
+    full_close = _make_signal(_make_pair(1), -25.0)
+    full_close.old_value = 25.0
+    full_close.normalised_weight = 0.0
+    partial_trim = _make_signal(_make_pair(2), -25.0)
+    buy = _make_signal(_make_pair(10), 60.0)
+    alpha = _make_alpha([full_close, partial_trim, buy])
+    pm = _StubPositionManager(
+        pricing_model=_StubPricing(open_pairs={10}, redeemable={}),
+        cash=10.0,
+    )
+
+    # 2. The close may execute, but its marked value is not safe same-cycle funding.
+    _run_cap(
+        alpha,
+        pm,
+        individual_threshold=50.0,
+        sell_threshold=50.0,
+        headroom=0.0,
+    )
+
+    # 3. Only verified cash funds the buy; the partial trim remains below the softband.
+    assert buy.position_adjust_usd == pytest.approx(10.0)
+    assert TradingPairSignalFlags.capped_by_sync_cash in buy.flags
+    assert alpha._will_sell_execute(
+        full_close,
+        pm,
+        {},
+        {},
+        set(),
+        50.0,
+        50.0,
+    )
+    assert not alpha._will_sell_execute(
+        partial_trim,
+        pm,
+        {},
+        {},
+        set(),
+        50.0,
+        50.0,
+    )
+
+
 def test_sync_cash_cap_buy_predicate_scope():
     """Only unleveraged, non-flip spot/vault buys are counted and scaled.
 

--- a/tradeexecutor/cli/commands/repair_hypercore_dust.py
+++ b/tradeexecutor/cli/commands/repair_hypercore_dust.py
@@ -17,8 +17,6 @@ from ...state.repair import (
     find_hypercore_duplicate_close_candidates,
 )
 from ...state.store import JSONFileStore
-from ...strategy.dust import configure_hyperliquid_vault_close_epsilon
-from ...strategy.strategy_module import read_strategy_module
 
 
 def _count_duplicate_hypercore_groups(state) -> int:
@@ -44,32 +42,6 @@ def _format_candidate_position(position) -> str:
         f"balance_updates={len(position.balance_updates)}, "
         f"trades={len(position.trades)}"
     )
-
-
-def _apply_strategy_hypercore_close_epsilon(
-    state,
-    strategy_file: Path | None,
-    logger,
-):
-    """Apply a strategy module's Hypercore dust threshold before repairing state."""
-
-    if strategy_file is None:
-        logger.info(
-            "No strategy file supplied; using persisted Hypercore close thresholds or the 2.00 default"
-        )
-        return None
-
-    strategy_module = read_strategy_module(strategy_file)
-    epsilon = configure_hyperliquid_vault_close_epsilon(
-        state.portfolio.get_open_and_frozen_positions(),
-        strategy_module.initial_cash,
-    )
-    logger.info(
-        "Applied Hypercore vault close epsilon %s from strategy module %s",
-        epsilon,
-        strategy_file,
-    )
-    return epsilon
 
 
 @app.command()
@@ -98,8 +70,9 @@ def repair_hypercore_dust(
 
     This command is intentionally local-state only. It does not attempt any
     on-chain execution; instead it creates repair trades for Hypercore vault
-    positions that are already within the configured close epsilon. When a
-    strategy file is supplied, its initial cash determines the threshold.
+    positions with ordinary transaction dust or a verified accepted residual.
+    The accepted-residual boundary is fixed at 5 USD and does not depend on
+    the strategy module.
 
     Duplicate Hypercore positions are diagnosed before and after cleanup so
     operators can see whether stale dust residuals were removed or whether a
@@ -124,8 +97,6 @@ def repair_hypercore_dust(
         backup_suffix="repair-hypercore-dust-backup",
         unit_testing=unit_testing,
     )
-
-    _apply_strategy_hypercore_close_epsilon(state, strategy_file, logger)
 
     duplicate_group_count_before = _count_duplicate_hypercore_groups(state)
     if duplicate_group_count_before:

--- a/tradeexecutor/ethereum/vault/hypercore_routing.py
+++ b/tradeexecutor/ethereum/vault/hypercore_routing.py
@@ -130,10 +130,12 @@ from eth_defi.compat import native_datetime_utc_now
 from tradeexecutor.ethereum.tx import TransactionBuilder
 from tradeexecutor.state.identifier import TradingPairIdentifier, AssetIdentifier
 from tradeexecutor.strategy.dust import (
+    HYPERCORE_ACCEPTED_RESIDUAL_USD,
+    HYPERCORE_CLOSE_RESIDUAL_STATUS_ACCEPTED,
+    HYPERCORE_CLOSE_RESIDUAL_STATUS_PENDING_RETRY,
     HYPERCORE_WITHDRAWAL_SAFETY_MARGIN_FLOOR,
     HYPERCORE_SMALL_POSITION_CLEANUP_CLOSE_EPSILON,
     HYPERCORE_SMALL_POSITION_CLEANUP_PENDING_REDEEM,
-    get_close_epsilon_for_pair,
     get_hypercore_withdrawal_safety_margin,
 )
 from tradingstrategy.pair import PandasPairUniverse
@@ -3165,9 +3167,7 @@ class HypercoreVaultRouting(RoutingModel):
             Decimal(str(trade.slippage_tolerance or 0)),
         )
         phase1_requested_reserve = raw_to_usdc(expected_raw)
-        remaining_equity_after_withdrawal: Decimal | None = (
-            Decimal(0) if self.simulate else None
-        )
+        remaining_equity_after_withdrawal: Decimal | None = None
 
         if self.simulate:
             # Simulate mode: mock CoreWriter does not bridge USDC,
@@ -3711,9 +3711,12 @@ class HypercoreVaultRouting(RoutingModel):
 
         position = state.portfolio.find_position_for_trade(trade, pending=True)
         position_quantity = position.get_quantity() if position else None
+        close_epsilon = position.get_close_epsilon() if position else None
         closes_position_quantity = (
             isinstance(position_quantity, Decimal)
-            and abs(position_quantity + trade.planned_quantity) <= get_close_epsilon_for_pair(trade.pair)
+            and position is not None
+            and isinstance(close_epsilon, Decimal)
+            and abs(position_quantity + trade.planned_quantity) <= close_epsilon
         )
 
         planned_price = Decimal(str(trade.planned_price))
@@ -3736,6 +3739,68 @@ class HypercoreVaultRouting(RoutingModel):
             (trade.closing or TradeFlag.close in trade.flags or closes_position_quantity)
             and not close_materially_short
         )
+
+        is_closing_trade = (
+            trade.closing
+            or TradeFlag.close in trade.flags
+            or closes_position_quantity
+        )
+        if (
+            is_closing_trade
+            and position is not None
+            and remaining_equity_after_withdrawal is not None
+            and not trade.other_data.get("hypercore_small_position_cleanup")
+        ):
+            if close_materially_short or remaining_equity_after_withdrawal > HYPERCORE_ACCEPTED_RESIDUAL_USD:
+                position.other_data["hypercore_close_residual_status"] = HYPERCORE_CLOSE_RESIDUAL_STATUS_PENDING_RETRY
+                position.other_data["hypercore_close_residual_value_usd"] = str(
+                    remaining_equity_after_withdrawal
+                )
+                position.other_data["hypercore_close_residual_observed_at"] = ts.isoformat()
+                position.other_data.setdefault(
+                    "hypercore_close_residual_first_seen_at",
+                    ts.isoformat(),
+                )
+                retry_count = position.other_data.get("hypercore_close_residual_retry_count", 0)
+                if not isinstance(retry_count, int):
+                    retry_count = 0
+                retry_count += 1
+                position.other_data["hypercore_close_residual_retry_count"] = retry_count
+                position.other_data.pop(
+                    HYPERCORE_SMALL_POSITION_CLEANUP_PENDING_REDEEM,
+                    None,
+                )
+                should_close_full_quantity = False
+                if retry_count >= 3:
+                    logger.error(
+                        "HyperCore close remains incomplete after %d attempts: "
+                        "position %d has %s USD remaining",
+                        retry_count,
+                        position.position_id,
+                        remaining_equity_after_withdrawal,
+                    )
+            else:
+                position.other_data["hypercore_close_residual_status"] = HYPERCORE_CLOSE_RESIDUAL_STATUS_ACCEPTED
+                position.other_data["hypercore_close_residual_value_usd"] = str(
+                    remaining_equity_after_withdrawal
+                )
+                position.other_data["hypercore_close_residual_observed_at"] = ts.isoformat()
+                position.other_data["hypercore_accepted_residual_writeoff_usd"] = str(
+                    remaining_equity_after_withdrawal
+                )
+                position.other_data["hypercore_accepted_residual_writeoff_at"] = ts.isoformat()
+                position.other_data["hypercore_accepted_residual_writeoff_reason"] = (
+                    "verified_hypercore_close"
+                )
+                position.other_data.pop(
+                    HYPERCORE_SMALL_POSITION_CLEANUP_PENDING_REDEEM,
+                    None,
+                )
+                # The normal shortfall guard above has already succeeded.
+                should_close_full_quantity = True
+                trade.other_data["hypercore_accepted_residual_writeoff_usd"] = str(
+                    remaining_equity_after_withdrawal
+                )
 
         if trade.other_data.get("hypercore_small_position_cleanup") and position is not None:
             retain_cleanup_residual = (
@@ -3794,7 +3859,7 @@ class HypercoreVaultRouting(RoutingModel):
                 trade.bridge_fee_usd = float(trade.bridge_fee_amount * Decimal(str(hype_usd_price)))
 
             if (
-                should_close_full_quantity
+                is_closing_trade
                 and vault_equity_before_phase1_snapshot is not None
                 and remaining_equity is not None
             ):
@@ -3820,7 +3885,7 @@ class HypercoreVaultRouting(RoutingModel):
                 and hype_usd_price is not None
                 and trade.bridge_fee_usd is not None
                 and (
-                    not should_close_full_quantity
+                    not is_closing_trade
                     or trade.hypercore_close_other_loss_usd is not None
                 )
             )

--- a/tradeexecutor/state/portfolio.py
+++ b/tradeexecutor/state/portfolio.py
@@ -42,8 +42,8 @@ logger = logging.getLogger(__name__)
 #: any real position, so a mis-scaled threshold cannot quietly delete one.
 #:
 #: The binding constraint is
-#: :py:data:`tradeexecutor.strategy.dust.HYPERLIQUID_VAULT_CLOSE_EPSILON_MAX_USD` (50 USD),
-#: the most a Hypercore residual can be worth and still count as dust. 100 USD leaves a
+#: :py:data:`tradeexecutor.strategy.dust.HYPERCORE_ACCEPTED_RESIDUAL_USD` (5 USD),
+#: the most a *verified* Hypercore residual can be worth and still count as dust. 100 USD leaves a
 #: clear margin above it while still catching the failure this guard exists for: a 8,963 USD
 #: position closed as "dust" because a USD threshold was compared against a share count.
 CLOSE_POSITION_VALUE_DESTRUCTION_LIMIT_USD = 100.0

--- a/tradeexecutor/state/position.py
+++ b/tradeexecutor/state/position.py
@@ -29,6 +29,9 @@ from tradeexecutor.state.trigger import Trigger
 from tradeexecutor.state.types import USDollarAmount, BPS, USDollarPrice, Percent, LeverageMultiplier, LegacyDataException
 from tradeexecutor.state.valuation import ValuationUpdate
 from tradeexecutor.strategy.dust import (
+    HYPERCORE_ACCEPTED_RESIDUAL_USD,
+    HYPERCORE_CLOSE_RESIDUAL_STATUS_ACCEPTED,
+    HYPERLIQUID_VAULT_CLOSE_EPSILON,
     HYPERCORE_SMALL_POSITION_CLEANUP_PENDING_REDEEM,
     convert_usd_close_epsilon_to_quantity,
     get_close_epsilon_for_pair,
@@ -316,13 +319,8 @@ class TradingPosition(GenericPosition):
     #: Misc bag of data, not often needed
     other_data: PositionOtherData = field(default_factory=dict)
 
-    #: Strategy-specific dust threshold for a Hypercore vault position.
-    #:
-    #: Stored on the position so state-level settlement can use the same
-    #: threshold without access to the active strategy module.
-    #:
-    #: TODO: Migrate account correction and close-planning paths that still use
-    #: pair-only thresholds to this persisted value.
+    #: Deprecated Hypercore vault close threshold retained for state
+    #: deserialisation compatibility. Hypercore uses fixed policy constants.
     hyperliquid_vault_close_epsilon: Decimal | None = None
 
     #: Position was produced by a fork-only vault-test-trade simulation.
@@ -461,16 +459,27 @@ class TradingPosition(GenericPosition):
         Always returned in **base token units**, because every caller compares it against
         :py:meth:`get_quantity`.
 
-        The Hypercore vault threshold is configured in US dollars. It covers small residuals
-        while remaining capped independently of the relative withdrawal safety margin, so it
-        is converted to share units at the position's mark price. Without that conversion the
-        threshold is silently multiplied by the share price, and any position smaller than
-        that is closed as dust the moment it opens - destroying the shares, because
+        A verified HyperCore close residual uses the fixed five USD accounting
+        boundary. All other HyperCore positions use the two USD transaction
+        dust threshold. Either value is converted to share units at the
+        position's mark price.
+        Without that conversion the threshold is silently multiplied by the share
+        price, and any position smaller than that is closed as dust the moment it
+        opens - destroying the shares, because
         :py:meth:`tradeexecutor.state.portfolio.Portfolio.close_position` is bookkeeping only.
         """
+        is_accepted_hypercore_residual = (
+            self.pair.is_hyperliquid_vault()
+            and self.other_data.get("hypercore_close_residual_status") == HYPERCORE_CLOSE_RESIDUAL_STATUS_ACCEPTED
+        )
+        hyperliquid_epsilon = (
+            HYPERCORE_ACCEPTED_RESIDUAL_USD
+            if is_accepted_hypercore_residual
+            else HYPERLIQUID_VAULT_CLOSE_EPSILON
+        )
         epsilon = get_close_epsilon_for_pair(
             self.pair,
-            hyperliquid_vault_close_epsilon=self.hyperliquid_vault_close_epsilon,
+            hyperliquid_vault_close_epsilon=hyperliquid_epsilon,
         )
 
         if self.pair.is_hyperliquid_vault():

--- a/tradeexecutor/state/repair.py
+++ b/tradeexecutor/state/repair.py
@@ -592,10 +592,19 @@ def close_hypercore_dust_positions(
             portfolio.open_positions[position.position_id] = position
             position.unfrozen_at = now
 
+        residual_value = position.get_value(include_interest=False)
+        position.other_data["hypercore_accepted_residual_writeoff_usd"] = str(
+            residual_value
+        )
+        position.other_data["hypercore_accepted_residual_writeoff_at"] = now.isoformat()
+        position.other_data["hypercore_accepted_residual_writeoff_reason"] = (
+            "local_hypercore_dust_cleanup"
+        )
         trade = close_position_with_empty_trade(portfolio, position)
         position.add_notes_message(
-            "Auto-closed Hypercore dust position after the safety-margin "
-            f"redemption left a final residual balance ({now.isoformat()})"
+            "Auto-closed locally marked Hypercore dust position after the safety-margin "
+            f"redemption left a {residual_value:.6f} USD residual "
+            f"({now.isoformat()})"
         )
         logger.info(
             "Auto-closed Hypercore dust position %s with repair trade %s",

--- a/tradeexecutor/strategy/account_correction.py
+++ b/tradeexecutor/strategy/account_correction.py
@@ -33,7 +33,7 @@ from tradeexecutor.state.generic_position import GenericPosition
 from tradeexecutor.state.portfolio import Portfolio
 from tradeexecutor.state.repair import close_position_with_empty_trade
 from tradeexecutor.state.trade import TradeFlag, TradeExecution, TradeStatus, TradeType
-from tradeexecutor.strategy.dust import DEFAULT_DUST_EPSILON, get_close_epsilon_for_pair, get_dust_epsilon_for_asset, DEFAULT_RELATIVE_EPSILON, \
+from tradeexecutor.strategy.dust import DEFAULT_DUST_EPSILON, HYPERCORE_ACCEPTED_RESIDUAL_USD, get_close_epsilon_for_pair, get_dust_epsilon_for_asset, DEFAULT_RELATIVE_EPSILON, \
     get_relative_epsilon_for_asset, get_relative_epsilon_for_pair, DEFAULT_USD_LOW_VALUE_THRESHOLD
 from tradeexecutor.strategy.lending_protocol_leverage import reset_credit_supply_loan
 from tradeexecutor.strategy.pandas_trader.position_manager import PositionManager
@@ -1181,10 +1181,9 @@ def create_missing_vault_positions(
         # leftover spot dust is ignored once a position has been closed.
         #
         # Hypercore vault withdrawals cannot safely request exact live equity.
-        # Normal full closes leave max(0.5% of live equity, 1.50 USDC) on-chain
-        # because NAV can move before HyperCore processes the queued action.
-        # Verified settlement records that residual and closes the original
-        # state position independently of this reconciliation threshold.
+        # A verified full close may leave up to five USD on-chain because NAV
+        # can move before HyperCore processes the queued action. This is the
+        # same global accounting boundary used by state settlement.
         #
         # We must NOT manufacture a closed "dust" position for the residual
         # here. This function runs on every correct-accounts cycle and the
@@ -1193,13 +1192,10 @@ def create_missing_vault_positions(
         # the hyper-ai closed-positions list with hundreds of zero-quantity
         # positions. Other trading pairs simply leave such sub-dust balances
         # written off; do the same for Hypercore vaults and just skip it.
-        # A percentage-derived residual above the default 2 USDC threshold is
-        # deliberately recreated as a tracked position below, allowing the
-        # specialised small-position cleanup path to recover it instead of
-        # silently discarding economically meaningful vault shares.
-        # Use <= so the threshold matches can_be_closed(), which treats a
-        # residual of exactly the close epsilon as closeable dust.
-        dust_epsilon = get_close_epsilon_for_pair(pair)
+        # We intentionally also ignore external deposits at or below this
+        # operational minimum: tracking them creates positions that cannot be
+        # distinguished safely from a retained close residual.
+        dust_epsilon = HYPERCORE_ACCEPTED_RESIDUAL_USD
         if equity <= float(dust_epsilon):
             logger.info(
                 "Vault equity $%.4f for %s is at or below dust epsilon %.2f, ignoring as written-off dust",

--- a/tradeexecutor/strategy/alpha_model.py
+++ b/tradeexecutor/strategy/alpha_model.py
@@ -21,7 +21,10 @@ from tradeexecutor.state.size_risk import SizeRisk
 from tradeexecutor.state.trade import TradeExecution, TradeType
 from tradeexecutor.state.types import (LeverageMultiplier, PairInternalId,
                                        Percent, USDollarAmount)
-from tradeexecutor.strategy.dust import get_close_epsilon_for_pair
+from tradeexecutor.strategy.dust import (
+    convert_usd_close_epsilon_to_quantity,
+    get_close_epsilon_for_pair,
+)
 from tradeexecutor.strategy.execution_context import ExecutionContext
 from tradeexecutor.strategy.pandas_trader.position_manager import \
     HypercorePositionReductionPlan, PositionManager
@@ -125,6 +128,18 @@ class TradingPairSignalFlags(enum.Enum):
     #: This buy re-emitted previously parked capital into a vault whose deposit
     #: window has now opened (PhaseAwareAlphaModel promote step).
     promoted_from_queue_vault = "promoted_from_queue_vault"
+
+    #: A full-close intent executed despite falling below the normal sell
+    #: softband. Its proceeds are not used to fund same-cycle buys.
+    full_close_softband_bypassed = "full_close_softband_bypassed"
+
+
+class SellExecutionClassification(enum.Enum):
+    """Whether a sell executes and may fund same-cycle reserve spending."""
+
+    skipped = "skipped"
+    executes_and_funds = "executes_and_funds"
+    executes_without_same_cycle_funding = "executes_without_same_cycle_funding"
 
 
 @dataclass_json
@@ -1077,6 +1092,105 @@ class AlphaModel:
             )
         return settlement_position
 
+    def _is_full_close_intent(self, signal: TradingPairSignal) -> bool:
+        """Does this signal intend to close an existing position completely?
+
+        A close target can be a small non-zero weight because the concrete trade
+        generator already treats every target below
+        ``close_position_weight_epsilon`` as a full close.
+        """
+        return (
+            signal.position_adjust_usd < 0
+            and (signal.old_value or 0) > 0
+            and signal.normalised_weight < self.close_position_weight_epsilon
+        )
+
+    def _get_sell_quantity_dust_epsilon(
+        self,
+        signal: TradingPairSignal,
+        current_position: TradingPosition | None = None,
+    ) -> Decimal:
+        """Get the sell dust threshold in the same units as signal quantity."""
+        pair = signal.synthetic_pair or signal.pair
+        epsilon = get_close_epsilon_for_pair(pair)
+        if not pair.is_hyperliquid_vault():
+            return epsilon
+
+        price = None
+        if current_position is not None:
+            price = current_position.get_current_price()
+        elif signal.position_adjust_quantity:
+            price = abs(signal.position_adjust_usd / signal.position_adjust_quantity)
+
+        return convert_usd_close_epsilon_to_quantity(epsilon, price)
+
+    def _classify_sell_execution(
+        self,
+        signal: TradingPairSignal,
+        position_manager: PositionManager,
+        current_positions: dict,
+        redemption_results: dict,
+        frozen_pairs: set,
+        individual_rebalance_min_threshold: USDollarAmount,
+        sell_rebalance_min_threshold: USDollarAmount | None,
+    ) -> SellExecutionClassification:
+        """Classify a sell once for both generation and cash funding.
+
+        Softband-bypassed full closes execute, but their marked value is not
+        spendable funding for same-cycle buys because HyperCore deliberately
+        retains withdrawal safety margin and live equity can move.
+        """
+        if signal.position_adjust_usd >= 0:
+            return SellExecutionClassification.skipped
+
+        if position_manager.is_problematic_pair(signal.pair):
+            return SellExecutionClassification.skipped
+
+        if signal.pair in frozen_pairs:
+            return SellExecutionClassification.skipped
+
+        softband_bypassed = False
+        if individual_rebalance_min_threshold:
+            threshold = sell_rebalance_min_threshold or individual_rebalance_min_threshold
+            if abs(signal.position_adjust_usd) < threshold:
+                if not self._is_full_close_intent(signal):
+                    return SellExecutionClassification.skipped
+                softband_bypassed = True
+
+        current_position = current_positions.get(signal.pair.internal_id)
+        if signal.leverage is None:
+            trade_quantity = abs(Decimal(str(signal.position_adjust_quantity)))
+            dust_epsilon = self._get_sell_quantity_dust_epsilon(
+                signal,
+                current_position,
+            )
+            if trade_quantity <= dust_epsilon:
+                return SellExecutionClassification.skipped
+
+        settlement_position = self._resolve_pending_settlement_position(
+            signal,
+            position_manager,
+            current_positions,
+        )
+        if settlement_position is not None and settlement_position.has_pending_vault_settlement():
+            return SellExecutionClassification.skipped
+
+        if current_position is not None:
+            redemption_result = redemption_results.get(signal.pair.internal_id)
+            if redemption_result is None:
+                redemption_result = self._check_redemption_for_position(
+                    position_manager,
+                    current_position,
+                    stage=RedemptionCheckStage.sell_rebalance,
+                )
+                redemption_results[signal.pair.internal_id] = redemption_result
+            if not redemption_result.can_redeem:
+                return SellExecutionClassification.skipped
+
+        if softband_bypassed:
+            return SellExecutionClassification.executes_without_same_cycle_funding
+        return SellExecutionClassification.executes_and_funds
+
     def _will_sell_execute(
         self,
         signal: TradingPairSignal,
@@ -1087,67 +1201,17 @@ class AlphaModel:
         individual_rebalance_min_threshold: USDollarAmount,
         sell_rebalance_min_threshold: USDollarAmount | None,
     ) -> bool:
-        """Will this sell signal actually emit a trade and free cash this cycle?
-
-        Read-only mirror of the sell-side drop reasons applied later in
-        :py:meth:`generate_rebalance_trades_and_triggers` /
-        :py:meth:`_generate_signal_rebalance_trades`, in the same order and with the
-        same semantics, so :py:meth:`_cap_buys_by_realisable_sync_cash` and the
-        generation loop cannot disagree about which sells fund this cycle's buys:
-
-        - problematic / blacklisted pair (:py:meth:`_should_skip_signal_rebalance`)
-        - frozen position pair (ditto)
-        - sell size below the sell threshold (ditto — note the loop only *flags*
-          such a sell and leaves ``position_adjust_usd`` untouched, which is
-          exactly why the cash cap must not trust raw adjusts)
-        - sell quantity below the pair dust epsilon (ditto)
-        - pending async vault settlement on the position
-          (:py:meth:`_generate_signal_rebalance_trades`)
-        - position not redeemable yet (ditto)
-
-        A redemption check computed here is stored into ``redemption_results`` so
-        the generation loop reuses it — each pair is checked at most once.
-
-        Mutates nothing on the signal.
-        """
-        if position_manager.is_problematic_pair(signal.pair):
-            return False
-
-        if signal.pair in frozen_pairs:
-            return False
-
-        # Same gate semantics as _should_skip_signal_rebalance: a falsy
-        # individual threshold disables sell-size suppression entirely.
-        if individual_rebalance_min_threshold:
-            threshold = sell_rebalance_min_threshold or individual_rebalance_min_threshold
-            if abs(signal.position_adjust_usd) < threshold:
-                return False
-
-        if signal.leverage is None:
-            trade_quantity = abs(Decimal(str(signal.position_adjust_quantity)))
-            dust_epsilon = get_close_epsilon_for_pair(signal.synthetic_pair or signal.pair)
-            if trade_quantity <= dust_epsilon:
-                return False
-
-        settlement_position = self._resolve_pending_settlement_position(signal, position_manager, current_positions)
-        if settlement_position is not None and settlement_position.has_pending_vault_settlement():
-            return False
-
-        current_position = current_positions.get(signal.pair.internal_id)
-        if current_position is not None:
-            redemption_result = redemption_results.get(signal.pair.internal_id)
-            if redemption_result is None:
-                redemption_result = self._check_redemption_for_position(
-                    position_manager,
-                    current_position,
-                    stage=RedemptionCheckStage.sell_rebalance,
-                )
-                # Share with the generation loop so the check runs once per pair.
-                redemption_results[signal.pair.internal_id] = redemption_result
-            if not redemption_result.can_redeem:
-                return False
-
-        return True
+        """Return whether the shared read-only sell classification executes."""
+        classification = self._classify_sell_execution(
+            signal,
+            position_manager,
+            current_positions,
+            redemption_results,
+            frozen_pairs,
+            individual_rebalance_min_threshold,
+            sell_rebalance_min_threshold,
+        )
+        return classification is not SellExecutionClassification.skipped
 
     def _is_executable_cash_spending_buy(
         self,
@@ -1157,25 +1221,7 @@ class AlphaModel:
         frozen_pairs: set,
         individual_rebalance_min_threshold: USDollarAmount,
     ) -> bool:
-        """Will this buy signal actually emit a reserve-spending spot/vault trade this cycle?
-
-        Used by :py:meth:`_cap_buys_by_realisable_sync_cash` both to build the buy
-        demand (denominator) and to select which buys get scaled. A buy that the
-        generation loop will drop anyway (problematic/frozen pair, deposit window
-        closed, below the buy threshold, pending settlement) must not inflate the
-        demand, or the surviving real buys would be scaled down more than needed.
-
-        Cash-spending means unleveraged, non-flip, spot *or* vault: a Hyperliquid
-        vault pair is ``kind=vault`` and NOT ``is_spot()``
-        (see :py:meth:`tradeexecutor.state.identifier.TradingPairKind.is_spot`),
-        so both kinds must be included or vault deposits — the very trades that
-        overshoot in the Hyper AI strategies — would be exempt from the cap.
-        Leveraged, short and flip signals size from ``position_target`` in their
-        own generation branches and their cash flow is not reserve-linear, so the
-        cap never touches them.
-
-        Mutates nothing on the signal.
-        """
+        """Return whether a buy is an executable reserve-spending spot/vault trade."""
         if signal.position_adjust_usd <= 0:
             return False
 
@@ -1219,63 +1265,11 @@ class AlphaModel:
         sell_rebalance_min_threshold: USDollarAmount | None,
         sync_cash_headroom_usd: USDollarAmount,
     ) -> None:
-        """Scale spot/vault buys down to the synchronous cash that actually arrives this cycle.
+        """Scale buys to cash plus sells that execute and release cash this cycle.
 
-        Opt-in via ``generate_rebalance_trades_and_triggers(cap_buys_to_sync_cash=True)``;
-        with the default opt-out this method never runs and the generator behaves
-        byte-for-byte as before.
-
-        Rebalance buys are financed by the same cycle's sells executing first
-        (sells sort ahead of buys in
-        :py:meth:`tradeexecutor.state.trade.TradeExecution.get_execution_sort_position`).
-        But the per-signal generation loop drops some sells *after* buy sizing has
-        already assumed their proceeds — most importantly sub-threshold trims,
-        which are only flagged (``individual_trade_size_too_small``) and never
-        zeroed — so the buys can overspend the reserve and crash the backtest
-        wallet (``OutOfSimulatedBalance``) or, live, bounce a vault deposit.
-
-        Worked example — the exact cycle this cap was written for (hyper-ai.py,
-        cycle #19, 2025-08-20, sell threshold $5.00, headroom $0.50). Nine
-        ~equal-weight Hyperliquid vault positions want trims of −13.69, −8.61,
-        −4.99, −4.97, −4.39, −4.39, −3.81, −1.13 USD and one underweight buy of
-        +46.72 USD (Scared Money). Only the first two trims clear the $5 sell
-        threshold; the other six ($23.68 total) are dropped by the loop and free
-        no cash, yet the old cash math counted them::
-
-            cash                    = 21.80
-            realisable sync sells   = 13.69 + 8.61 = 22.30
-            budget                  = 21.80 + 22.30 - 0.50 = 43.60
-            buy demand              = 46.72  > budget   (would overshoot by 2.62 + headroom)
-            scale                   = 43.60 / 46.72 = 0.9332
-            scaled buy              = 43.60
-            reserve after cycle     = 0.50  (the headroom — safe)
-
-        Classification is **read-only**: nothing is mutated except the
-        ``position_adjust_usd`` of the buys that get scaled (plus their
-        :py:attr:`TradingPairSignalFlags.capped_by_sync_cash` flag). Signals the
-        loop will drop are excluded from the budget via the same predicates the
-        loop itself uses (:py:meth:`_will_sell_execute`,
-        :py:meth:`_is_executable_cash_spending_buy`), so the cap and the loop
-        cannot disagree; diagnostics of unscaled signals are untouched.
-
-        Composition with :py:meth:`_cap_buys_by_async_sell_proceeds` (which runs
-        first, unchanged): this cap re-derives its budget from the post-async
-        adjusts and re-scales, so the final buys always fit ``cash + executing
-        sync sells − headroom`` regardless of what the async cap did. (When
-        ``sync_cash_headroom_usd >= same_cycle_cash_buffer_usd`` — the hyper-ai
-        case, 0.50 vs 0.0 — this budget is also numerically ≤ the async budget,
-        so the sync cap is simply the tighter of the two.) Async-cycle behaviour
-        is otherwise unaffected.
-
-        The withheld capital stays in reserve and is redeployed by a later
-        rebalance once a trim grows past the sell threshold. If scaling pushes a
-        buy below the buy threshold the loop drops it entirely: the full scaled
-        amount stays in cash — under-invested for a cycle, never overspent.
-
-        :param sync_cash_headroom_usd:
-            Margin subtracted from the buy budget because sell proceeds here are
-            mark-to-market while execution realises slightly less (fees, price
-            impact, raw-unit rounding).
+        This optional guard is deliberately read-only for excluded signals. A
+        softband-bypassed full close can execute, but its marked proceeds do not
+        fund a buy until settlement confirms the returned USDC.
         """
         sync_sell_usd = 0.0
         executable_buys = []
@@ -1297,7 +1291,7 @@ class AlphaModel:
                 # (a live RPC) on a sell we are about to exclude anyway.
                 if position_manager.is_async_vault_sell_pair(s.pair, position_pair=pair):
                     continue
-                if not self._will_sell_execute(
+                classification = self._classify_sell_execution(
                     s,
                     position_manager,
                     current_positions,
@@ -1305,7 +1299,8 @@ class AlphaModel:
                     frozen_pairs,
                     individual_rebalance_min_threshold,
                     sell_rebalance_min_threshold,
-                ):
+                )
+                if classification is not SellExecutionClassification.executes_and_funds:
                     continue
                 sync_sell_usd += -adjust
             elif adjust > 0:
@@ -2256,6 +2251,7 @@ class AlphaModel:
         frozen_pairs: set,
         individual_rebalance_min_threshold: USDollarAmount,
         sell_rebalance_min_threshold: USDollarAmount | None,
+        current_position: TradingPosition | None = None,
     ) -> bool:
         """Handle early skip conditions before any rebalance trades are built."""
         if position_manager.is_problematic_pair(signal.pair):
@@ -2279,6 +2275,7 @@ class AlphaModel:
             if not deposit_check.can_deposit:
                 return self._on_deposit_window_closed(signal, position_manager, deposit_check)
 
+        softband_bypassed = False
         if individual_rebalance_min_threshold:
             trade_size = abs(signal.position_adjust_usd)
             if signal.position_adjust_usd < 0:
@@ -2287,13 +2284,18 @@ class AlphaModel:
                 threshold = individual_rebalance_min_threshold
 
             if trade_size < threshold:
-                logger.info("Individual trade size too small, trade size is %s, our threshold %s", trade_size, individual_rebalance_min_threshold)
-                signal.flags.add(TradingPairSignalFlags.individual_trade_size_too_small)
-                return True
+                if not self._is_full_close_intent(signal):
+                    logger.info("Individual trade size too small, trade size is %s, our threshold %s", trade_size, individual_rebalance_min_threshold)
+                    signal.flags.add(TradingPairSignalFlags.individual_trade_size_too_small)
+                    return True
+                softband_bypassed = True
 
         if signal.leverage is None and signal.position_adjust_usd < 0:
             trade_quantity = abs(Decimal(str(signal.position_adjust_quantity)))
-            dust_epsilon = get_close_epsilon_for_pair(signal.synthetic_pair or signal.pair)
+            dust_epsilon = self._get_sell_quantity_dust_epsilon(
+                signal,
+                current_position,
+            )
             if trade_quantity <= dust_epsilon:
                 logger.info(
                     "Individual trade quantity too small, trade quantity is %s, dust epsilon is %s",
@@ -2302,6 +2304,10 @@ class AlphaModel:
                 )
                 signal.flags.add(TradingPairSignalFlags.individual_trade_quantity_too_small)
                 return True
+
+        if softband_bypassed:
+            signal.flags.add(TradingPairSignalFlags.full_close_softband_bypassed)
+            signal.other_data["full_close_softband_bypassed"] = True
 
         return False
 
@@ -2695,16 +2701,42 @@ class AlphaModel:
         max_diff = max((abs(s.position_adjust_usd) for s in self.iterate_signals()), default=0)
         self.max_position_adjust_usd = max_diff
         self.position_adjust_threshold_usd = min_trade_threshold
+        full_close_only = False
         if max_diff < min_trade_threshold:
-            logger.info(
-                "Total adjust difference is %f USD, our threshold is %f USD, ignoring all the trades",
-                max_diff,
-                min_trade_threshold,
-            )
-            for s in self.iterate_signals():
-                s.position_adjust_ignored = True
-                s.flags.add(TradingPairSignalFlags.max_adjust_too_small)
-            return []
+            full_close_signals = [
+                s for s in self.iterate_signals()
+                if self._is_full_close_intent(s)
+            ]
+            if full_close_signals:
+                full_close_only = True
+                logger.info(
+                    "Portfolio rebalance is below %f USD, but generating %d full close intent(s)",
+                    min_trade_threshold,
+                    len(full_close_signals),
+                )
+            else:
+                logger.info(
+                    "Total adjust difference is %f USD, our threshold is %f USD, ignoring all the trades",
+                    max_diff,
+                    min_trade_threshold,
+                )
+                for s in self.iterate_signals():
+                    s.position_adjust_ignored = True
+                    s.flags.add(TradingPairSignalFlags.max_adjust_too_small)
+                return []
+
+        if full_close_only:
+            for signal in self.iterate_signals():
+                if self._is_full_close_intent(signal):
+                    continue
+                signal.position_adjust_ignored = True
+                # The portfolio-wide threshold normally suppresses the entire
+                # cycle. When preserving a full close as its sole exception,
+                # clear every other adjustment: later cash-cap and
+                # trade-generation passes iterate all signals.
+                signal.position_adjust_usd = 0.0
+                signal.position_adjust_quantity = 0.0
+                signal.flags.add(TradingPairSignalFlags.max_adjust_too_small)
 
         frozen_pairs = {p.pair for p in position_manager.state.portfolio.frozen_positions.values()}
 
@@ -2776,6 +2808,7 @@ class AlphaModel:
                 frozen_pairs,
                 individual_rebalance_min_threshold,
                 sell_rebalance_min_threshold,
+                current_position=current_position,
             ):
                 continue
 

--- a/tradeexecutor/strategy/dust.py
+++ b/tradeexecutor/strategy/dust.py
@@ -5,7 +5,6 @@ a lot of trades may end up having rounding artifacts.
 We need to deal with these rounding artifacts by checking for "dust".
 
 """
-from collections.abc import Iterable
 from decimal import Decimal, ROUND_CEILING
 
 from tradeexecutor.state.identifier import TradingPairIdentifier, AssetIdentifier
@@ -65,6 +64,16 @@ DEFAULT_VAULT_EPSILON = Decimal(10 ** -6)
 #:     threshold 25.56 USD instead of 2.00 USD.
 HYPERLIQUID_VAULT_CLOSE_EPSILON = Decimal("2.00")
 
+#: Maximum verified HyperCore equity we deliberately leave on-chain after a
+#: withdrawal close. This is larger than the transaction dust threshold above:
+#: positions in the interval are locally closed only after routing records a
+#: verified accepted residual.
+HYPERCORE_ACCEPTED_RESIDUAL_USD = Decimal("5.00")
+
+#: Persisted status values for a HyperCore close residual observation.
+HYPERCORE_CLOSE_RESIDUAL_STATUS_PENDING_RETRY = "pending_retry"
+HYPERCORE_CLOSE_RESIDUAL_STATUS_ACCEPTED = "accepted"
+
 #: A HyperCore small-position cleanup residual above this amount can still
 #: produce verifiable movement through every withdrawal phase.
 HYPERCORE_SMALL_POSITION_CLEANUP_CLOSE_EPSILON = Decimal("0.30")
@@ -75,22 +84,7 @@ HYPERCORE_SMALL_POSITION_CLEANUP_PENDING_REDEEM = (
     "hypercore_small_position_cleanup_pending_redeem"
 )
 
-HYPERLIQUID_VAULT_CLOSE_EPSILON_CAPITAL_PCT = Decimal("0.005")
-
-#: Absolute ceiling, in US dollars, for the capital-scaled Hypercore close epsilon.
-#:
-#: This threshold was originally scaled with ``initial_cash`` to cover withdrawal
-#: headroom, but without a ceiling a 150,000 USD strategy gets a 750 USD "dust"
-#: threshold, comfortably large enough to swallow a real position. Normal withdrawals
-#: now use a separate relative/floor margin; any residual above this close-epsilon cap
-#: must remain tracked for another redemption instead of being written off as dust.
-#:
-#: 50 USD covers the 31.94 USDC margin from the 2026-08-22 pmalt incident. It
-#: is not intended to cover every percentage-derived margin: full-close
-#: settlement records a verified larger residual while closing the state
-#: position, whereas writing off an arbitrary live position as dust would lose
-#: its shares from bookkeeping.
-HYPERLIQUID_VAULT_CLOSE_EPSILON_MAX_USD = Decimal("50.00")
+assert HYPERLIQUID_VAULT_CLOSE_EPSILON < HYPERCORE_ACCEPTED_RESIDUAL_USD
 
 #: Minimum NAV-drift headroom left when withdrawing from a HyperCore vault.
 HYPERCORE_WITHDRAWAL_SAFETY_MARGIN_FLOOR = Decimal("1.50")
@@ -203,28 +197,6 @@ def get_dust_epsilon_for_pair(pair: TradingPairIdentifier) -> Decimal:
     return get_dust_epsilon_for_asset(pair.base)
 
 
-def get_hyperliquid_vault_close_epsilon(initial_cash: float | None = None) -> Decimal:
-    """Get a Hypercore vault close epsilon, in **US dollars**, from a strategy's initial cash.
-
-    A strategy with initial cash uses 0.5% of that value, clamped between the default
-    safety-margin floor and :py:data:`HYPERLIQUID_VAULT_CLOSE_EPSILON_MAX_USD`. Strategies
-    without configured initial cash retain the default close epsilon.
-
-    ``initial_cash`` is a strategy-module input and can differ materially from live
-    strategy equity, so the clamp is what stops a large configured bankroll turning the
-    dust threshold into a real position size.
-
-    :return:
-        Dust threshold in US dollars. Convert with
-        :py:func:`convert_usd_close_epsilon_to_quantity` before comparing to a quantity.
-    """
-    if initial_cash is None or initial_cash <= 0:
-        return HYPERLIQUID_VAULT_CLOSE_EPSILON
-
-    scaled = Decimal(str(initial_cash)) * HYPERLIQUID_VAULT_CLOSE_EPSILON_CAPITAL_PCT
-    return min(max(scaled, HYPERLIQUID_VAULT_CLOSE_EPSILON), HYPERLIQUID_VAULT_CLOSE_EPSILON_MAX_USD)
-
-
 def convert_usd_close_epsilon_to_quantity(
     epsilon_usd: Decimal,
     price: USDollarPrice | None,
@@ -254,18 +226,6 @@ def convert_usd_close_epsilon_to_quantity(
     if not price or price <= 0:
         return DEFAULT_VAULT_EPSILON
     return epsilon_usd / Decimal(str(price))
-
-
-def configure_hyperliquid_vault_close_epsilon(
-    positions: Iterable,
-    initial_cash: float | None = None,
-) -> Decimal:
-    """Apply the strategy-specific close epsilon to Hypercore positions."""
-    epsilon = get_hyperliquid_vault_close_epsilon(initial_cash)
-    for position in positions:
-        if position.pair.is_hyperliquid_vault():
-            position.hyperliquid_vault_close_epsilon = epsilon
-    return epsilon
 
 
 def get_close_epsilon_for_pair(

--- a/tradeexecutor/strategy/pandas_trader/position_manager.py
+++ b/tradeexecutor/strategy/pandas_trader/position_manager.py
@@ -28,6 +28,7 @@ from tradeexecutor.state.state import State
 from tradeexecutor.state.trade import TradeType, TradeExecution, TradeFlag, TradeStatus
 from tradeexecutor.state.types import USDollarAmount, Percent, LeverageMultiplier, USDollarPrice
 from tradeexecutor.strategy.dust import (
+    convert_usd_close_epsilon_to_quantity,
     get_close_epsilon_for_pair,
     get_hypercore_withdrawal_safety_margin,
 )
@@ -1699,6 +1700,11 @@ class PositionManager:
 
         remaining_quantity = max(Decimal(0), available_quantity - effective_quantity)
         close_epsilon = get_close_epsilon_for_pair(position.pair)
+        if position.pair.is_hyperliquid_vault():
+            close_epsilon = convert_usd_close_epsilon_to_quantity(
+                close_epsilon,
+                float(current_price),
+            )
         treat_as_full_close = not redemption_cap_bound and remaining_quantity <= close_epsilon
 
         return HypercorePositionReductionPlan(

--- a/tradeexecutor/strategy/runner.py
+++ b/tradeexecutor/strategy/runner.py
@@ -28,7 +28,6 @@ from tradeexecutor.statistics.statistics_table import StatisticsTable
 from tradeexecutor.strategy.account_correction import check_accounts, UnexpectedAccountingCorrectionIssue
 from tradeexecutor.strategy.approval import ApprovalModel
 from tradeexecutor.strategy.cycle import CycleDuration
-from tradeexecutor.strategy.dust import configure_hyperliquid_vault_close_epsilon
 from tradeexecutor.strategy.execution_context import ExecutionContext, ExecutionMode
 from tradeexecutor.strategy.execution_model import ExecutionModel
 from tradeexecutor.strategy.generic.generic_pricing_model import GenericPricing
@@ -680,8 +679,6 @@ class StrategyRunner(abc.ABC):
         - Call after we have stored the execution state in the database
         """
 
-        self.configure_hyperliquid_vault_close_epsilon(state)
-
         # We cannot call account check right after the trades,
         # as meny low quality nodes might still report old token balances
         # from eth_call
@@ -700,16 +697,16 @@ class StrategyRunner(abc.ABC):
             else:
                 end_block = self.execution_model.get_safe_latest_block()
             logger.info("Post-trade accounts balance check for block %s, cycle %d", end_block, cycle)
+            self._revalue_open_hypercore_positions_before_post_trade_account_check(
+                universe,
+                state,
+            )
             closed_dust_trades = close_hypercore_dust_positions(state.portfolio)
             if closed_dust_trades:
                 logger.info(
                     "Auto-closed %d Hypercore dust position(s) before post-trade account checks",
                     len(closed_dust_trades),
                 )
-            self._revalue_open_hypercore_positions_before_post_trade_account_check(
-                universe,
-                state,
-            )
             self.check_accounts(
                 universe,
                 state,
@@ -717,23 +714,8 @@ class StrategyRunner(abc.ABC):
                 cycle=cycle,
             )
 
-    def configure_hyperliquid_vault_close_epsilon(self, state: State):
-        """Apply this strategy module's Hypercore dust threshold to its positions."""
-        initial_cash = self.parameters.get("initial_cash") if self.parameters else None
-        configure_hyperliquid_vault_close_epsilon(
-            state.portfolio.get_open_and_frozen_positions(),
-            initial_cash,
-        )
-
     def _has_open_hypercore_vault_positions(self, state: State) -> bool:
-        """Check if the portfolio currently has any live Hypercore vault positions.
-
-        Hypercore account checks cover both open and frozen positions, so the
-        post-trade revaluation guard must mirror that same scope. Otherwise a
-        portfolio that currently has only frozen Hypercore vault positions would
-        skip the refresh and still compare stale state marks against fresh live
-        API equity during account checks.
-        """
+        """Check whether account checks need a fresh HyperCore position mark."""
         return any(
             position.pair.is_hyperliquid_vault()
             for position in state.portfolio.get_open_and_frozen_positions()
@@ -744,42 +726,21 @@ class StrategyRunner(abc.ABC):
         universe: StrategyExecutionUniverse,
         state: State,
     ) -> None:
-        """Refresh Hypercore vault marks right before post-trade accounting checks.
+        """Refresh HyperCore marks immediately before the live post-trade check.
 
-        Hypercore account checks compare a fresh live Hyperliquid API equity
-        reading against the state-side marked value ``quantity * last_token_price``.
-        A long live cycle can execute sequential Hypercore trades for many minutes,
-        so the earlier cycle-start valuation can be stale enough to trip the
-        post-trade accounting guard even when settlement itself succeeded.
-
-        Only run this extra pass when we still have an open Hypercore vault
-        position. This keeps the normal non-Hypercore path untouched and avoids
-        an extra live valuation round on cycles that cannot benefit from it.
+        A sequential HyperCore batch can run long enough for a cycle-start mark
+        to differ materially from the fresh live equity used by account checks.
+        This hook is only called from the live post-execution path.
         """
-
         if not self._has_open_hypercore_vault_positions(state):
             return
-
-        hypercore_positions = [
-            position
-            for position in state.portfolio.get_open_and_frozen_positions()
-            if position.pair.is_hyperliquid_vault()
-        ]
-
-        if not hypercore_positions:
-            return
-
-        logger.info(
-            "Refreshing %d Hypercore vault position(s) immediately before post-trade account checks",
-            len(hypercore_positions),
-        )
 
         routing_setup = self.setup_routing_context(universe)
         valuation_model = routing_setup.valuation_model
         valuation_timestamp = native_datetime_utc_now()
-
-        for position in hypercore_positions:
-            valuation_model(valuation_timestamp, position)
+        for position in state.portfolio.get_open_and_frozen_positions():
+            if position.pair.is_hyperliquid_vault():
+                valuation_model(valuation_timestamp, position)
 
     def tick(
         self,
@@ -832,8 +793,6 @@ class StrategyRunner(abc.ABC):
         assert isinstance(universe, StrategyExecutionUniverse)
 
         assert isinstance(strategy_cycle_timestamp, datetime.datetime)
-
-        self.configure_hyperliquid_vault_close_epsilon(state)
 
         if cycle_duration not in (CycleDuration.cycle_unknown, CycleDuration.cycle_1s, None) and not allow_unaligned_strategy_cycle_timestamp:
             assert strategy_cycle_timestamp.second == 0, f"Cycle duration {cycle_duration}: Does not look like a cycle timestamp: {strategy_cycle_timestamp}, should be even minutes"
@@ -956,8 +915,6 @@ class StrategyRunner(abc.ABC):
                         trade_set.add(t)
 
                     # logger.info("decide_trades() returned %d trades", len(rebalance_trades))
-
-                self.configure_hyperliquid_vault_close_epsilon(state)
 
                 new_position_ids = set(state.portfolio.open_positions.keys())
                 if old_position_ids != new_position_ids and len(trade_set) == 0:


### PR DESCRIPTION
## Why

Small HyperCore full closes were suppressed by rebalance softbands, while successful withdrawals could leave residual on-chain equity that later appeared as phantom positions.

## Lessons learnt

A ledger-only close threshold must be expressed in vault-share units at every quantity comparison, and an accepted residual must be distinct from ordinary transaction dust.

## Summary

- Allow genuine full closes through portfolio and individual softbands without releasing assumed same-cycle cash under the opt-in sync cap.
- Record and retry verified residuals above $5; accept only verified residuals at or below $5.
- Simplify legacy capital-scaled threshold plumbing, update state/accounting safeguards, tests, and HyperCore/alpha-model documentation.