### PR TITLE
test: isolate HyperCore account discovery

### DIFF
--- a/.github/workflows/test-slow.yml
+++ b/.github/workflows/test-slow.yml
@@ -44,7 +44,7 @@ jobs:
           path: .venv
           key: venv-${{ runner.os }}-${{ steps.setup-python.outputs.python-version }}-${{ hashFiles('**/poetry.lock') }}
       - name: Install Foundry
-        uses: foundry-rs/foundry-toolchain@v1.8.0
+        uses: foundry-rs/foundry-toolchain@v1.9.1
         with:
           # pick a nightly release from: https://github.com/foundry-rs/foundry/releases
           version: 'v0.3.0'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -63,7 +63,7 @@ jobs:
 
       # Needed for Anvil / fork tests
       - name: Install Foundry
-        uses: foundry-rs/foundry-toolchain@v1.8.0
+        uses: foundry-rs/foundry-toolchain@v1.9.1
         with:
           # pick a nightly release from: https://github.com/foundry-rs/foundry/releases
           # version: 'nightly-de33b6af53005037b463318d2628b5cfcaf39916'

--- a/tests/hyperliquid/test_correct_accounts_hypercore.py
+++ b/tests/hyperliquid/test_correct_accounts_hypercore.py
@@ -57,6 +57,9 @@ def environment(state_file: Path, strategy_file: Path) -> dict:
         "NETWORK": "mainnet",
         "UNIT_TESTING": "true",
         "LOG_LEVEL": "warning",
+        # This test covers position discovery, not live Safe transit recovery.
+        # The shared Trial 3 Safe may contain unrelated spot or perp USDC.
+        "SKIP_HYPERCORE_TRANSIT_RECOVERY": "true",
         "TRADING_STRATEGY_API_KEY": os.environ.get("TRADING_STRATEGY_API_KEY", ""),
         "PATH": os.environ.get("PATH", ""),
     }
@@ -69,11 +72,11 @@ def test_correct_accounts_picks_up_vault_position(
     """Test that correct-accounts detects an existing HLP vault deposit.
 
     Uses the Trial 3 deployment on HyperEVM mainnet where 5 USDC was
-    deposited into HLP via the Safe. The test:
+    deposited into HLP via the Safe.
 
-    1. Inits empty state with USDC reserve
-    2. Runs correct-accounts which should auto-create a vault position
-    3. Verifies the position has correct attributes and non-zero equity
+    1. Initialise empty state with a USDC reserve.
+    2. Run correct-accounts with unrelated live transit recovery disabled.
+    3. Verify the position has correct attributes and non-zero equity.
     """
     cli = get_command(app)
 


### PR DESCRIPTION
## Why

The live HyperCore `correct-accounts` position-discovery test also triggered the command's default Safe transit-recovery workflow. The shared Trial 3 Safe currently contains unrelated spot USDC, causing the test to attempt a CoreWriter transaction and fail with `CoreWriter action ID not allowed` before it could verify position discovery.

Both CI suites then failed before running any tests because `foundry-toolchain@v1.8.0` invoked the newly executable `foundryup` binary through Bash. The current upstream action executes the binary directly.

## Lessons learnt

Shared live deployments can accumulate balances outside a test's intended scope. Integration tests should explicitly disable independent state-changing workflows when those workflows are covered separately. CI bootstrap actions also need updating when an upstream installer changes its executable format.

## Summary

- Disable HyperCore transit recovery in the vault-position discovery test using the existing `SKIP_HYPERCORE_TRANSIT_RECOVERY` option.
- Clarify the test scope and ordered steps.
- Upgrade both test workflows from `foundry-toolchain@v1.8.0` to `v1.9.1`, retaining the existing Foundry version pins.
- Leave production `correct-accounts` behaviour unchanged.
