### PR TITLE
fix: close HyperCore residuals within one cycle

### DIFF
--- a/.claude/docs/alpha-model.md
+++ b/.claude/docs/alpha-model.md
@@ -182,6 +182,14 @@ against the portfolio and emits trades, applying gates in this order:
    redemptions → sells → bridge legs → buys → vault deposits → credit supply,
    so cash is always released before it is spent.
 
+A zero-target HyperCore signal remains a real full-position close even when
+its live redemption cap only supports a conservative first withdrawal. The
+signal keeps the capped amount for thresholds and same-cycle buy sizing, while
+the emitted trade carries the full position quantity, `TradeFlag.close`,
+`TradeFlag.reduce`, and `closing=True`. The conservative amount is persisted as
+`hypercore_first_stage_conservative_reserve_usd`; cash tripwire checks use it
+instead of assuming the full accounting quantity will settle immediately.
+
 Thresholds exist because tiny rebalances cost more in fees and execution risk
 than they earn: hyper-ai floors both at Hyperliquid's $5 hard minimum
 ([hyper-ai.py:178-220](../../strategies/hyper-ai.py#L178)).

--- a/.claude/docs/hypercore-vault.md
+++ b/.claude/docs/hypercore-vault.md
@@ -101,6 +101,7 @@ the contract between `setup_trades()` and `settle_trade()`:
 | `hypercore_first_stage_residual_usd` | after the first verified vault withdrawal | Fresh residual used to decide whether a second protected withdrawal is eligible. |
 | `hypercore_second_stage_status` / `_requested_raw` / `_requested_usd` / `_expected_residual_usd` / `_tx_hash` / `_residual_usd` / `_error` / `_failure_phase` | optional same-cycle residual withdrawal | Durable planning, broadcast, verification, failure, and final-residual diagnostics. |
 | `hypercore_total_requested_gross_usd` / `hypercore_total_observed_perp_increase_usd` | two-stage close settlement | Aggregate gross requests and verified net perp proceeds before the shared downstream sweep. |
+| `hypercore_accounting_reconciliation_required` | failed withdrawal after proceeds reached the Safe | Prevents generic repair from assuming no assets moved when final quantity or residual verification is unavailable. |
 | `hypercore_accepted_residual_writeoff_usd` / `_at` / `_reason` | verified close or local dust cleanup | Audit record for equity intentionally removed from local tracking. |
 | `hypercore_close_residual_status` / `_value_usd` / `_observed_at` | verified full-close settlement | Whether the live residual was accepted or needs another close attempt. |
 | `hypercore_close_residual_first_seen_at` / `_retry_count` | residual above 5 USDC | Retry diagnostics; log an escalation after three verified incomplete closes. |

--- a/.claude/docs/hypercore-vault.md
+++ b/.claude/docs/hypercore-vault.md
@@ -96,6 +96,11 @@ the contract between `setup_trades()` and `settle_trade()`:
 | `hypercore_deposit_capital_at_risk` | during phase-1 preparation, persisted immediately before broadcast | Conservative checkpoint for USDC a node may already have accepted from the Safe. It blocks generic failed-buy refunds after a crash or indeterminate broadcast until live reconciliation. |
 | `hypercore_capped_deposit_raw` | deposit preflight | Deposit capped to actual Safe EVM USDC balance. |
 | `hypercore_capped_withdrawal_raw` | withdrawal preflight / retry | Withdrawal capped to live vault equity minus safety margin. |
+| `hypercore_first_stage_conservative_reserve_usd` / `hypercore_first_stage_conservative_raw` | alpha generation / withdrawal preflight | Maximum first-stage proceeds allowed to fund same-cycle buys when a full close is cap-bound. |
+| `hypercore_first_stage_requested_raw` | withdrawal preflight | Actual protected first-stage request after live and conservative caps. |
+| `hypercore_first_stage_residual_usd` | after the first verified vault withdrawal | Fresh residual used to decide whether a second protected withdrawal is eligible. |
+| `hypercore_second_stage_status` / `_requested_raw` / `_requested_usd` / `_expected_residual_usd` / `_tx_hash` / `_residual_usd` / `_error` / `_failure_phase` | optional same-cycle residual withdrawal | Durable planning, broadcast, verification, failure, and final-residual diagnostics. |
+| `hypercore_total_requested_gross_usd` / `hypercore_total_observed_perp_increase_usd` | two-stage close settlement | Aggregate gross requests and verified net perp proceeds before the shared downstream sweep. |
 | `hypercore_accepted_residual_writeoff_usd` / `_at` / `_reason` | verified close or local dust cleanup | Audit record for equity intentionally removed from local tracking. |
 | `hypercore_close_residual_status` / `_value_usd` / `_observed_at` | verified full-close settlement | Whether the live residual was accepted or needs another close attempt. |
 | `hypercore_close_residual_first_seen_at` / `_retry_count` | residual above 5 USDC | Retry diagnostics; log an escalation after three verified incomplete closes. |
@@ -326,12 +331,15 @@ its live Safe, escrow, spot, perp, and vault balances first.
 A withdrawal walks USDC back from the vault to the HyperEVM Safe through three
 HyperCore legs, each verified against a balance poll:
 
-1. **Phase 1**: `vaultTransfer(vault→perp)` — redeem to the perp account.
+1. **Phase 1**: `vaultTransfer(vault→perp)` — redeem the protected first amount.
 2. **Perp wait**: poll `clearinghouseState` until withdrawable USDC appears
    (`_wait_for_perp_withdrawable_balance`).
-3. **Phase 2**: `transferUsdClass(perp→spot)`.
-4. **Spot wait**: poll `spotClearinghouseState` until free USDC appears.
-5. **Phase 3**: `sendAsset(spot→HyperEVM)` — bridge back; then verify the Safe's
+3. **Optional residual phase**: for `TradeFlag.close`, refresh vault equity and
+   capacity. If one more protected `vaultTransfer(vault→perp)` can leave at
+   most 5 USDC, checkpoint, broadcast, and verify it before continuing.
+4. **Phase 2**: `transferUsdClass(perp→spot)` for the combined observed perp increase.
+5. **Spot wait**: poll `spotClearinghouseState` until free USDC appears.
+6. **Phase 3**: `sendAsset(spot→HyperEVM)` — bridge back; then verify the Safe's
    EVM USDC balance increased (`_wait_for_usdc_arrival`).
 
 ```mermaid
@@ -348,6 +356,11 @@ sequenceDiagram
     EX->>R: settle_trade(sell)
     R->>HC: perp wait — withdrawable reached gross − fee tolerance?
     Note over R,HC: net arrival reduced by leader performance fee
+    opt flagged close has eligible residual above 5 USDC
+        R->>HC: refresh residual + max withdrawable
+        R->>Safe: checkpoint then vaultTransfer(residual vault→perp)
+        R->>HC: verify second perp increase + vault-equity decrease
+    end
     R->>Safe: phase 2 — transferUsdClass(perp→spot)
     R->>HC: spot wait — free USDC appeared?
     R->>Safe: phase 3 — sendAsset(spot→HyperEVM) (minus reserved headroom)
@@ -379,6 +392,20 @@ a redemption already visible as reduced vault equity. A fee-shaped shortfall is
 booked as **execution price slippage** (fewer USDC for the same quantity), not
 as fewer vault units sold.
 
+HyperCore's execution pricing model deliberately reports 1:1 USDC and does not
+represent the latest marked vault value. Full-close planning therefore uses
+the position's latest API-derived share price, while settlement derives the
+executed price from the USDC actually received.
+
+The optional residual withdrawal uses the same per-vault performance-fee
+tolerance and the same `max(0.5% × amount, 1.50 USDC)` NAV-drift margin as the
+first request. It is attempted only when fresh capacity can leave at most
+5 USDC; with a 0.5% margin, a residual above 1,000 USDC cannot reach that
+threshold in one more protected leg. A status-1 receipt without both the
+expected perp increase and a matching vault-equity decrease is ambiguous and
+halts sequential execution before shared perp USDC can be swept or attributed
+to another trade.
+
 ## Withdrawal settlement state machine
 
 ```mermaid
@@ -386,7 +413,12 @@ flowchart TD
     A[phase 1 vaultTransfer EVM tx] --> B{EVM receipt ok?}
     B -- no --> F[report_failure]
     B -- yes --> C[perp wait: gross − max-fee tolerance]
-    C -- reached --> P2[phase 2 transferUsdClass]
+    C -- reached --> RC{flagged close residual<br/>eligible above 5 USD?}
+    RC -- no --> P2[phase 2 transferUsdClass]
+    RC -- yes --> R2[checkpoint + second vaultTransfer]
+    R2 --> V2{perp increase + equity decrease verified?}
+    V2 -- yes --> P2
+    V2 -- no / ambiguous --> F
     C -- timeout --> D{equity decrease ≈ request<br/>within fee tolerance?}
     D -- yes --> P2
     D -- no --> E{fresh equity < request?<br/>silent no-op pattern}
@@ -625,8 +657,14 @@ after a full close; this is distinct from the 2 USDC transaction-dust rule and
 never widens the close threshold for a fresh position. `correct-accounts`
 ignores untracked HyperCore equity at or below 5 USDC, since it cannot safely
 distinguish a retained account-scoped residual from an external micro-deposit.
-Larger residuals remain tracked for another normal close attempt. These guards
-are intentionally independent: changing the margin cannot make incomplete
+Larger residuals first receive one eligible same-cycle protected withdrawal.
+If fresh capacity cannot reach 5 USDC, or the second transaction definitely
+reverts, they remain tracked for another normal close attempt. Ambiguous
+second-stage broadcasts fail closed before the shared perp balance is swept.
+An explicit full close also fails closed when its final uncached vault-equity
+read is unavailable; an EVM receipt or USDC arrival does not prove that the
+physical residual is within the accepted boundary.
+These guards are intentionally independent: changing the margin cannot make incomplete
 trade state safe to repair, and the state guard cannot prevent stale live
 withdrawal caps.
 

--- a/.claude/docs/hypercore-vault.md
+++ b/.claude/docs/hypercore-vault.md
@@ -404,7 +404,9 @@ first request. It is attempted only when fresh capacity can leave at most
 threshold in one more protected leg. A status-1 receipt without both the
 expected perp increase and a matching vault-equity decrease is ambiguous and
 halts sequential execution before shared perp USDC can be swept or attributed
-to another trade.
+to another trade. Its combined first- and second-leg exposure is recorded as
+`hypercore_perp_or_vault`: the first leg is verified in perp, while the second
+leg may still be either in the vault or in perp.
 
 ## Withdrawal settlement state machine
 

--- a/docs/plans/hypercore-full-close-residual-cleanup.md
+++ b/docs/plans/hypercore-full-close-residual-cleanup.md
@@ -2,7 +2,10 @@
 
 ## Status
 
-Implemented on 2026-08-24.
+Superseded on 2026-08-27 by
+`docs/plans/hypercore-same-cycle-two-stage-full-close.md` for ordinary strategy
+full closes. The next-cycle retry described here remains the fallback when a
+second protected withdrawal cannot safely reach 5 USD.
 
 ## Decision
 
@@ -33,8 +36,8 @@ trade safeguards.
 | Observation after a closing withdrawal | State action |
 | --- | --- |
 | Verified residual `<= 5 USD` | Close the ledger position, credit only received USDC, and record accepted-residual metadata. |
-| Verified residual `> 5 USD` | Book only proven redemption, keep the position open, and retry on the next normal alpha cycle. |
-| Residual unavailable | Preserve the normal successful-close result. The post-withdrawal equity read is diagnostic and must not turn a verified EVM withdrawal into a phantom open position. |
+| Verified residual `> 5 USD` | Attempt one eligible protected residual withdrawal before the shared downstream sweep; if it cannot safely reach 5 USD, book only proven redemption and retry on the next normal alpha cycle. |
+| Residual unavailable | An explicit full close fails closed for live reconciliation; do not infer that the physical residual is within the accepted boundary. |
 
 The 5 USD boundary applies only to a verified close residual in state
 settlement. Ordinary close planning and fresh positions retain the narrower

--- a/docs/plans/hypercore-same-cycle-two-stage-full-close.md
+++ b/docs/plans/hypercore-same-cycle-two-stage-full-close.md
@@ -1,0 +1,170 @@
+# HyperCore same-cycle two-stage full close
+
+## Status
+
+Implemented on 2026-08-27.
+
+This supersedes the next-cycle-only handling in
+`docs/plans/hypercore-full-close-residual-cleanup.md` for ordinary strategy full
+closes. The existing later-cycle retry remains the fallback when one additional
+protected withdrawal cannot safely reduce the residual to 5 USD or less.
+
+## Goal
+
+When a HyperCore strategy target is zero:
+
+1. Preserve full-close intent from the alpha signal through settlement.
+2. Withdraw the amount that can safely fund the current cycle.
+3. Read the remaining vault equity after the first withdrawal is verified.
+4. If one more protected withdrawal can leave at most 5 USD, execute it before
+   the shared downstream sweep.
+5. Credit only USDC observed back in the HyperEVM Safe and close the ledger
+   position only from a verified final residual.
+
+This is a best-effort live target, not an unconditional guarantee. Lockups,
+limited `max_withdrawable`, NAV movement, unavailable API data, or an ambiguous
+HyperCore action can prevent a same-cycle close.
+
+## Architecture decision
+
+Use one `TradeExecution`, at most two `vaultTransfer(vault -> perp)`
+transactions, and one combined `perp -> spot -> HyperEVM` sweep.
+
+A second trade or cleaning job is unnecessary for the eligible happy path. The
+residual is not known until the first transaction settles, while HyperCore
+routing already performs additional verified settlement transactions during
+sequential execution. The later-cycle cleaner remains useful only as fallback.
+
+No change is needed in `strategies/hyper-ai.py`. Generic alpha-model and
+HyperCore routing code own these semantics.
+
+## Implementation
+
+### Preserve full-close intent
+
+`TradeFlag.close` is the durable close signal across the stack.
+
+For a cap-bound zero-target HyperCore signal:
+
+- The alpha signal retains the conservative redemption amount for thresholds
+  and same-cycle cash planning.
+- `PositionManager.close_position()` creates one trade for the full available
+  position quantity with `TradeFlag.close`, `TradeFlag.reduce`, and
+  `trade.closing == True`.
+- The conservative first-stage value is stored as
+  `hypercore_first_stage_conservative_reserve_usd`.
+- Cash sufficiency checks use that conservative value rather than treating the
+  trade's full marked value as immediately spendable proceeds.
+
+An exact zero weight is a full close even when
+`close_position_weight_epsilon == 0`.
+
+### Execute the protected residual leg
+
+Routing limits the first physical withdrawal to the smaller of:
+
+- fresh live equity minus the normal withdrawal safety margin; and
+- `hypercore_first_stage_conservative_reserve_usd`, when present.
+
+After the first perp increase is verified, an explicit close obtains fresh,
+uncached vault equity and fresh `max_withdrawable`. If the residual is already
+5 USD or less, no second transaction is needed.
+
+Otherwise routing applies the same safety rule to the second request:
+
+```text
+margin(amount) = max(0.5% × amount, 1.50 USD)
+```
+
+It broadcasts only when the protected, capacity-capped request can leave at
+most 5 USD after raw USDC rounding. A residual above 1,000 USD cannot meet this
+condition with the current percentage margin and therefore waits for another
+cycle.
+
+If the first withdrawal needed its existing silent-no-op retry, that retry has
+already consumed the cycle's second vault transaction. The intentional
+residual leg is then skipped.
+
+### Persist and verify the second transaction
+
+Before broadcasting the optional transaction, routing:
+
+1. appends the signed transaction to the original trade;
+2. records `hypercore_second_stage_status = "broadcast_pending"` and its hash;
+3. invokes the routing state checkpoint supplied by live execution.
+
+The transaction must then have both:
+
+- a verified increase relative to the post-first-stage perp balance, allowing
+  for the vault's performance fee; and
+- a fresh vault-equity decrease relative to the equity immediately before the
+  second leg.
+
+Successful first and second withdrawals are aggregated before the existing
+phase-2 and phase-3 settlement code runs once.
+
+## Failure handling
+
+The second transaction is an optimisation after a verified first withdrawal:
+
+| Outcome | Action |
+| --- | --- |
+| Preparation fails before broadcast | Skip the second leg and settle the verified first leg. |
+| Receipt has `status = 0` | Treat it as a definite revert and settle the verified first leg. |
+| Broadcast or confirmation outcome is unknown | Mark the combined amount stranded, fail the trade, and do not sweep shared perp USDC. |
+| Receipt has `status = 1` but balance movement is not verified | Treat it as ambiguous, fail the trade, and do not sweep shared perp USDC. |
+| Final vault equity is unavailable | Fail the explicit close instead of inferring a residual or writing it off. |
+
+Ambiguous outcomes use the existing `hypercore_stranded_usdc` repair guard.
+The normal repair command must not create a synthetic counter-trade or unfreeze
+the position. An operator resolves the persisted hash and live vault, perp,
+spot, and Safe balances with `correct-accounts` before adjusting accounting.
+Automatic rebroadcast of an unresolved HyperCore action is outside this
+implementation.
+
+## Accounting
+
+Cash and position quantity have different sources of truth:
+
+- Reserve credit is the combined USDC actually observed in the HyperEVM Safe.
+- Planned close value uses the latest valued share price because HyperCore's
+  execution pricing is deliberately fixed at 1:1 USDC; executed price still
+  comes from observed settlement proceeds.
+- A partial close composes the independently verified equity-reduction
+  fraction of each completed vault leg. This prevents NAV movement between
+  legs from appearing as sold shares.
+- A verified final residual of 5 USD or less books the full planned quantity
+  and records the residual as an accepted write-off.
+- A verified residual above 5 USD books only the proven reduction and leaves
+  the position open with retry metadata.
+- Executed quantity must never exceed the full-position planned quantity.
+
+## Diagnostics
+
+The trade records:
+
+- conservative and requested first-stage amounts;
+- fresh first-stage residual;
+- second-stage status, requested amount, transaction hash, error, and final
+  residual;
+- total requested gross amount and total observed perp increase; and
+- accepted residual or stranded-capital metadata.
+
+## Verification
+
+Focused tests cover:
+
+1. exact-zero alpha signal to full-close trade propagation;
+2. conservative cash and first-stage routing caps;
+3. accepted and capacity-limited residual planning;
+4. successful two-stage aggregation into one downstream sweep;
+5. ambiguous second-stage settlement failing before phase 2;
+6. unavailable final equity failing an explicit close;
+7. partial-quantity composition across NAV movement;
+8. simulated/mainnet-fork full closes without live API residuals; and
+9. Hyper AI live-loop close, partial reduction, and fee-slippage regressions.
+
+The earlier Claude Fable plan review agreed with the one-trade, two-vault-leg
+architecture. Its safety findings are reflected in the pre-broadcast
+checkpoint, ambiguity guard, final-equity requirement, performance-fee-aware
+verification, and per-leg quantity accounting.

--- a/docs/plans/hypercore-same-cycle-two-stage-full-close.md
+++ b/docs/plans/hypercore-same-cycle-two-stage-full-close.md
@@ -116,6 +116,9 @@ The second transaction is an optimisation after a verified first withdrawal:
 | Final vault equity is unavailable | Fail the explicit close instead of inferring a residual or writing it off. |
 
 Ambiguous outcomes use the existing `hypercore_stranded_usdc` repair guard.
+They record the combined exposure at `hypercore_perp_or_vault`, because the
+verified first leg is in perp while the unresolved second leg may still be in
+the vault or may have reached perp.
 The normal repair command must not create a synthetic counter-trade or unfreeze
 the position. An operator resolves the persisted hash and live vault, perp,
 spot, and Safe balances with `correct-accounts` before adjusting accounting.

--- a/docs/plans/hypercore-same-cycle-two-stage-full-close.md
+++ b/docs/plans/hypercore-same-cycle-two-stage-full-close.md
@@ -125,6 +125,11 @@ spot, and Safe balances with `correct-accounts` before adjusting accounting.
 Automatic rebroadcast of an unresolved HyperCore action is outside this
 implementation.
 
+If proceeds have verifiably reached the Safe but final residual or quantity
+verification fails, `hypercore_accounting_reconciliation_required` prevents
+generic repair from assuming the withdrawal moved no assets. `correct-accounts`
+must reconcile the live vault equity and observed Safe proceeds.
+
 ## Accounting
 
 Cash and position quantity have different sources of truth:

--- a/tests/hyperliquid/test_hypercore_activation_cost.py
+++ b/tests/hyperliquid/test_hypercore_activation_cost.py
@@ -432,6 +432,60 @@ def test_withdrawal_uses_live_equity_on_close():
     assert trade.other_data["hypercore_capped_withdrawal_raw"] == expected_withdrawal_raw
 
 
+def test_full_close_first_stage_keeps_conservative_cash_cap() -> None:
+    """Keep the alpha model's cash cap while planning a full accounting close.
+
+    1. Create a flagged full close whose accounting value is 50 USDC but conservative first stage is 8.50 USDC.
+    2. Give routing 20 USDC of live equity, which would otherwise permit an 18.50 USDC first withdrawal.
+    3. Verify phase 1 requests only 8.50 USDC and persists both conservative and actual amounts.
+
+    Live equity, call building, and signing are mocked to isolate withdrawal amount selection.
+    """
+    routing = _make_routing(simulate=False)
+    trade = _make_trade(planned_reserve=Decimal("50"), is_buy=False)
+    trade.flags = {TradeFlag.close, TradeFlag.reduce}
+    trade.other_data = {
+        "hypercore_first_stage_conservative_reserve_usd": "8.5",
+    }
+    withdraw_fn = MagicMock()
+    signed_tx = MagicMock()
+    live_equity = UserVaultEquity(
+        vault_address=trade.pair.pool_address,
+        equity=Decimal("20"),
+        locked_until=datetime.datetime(2020, 1, 1),
+    )
+
+    # 1. Create a flagged full close whose accounting value is 50 USDC but conservative first stage is 8.50 USDC.
+    with (
+        patch(
+            "tradeexecutor.ethereum.vault.hypercore_routing.fetch_user_vault_equity",
+            return_value=live_equity,
+        ),
+        patch.object(
+            routing,
+            "_check_live_withdrawal_preconditions",
+            return_value=8_500_000,
+        ),
+        patch(
+            "tradeexecutor.ethereum.vault.hypercore_routing.build_hypercore_withdraw_from_vault_call",
+            return_value=withdraw_fn,
+        ) as build_withdraw,
+        patch.object(routing, "_sign_module_call", return_value=signed_tx),
+    ):
+        # 2. Give routing 20 USDC of live equity, which would otherwise permit an 18.50 USDC first withdrawal.
+        txs = routing._create_deposit_or_withdraw_txs(trade)
+
+    # 3. Verify phase 1 requests only 8.50 USDC and persists both conservative and actual amounts.
+    assert txs == [signed_tx]
+    build_withdraw.assert_called_once_with(
+        routing.lagoon_vault,
+        vault_address=trade.pair.pool_address,
+        hypercore_usdc_amount=8_500_000,
+    )
+    assert trade.other_data["hypercore_first_stage_conservative_raw"] == 8_500_000
+    assert trade.other_data["hypercore_first_stage_requested_raw"] == 8_500_000
+
+
 def test_withdrawal_logs_large_equity_mismatch_but_uses_live_amount(caplog):
     """Large planned/live drift should warn loudly but still use live equity.
 

--- a/tests/hyperliquid/test_hypercore_dual_chain.py
+++ b/tests/hyperliquid/test_hypercore_dual_chain.py
@@ -377,6 +377,9 @@ def test_full_close_fails_when_final_equity_is_unavailable(
     state.mark_trade_success.assert_not_called()
     mock_report_failure.assert_called_once()
     assert diagnose.call_args.args[2] == "final_residual_verification"
+    reconciliation = trade.other_data["hypercore_accounting_reconciliation_required"]
+    assert reconciliation["phase"] == "final_residual_verification"
+    assert reconciliation["observed_safe_proceeds_usd"] == "50"
 
 
 # --- P2: _wait_for_usdc_arrival tests ---
@@ -1606,6 +1609,7 @@ def test_withdrawal_phase1_retry_handles_silent_noop_from_equity_drift(
     assert captured_phase2_raw == [retry_raw]
     assert captured_phase3_raw == [retry_raw]
     assert trade.other_data["hypercore_capped_withdrawal_raw"] == retry_raw
+    assert trade.other_data["hypercore_first_stage_requested_raw"] == retry_raw
     assert phase1_retry_tx in trade.blockchain_transactions
     state.mark_trade_success.assert_called_once()
     mock_report_failure.assert_not_called()

--- a/tests/hyperliquid/test_hypercore_dual_chain.py
+++ b/tests/hyperliquid/test_hypercore_dual_chain.py
@@ -14,7 +14,12 @@ import pytest
 
 from eth_defi.hyperliquid.api import UserVaultEquity
 from hexbytes import HexBytes
-from tradeexecutor.strategy.dust import HYPERCORE_CLOSE_RESIDUAL_STATUS_PENDING_RETRY
+from tradeexecutor.ethereum.vault.hypercore_routing import HypercoreWithdrawalVerificationError
+from tradeexecutor.state.trade import TradeFlag
+from tradeexecutor.strategy.dust import (
+    HYPERCORE_CLOSE_RESIDUAL_STATUS_ACCEPTED,
+    HYPERCORE_CLOSE_RESIDUAL_STATUS_PENDING_RETRY,
+)
 
 
 VAULT_ADDR = "0xdfc24b077bc1425ad1dea75bcb6f8158e10df303"
@@ -27,6 +32,15 @@ def _make_equity(equity: Decimal) -> UserVaultEquity:
         vault_address=VAULT_ADDR,
         equity=equity,
         locked_until=LOCKED_UNTIL,
+    )
+
+
+def _make_unlocked_equity(equity: Decimal) -> UserVaultEquity:
+    """Create a vault-equity result whose redemption lock has expired."""
+    return UserVaultEquity(
+        vault_address=VAULT_ADDR,
+        equity=equity,
+        locked_until=datetime.datetime(2020, 1, 1),
     )
 
 
@@ -78,6 +92,113 @@ def _monotonic_time():
     """
     counter = itertools.count()
     return lambda: float(next(counter))
+
+
+def test_partial_close_quantity_composes_verified_leg_fractions() -> None:
+    """Keep NAV movement between withdrawal legs out of executed quantity.
+
+    1. Reduce half of a 100-share position in the first verified withdrawal leg.
+    2. Let retained equity move from 500 to 490 before withdrawing half again.
+    3. Verify the composed reduction sells 75 shares while a skipped second leg sells exactly 50.
+    """
+    routing = _make_routing()
+
+    # 1. Reduce half of a 100-share position in the first verified withdrawal leg.
+    first_leg = (Decimal("1000"), Decimal("500"))
+
+    # 2. Let retained equity move from 500 to 490 before withdrawing half again.
+    second_leg = (Decimal("490"), Decimal("245"))
+
+    # 3. Verify the composed reduction sells 75 shares while a skipped second leg sells exactly 50.
+    assert routing._calculate_partial_close_quantity(
+        Decimal("100"),
+        [first_leg, second_leg],
+    ) == Decimal("75.00")
+    assert routing._calculate_partial_close_quantity(
+        Decimal("100"),
+        [first_leg],
+    ) == Decimal("50.0")
+
+
+@patch("tradeexecutor.ethereum.vault.hypercore_routing.get_block_timestamp")
+def test_simulated_full_close_does_not_require_live_residual(mock_block_ts) -> None:
+    """Allow a mainnet-fork full close without HyperCore API residual data.
+
+    1. Create a simulated, explicitly flagged full-close trade.
+    2. Settle its successful fork transaction without any live equity reads.
+    3. Verify the full planned quantity is booked successfully.
+
+    State and receipt objects are mocked because fork mode deliberately skips live HyperCore settlement.
+    """
+    routing = _make_routing(simulate=True)
+    trade = _make_trade(planned_reserve=Decimal("50"))
+    trade.closing = True
+    trade.flags = {TradeFlag.close, TradeFlag.reduce}
+    state = MagicMock()
+    position = state.portfolio.find_position_for_trade.return_value
+    position.get_quantity.return_value = Decimal("50")
+    position.get_close_epsilon.return_value = Decimal("0.0001")
+    mock_block_ts.return_value = datetime.datetime(2026, 8, 27)
+    receipts = {HexBytes("0xabc"): {"status": 1, "blockNumber": 100}}
+
+    # 1. Create a simulated, explicitly flagged full-close trade.
+    assert trade.planned_quantity == Decimal("-50")
+
+    # 2. Settle its successful fork transaction without any live equity reads.
+    routing._settle_withdrawal(
+        routing.web3,
+        state,
+        trade,
+        receipts,
+        stop_on_execution_failure=False,
+    )
+
+    # 3. Verify the full planned quantity is booked successfully.
+    success_kwargs = state.mark_trade_success.call_args.kwargs
+    assert success_kwargs["executed_amount"] == Decimal("-50")
+    assert success_kwargs["executed_reserve"] == Decimal("50")
+
+
+@patch("tradeexecutor.ethereum.vault.hypercore_routing.fetch_user_vault_equity")
+def test_residual_planner_skips_accepted_or_unreachable_residual(
+    mock_fetch_equity,
+) -> None:
+    """Spend no second-stage gas when it is unnecessary or cannot reach 5 USD.
+
+    1. Return a 4.99 USD residual and verify it is accepted without another request.
+    2. Return a 28 USD residual with only 20 USD of fresh capacity.
+    3. Verify the protected capacity would leave too much equity and is skipped.
+
+    HyperCore API reads are mocked to make both eligibility branches deterministic.
+    """
+    routing = _make_routing()
+    trade = _make_trade(planned_reserve=Decimal("100"))
+    mock_fetch_equity.side_effect = [
+        _make_unlocked_equity(Decimal("4.99")),
+        _make_unlocked_equity(Decimal("28")),
+    ]
+
+    # 1. Return a 4.99 USD residual and verify it is accepted without another request.
+    residual, request_raw = routing._plan_same_cycle_residual_withdrawal(
+        trade,
+        VAULT_ADDR,
+    )
+    assert residual == Decimal("4.99")
+    assert request_raw is None
+    assert trade.other_data["hypercore_second_stage_status"] == "skipped_residual_accepted"
+
+    # 2. Return a 28 USD residual with only 20 USD of fresh capacity.
+    with patch("tradeexecutor.ethereum.vault.hypercore_routing.HyperliquidVault") as vault_class:
+        vault_class.return_value.fetch_info.return_value.max_withdrawable = Decimal("20")
+        residual, request_raw = routing._plan_same_cycle_residual_withdrawal(
+            trade,
+            VAULT_ADDR,
+        )
+
+    # 3. Verify the protected capacity would leave too much equity and is skipped.
+    assert residual == Decimal("28")
+    assert request_raw is None
+    assert trade.other_data["hypercore_second_stage_status"] == "skipped_insufficient_capacity"
 
 
 @patch("tradeexecutor.ethereum.vault.hypercore_routing.get_block_timestamp")
@@ -198,6 +319,64 @@ def test_withdrawal_equity_check_non_fatal_on_api_failure(mock_fetch_equity, moc
     # Trade still succeeds despite P6 check failure
     state.mark_trade_success.assert_called_once()
     assert any("Could not verify vault equity" in r.message for r in caplog.records)
+
+
+@patch("tradeexecutor.ethereum.vault.hypercore_routing.report_failure")
+@patch("tradeexecutor.ethereum.vault.hypercore_routing.get_block_timestamp")
+@patch("tradeexecutor.ethereum.vault.hypercore_routing.fetch_user_vault_equity")
+def test_full_close_fails_when_final_equity_is_unavailable(
+    mock_fetch_equity,
+    mock_block_ts,
+    mock_report_failure,
+) -> None:
+    """Do not close a flagged position without a verified final residual.
+
+    1. Start a full close with a valid pre-withdrawal equity snapshot.
+    2. Make both fresh residual reads fail after verified USDC settlement.
+    3. Verify the trade fails closed instead of booking the full quantity.
+
+    Balance polling and broadcasts are mocked to isolate final-equity verification.
+    """
+    routing = _make_routing()
+    trade = _make_trade(planned_reserve=Decimal("50"))
+    trade.closing = True
+    trade.flags = {TradeFlag.close, TradeFlag.reduce}
+    trade.other_data = {
+        "hypercore_phase1_perp_baseline_usdc": "0",
+        "hypercore_phase1_vault_equity_usdc": "50",
+    }
+    state = MagicMock()
+    mock_block_ts.return_value = datetime.datetime(2026, 8, 27)
+    mock_fetch_equity.side_effect = Exception("API timeout")
+    receipts = {HexBytes("0xabc"): {"status": 1, "blockNumber": 100}}
+
+    # 1. Start a full close with a valid pre-withdrawal equity snapshot.
+    with (
+        patch.object(routing, "_fetch_safe_evm_usdc_balance", return_value=100_000_000),
+        patch.object(routing, "_fetch_safe_perp_withdrawable_balance", return_value=Decimal("0")),
+        patch.object(routing, "_fetch_safe_spot_free_usdc_balance", return_value=Decimal("0")),
+        patch.object(routing, "_fetch_safe_spot_free_balances", return_value={}),
+        patch.object(routing, "_resolve_vault_performance_fee", return_value=Decimal("0")),
+        patch.object(routing, "_wait_for_perp_withdrawable_balance", return_value=Decimal("50")),
+        patch.object(routing, "_broadcast_withdrawal_phase2", return_value=(MagicMock(), {"status": 1, "blockNumber": 101})),
+        patch.object(routing, "_wait_for_spot_free_usdc_balance", return_value=Decimal("50")),
+        patch.object(routing, "_broadcast_withdrawal_phase3", return_value=(MagicMock(), {"status": 1, "blockNumber": 102})),
+        patch.object(routing, "_wait_for_usdc_arrival", return_value=50_000_000),
+        patch.object(routing, "diagnose_hyperliquid_vault_redemption_failure") as diagnose,
+    ):
+        # 2. Make both fresh residual reads fail after verified USDC settlement.
+        routing._settle_withdrawal(
+            routing.web3,
+            state,
+            trade,
+            receipts,
+            stop_on_execution_failure=False,
+        )
+
+    # 3. Verify the trade fails closed instead of booking the full quantity.
+    state.mark_trade_success.assert_not_called()
+    mock_report_failure.assert_called_once()
+    assert diagnose.call_args.args[2] == "final_residual_verification"
 
 
 # --- P2: _wait_for_usdc_arrival tests ---
@@ -1001,6 +1180,201 @@ def test_withdrawal_caps_gross_quantity_to_planned_sell_value(
     assert success_kwargs["executed_amount"] == Decimal("-65")
     assert success_kwargs["executed_reserve"] == Decimal("122.99")
     assert success_kwargs["executed_price"] == pytest.approx(122.99 / 65)
+
+
+@patch("tradeexecutor.ethereum.vault.hypercore_routing.get_block_timestamp")
+@patch("tradeexecutor.ethereum.vault.hypercore_routing.fetch_user_vault_equity")
+def test_full_close_redeems_residual_in_second_same_cycle_transaction(
+    mock_fetch_equity,
+    mock_block_ts,
+) -> None:
+    """Close a protected first-stage residual with one additional vault transaction.
+
+    1. Start a flagged 100 USDC full close whose protected first withdrawal leaves 28 USDC.
+    2. Verify a second protected withdrawal reduces the residual to 1.50 USDC before the downstream sweep.
+    3. Verify one trade aggregates both vault transactions and closes its full planned quantity.
+
+    HyperCore balance polling and transaction broadcasts are mocked to model asynchronous settlement deterministically.
+    """
+    routing = _make_routing()
+    trade = _make_trade(planned_reserve=Decimal("100"))
+    trade.planned_quantity = Decimal("-100")
+    trade.closing = True
+    trade.flags = {TradeFlag.close, TradeFlag.reduce}
+    trade.other_data = {
+        "hypercore_capped_withdrawal_raw": 72_000_000,
+        "hypercore_phase1_perp_baseline_usdc": "0",
+        "hypercore_phase1_vault_equity_usdc": "100",
+    }
+    state = MagicMock()
+    state.portfolio.get_position_by_id.return_value.get_quantity.return_value = Decimal("100")
+    position = state.portfolio.find_position_for_trade.return_value
+    position.get_quantity.return_value = Decimal("100")
+    position.get_close_epsilon.return_value = Decimal("0.0001")
+    position.position_id = 1
+    position.other_data = {}
+    mock_block_ts.return_value = datetime.datetime(2026, 8, 27)
+    mock_fetch_equity.side_effect = [
+        _make_unlocked_equity(Decimal("28")),
+        _make_unlocked_equity(Decimal("1.5")),
+        _make_unlocked_equity(Decimal("1.5")),
+    ]
+    receipts = {HexBytes("0xabc"): {"status": 1, "blockNumber": 100}}
+    vault_info = MagicMock(max_withdrawable=Decimal("28"))
+    second_stage_tx = MagicMock(tx_hash="0xsecond")
+    phase2_tx = MagicMock(tx_hash="0xphase2")
+    phase3_tx = MagicMock(tx_hash="0xphase3")
+    checkpoint_statuses: list[str] = []
+    captured_phase2_raw: list[int] = []
+
+    def checkpoint() -> None:
+        checkpoint_statuses.append(trade.other_data["hypercore_second_stage_status"])
+
+    def capture_phase2(raw_amount: int):
+        captured_phase2_raw.append(raw_amount)
+        return phase2_tx, {"status": 1, "blockNumber": 102}
+
+    # 1. Start a flagged 100 USDC full close whose protected first withdrawal leaves 28 USDC.
+    routing.set_pre_broadcast_state_sync_callback(checkpoint)
+    with (
+        patch("tradeexecutor.ethereum.vault.hypercore_routing.HyperliquidVault") as vault_class,
+        patch.object(routing, "_fetch_safe_evm_usdc_balance", return_value=100_000_000),
+        patch.object(routing, "_fetch_safe_perp_withdrawable_balance", return_value=Decimal("0")),
+        patch.object(routing, "_fetch_safe_spot_free_usdc_balance", return_value=Decimal("0")),
+        patch.object(routing, "_fetch_safe_spot_free_balances", return_value={}),
+        patch.object(routing, "_resolve_vault_performance_fee", return_value=Decimal("0")),
+        patch.object(
+            routing,
+            "_wait_for_perp_withdrawable_balance",
+            side_effect=[Decimal("72"), Decimal("98.5")],
+        ),
+        patch.object(
+            routing,
+            "_prepare_withdrawal_vault_to_perp_transaction",
+            return_value=second_stage_tx,
+        ),
+        patch.object(
+            routing,
+            "_broadcast_and_confirm_settlement_tx",
+            return_value={"status": 1, "blockNumber": 101},
+        ),
+        patch.object(routing, "_broadcast_withdrawal_phase2", side_effect=capture_phase2),
+        patch.object(routing, "_wait_for_spot_free_usdc_balance", return_value=Decimal("98.5")),
+        patch.object(
+            routing,
+            "_broadcast_withdrawal_phase3",
+            return_value=(phase3_tx, {"status": 1, "blockNumber": 103}),
+        ),
+        patch.object(routing, "_wait_for_usdc_arrival", return_value=98_490_000),
+        patch.object(routing, "_fetch_hype_usd_price", return_value=None),
+    ):
+        vault_class.return_value.fetch_info.return_value = vault_info
+
+        # 2. Verify a second protected withdrawal reduces the residual to 1.50 USDC before the downstream sweep.
+        routing._settle_withdrawal(
+            routing.web3,
+            state,
+            trade,
+            receipts,
+            stop_on_execution_failure=False,
+        )
+
+    # 3. Verify one trade aggregates both vault transactions and closes its full planned quantity.
+    assert trade.other_data["hypercore_second_stage_requested_raw"] == 26_500_000
+    assert trade.other_data["hypercore_second_stage_status"] == "verified"
+    assert trade.other_data["hypercore_second_stage_residual_usd"] == "1.5"
+    assert checkpoint_statuses[0] == "broadcast_pending"
+    assert captured_phase2_raw == [98_500_000]
+    assert len(trade.blockchain_transactions) == 4
+    assert trade.blockchain_transactions[1:] == [
+        second_stage_tx,
+        phase2_tx,
+        phase3_tx,
+    ]
+    success_kwargs = state.mark_trade_success.call_args.kwargs
+    assert success_kwargs["executed_amount"] == Decimal("-100")
+    assert success_kwargs["executed_reserve"] == Decimal("98.49")
+    assert position.other_data["hypercore_close_residual_status"] == HYPERCORE_CLOSE_RESIDUAL_STATUS_ACCEPTED
+
+
+@patch("tradeexecutor.ethereum.vault.hypercore_routing.report_failure")
+@patch("tradeexecutor.ethereum.vault.hypercore_routing.get_block_timestamp")
+@patch("tradeexecutor.ethereum.vault.hypercore_routing.fetch_user_vault_equity")
+def test_full_close_fails_closed_when_second_stage_is_ambiguous(
+    mock_fetch_equity,
+    mock_block_ts,
+    mock_report_failure,
+) -> None:
+    """Do not sweep shared perp USDC after an ambiguous second close transaction.
+
+    1. Verify the first withdrawal and plan a second transaction for its 28 USDC residual.
+    2. Give the second transaction a successful EVM receipt but no verifiable perp increase.
+    3. Verify settlement fails before phase 2 and persists ambiguity diagnostics.
+
+    HyperCore balance polling and transaction broadcasts are mocked to isolate the ambiguous status-1 path.
+    """
+    routing = _make_routing()
+    trade = _make_trade(planned_reserve=Decimal("100"))
+    trade.planned_quantity = Decimal("-100")
+    trade.closing = True
+    trade.flags = {TradeFlag.close, TradeFlag.reduce}
+    trade.other_data = {
+        "hypercore_capped_withdrawal_raw": 72_000_000,
+        "hypercore_phase1_perp_baseline_usdc": "0",
+        "hypercore_phase1_vault_equity_usdc": "100",
+    }
+    state = MagicMock()
+    state.portfolio.get_position_by_id.return_value.get_quantity.return_value = Decimal("100")
+    mock_block_ts.return_value = datetime.datetime(2026, 8, 27)
+    mock_fetch_equity.return_value = _make_unlocked_equity(Decimal("28"))
+    receipts = {HexBytes("0xabc"): {"status": 1, "blockNumber": 100}}
+    vault_info = MagicMock(max_withdrawable=Decimal("28"))
+    second_stage_tx = MagicMock(tx_hash="0xsecond")
+
+    # 1. Verify the first withdrawal and plan a second transaction for its 28 USDC residual.
+    with (
+        patch("tradeexecutor.ethereum.vault.hypercore_routing.HyperliquidVault") as vault_class,
+        patch.object(routing, "_fetch_safe_evm_usdc_balance", return_value=100_000_000),
+        patch.object(routing, "_fetch_safe_perp_withdrawable_balance", return_value=Decimal("0")),
+        patch.object(routing, "_fetch_safe_spot_free_usdc_balance", return_value=Decimal("0")),
+        patch.object(routing, "_resolve_vault_performance_fee", return_value=Decimal("0")),
+        patch.object(
+            routing,
+            "_wait_for_perp_withdrawable_balance",
+            side_effect=[
+                Decimal("72"),
+                HypercoreWithdrawalVerificationError("second leg did not arrive"),
+            ],
+        ),
+        patch.object(
+            routing,
+            "_prepare_withdrawal_vault_to_perp_transaction",
+            return_value=second_stage_tx,
+        ),
+        patch.object(
+            routing,
+            "_broadcast_and_confirm_settlement_tx",
+            return_value={"status": 1, "blockNumber": 101},
+        ),
+        patch.object(routing, "_broadcast_withdrawal_phase2") as phase2,
+    ):
+        vault_class.return_value.fetch_info.return_value = vault_info
+
+        # 2. Give the second transaction a successful EVM receipt but no verifiable perp increase.
+        routing._settle_withdrawal(
+            routing.web3,
+            state,
+            trade,
+            receipts,
+            stop_on_execution_failure=False,
+        )
+
+    # 3. Verify settlement fails before phase 2 and persists ambiguity diagnostics.
+    phase2.assert_not_called()
+    mock_report_failure.assert_called_once()
+    assert trade.other_data["hypercore_second_stage_status"] == "verification_ambiguous"
+    assert trade.other_data["hypercore_second_stage_tx_hash"] == "0xsecond"
+    assert trade.other_data["hypercore_stranded_usdc"]["location"] == "hypercore_perp"
 
 
 @patch("tradeexecutor.ethereum.vault.hypercore_routing.get_block_timestamp")

--- a/tests/hyperliquid/test_hypercore_dual_chain.py
+++ b/tests/hyperliquid/test_hypercore_dual_chain.py
@@ -1374,7 +1374,9 @@ def test_full_close_fails_closed_when_second_stage_is_ambiguous(
     mock_report_failure.assert_called_once()
     assert trade.other_data["hypercore_second_stage_status"] == "verification_ambiguous"
     assert trade.other_data["hypercore_second_stage_tx_hash"] == "0xsecond"
-    assert trade.other_data["hypercore_stranded_usdc"]["location"] == "hypercore_perp"
+    stranded = trade.other_data["hypercore_stranded_usdc"]
+    assert stranded["location"] == "hypercore_perp_or_vault"
+    assert "final location is ambiguous" in stranded["recovery"]
 
 
 @patch("tradeexecutor.ethereum.vault.hypercore_routing.get_block_timestamp")

--- a/tests/hyperliquid/test_hypercore_stranded_usdc.py
+++ b/tests/hyperliquid/test_hypercore_stranded_usdc.py
@@ -146,7 +146,9 @@ def test_state_only_repair_repairs_unrelated_trade_while_deferring_hypercore_wit
     # 1. The protected trade models an ambiguous second-stage withdrawal,
     # while the ordinary trade models an independent accounting failure.
     state = MagicMock()
-    state.portfolio.frozen_positions.values.return_value = []
+    frozen_position = MagicMock()
+    frozen_position.position_id = 489
+    state.portfolio.frozen_positions.values.return_value = [frozen_position]
     hypercore_trade = MagicMock()
     hypercore_trade.trade_id = 1605
     hypercore_trade.position_id = 489
@@ -166,7 +168,9 @@ def test_state_only_repair_repairs_unrelated_trade_while_deferring_hypercore_wit
     with patch("tradeexecutor.state.repair.find_trades_to_be_repaired", return_value=[hypercore_trade, ordinary_trade]), patch(
         "tradeexecutor.state.repair.repair_trade",
         return_value=counter_trade,
-    ) as repair_trade, patch("tradeexecutor.state.repair.logger.error") as logger_error:
+    ) as repair_trade, patch("tradeexecutor.state.repair.logger.error") as logger_error, patch(
+        "tradeexecutor.state.repair.logger.warning"
+    ) as logger_warning:
         result = repair_trades(state, attempt_repair=True, interactive=False)
 
     # 3. The command completes, but never rewrites the withdrawal or calls it a deposit.
@@ -176,3 +180,6 @@ def test_state_only_repair_repairs_unrelated_trade_while_deferring_hypercore_wit
     message = logger_error.call_args.args[0]
     assert "HyperCore trade(s)" in message
     assert "deposit trade" not in message
+    warning = logger_warning.call_args.args[0]
+    assert "HyperCore trade" in warning
+    assert "deposit" not in warning

--- a/tests/hyperliquid/test_hypercore_stranded_usdc.py
+++ b/tests/hyperliquid/test_hypercore_stranded_usdc.py
@@ -130,27 +130,32 @@ def test_state_only_repair_defers_unreconciled_hypercore_deposit() -> None:
     unfreeze_position.assert_not_called()
 
 
-def test_state_only_repair_repairs_unrelated_trade_while_deferring_hypercore_deposit() -> None:
-    """Repair must clear independent failures without refunding stranded HyperCore USDC.
+def test_state_only_repair_repairs_unrelated_trade_while_deferring_hypercore_withdrawal() -> None:
+    """Repair must clear independent failures without rewriting an ambiguous withdrawal.
 
     1. Model the production combination of one ordinary failed trade and one
-       failed HyperCore deposit carrying its stranded-USDC marker.
+       failed HyperCore withdrawal carrying its stranded-USDC marker.
     2. Run the state-only repair workflow without interactive confirmation.
     3. Verify only the ordinary trade receives a counter-trade and the
-       HyperCore trade remains explicitly deferred for live reconciliation.
+       HyperCore trade remains explicitly deferred with neutral diagnostics.
 
     Trades are mocked because this test isolates the command's selection rule;
     the real state-bookkeeping path is covered by the no-transaction regression
     in ``test_repair_trade_missing_tx.py``.
     """
-    # 1. The protected trade models #1486, while the ordinary trade models the
-    # independent failure which made correct-accounts' coherence check fail.
+    # 1. The protected trade models an ambiguous second-stage withdrawal,
+    # while the ordinary trade models an independent accounting failure.
     state = MagicMock()
     state.portfolio.frozen_positions.values.return_value = []
     hypercore_trade = MagicMock()
-    hypercore_trade.trade_id = 1486
+    hypercore_trade.trade_id = 1605
     hypercore_trade.position_id = 489
-    hypercore_trade.other_data = {"hypercore_stranded_usdc": {"amount_raw": 48_884_068}}
+    hypercore_trade.other_data = {
+        "hypercore_stranded_usdc": {
+            "amount_raw": 48_884_068,
+            "location": "hypercore_perp_or_vault",
+        },
+    }
     ordinary_trade = MagicMock()
     ordinary_trade.trade_id = 4700
     ordinary_trade.position_id = 470
@@ -161,10 +166,13 @@ def test_state_only_repair_repairs_unrelated_trade_while_deferring_hypercore_dep
     with patch("tradeexecutor.state.repair.find_trades_to_be_repaired", return_value=[hypercore_trade, ordinary_trade]), patch(
         "tradeexecutor.state.repair.repair_trade",
         return_value=counter_trade,
-    ) as repair_trade:
+    ) as repair_trade, patch("tradeexecutor.state.repair.logger.error") as logger_error:
         result = repair_trades(state, attempt_repair=True, interactive=False)
 
-    # 3. The command completes, but never manufactures a refund for #1486.
+    # 3. The command completes, but never rewrites the withdrawal or calls it a deposit.
     repair_trade.assert_called_once_with(state.portfolio, ordinary_trade)
     assert result.trades_needing_repair == [hypercore_trade, ordinary_trade]
     assert result.new_trades == [counter_trade]
+    message = logger_error.call_args.args[0]
+    assert "HyperCore trade(s)" in message
+    assert "deposit trade" not in message

--- a/tests/test_generic_router_hypercore_satellite.py
+++ b/tests/test_generic_router_hypercore_satellite.py
@@ -15,6 +15,7 @@ GenericRouting.setup_trades() crashes with:
 """
 
 from types import SimpleNamespace
+from unittest.mock import MagicMock
 
 import pytest
 from eth_defi.compat import native_datetime_utc_now
@@ -55,17 +56,17 @@ class _TestLagoonTransactionBuilder(LagoonTransactionBuilder):
         self.web3 = SimpleNamespace(eth=SimpleNamespace(chain_id=chain_id))
 
 
-def test_hypercore_satellite_vault_lookup_maps_chain_9999_to_999():
+def test_hypercore_satellite_vault_lookup_maps_chain_9999_to_999() -> None:
     """Verify GenericRouting maps synthetic chain 9999 to HyperEVM 999 for satellite lookup.
 
-    1. Build a GenericRouting with satellite_vaults={999: vault} and match_router/get_config
-    2. Build a real GenericRoutingState with a state_map entry for hypercore_vault
-    3. Use _TestLagoonTransactionBuilder so isinstance check at line 199 passes
-    4. Create a Hypercore vault trade (chain_id=9999) via create_hypercore_vault_pair
-    5. Call setup_trades — should NOT crash with 'No satellite vault for chain 9999'
-    6. It will fail later (nonce sync on fake web3) but that proves the satellite lookup passed
+    1. Build the HyperCore pair and a GenericRouting with a HyperEVM satellite vault.
+    2. Install a state-checkpoint callback and a child-router recorder.
+    3. Build a real routing state with a Lagoon transaction builder.
+    4. Create a trade for the synthetic HyperCore chain.
+    5. Call setup_trades and let the fake Web3 fail after satellite lookup.
+    6. Verify callback propagation and that lookup did not use synthetic chain 9999.
     """
-    # 1. Create pair
+    # 1. Build the HyperCore pair and a GenericRouting with a HyperEVM satellite vault.
     usdc = AssetIdentifier(
         chain_id=ChainId.hyperliquid.value,
         address="0xb88339CB7199b77E23DB6E890353E22632Ba630f",
@@ -85,7 +86,10 @@ def test_hypercore_satellite_vault_lookup_maps_chain_9999_to_999():
     # A stub routing model — setup_trades will be called on this after
     # the satellite lookup. It doesn't need to work, just not crash before
     # the satellite lookup code.
-    stub_routing_model = SimpleNamespace()
+    propagated_callbacks = []
+    stub_routing_model = SimpleNamespace(
+        set_pre_broadcast_state_sync_callback=propagated_callbacks.append,
+    )
 
     hypercore_routing_id = ProtocolRoutingId(router_name="hypercore_vault", exchange_slug=None)
     hypercore_config = ProtocolRoutingConfig(
@@ -113,7 +117,11 @@ def test_hypercore_satellite_vault_lookup_maps_chain_9999_to_999():
 
     routing = GenericRouting(pair_configurator)
 
-    # 3. Build real GenericRoutingState with a LagoonTransactionBuilder
+    # 2. Install a state-checkpoint callback and a child-router recorder.
+    checkpoint_callback = MagicMock()
+    routing.set_pre_broadcast_state_sync_callback(checkpoint_callback)
+
+    # 3. Build a real routing state with a Lagoon transaction builder.
     hot_wallet = HotWallet(TEST_ACCOUNT)
     tx_builder = _TestLagoonTransactionBuilder(
         chain_id=ChainId.arbitrum.value,  # Primary chain (not HyperEVM)
@@ -141,7 +149,7 @@ def test_hypercore_satellite_vault_lookup_maps_chain_9999_to_999():
         state_map={"hypercore_vault": router_state},
     )
 
-    # 4. Create trade
+    # 4. Create a trade for the synthetic HyperCore chain.
     trade = TradeExecution(
         trade_id=1,
         position_id=1,
@@ -155,7 +163,7 @@ def test_hypercore_satellite_vault_lookup_maps_chain_9999_to_999():
     )
     state = State()
 
-    # 5. Call setup_trades — the satellite lookup at line 201 should find
+    # 5. Call setup_trades — the satellite lookup should find
     # satellite_vaults[999] (not satellite_vaults[9999]) thanks to the mapping.
     # It will fail AFTER the lookup (nonce sync on fake web3, or
     # LagoonTransactionBuilder construction with the namespace vault).
@@ -166,9 +174,10 @@ def test_hypercore_satellite_vault_lookup_maps_chain_9999_to_999():
             trades=[trade],
         )
 
-    # 6. Verify the error is NOT the satellite vault lookup failure.
+    # 6. Verify callback propagation and that lookup did not use synthetic chain 9999.
     # Any other error means we got past the 9999 → 999 mapping.
     error_msg = str(exc_info.value)
+    assert propagated_callbacks == [checkpoint_callback]
     assert "No satellite vault configured for chain 9999" not in error_msg, (
         f"Chain 9999 → 999 mapping failed. The satellite vault lookup used "
         f"the synthetic chain_id 9999 instead of HyperEVM 999: {error_msg}"

--- a/tests/test_rebalance.py
+++ b/tests/test_rebalance.py
@@ -9,6 +9,7 @@
 import datetime
 import random
 from decimal import Decimal
+from unittest.mock import MagicMock
 
 import pandas as pd
 import pytest
@@ -26,7 +27,7 @@ from tradeexecutor.state.size_risk import SizeRisk
 from tradeexecutor.state.state import State, TradeType
 from tradeexecutor.state.portfolio import Portfolio
 from tradeexecutor.state.position import TradingPosition
-from tradeexecutor.state.trade import TradeExecution
+from tradeexecutor.state.trade import TradeExecution, TradeFlag
 from tradeexecutor.state.blockhain_transaction import BlockchainTransaction
 from tradeexecutor.state.reserve import ReservePosition
 from tradeexecutor.state.identifier import AssetIdentifier, TradingPairIdentifier, TradingPairKind
@@ -2260,18 +2261,21 @@ def test_alpha_model_keeps_hypercore_partial_sell_value_and_quantity_separate(
     assert trade.planned_price == pytest.approx(float(live_share_price))
 
 
-def test_alpha_model_converts_loss_making_hypercore_usd_cap_to_quantity(
+def test_alpha_model_preserves_full_close_flag_with_capped_hypercore_funding(
     start_ts: datetime.datetime,
     strategy_universe: TradingStrategyUniverse,
     pricing_model: BacktestPricing,
     usdc: AssetIdentifier,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Check Hypercore USD redemption cap is converted to vault units when share price is below 1.
+    """Check a capped zero-target HyperCore signal remains a full-close trade.
 
     1. Create a loss-making Hypercore position with share price below 1.
     2. Cap the redemption in USD below the requested sell and reserve safety headroom.
-    3. Verify safety-adjusted USD is converted to the corresponding vault-unit quantity.
+    3. Verify cash planning keeps the conservative amount while the emitted trade closes the full quantity.
+    4. Verify the cash tripwire does not treat the full accounting quantity as guaranteed proceeds.
+
+    Pricing and redemption capacity are mocked to isolate alpha-to-trade propagation.
     """
     state = State()
     hypercore_vault_pair = _create_hypercore_position_for_rebalance_test(
@@ -2306,6 +2310,7 @@ def test_alpha_model_converts_loss_making_hypercore_usd_cap_to_quantity(
     )
 
     alpha_model = AlphaModel(timestamp=position_manager.timestamp)
+    alpha_model.close_position_weight_epsilon = 0.0
     alpha_model.set_signal(hypercore_vault_pair, 0.0)
     alpha_model.select_top_signals(count=5)
     alpha_model.assign_weights(method=weight_passthrouh)
@@ -2324,14 +2329,30 @@ def test_alpha_model_converts_loss_making_hypercore_usd_cap_to_quantity(
     signal = alpha_model.get_signal_by_pair(hypercore_vault_pair)
     assert signal is not None
 
-    # 3. Verify safety-adjusted USD is converted to the corresponding vault-unit quantity.
+    # 3. Verify cash planning keeps the conservative amount while the emitted trade closes the full quantity.
     assert signal.position_adjust_usd == pytest.approx(-8.5)
     assert signal.position_adjust_quantity == pytest.approx(-17.0)
     assert len(trades) == 1
-    assert trades[0].is_sell()
-    assert trades[0].planned_quantity == Decimal("-17")
-    assert trades[0].planned_reserve == Decimal("8.50")
-    assert trades[0].planned_price == pytest.approx(0.5)
+    trade = trades[0]
+    assert trade.is_sell()
+    assert trade.planned_quantity == Decimal("-50")
+    assert trade.planned_reserve == Decimal("25.00")
+    assert trade.planned_price == pytest.approx(0.5)
+    assert trade.closing is True
+    assert TradeFlag.close in trade.flags
+    assert TradeFlag.reduce in trade.flags
+    assert trade.other_data["hypercore_first_stage_conservative_reserve_usd"] == "8.5"
+
+    # 4. Verify the cash tripwire does not treat the full accounting quantity as guaranteed proceeds.
+    buy_trade = MagicMock()
+    buy_trade.is_spot.return_value = True
+    buy_trade.is_credit_supply.return_value = False
+    buy_trade.is_buy.return_value = True
+    buy_trade.is_sell.return_value = False
+    buy_trade.planned_reserve = Decimal("9")
+    monkeypatch.setattr(position_manager, "get_current_cash", lambda: 0.0)
+    with pytest.raises(NotEnoughCasForBuys):
+        position_manager.check_enough_cash([trade, buy_trade])
 
 
 def test_alpha_model_skips_hypercore_sell_below_threshold_after_capping(

--- a/tradeexecutor/ethereum/execution.py
+++ b/tradeexecutor/ethereum/execution.py
@@ -811,6 +811,10 @@ class EthereumExecution(ExecutionModel):
         if not trades:
             return
 
+        routing_model.set_pre_broadcast_state_sync_callback(
+            self.sync_state_before_broadcast,
+        )
+
         for t in trades:
             assert not t.pair.is_exchange_account(), \
                 f"Unsupported: exchange account trades must not reach execute_trades(). Trade: {t}"

--- a/tradeexecutor/ethereum/execution.py
+++ b/tradeexecutor/ethereum/execution.py
@@ -34,7 +34,7 @@ from tradingstrategy.chain import ChainId
 from tradeexecutor.ethereum.tx import TransactionBuilder
 from tradeexecutor.ethereum.swap import report_failure
 from tradeexecutor.state.state import State
-from tradeexecutor.state.trade import TradeExecution, TradeStatus
+from tradeexecutor.state.trade import TradeExecution, TradeStatus, has_unresolved_hypercore_accounting
 from tradeexecutor.state.blockhain_transaction import BlockchainTransaction
 from tradeexecutor.state.freeze import freeze_position_on_failed_trade
 from tradeexecutor.state.identifier import AssetIdentifier
@@ -195,20 +195,16 @@ class EthereumExecution(ExecutionModel):
         at_risk_hypercore_trades = [
             trade
             for trade in trades_to_be_repaired
-            if trade.other_data.get("hypercore_deposit_capital_at_risk") is not None
-            or trade.other_data.get("hypercore_stranded_usdc") is not None
+            if has_unresolved_hypercore_accounting(trade)
         ]
         if at_risk_hypercore_trades:
             trade_ids = ", ".join(str(trade.trade_id) for trade in at_risk_hypercore_trades)
-            # Do not use this generic receipt-repair loop for CoreWriter
-            # deposits. A missing receipt or a receipt for a wrapper call does
-            # not say whether HyperCore left USDC in escrow, spot, perp, or the
-            # vault. Treating it as an ordinary failed buy could re-credit the
-            # Safe and repeat the #1486 double-spend accounting failure.
+            # Do not use this generic receipt-repair loop when HyperCore asset
+            # location or withdrawal accounting still needs live evidence.
             raise RuntimeError(
-                f"Cannot automatically repair HyperCore deposit trade(s) {trade_ids}: "
-                "reconcile the Safe, escrow, spot, perp and vault balances with "
-                "check-hypercore-user.py before releasing any allocation."
+                f"Cannot automatically repair HyperCore trade(s) {trade_ids}: "
+                "reconcile the Safe, escrow, spot, perp and vault balances before "
+                "changing their accounting."
             )
 
         print("Found %d trades to be repaired", len(trades_to_be_repaired))

--- a/tradeexecutor/ethereum/vault/hypercore_routing.py
+++ b/tradeexecutor/ethereum/vault/hypercore_routing.py
@@ -17,9 +17,10 @@ If the Safe is already activated, step 0 is skipped.
 
 1. Phase 1: ``vaultTransfer`` — withdraw from vault to HyperCore perp
 2. Perp wait: poll ``clearinghouseState`` until withdrawable USDC appears
-3. Phase 2: ``transferUsdClass`` — move from perp to spot
-4. Spot wait: poll ``spotClearinghouseState`` until free USDC appears
-5. Phase 3: ``sendAsset`` — bridge USDC from HyperCore spot back to HyperEVM
+3. Optional full-close residual: one more verified ``vaultTransfer``
+4. Phase 2: ``transferUsdClass`` — move the combined proceeds from perp to spot
+5. Spot wait: poll ``spotClearinghouseState`` until free USDC appears
+6. Phase 3: ``sendAsset`` — bridge USDC from HyperCore spot back to HyperEVM
 
 **Performance fee on withdrawal**:
 
@@ -891,6 +892,17 @@ class HypercoreVaultRouting(RoutingModel):
         #    retries if the first attempt silently no-ops.
         safety_margin_raw = self._get_full_close_safety_margin_raw(trade, live_raw)
         safe_raw = live_raw - safety_margin_raw
+        conservative_first_stage = trade.other_data.get(
+            "hypercore_first_stage_conservative_reserve_usd"
+        )
+        if conservative_first_stage is not None:
+            conservative_first_stage_raw = usdc_to_raw(
+                Decimal(str(conservative_first_stage))
+            )
+            safe_raw = min(safe_raw, conservative_first_stage_raw)
+            trade.other_data["hypercore_first_stage_conservative_raw"] = (
+                conservative_first_stage_raw
+            )
         assert safe_raw > 0, (
             f"Live vault equity {live_raw} raw ({equity.equity} USDC) is too small to "
             f"withdraw after subtracting safety margin {safety_margin_raw} raw"
@@ -910,6 +922,7 @@ class HypercoreVaultRouting(RoutingModel):
         #    it back.  Phases 2-3 (transferUsdClass, sendAsset) must use the
         #    same amount that phase 1's vaultTransfer was built with.
         trade.other_data["hypercore_capped_withdrawal_raw"] = safe_raw
+        trade.other_data["hypercore_first_stage_requested_raw"] = safe_raw
 
         return safe_raw
 
@@ -2455,15 +2468,10 @@ class HypercoreVaultRouting(RoutingModel):
         :raises SettlementBroadcastError:
             If transaction preparation, broadcast or confirmation fails.
         """
-        fn = build_hypercore_withdraw_from_vault_call(
-            self.lagoon_vault,
+        tx = self._prepare_withdrawal_vault_to_perp_transaction(
             vault_address=vault_address,
-            hypercore_usdc_amount=raw_amount,
-        )
-        tx = self._sign_module_call(
-            fn,
+            raw_amount=raw_amount,
             notes=f"Hypercore withdrawal phase 1 retry: {raw_amount} raw USDC from vault {vault_address}",
-            logical_function_name="sendRawAction",
         )
 
         try:
@@ -2471,6 +2479,256 @@ class HypercoreVaultRouting(RoutingModel):
         except Exception as e:
             raise SettlementBroadcastError(tx, e) from e
         return tx, receipt
+
+    def _prepare_withdrawal_vault_to_perp_transaction(
+        self,
+        vault_address: str,
+        raw_amount: int,
+        notes: str,
+    ) -> BlockchainTransaction:
+        """Build and sign one vault-to-perp withdrawal transaction."""
+        fn = build_hypercore_withdraw_from_vault_call(
+            self.lagoon_vault,
+            vault_address=vault_address,
+            hypercore_usdc_amount=raw_amount,
+        )
+        return self._sign_module_call(
+            fn,
+            notes=notes,
+            logical_function_name="sendRawAction",
+        )
+
+    def _plan_same_cycle_residual_withdrawal(
+        self,
+        trade: TradeExecution,
+        vault_address: str,
+    ) -> tuple[Decimal | None, int | None]:
+        """Read the first-stage residual and plan one protected follow-up withdrawal.
+
+        :return:
+            The fresh post-first-stage equity and an optional raw second-stage
+            request. A missing request means the first-stage proceeds should
+            continue through the normal downstream sweep.
+        """
+        try:
+            user_equity = fetch_user_vault_equity(
+                self._get_session(),
+                user=self.safe_address,
+                vault_address=vault_address,
+                bypass_cache=True,
+            )
+        except Exception as e:
+            trade.other_data["hypercore_second_stage_status"] = "skipped_equity_unavailable"
+            trade.other_data["hypercore_second_stage_error"] = str(e)
+            logger.warning(
+                "Could not read same-cycle HyperCore close residual for trade %s: %s",
+                trade.trade_id,
+                e,
+            )
+            return None, None
+
+        if user_equity is None:
+            trade.other_data["hypercore_second_stage_status"] = "skipped_no_position_data"
+            return None, None
+
+        residual = user_equity.equity
+        trade.other_data["hypercore_first_stage_residual_usd"] = str(residual)
+        if residual <= HYPERCORE_ACCEPTED_RESIDUAL_USD:
+            trade.other_data["hypercore_second_stage_status"] = "skipped_residual_accepted"
+            return residual, None
+
+        if not user_equity.is_lockup_expired:
+            trade.other_data["hypercore_second_stage_status"] = "skipped_lockup_active"
+            return residual, None
+
+        residual_margin = get_hypercore_withdrawal_safety_margin(residual)
+        try:
+            vault_info = HyperliquidVault(
+                session=self._get_session(),
+                vault_address=vault_address,
+            ).fetch_info(user=self.safe_address)
+        except Exception as e:
+            trade.other_data["hypercore_second_stage_status"] = "skipped_capacity_unavailable"
+            trade.other_data["hypercore_second_stage_error"] = str(e)
+            logger.warning(
+                "Could not read same-cycle HyperCore withdrawal capacity for trade %s: %s",
+                trade.trade_id,
+                e,
+            )
+            return residual, None
+
+        capacity = min(residual, vault_info.max_withdrawable)
+        capacity_margin = get_hypercore_withdrawal_safety_margin(capacity)
+        protected_capacity = max(Decimal(0), capacity - capacity_margin)
+        desired_request = max(Decimal(0), residual - residual_margin)
+        request = min(desired_request, protected_capacity)
+        if request <= 0:
+            trade.other_data["hypercore_second_stage_status"] = "skipped_insufficient_capacity"
+            return residual, None
+
+        request_raw = usdc_to_raw(request)
+        if request_raw <= 0:
+            trade.other_data["hypercore_second_stage_status"] = "skipped_zero_raw_amount"
+            return residual, None
+
+        rounded_expected_residual = residual - raw_to_usdc(request_raw)
+        trade.other_data["hypercore_second_stage_expected_residual_usd"] = str(
+            rounded_expected_residual
+        )
+        if rounded_expected_residual > HYPERCORE_ACCEPTED_RESIDUAL_USD:
+            trade.other_data["hypercore_second_stage_status"] = "skipped_insufficient_capacity"
+            return residual, None
+
+        trade.other_data["hypercore_second_stage_status"] = "planned"
+        trade.other_data["hypercore_second_stage_requested_raw"] = request_raw
+        trade.other_data["hypercore_second_stage_requested_usd"] = str(
+            raw_to_usdc(request_raw)
+        )
+        return residual, request_raw
+
+    def _execute_second_stage_withdrawal(
+        self,
+        web3: Web3,
+        trade: TradeExecution,
+        session: HyperliquidSession,
+        vault_address: str,
+        request_raw: int,
+        baseline_perp: Decimal,
+        equity_before: Decimal | None,
+        withdrawal_relative_tolerance: Decimal,
+        performance_fee_rate: Decimal,
+    ) -> tuple[Decimal, Decimal] | None:
+        """Broadcast and verify one optional full-close residual withdrawal.
+
+        A preparation failure or reverted receipt is a definite no-op and
+        returns ``None``. Any outcome that may still arrive on HyperCore raises
+        :class:`HypercoreWithdrawalVerificationError` so the caller can freeze
+        the trade before sweeping the shared perp balance.
+        """
+        try:
+            self.deployer.sync_nonce(web3)
+            tx = self._prepare_withdrawal_vault_to_perp_transaction(
+                vault_address=vault_address,
+                raw_amount=request_raw,
+                notes=(
+                    "Hypercore full-close residual withdrawal: "
+                    f"{request_raw} raw USDC from vault {vault_address}"
+                ),
+            )
+        except Exception as e:
+            trade.other_data["hypercore_second_stage_status"] = "skipped_preparation_failed"
+            trade.other_data["hypercore_second_stage_error"] = str(e)
+            logger.warning(
+                "Could not prepare optional HyperCore residual withdrawal for trade %s: %s",
+                trade.trade_id,
+                e,
+            )
+            return None
+
+        trade.blockchain_transactions.append(tx)
+        trade.other_data["hypercore_second_stage_status"] = "broadcast_pending"
+        trade.other_data["hypercore_second_stage_tx_hash"] = str(tx.tx_hash)
+        self.checkpoint_state()
+
+        try:
+            receipt = self._broadcast_and_confirm_settlement_tx(tx)
+        except Exception as e:
+            trade.other_data["hypercore_second_stage_status"] = "broadcast_ambiguous"
+            trade.other_data["hypercore_second_stage_error"] = str(e)
+            trade.other_data["hypercore_second_stage_failure_phase"] = "second_stage_broadcast"
+            self.checkpoint_state()
+            raise HypercoreWithdrawalVerificationError(
+                f"Second-stage broadcast outcome is ambiguous: {e}"
+            ) from e
+
+        receipt_status = receipt.get("status")
+        if receipt_status == 0:
+            trade.other_data["hypercore_second_stage_status"] = "reverted"
+            self.checkpoint_state()
+            return None
+        if receipt_status != 1:
+            trade.other_data["hypercore_second_stage_status"] = "broadcast_ambiguous"
+            trade.other_data["hypercore_second_stage_error"] = (
+                f"Receipt has invalid status: {receipt_status!r}"
+            )
+            trade.other_data["hypercore_second_stage_failure_phase"] = "second_stage_broadcast"
+            self.checkpoint_state()
+            raise HypercoreWithdrawalVerificationError(
+                f"Second-stage receipt has invalid status: {receipt_status!r}"
+            )
+
+        trade.other_data["hypercore_second_stage_status"] = "receipt_confirmed"
+        self.checkpoint_state()
+        requested_reserve = raw_to_usdc(request_raw)
+        fee_tolerance = estimate_max_withdrawal_commission(
+            requested_reserve,
+            performance_fee_rate,
+        )
+
+        try:
+            perp_after = self._wait_for_perp_withdrawable_balance(
+                baseline_balance=baseline_perp,
+                expected_increase_raw=request_raw,
+                relative_tolerance=withdrawal_relative_tolerance,
+                performance_fee_tolerance=fee_tolerance,
+                timeout=30.0,
+                poll_interval=2.0,
+            )
+            equity = fetch_user_vault_equity(
+                session,
+                user=self.safe_address,
+                vault_address=vault_address,
+                bypass_cache=True,
+            )
+            equity_after = equity.equity if equity is not None else None
+            if (
+                equity_before is None
+                or equity_after is None
+                or equity_after >= equity_before
+            ):
+                raise HypercoreWithdrawalVerificationError(
+                    "Second-stage perp increase did not have a matching vault-equity decrease"
+                )
+        except Exception as e:
+            trade.other_data["hypercore_second_stage_status"] = "verification_ambiguous"
+            trade.other_data["hypercore_second_stage_error"] = str(e)
+            trade.other_data["hypercore_second_stage_failure_phase"] = "second_stage_verification"
+            self.checkpoint_state()
+            if isinstance(e, HypercoreWithdrawalVerificationError):
+                raise
+            raise HypercoreWithdrawalVerificationError(
+                f"Second-stage verification is ambiguous: {e}"
+            ) from e
+
+        trade.other_data["hypercore_second_stage_status"] = "verified"
+        trade.other_data["hypercore_second_stage_residual_usd"] = str(equity_after)
+        self.checkpoint_state()
+        return perp_after, equity_after
+
+    @staticmethod
+    def _calculate_partial_close_quantity(
+        position_quantity: Decimal,
+        equity_snapshots: list[tuple[Decimal, Decimal]],
+    ) -> Decimal:
+        """Compose per-leg equity reductions into an executed share quantity."""
+        assert position_quantity > 0, f"Position quantity must be positive: {position_quantity}"
+        assert equity_snapshots, "At least one verified equity reduction is required"
+
+        retained_fraction = Decimal(1)
+        for equity_before, equity_after in equity_snapshots:
+            if equity_before <= 0:
+                raise HypercoreWithdrawalVerificationError(
+                    f"Withdrawal leg has non-positive starting equity: {equity_before}"
+                )
+            reduction_fraction = (equity_before - equity_after) / equity_before
+            if reduction_fraction < 0 or reduction_fraction > 1:
+                raise HypercoreWithdrawalVerificationError(
+                    "Withdrawal leg equity reduction fraction is outside [0, 1]: "
+                    f"before {equity_before}, after {equity_after}, fraction {reduction_fraction}"
+                )
+            retained_fraction *= Decimal(1) - reduction_fraction
+
+        return position_quantity * (Decimal(1) - retained_fraction)
 
     def _broadcast_withdrawal_phase3(
         self,
@@ -2990,12 +3248,13 @@ class HypercoreVaultRouting(RoutingModel):
 
         1. Verifies the phase 1 EVM receipt.
         2. Waits for the withdrawn USDC to appear in HyperCore perp.
-        3. Broadcasts phase 2 (``transferUsdClass(perp->spot)``).
-        4. Waits for the USDC to appear in HyperCore spot.
-        5. Broadcasts phase 3 (``sendAsset`` / spot -> EVM).
-        6. Polls the Safe's EVM USDC balance until the bridged USDC arrives.
-        7. Compares actual received USDC against planned amount.
-        8. Marks the trade as success or failure.
+        3. Optionally withdraws one protected full-close residual to perp.
+        4. Broadcasts phase 2 (``transferUsdClass(perp->spot)``).
+        5. Waits for the USDC to appear in HyperCore spot.
+        6. Broadcasts phase 3 (``sendAsset`` / spot -> EVM).
+        7. Polls the Safe's EVM USDC balance until the bridged USDC arrives.
+        8. Compares actual received USDC and final vault equity against the plan.
+        9. Marks the trade as success or failure.
 
         In simulate mode, the balance verification is skipped because
         the mock CoreWriter does not actually bridge USDC.
@@ -3028,10 +3287,10 @@ class HypercoreVaultRouting(RoutingModel):
         # Capture baseline EVM USDC balance and vault equity before the
         # bridge delivers the withdrawal.  These are used for dual-chain
         # verification after the USDC arrives on EVM.
+        expected_raw = self._get_raw_usdc_amount(trade)
+        position_quantity_before: Decimal | None = None
         if not self.simulate:
             baseline_balance_raw = self._fetch_safe_evm_usdc_balance()
-            expected_raw = self._get_raw_usdc_amount(trade)
-            position_quantity_before: Decimal | None = None
             try:
                 candidate_position_quantity = state.portfolio.get_position_by_id(
                     trade.position_id
@@ -3167,7 +3426,13 @@ class HypercoreVaultRouting(RoutingModel):
             Decimal(str(trade.slippage_tolerance or 0)),
         )
         phase1_requested_reserve = raw_to_usdc(expected_raw)
+        total_requested_reserve = phase1_requested_reserve
         remaining_equity_after_withdrawal: Decimal | None = None
+        verified_leg_equity_snapshots: list[tuple[Decimal, Decimal]] = []
+        is_explicit_full_close = (
+            TradeFlag.close in trade.flags
+            and not trade.other_data.get("hypercore_small_position_cleanup")
+        )
 
         if self.simulate:
             # Simulate mode: mock CoreWriter does not bridge USDC,
@@ -3314,6 +3579,7 @@ class HypercoreVaultRouting(RoutingModel):
 
                         expected_raw = retry_raw
                         phase1_requested_reserve = raw_to_usdc(expected_raw)
+                        total_requested_reserve = phase1_requested_reserve
                         phase1_performance_fee_tolerance = estimate_max_withdrawal_commission(
                             phase1_requested_reserve,
                             performance_fee_rate,
@@ -3414,12 +3680,91 @@ class HypercoreVaultRouting(RoutingModel):
                 perp_balance,
             )
 
+            if is_explicit_full_close:
+                # A silent-no-op retry has already consumed the second and
+                # final vault transaction allowed for this close cycle.
+                if "hypercore_phase1_retry_safety_margin_raw" in trade.other_data:
+                    trade.other_data["hypercore_second_stage_status"] = "skipped_phase1_retry_budget_used"
+                    first_stage_equity_after = None
+                    second_stage_raw = None
+                elif not has_pre_phase1_vault_equity_snapshot:
+                    trade.other_data["hypercore_second_stage_status"] = "skipped_missing_phase1_equity_snapshot"
+                    first_stage_equity_after = None
+                    second_stage_raw = None
+                else:
+                    first_stage_equity_after, second_stage_raw = self._plan_same_cycle_residual_withdrawal(
+                        trade,
+                        vault_address,
+                    )
+                    if (
+                        vault_equity_before_phase1_snapshot is not None
+                        and first_stage_equity_after is not None
+                        and first_stage_equity_after < vault_equity_before_phase1_snapshot
+                    ):
+                        verified_leg_equity_snapshots.append(
+                            (
+                                vault_equity_before_phase1_snapshot,
+                                first_stage_equity_after,
+                            )
+                        )
+                    elif first_stage_equity_after is not None:
+                        trade.other_data["hypercore_second_stage_status"] = "skipped_first_stage_equity_decrease_unverified"
+                        second_stage_raw = None
+
+                if second_stage_raw is not None:
+                    try:
+                        second_stage_result = self._execute_second_stage_withdrawal(
+                            web3=web3,
+                            trade=trade,
+                            session=session,
+                            vault_address=vault_address,
+                            request_raw=second_stage_raw,
+                            baseline_perp=perp_balance,
+                            equity_before=first_stage_equity_after,
+                            withdrawal_relative_tolerance=withdrawal_relative_tolerance,
+                            performance_fee_rate=performance_fee_rate,
+                        )
+                    except HypercoreWithdrawalVerificationError as e:
+                        self._mark_stranded_usdc(
+                            trade,
+                            usdc_to_raw(perp_balance - baseline_perp_withdrawable) + second_stage_raw,
+                            "hypercore_perp",
+                        )
+                        self.diagnose_hyperliquid_vault_redemption_failure(
+                            trade,
+                            vault_address,
+                            trade.other_data.get(
+                                "hypercore_second_stage_failure_phase",
+                                "second_stage_verification",
+                            ),
+                            str(e),
+                        )
+                        report_failure(ts, state, trade, stop_on_execution_failure)
+                        return
+
+                    if second_stage_result is not None:
+                        second_stage_perp, final_second_stage_equity = second_stage_result
+                        assert first_stage_equity_after is not None
+                        verified_leg_equity_snapshots.append(
+                            (first_stage_equity_after, final_second_stage_equity)
+                        )
+                        perp_balance = second_stage_perp
+                        expected_raw += second_stage_raw
+                        total_requested_reserve += raw_to_usdc(second_stage_raw)
+                        trade.other_data["hypercore_total_requested_gross_usd"] = str(
+                            total_requested_reserve
+                        )
+                        self.checkpoint_state()
+
             # Propagate the observed perp balance into the phase 2 amount.
             # Phase 1 may have delivered slightly less USDC than expected
             # (HyperCore fees/rounding).  If we request more than what the
             # perp account holds, HyperCore silently rejects the
             # transferUsdClass action (EVM tx status=1 but nothing moves).
             actual_perp_increase_raw = usdc_to_raw(perp_balance - baseline_perp_withdrawable)
+            trade.other_data["hypercore_total_observed_perp_increase_usd"] = str(
+                raw_to_usdc(actual_perp_increase_raw)
+            )
             if actual_perp_increase_raw > 0 and actual_perp_increase_raw < expected_raw:
                 logger.info(
                     "Capping phase 2 amount to observed perp increase for trade %s: "
@@ -3652,7 +3997,7 @@ class HypercoreVaultRouting(RoutingModel):
             # capped, else planned) to avoid spurious "partial" warnings on
             # normal capped-close trades where live equity < planned_reserve.
             effective_reserve = raw_to_usdc(phase3_raw)
-            gross_vault_redeemed_reserve = phase1_requested_reserve
+            gross_vault_redeemed_reserve = total_requested_reserve
             if executed_reserve < effective_reserve:
                 logger.warning(
                     "Withdrawal partial: received %s USDC but expected %s USDC (trade %s)",
@@ -3681,6 +4026,20 @@ class HypercoreVaultRouting(RoutingModel):
                         # EVM arrival verifies net proceeds, while HyperCore's observed gross debit
                         # determines the quantity settled when a withdrawal under-redeems.
                         gross_vault_redeemed_reserve = equity_decrease
+                        if (
+                            is_explicit_full_close
+                            and not verified_leg_equity_snapshots
+                            and has_pre_phase1_vault_equity_snapshot
+                        ):
+                            # The optional between-leg equity read may have
+                            # failed. The durable pre-phase-1 snapshot and the
+                            # final uncached read still prove the total debit.
+                            verified_leg_equity_snapshots.append(
+                                (
+                                    vault_equity_before_phase1_snapshot,
+                                    remaining_equity,
+                                )
+                            )
                     expected_decrease = executed_reserve
                     tolerance = expected_decrease * Decimal("0.01")
                     if equity_decrease < expected_decrease - tolerance:
@@ -3723,7 +4082,7 @@ class HypercoreVaultRouting(RoutingModel):
         assert planned_price > 0, f"Planned Hypercore vault sell price must be positive, got {planned_price}"
         planned_gross_reserve = abs(trade.planned_quantity) * planned_price
         expected_gross_redeemed_reserve = min(
-            phase1_requested_reserve,
+            total_requested_reserve,
             planned_gross_reserve,
         )
         close_shortfall = effective_reserve - executed_reserve
@@ -3745,6 +4104,20 @@ class HypercoreVaultRouting(RoutingModel):
             or TradeFlag.close in trade.flags
             or closes_position_quantity
         )
+        if (
+            is_explicit_full_close
+            and not self.simulate
+            and remaining_equity_after_withdrawal is None
+        ):
+            self.diagnose_hyperliquid_vault_redemption_failure(
+                trade,
+                self._get_vault_address(trade),
+                "final_residual_verification",
+                "Final vault equity was unavailable after an explicit full close",
+            )
+            report_failure(ts, state, trade, stop_on_execution_failure)
+            return
+
         if (
             is_closing_trade
             and position is not None
@@ -3822,11 +4195,51 @@ class HypercoreVaultRouting(RoutingModel):
         if should_close_full_quantity:
             executed_amount = trade.planned_quantity
         else:
-            gross_vault_redeemed_reserve = min(
-                gross_vault_redeemed_reserve,
-                planned_gross_reserve,
+            if is_explicit_full_close:
+                if not isinstance(position_quantity_before, Decimal):
+                    self.diagnose_hyperliquid_vault_redemption_failure(
+                        trade,
+                        self._get_vault_address(trade),
+                        "partial_quantity_verification",
+                        "Position quantity was unavailable for partial full-close settlement",
+                    )
+                    report_failure(ts, state, trade, stop_on_execution_failure)
+                    return
+                try:
+                    partial_close_quantity = self._calculate_partial_close_quantity(
+                        position_quantity_before,
+                        verified_leg_equity_snapshots,
+                    )
+                except (AssertionError, HypercoreWithdrawalVerificationError) as e:
+                    self.diagnose_hyperliquid_vault_redemption_failure(
+                        trade,
+                        self._get_vault_address(trade),
+                        "partial_quantity_verification",
+                        str(e),
+                    )
+                    report_failure(ts, state, trade, stop_on_execution_failure)
+                    return
+                executed_amount = -partial_close_quantity
+            else:
+                gross_vault_redeemed_reserve = min(
+                    gross_vault_redeemed_reserve,
+                    planned_gross_reserve,
+                )
+                executed_amount = -(gross_vault_redeemed_reserve / planned_price)
+
+        if abs(executed_amount) > abs(trade.planned_quantity):
+            error = (
+                f"Executed HyperCore quantity {executed_amount} exceeds "
+                f"planned quantity {trade.planned_quantity}"
             )
-            executed_amount = -(gross_vault_redeemed_reserve / planned_price)
+            self.diagnose_hyperliquid_vault_redemption_failure(
+                trade,
+                self._get_vault_address(trade),
+                "executed_quantity_verification",
+                error,
+            )
+            report_failure(ts, state, trade, stop_on_execution_failure)
+            return
 
         executed_price = float(executed_reserve / abs(executed_amount)) if executed_amount else 1.0
 

--- a/tradeexecutor/ethereum/vault/hypercore_routing.py
+++ b/tradeexecutor/ethereum/vault/hypercore_routing.py
@@ -119,7 +119,13 @@ from tradeexecutor.state.blockhain_transaction import (
 )
 from tradeexecutor.state.pickle_over_json import encode_pickle_over_json
 from tradeexecutor.state.state import State
-from tradeexecutor.state.trade import TradeExecution, TradeFlag
+from tradeexecutor.state.trade import (
+    HYPERCORE_ACCOUNTING_RECONCILIATION_REQUIRED_KEY,
+    HYPERCORE_DEPOSIT_CAPITAL_AT_RISK_KEY,
+    HYPERCORE_STRANDED_USDC_KEY,
+    TradeExecution,
+    TradeFlag,
+)
 from tradeexecutor.state.types import JSONHexAddress
 from tradeexecutor.strategy.routing import RoutingState, RoutingModel
 from tradeexecutor.strategy.trading_strategy_universe import TradingStrategyUniverse
@@ -264,8 +270,6 @@ HYPERCORE_RELATIVE_BALANCE_TOLERANCE = Decimal("0.01")
 #: failed-buy reserve recovery. Re-crediting a Safe after the deposit was in
 #: fact accepted would make the same USDC both spendable in portfolio state and
 #: present on HyperCore: the accounting half of the #1486 incident.
-HYPERCORE_DEPOSIT_CAPITAL_AT_RISK_KEY = "hypercore_deposit_capital_at_risk"
-HYPERCORE_STRANDED_USDC_KEY = "hypercore_stranded_usdc"
 RETAIN_RESERVE_ALLOCATION_ON_FAILURE_KEY = "retain_reserve_allocation_on_failure"
 
 #: Last-resort HyperCore vault leader performance fee, as a fraction.
@@ -1082,6 +1086,7 @@ class HypercoreVaultRouting(RoutingModel):
                 # full-close live-equity caps so downstream code remains on a
                 # single path.
                 trade.other_data["hypercore_capped_withdrawal_raw"] = effective_requested_raw
+                trade.other_data["hypercore_first_stage_requested_raw"] = effective_requested_raw
             else:
                 # A larger gap is not the 2026-04-15 dust-drift incident.
                 # Preserve the original fail-fast behaviour for material
@@ -1809,6 +1814,26 @@ class HypercoreVaultRouting(RoutingModel):
             "Use check-hypercore-user.py to verify and recover.",
             human_amount, location, self.safe_address, trade.trade_id,
         )
+
+    def _mark_accounting_reconciliation_required(
+        self,
+        trade: TradeExecution,
+        phase: str,
+        reason: str,
+        observed_safe_proceeds: Decimal,
+    ) -> None:
+        """Protect a failed withdrawal whose proceeds already reached the Safe."""
+        trade.other_data[HYPERCORE_ACCOUNTING_RECONCILIATION_REQUIRED_KEY] = {
+            "phase": phase,
+            "reason": reason,
+            "safe_address": self.safe_address,
+            "observed_safe_proceeds_usd": str(observed_safe_proceeds),
+        }
+        trade.add_note(
+            "HyperCore withdrawal needs live accounting reconciliation after "
+            f"{observed_safe_proceeds} USDC reached the Safe"
+        )
+        self.checkpoint_state()
 
     def diagnose_hyperliquid_vault_redemption_failure(
         self,
@@ -3585,6 +3610,7 @@ class HypercoreVaultRouting(RoutingModel):
                             performance_fee_rate,
                         )
                         trade.other_data["hypercore_capped_withdrawal_raw"] = retry_raw
+                        trade.other_data["hypercore_first_stage_requested_raw"] = retry_raw
                         trade.other_data["hypercore_phase1_retry_safety_margin_raw"] = retry_safety_margin_raw
                         vault_equity_before_phase1_snapshot = current_vault_equity
                         has_pre_phase1_vault_equity_snapshot = True
@@ -3709,6 +3735,9 @@ class HypercoreVaultRouting(RoutingModel):
                         )
                     elif first_stage_equity_after is not None:
                         trade.other_data["hypercore_second_stage_status"] = "skipped_first_stage_equity_decrease_unverified"
+                        trade.other_data.pop("hypercore_second_stage_requested_raw", None)
+                        trade.other_data.pop("hypercore_second_stage_requested_usd", None)
+                        trade.other_data.pop("hypercore_second_stage_expected_residual_usd", None)
                         second_stage_raw = None
 
                 if second_stage_raw is not None:
@@ -4109,11 +4138,18 @@ class HypercoreVaultRouting(RoutingModel):
             and not self.simulate
             and remaining_equity_after_withdrawal is None
         ):
+            reason = "Final vault equity was unavailable after an explicit full close"
+            self._mark_accounting_reconciliation_required(
+                trade,
+                "final_residual_verification",
+                reason,
+                executed_reserve,
+            )
             self.diagnose_hyperliquid_vault_redemption_failure(
                 trade,
                 self._get_vault_address(trade),
                 "final_residual_verification",
-                "Final vault equity was unavailable after an explicit full close",
+                reason,
             )
             report_failure(ts, state, trade, stop_on_execution_failure)
             return
@@ -4197,11 +4233,18 @@ class HypercoreVaultRouting(RoutingModel):
         else:
             if is_explicit_full_close:
                 if not isinstance(position_quantity_before, Decimal):
+                    reason = "Position quantity was unavailable for partial full-close settlement"
+                    self._mark_accounting_reconciliation_required(
+                        trade,
+                        "partial_quantity_verification",
+                        reason,
+                        executed_reserve,
+                    )
                     self.diagnose_hyperliquid_vault_redemption_failure(
                         trade,
                         self._get_vault_address(trade),
                         "partial_quantity_verification",
-                        "Position quantity was unavailable for partial full-close settlement",
+                        reason,
                     )
                     report_failure(ts, state, trade, stop_on_execution_failure)
                     return
@@ -4211,6 +4254,12 @@ class HypercoreVaultRouting(RoutingModel):
                         verified_leg_equity_snapshots,
                     )
                 except (AssertionError, HypercoreWithdrawalVerificationError) as e:
+                    self._mark_accounting_reconciliation_required(
+                        trade,
+                        "partial_quantity_verification",
+                        str(e),
+                        executed_reserve,
+                    )
                     self.diagnose_hyperliquid_vault_redemption_failure(
                         trade,
                         self._get_vault_address(trade),
@@ -4231,6 +4280,12 @@ class HypercoreVaultRouting(RoutingModel):
             error = (
                 f"Executed HyperCore quantity {executed_amount} exceeds "
                 f"planned quantity {trade.planned_quantity}"
+            )
+            self._mark_accounting_reconciliation_required(
+                trade,
+                "executed_quantity_verification",
+                error,
+                executed_reserve,
             )
             self.diagnose_hyperliquid_vault_redemption_failure(
                 trade,

--- a/tradeexecutor/ethereum/vault/hypercore_routing.py
+++ b/tradeexecutor/ethereum/vault/hypercore_routing.py
@@ -3728,7 +3728,7 @@ class HypercoreVaultRouting(RoutingModel):
                         self._mark_stranded_usdc(
                             trade,
                             usdc_to_raw(perp_balance - baseline_perp_withdrawable) + second_stage_raw,
-                            "hypercore_perp",
+                            "hypercore_perp_or_vault",
                         )
                         self.diagnose_hyperliquid_vault_redemption_failure(
                             trade,

--- a/tradeexecutor/ethereum/vault/hyperliquid_cleanup.py
+++ b/tradeexecutor/ethereum/vault/hyperliquid_cleanup.py
@@ -75,6 +75,10 @@ from tradeexecutor.ethereum.vault.hypercore_transit_recovery import (
 from tradeexecutor.state.repair import close_hypercore_dust_positions, repair_trades
 from tradeexecutor.state.state import State
 from tradeexecutor.state.store import JSONFileStore
+from tradeexecutor.state.trade import (
+    HYPERCORE_ACCOUNTING_RECONCILIATION_REQUIRED_KEY,
+    has_unresolved_hypercore_accounting,
+)
 from tradeexecutor.strategy.account_correction import (
     UnknownTokenPositionFix, calculate_account_corrections, check_accounts,
     check_state_internal_coherence, correct_accounts)
@@ -275,6 +279,9 @@ def _build_state_snapshot(state: State) -> HyperliquidStateSnapshot:
             data = getattr(trade, "other_data", None) or {}
             if "hypercore_stranded_usdc" in data:
                 stranded_metadata = data["hypercore_stranded_usdc"]
+                break
+            if HYPERCORE_ACCOUNTING_RECONCILIATION_REQUIRED_KEY in data:
+                stranded_metadata = data[HYPERCORE_ACCOUNTING_RECONCILIATION_REQUIRED_KEY]
                 break
 
         positions.append(
@@ -755,18 +762,17 @@ def _repair_and_correct_state(
     deferred_hypercore_trades = [
         trade
         for trade in repair_result.trades_needing_repair
-        if trade.other_data.get("hypercore_deposit_capital_at_risk") is not None
-        or trade.other_data.get("hypercore_stranded_usdc") is not None
+        if has_unresolved_hypercore_accounting(trade)
     ]
     if deferred_hypercore_trades:
         # This legacy cleanup tool has no transaction-level evidence for a
-        # failed deposit and no Safe-level transit-recovery planner. Letting
+        # failed HyperCore trade and no Safe-level transit-recovery planner. Letting
         # generic account correction continue could re-credit Safe reserves
         # while the same USDC still has an unknown HyperCore location. Keep
         # the historical fail-closed behaviour and leave reconciliation to
         # ``correct-accounts --dry-run`` followed by the live command.
         logger.error(
-            "Hyperliquid cleanup stopped: deferred HyperCore deposit trade(s) %s "
+            "Hyperliquid cleanup stopped: deferred HyperCore trade(s) %s "
             "need live reconciliation before account correction",
             ", ".join(str(trade.trade_id) for trade in deferred_hypercore_trades),
         )

--- a/tradeexecutor/state/repair.py
+++ b/tradeexecutor/state/repair.py
@@ -29,7 +29,13 @@ from eth_defi.compat import native_datetime_utc_now
 from tradeexecutor.state.portfolio import Portfolio
 from tradeexecutor.state.position import TradingPosition
 from tradeexecutor.state.state import State
-from tradeexecutor.state.trade import TradeExecution, TradeType, TradeStatus, TradeFlag
+from tradeexecutor.state.trade import (
+    TradeExecution,
+    TradeType,
+    TradeStatus,
+    TradeFlag,
+    has_unresolved_hypercore_accounting,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -750,8 +756,7 @@ def repair_trades(
     at_risk_hypercore_trades = [
         trade
         for trade in trades_to_be_repaired
-        if trade.other_data.get("hypercore_deposit_capital_at_risk") is not None
-        or trade.other_data.get("hypercore_stranded_usdc") is not None
+        if has_unresolved_hypercore_accounting(trade)
     ]
     protected_position_ids = {trade.position_id for trade in at_risk_hypercore_trades}
     repairable_trades = [
@@ -810,7 +815,7 @@ def repair_trades(
     for p in frozen_positions:
         if p.position_id in protected_position_ids:
             logger.warning(
-                "Leaving position %s frozen because its HyperCore deposit still needs live reconciliation",
+                "Leaving position %s frozen because its HyperCore trade still needs live reconciliation",
                 p,
             )
             continue

--- a/tradeexecutor/state/repair.py
+++ b/tradeexecutor/state/repair.py
@@ -761,10 +761,11 @@ def repair_trades(
     ]
     if at_risk_hypercore_trades:
         trade_ids = ", ".join(str(trade.trade_id) for trade in at_risk_hypercore_trades)
-        # ``repair_trade()`` would otherwise make a counter trade and restore
-        # the planned reserve without querying HyperCore.  Never infer a
-        # location from a failed status or a successful EVM wrapper receipt:
-        # trade #1486 proved that either can coexist with USDC in HyperCore.
+        # ``repair_trade()`` would otherwise make a counter trade and assume
+        # the failed action moved no assets without querying HyperCore. Never
+        # infer a location from a failed status or a successful EVM wrapper
+        # receipt: trade #1486 proved that either can coexist with USDC in
+        # HyperCore.
         #
         # Do not abort the entire repair command, however.  Production also had
         # an unrelated planned no-transaction trade which blocked
@@ -773,10 +774,10 @@ def repair_trades(
         # correct-accounts --dry-run can safely inspect and plan the live
         # HyperCore recovery.  The affected position remains frozen below.
         logger.error(
-            "Deferring state repair for HyperCore deposit trade(s) %s: USDC may be in "
-            "HyperCore escrow, spot, perp, or vault. Their positions remain frozen; "
+            "Deferring state repair for HyperCore trade(s) %s: funds may be in "
+            "the Safe, HyperCore escrow, spot, perp, or vault. Their positions remain frozen; "
             "run correct-accounts --dry-run and reconcile the live destination before "
-            "releasing any allocation.",
+            "changing their accounting.",
             trade_ids,
         )
         if not repairable_trades:

--- a/tradeexecutor/state/trade.py
+++ b/tradeexecutor/state/trade.py
@@ -39,6 +39,22 @@ CCTP_BRIDGE_OUT_ORDER_BUMP = 20_000_000
 
 VAULT_SETTLEMENT_REQUEST_RESERVE_KEY = "vault_settlement_request_reserve"
 VAULT_SETTLEMENT_REQUEST_QUANTITY_KEY = "vault_settlement_request_quantity"
+HYPERCORE_DEPOSIT_CAPITAL_AT_RISK_KEY = "hypercore_deposit_capital_at_risk"
+HYPERCORE_STRANDED_USDC_KEY = "hypercore_stranded_usdc"
+HYPERCORE_ACCOUNTING_RECONCILIATION_REQUIRED_KEY = "hypercore_accounting_reconciliation_required"
+
+
+def has_unresolved_hypercore_accounting(trade: "TradeExecution") -> bool:
+    """Check whether generic repair must defer to live HyperCore reconciliation."""
+    metadata = trade.other_data or {}
+    return any(
+        metadata.get(key) is not None
+        for key in (
+            HYPERCORE_DEPOSIT_CAPITAL_AT_RISK_KEY,
+            HYPERCORE_STRANDED_USDC_KEY,
+            HYPERCORE_ACCOUNTING_RECONCILIATION_REQUIRED_KEY,
+        )
+    )
 
 
 class TradeType(enum.Enum):

--- a/tradeexecutor/strategy/account_correction.py
+++ b/tradeexecutor/strategy/account_correction.py
@@ -32,7 +32,14 @@ from tradeexecutor.ethereum.tx import TransactionBuilder
 from tradeexecutor.state.generic_position import GenericPosition
 from tradeexecutor.state.portfolio import Portfolio
 from tradeexecutor.state.repair import close_position_with_empty_trade
-from tradeexecutor.state.trade import TradeFlag, TradeExecution, TradeStatus, TradeType
+from tradeexecutor.state.trade import (
+    HYPERCORE_ACCOUNTING_RECONCILIATION_REQUIRED_KEY,
+    TradeFlag,
+    TradeExecution,
+    TradeStatus,
+    TradeType,
+    has_unresolved_hypercore_accounting,
+)
 from tradeexecutor.strategy.dust import DEFAULT_DUST_EPSILON, HYPERCORE_ACCEPTED_RESIDUAL_USD, get_close_epsilon_for_pair, get_dust_epsilon_for_asset, DEFAULT_RELATIVE_EPSILON, \
     get_relative_epsilon_for_asset, get_relative_epsilon_for_pair, DEFAULT_USD_LOW_VALUE_THRESHOLD
 from tradeexecutor.strategy.lending_protocol_leverage import reset_credit_supply_loan
@@ -1347,18 +1354,20 @@ def _build_hypercore_vault_account_checks(
         # integrations which only need the vault-equity account check.
         for trade in getattr(position, "trades", {}).values():
             metadata = trade.other_data or {}
-            transit = metadata.get("hypercore_stranded_usdc") or metadata.get(
-                "hypercore_deposit_capital_at_risk"
-            )
-            if transit is not None:
-                transit_trades.append((trade.trade_id, transit))
+            if has_unresolved_hypercore_accounting(trade):
+                reconciliation = (
+                    metadata.get("hypercore_stranded_usdc")
+                    or metadata.get("hypercore_deposit_capital_at_risk")
+                    or metadata.get(HYPERCORE_ACCOUNTING_RECONCILIATION_REQUIRED_KEY)
+                )
+                transit_trades.append((trade.trade_id, reconciliation))
     for trade_id, transit in transit_trades:
         # HyperCore transit USDC is not an ERC-20 Safe balance and must not be
         # manufactured by account correction. Keep the condition visible to the
         # operator while the routing/repair guards retain the allocation.
         logger.warning(
-            "HyperCore transit capital retained for failed trade #%s: %s. "
-            "This HyperCore-specific check will not release it; reconcile live balances first.",
+            "HyperCore live reconciliation required for failed trade #%s: %s. "
+            "This HyperCore-specific check will not infer settlement; reconcile live balances first.",
             trade_id,
             transit,
         )

--- a/tradeexecutor/strategy/alpha_model.py
+++ b/tradeexecutor/strategy/alpha_model.py
@@ -18,7 +18,7 @@ from tradeexecutor.state.identifier import TradingPairIdentifier
 from tradeexecutor.state.portfolio import Portfolio
 from tradeexecutor.state.position import TradingPosition
 from tradeexecutor.state.size_risk import SizeRisk
-from tradeexecutor.state.trade import TradeExecution, TradeType
+from tradeexecutor.state.trade import TradeExecution, TradeFlag, TradeType
 from tradeexecutor.state.types import (LeverageMultiplier, PairInternalId,
                                        Percent, USDollarAmount)
 from tradeexecutor.strategy.dust import (
@@ -1102,7 +1102,10 @@ class AlphaModel:
         return (
             signal.position_adjust_usd < 0
             and (signal.old_value or 0) > 0
-            and signal.normalised_weight < self.close_position_weight_epsilon
+            and (
+                signal.normalised_weight == 0
+                or signal.normalised_weight < self.close_position_weight_epsilon
+            )
         )
 
     def _get_sell_quantity_dust_epsilon(
@@ -2472,7 +2475,10 @@ class AlphaModel:
             )
             return position_rebalance_trades
 
-        if signal.normalised_weight < self.close_position_weight_epsilon:
+        if (
+            signal.normalised_weight == 0
+            or signal.normalised_weight < self.close_position_weight_epsilon
+        ):
             if current_position:
                 use_partial_hypercore_close = (
                     current_position.pair.is_hyperliquid_vault()
@@ -2481,9 +2487,28 @@ class AlphaModel:
                 )
                 if use_partial_hypercore_close:
                     logger.info(
-                        "Hypercore close signal capped to a partial reduction because live redemption limits are binding: %s",
+                        "Planning a full Hypercore close with conservative first-stage funding because live redemption limits are binding: %s",
                         current_position,
                     )
+                    conservative_reserve = abs(Decimal(str(hypercore_reduction_plan.effective_marked_value_delta)))
+                    position_rebalance_trades += position_manager.close_position(
+                        current_position,
+                        TradeType.rebalance,
+                        notes=f"Closing position in up to two protected HyperCore withdrawal legs: {signal}",
+                        flags={TradeFlag.reduce},
+                    )
+                    assert len(position_rebalance_trades) == 1
+                    close_trade = position_rebalance_trades[0]
+                    close_trade.other_data["hypercore_first_stage_conservative_reserve_usd"] = str(
+                        conservative_reserve
+                    )
+                    assert close_trade.closing
+                    assert TradeFlag.close in close_trade.flags
+                    assert TradeFlag.reduce in close_trade.flags
+                    signal.position_id = current_position.position_id
+                    signal.flags.add(TradingPairSignalFlags.closed)
+                    signal.flags.add(TradingPairSignalFlags.close_position_weight_limit)
+                    return position_rebalance_trades
                 else:
                     logger.info("Closing the position fully: %s", current_position)
                     position_rebalance_trades += position_manager.close_position(

--- a/tradeexecutor/strategy/generic/generic_router.py
+++ b/tradeexecutor/strategy/generic/generic_router.py
@@ -140,6 +140,10 @@ class GenericRouting(RoutingModel):
             router_state = routing_state.state_map.get(protocol_config.routing_id.router_name)
             assert router_state, f"No router state for: {protocol_config.routing_id.router_name}, we have {list(routing_state.state_map.keys())}"
 
+            router.set_pre_broadcast_state_sync_callback(
+                getattr(self, "_pre_broadcast_state_sync_callback", None),
+            )
+
             # Multichain: if the trade targets a satellite chain, temporarily
             # swap the tx_builder and web3 so transactions are signed for and
             # contract calls hit the correct chain.

--- a/tradeexecutor/strategy/pandas_trader/position_manager.py
+++ b/tradeexecutor/strategy/pandas_trader/position_manager.py
@@ -1202,6 +1202,14 @@ class PositionManager:
         price_structure = self.pricing_model.get_sell_price(self.timestamp, pair, quantity=quantity)
         price = price_structure.price
 
+        if pair.is_hyperliquid_vault():
+            # Live HyperCore execution pricing is intentionally fixed at 1:1
+            # USDC and does not express the latest marked position value.
+            # Position valuation is the authoritative close price in live and
+            # backtest paths; settlement still books the executed price from
+            # USDC actually received.
+            price = position.get_current_price()
+
         # use trigger price as planned_price if available on pending trade
         if trigger_price and pending:
             price = trigger_price
@@ -3049,7 +3057,11 @@ xz
                 if t.is_credit_supply():
                     credit_released += float(t.planned_reserve)
                 else:
-                    cash_released += float(t.planned_reserve)
+                    conservative_release = t.other_data.get(
+                        "hypercore_first_stage_conservative_reserve_usd",
+                        t.planned_reserve,
+                    )
+                    cash_released += float(conservative_release)
             else:
                 raise RuntimeError(f"Unsupported: {t}")
 

--- a/tradeexecutor/strategy/routing.py
+++ b/tradeexecutor/strategy/routing.py
@@ -8,7 +8,7 @@ Here we define the abstract overview of routing.
 import abc
 from dataclasses import dataclass
 from decimal import Decimal
-from typing import List, Optional, Dict
+from typing import Callable, List, Optional, Dict
 import logging
 
 from hexbytes import HexBytes
@@ -135,6 +135,19 @@ class RoutingModel(abc.ABC):
                 )
         else:
             logger.info("No intermediate pairs whitelisted")
+
+    def set_pre_broadcast_state_sync_callback(
+        self,
+        callback: Callable[[], None] | None,
+    ) -> None:
+        """Set a checkpoint callback for transactions created during settlement."""
+        self._pre_broadcast_state_sync_callback = callback
+
+    def checkpoint_state(self) -> None:
+        """Persist routing-created transaction and settlement state."""
+        callback = getattr(self, "_pre_broadcast_state_sync_callback", None)
+        if callback is not None:
+            callback()
 
     @staticmethod
     def convert_address_dict_to_lower(address_dict) -> dict:

--- a/tradeexecutor/testing/hypercore.py
+++ b/tradeexecutor/testing/hypercore.py
@@ -112,6 +112,24 @@ def install_hypercore_live_withdrawal_mocks(
         lambda self, user=None: SimpleNamespace(max_withdrawable=Decimal("1000000")),
     )
     mocked_vault_equity = Decimal("1000000")
+    mocked_phase1_gross = Decimal(0)
+
+    original_get_raw_usdc_amount = router._get_raw_usdc_amount
+
+    def capture_mocked_phase1_gross(trade: TradeExecution) -> int:
+        """Use the current trade's gross request as its synthetic vault equity."""
+        nonlocal mocked_phase1_gross, mocked_vault_equity
+        raw_amount = original_get_raw_usdc_amount(trade)
+        mocked_phase1_gross = raw_to_usdc(raw_amount)
+        if trade.closing:
+            mocked_vault_equity = mocked_phase1_gross
+        return raw_amount
+
+    monkeypatch.setattr(
+        router,
+        "_get_raw_usdc_amount",
+        capture_mocked_phase1_gross,
+    )
 
     def fetch_mocked_vault_equity(session, user, vault_address, **kwargs) -> UserVaultEquity:
         return UserVaultEquity(
@@ -123,6 +141,42 @@ def install_hypercore_live_withdrawal_mocks(
     monkeypatch.setattr(
         "tradeexecutor.ethereum.vault.hypercore_routing.fetch_user_vault_equity",
         fetch_mocked_vault_equity,
+    )
+
+    def use_planned_close_equity(
+        trade: TradeExecution,
+        planned_raw: int,
+        vault_address: str,
+    ) -> int:
+        """Anchor this settlement harness to the trade value, not its synthetic cap."""
+        nonlocal mocked_vault_equity
+        del vault_address
+        mocked_vault_equity = raw_to_usdc(planned_raw)
+        trade.other_data["hypercore_capped_withdrawal_raw"] = planned_raw
+        trade.other_data["hypercore_phase1_vault_equity_usdc"] = str(mocked_vault_equity)
+        trade.other_data["hypercore_first_stage_requested_raw"] = planned_raw
+        return planned_raw
+
+    monkeypatch.setattr(
+        router,
+        "_get_live_withdrawal_amount_for_close",
+        use_planned_close_equity,
+    )
+
+    def accept_mocked_close_residual(
+        trade: TradeExecution,
+        vault_address: str,
+    ) -> tuple[Decimal, None]:
+        """Model the synthetic phase-1 withdrawal as a complete vault debit."""
+        del vault_address
+        trade.other_data["hypercore_first_stage_residual_usd"] = "0"
+        trade.other_data["hypercore_second_stage_status"] = "skipped_residual_accepted"
+        return Decimal(0), None
+
+    monkeypatch.setattr(
+        router,
+        "_plan_same_cycle_residual_withdrawal",
+        accept_mocked_close_residual,
     )
     monkeypatch.setattr(router, "_fetch_safe_evm_usdc_balance", lambda: 0)
     monkeypatch.setattr(router, "_fetch_safe_perp_withdrawable_balance", lambda: Decimal("0"))
@@ -156,9 +210,12 @@ def install_hypercore_live_withdrawal_mocks(
         poll_interval=2.0,
     ) -> int:
         nonlocal mocked_vault_equity
-        # Apply the equity change only once the mock knows the EVM settlement amount.
-        # This prevents a bridge-fee adjustment from turning a complete close into a partial one.
-        mocked_vault_equity -= raw_to_usdc(expected_increase_raw)
+        # Apply the gross vault debit after the net bridge amount is verified.
+        # Performance fees and bridge headroom reduce proceeds, not sold shares.
+        mocked_vault_equity = max(
+            Decimal(0),
+            mocked_vault_equity - mocked_phase1_gross,
+        )
         return expected_increase_raw
 
     monkeypatch.setattr(router, "_wait_for_usdc_arrival", wait_for_mocked_usdc_arrival)


### PR DESCRIPTION
## Why

Cap-bound zero-target HyperCore signals were converted into partial reductions before trade construction. This lost the full-close intent across the stack and left residual vault positions above the accepted 5 USD boundary. A single conservative withdrawal could not determine and redeem the actual residual within the same execution cycle.

## Lessons learnt

- Accounting intent must remain separate from the amount that is safe to withdraw and spend in the current cycle.
- A successful wrapper transaction receipt is insufficient evidence for HyperCore settlement; both perp balance movement and vault-equity reduction must be verified.
- Settlement-created transactions need their signed transaction and diagnostics checkpointed before broadcast.
- Partial-close quantity across multiple vault legs must compose independently verified equity-reduction fractions so NAV movement is not mistaken for sold shares.

## Summary

- Preserve exact-zero HyperCore signals as one full-close `TradeExecution` with the full position quantity and close flags.
- Cap only first-stage funding, then optionally execute one protected residual vault-to-perp transaction before the shared downstream sweep.
- Aggregate verified proceeds into one settlement while failing closed on ambiguous transactions or unavailable final residual data.
- Simplify the settlement code around a dedicated second-stage helper and state-checkpoint callback.
- Correct HyperCore accounting documentation, metadata descriptions, recovery guidance, and the implementation plan.
- Add focused unit and Hyper AI live-loop coverage for flag propagation, conservative funding, two-stage settlement, ambiguity handling, simulation, and quantity accounting.
