### PR TITLE
fix: repair Hyper AI closed-position profitability

### DIFF
--- a/.claude/docs/hypercore-vault.md
+++ b/.claude/docs/hypercore-vault.md
@@ -544,8 +544,16 @@ comments before changing settlement logic.
 ## Profit accounting
 
 HyperCore vault positions report profit from their **cash flows** — sell proceeds, plus the value
-still held, minus what was paid — via `TradingPosition.get_cash_flow_profit_usd()`. Every dollar in
-such a position enters and leaves through a trade, so this is exact and model-independent.
+still held, minus what was paid — via `TradingPosition.get_cash_flow_profit_usd()`. Percentage
+profitability uses the same basis through `get_cash_flow_profit_percent()`: cash-flow profit divided
+by successful buy cash flow. For the affected historical states, these USDC flows are intact even
+though some vault quantities are not, making them the reliable source for reported P&L.
+
+Before the 2026-06-16 withdrawal settlement fix, a sell could record net USDC proceeds as the
+negative vault quantity. The internal-share calculation treated that value as vault units and
+burned shares in proportion to it. Partial withdrawals could therefore leave a false residual
+supply; when a position closed with zero assets, dividing those assets by the residual produced
+misleading returns such as -100%.
 
 This matters because `is_using_internal_share_price_profit()` is also true for **exchange account**
 positions, which share the same code path but must *not* use cash flows: they establish their
@@ -581,6 +589,13 @@ from these accessors, which is why the defect showed up as an attribution error 
 reconciled exactly against cash plus holdings. Any audit comparing equity against reconstructed
 P&L should also **not** subtract a redemption-fee estimate — proceeds are already booked net of
 fee, so cash-flow profit carries it and subtracting again double-counts.
+
+Historical percentage caches can be repaired with
+`scripts/hyper-ai/repair-closed-position-profitability.py`. The script only changes the derived
+final P&L fields for affected closed positions. It preserves the internal-share diagnostics for
+post-incident analysis and does not rewrite trades, position quantities, cash, equity, or the
+position's original internal-share state. Preview is the default and `--write` creates a state
+backup before atomically saving the repair.
 
 ## Small-position cleanup
 

--- a/scripts/hyper-ai/repair-closed-position-profitability.py
+++ b/scripts/hyper-ai/repair-closed-position-profitability.py
@@ -1,0 +1,116 @@
+"""Repair historical Hyper AI closed-position profitability.
+
+The command previews changes by default.  Pass ``--write`` to create a backup
+and atomically replace the local state file.
+
+Usage::
+
+    source .local-test.env && poetry run python scripts/hyper-ai/repair-closed-position-profitability.py state/hyper-ai.json
+    source .local-test.env && poetry run python scripts/hyper-ai/repair-closed-position-profitability.py state/hyper-ai.json --write
+"""
+
+import argparse
+from pathlib import Path
+
+from tabulate import tabulate
+
+from tradeexecutor.cli.bootstrap import backup_state
+from tradeexecutor.state.repair import repair_hypercore_closed_position_profitability
+from tradeexecutor.state.state import State
+
+
+def format_pct(value: float) -> str:
+    """Format a profitability value."""
+    return f"{value:+.4%}"
+
+
+def format_usd(value: float) -> str:
+    """Format a dollar value."""
+    return f"{value:+,.2f}"
+
+
+def main() -> None:
+    """Run the local state profitability repair."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "state_file", type=Path, help="Local trade-executor state JSON file"
+    )
+    parser.add_argument(
+        "--position-id",
+        type=int,
+        action="append",
+        dest="position_ids",
+        help="Repair only this closed position id; may be supplied more than once",
+    )
+    parser.add_argument(
+        "--write",
+        action="store_true",
+        help="Back up and replace the state file; without this flag only preview changes",
+    )
+    args = parser.parse_args()
+
+    if not args.state_file.is_file():
+        parser.error(f"State file does not exist: {args.state_file}")
+
+    selected_ids = set(args.position_ids) if args.position_ids else None
+    state = State.read_json_file(args.state_file)
+    try:
+        repairs = repair_hypercore_closed_position_profitability(
+            state,
+            position_ids=selected_ids,
+        )
+    except ValueError as e:
+        parser.error(str(e))
+
+    rows = [
+        (
+            repair.position_id,
+            repair.symbol,
+            format_pct(repair.old_profitability),
+            format_pct(repair.new_profitability),
+            format_usd(repair.old_profit_usd),
+            format_usd(repair.new_profit_usd),
+        )
+        for repair in repairs
+    ]
+    if rows:
+        print(
+            tabulate(
+                rows,
+                headers=(
+                    "position",
+                    "pair",
+                    "old return",
+                    "new return",
+                    "old PnL",
+                    "new PnL",
+                ),
+            )
+        )
+    else:
+        print("No closed Hypercore profitability records need repair.")
+
+    if args.write and repairs:
+        store, state = backup_state(
+            args.state_file,
+            backup_suffix="hypercore-profitability-backup",
+        )
+        written_repairs = repair_hypercore_closed_position_profitability(
+            state,
+            position_ids=selected_ids,
+        )
+        assert written_repairs == repairs, (
+            "State file changed between preview and write"
+        )
+        store.sync(state)
+        print(f"Repaired {len(repairs)} position(s) in {args.state_file}.")
+    elif args.write:
+        print("State file was not changed.")
+    else:
+        print(
+            f"Preview only: {len(repairs)} position(s) would be repaired; pass --write to apply."
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/hyperliquid/test_hypercore_position_profit_attribution.py
+++ b/tests/hyperliquid/test_hypercore_position_profit_attribution.py
@@ -15,8 +15,8 @@ position traded 59 times reported 13,028 USD of profit against 6,185 USD implied
 flows, which made position-level P&L unusable for exactly the heavily traded positions a
 rebalancing strategy produces.
 
-Ground truth throughout is the position's cash flows - proceeds, plus holdings, minus cost -
-which is definitional and model-independent.
+For the affected historical Hypercore records, the reliable source is the position's USDC cash
+flows - proceeds, plus holdings, minus cost.
 """
 
 import datetime
@@ -26,8 +26,10 @@ import pytest
 
 from tradeexecutor.state.identifier import AssetIdentifier, TradingPairIdentifier, TradingPairKind
 from tradeexecutor.state.position import TradingPosition
+from tradeexecutor.state.repair import repair_hypercore_closed_position_profitability
 from tradeexecutor.state.state import State
 from tradeexecutor.state.trade import TradeType
+from tradeexecutor.statistics.core import calculate_position_statistics
 
 
 @pytest.fixture()
@@ -131,6 +133,7 @@ def test_profit_attribution_across_a_position_lifecycle(state: State, pair: Trad
     assert cash_flow_profit(position) == pytest.approx(400.0)
     assert (position.get_realised_profit_usd() or 0.0) == pytest.approx(0.0)
     assert position.get_unrealised_profit_usd() == pytest.approx(400.0)
+    assert position.get_unrealised_profit_pct() == pytest.approx(400.0 / 2000.0)
     assert position.get_total_profit_usd() == pytest.approx(400.0)
 
     # 2. Sell half - realised and unrealised must still sum to the cash-flow profit
@@ -139,6 +142,7 @@ def test_profit_attribution_across_a_position_lifecycle(state: State, pair: Trad
     assert truth == pytest.approx(400.0)
     assert position.get_realised_profit_usd() == pytest.approx(200.0)
     assert position.get_unrealised_profit_usd() == pytest.approx(200.0)
+    assert position.get_unrealised_profit_pct() == pytest.approx(200.0 / 2000.0)
 
     # 3. Rebuy higher and sell again, so average cost and share price diverge
     position = execute(state, pair, 100, 20.0, start + 10 * day)
@@ -150,6 +154,7 @@ def test_profit_attribution_across_a_position_lifecycle(state: State, pair: Trad
     realised = position.get_realised_profit_usd() or 0.0
     unrealised = position.get_unrealised_profit_usd() or 0.0
     assert realised + unrealised == pytest.approx(truth, abs=0.01)
+    assert position.get_unrealised_profit_pct() == pytest.approx(unrealised / 6250.0)
     assert position.get_total_profit_usd() == pytest.approx(truth, abs=0.01)
 
     # 4. Close the position - unrealised must be zero and total profit must equal the truth
@@ -159,6 +164,9 @@ def test_profit_attribution_across_a_position_lifecycle(state: State, pair: Trad
     assert position.get_unrealised_profit_usd() == pytest.approx(0.0)
     assert position.get_realised_profit_usd() == pytest.approx(750.0, abs=0.01)
     assert position.get_total_profit_usd() == pytest.approx(750.0, abs=0.01)
+    assert position.get_total_profit_percent() == pytest.approx(750.0 / 6250.0)
+    assert position.get_realised_profit_percent() == pytest.approx(750.0 / 6250.0)
+    assert position.get_unrealised_profit_pct() == 0.0
 
 
 def test_attribution_error_does_not_grow_with_trade_count(state: State, pair: TradingPairIdentifier):
@@ -190,3 +198,67 @@ def test_attribution_error_does_not_grow_with_trade_count(state: State, pair: Tr
     unrealised = position.get_unrealised_profit_usd() or 0.0
     assert realised + unrealised == pytest.approx(cash_flow_profit(position), abs=0.01)
     assert position.get_total_profit_usd() == pytest.approx(cash_flow_profit(position), abs=0.01)
+
+
+def test_repair_closed_hypercore_profitability(
+    state: State,
+    pair: TradingPairIdentifier,
+):
+    """Repair corrupt closed-position percentage caches without changing trade history.
+
+    1. Close a profitable Hypercore position and corrupt its final statistics record.
+    2. Reject an explicit repair while only a pre-close statistics snapshot exists.
+    3. Repair the close-time profitability data from authoritative executed cash flows.
+    4. Verify only the official final P&L changes and a second repair is a no-op.
+    """
+    start = datetime.datetime(2026, 1, 1)
+
+    # 1. Close a profitable Hypercore position and corrupt its final statistics record.
+    position = execute(state, pair, 100, 10.0, start)
+    position = execute(state, pair, -100, 11.0, start + datetime.timedelta(days=1))
+    position.share_price_state.current_share_price = 0.2
+    position.share_price_state.total_supply = 5.0
+    position.share_price_state.cumulative_quantity = 5.0
+    original_share_state = position.share_price_state.to_dict()
+    final_stats = calculate_position_statistics(position.closed_at, position)
+    final_stats.profitability = -0.8
+    final_stats.profit_usd = -800.0
+    original_internal_stats = (
+        final_stats.internal_share_price,
+        final_stats.internal_total_supply,
+        final_stats.internal_profit_pct,
+        final_stats.internal_profit_usd,
+    )
+    state.stats.positions[position.position_id] = [final_stats]
+
+    # 2. Reject an explicit repair while only a pre-close statistics snapshot exists.
+    final_stats.calculated_at = position.closed_at - datetime.timedelta(seconds=1)
+    with pytest.raises(ValueError, match="no close-time position statistics"):
+        repair_hypercore_closed_position_profitability(
+            state,
+            position_ids={position.position_id},
+        )
+
+    # 3. Repair the close-time profitability data from authoritative executed cash flows.
+    final_stats.calculated_at = position.closed_at
+    repairs = repair_hypercore_closed_position_profitability(
+        state,
+        position_ids={position.position_id},
+    )
+
+    # 4. Verify only the official final P&L changes and a second repair is a no-op.
+    assert len(repairs) == 1
+    assert repairs[0].position_id == position.position_id
+    assert repairs[0].old_profitability == pytest.approx(-0.8)
+    assert repairs[0].new_profitability == pytest.approx(0.1)
+    assert repairs[0].new_profit_usd == pytest.approx(100.0)
+    assert position.share_price_state.to_dict() == original_share_state
+    assert final_stats.profitability == pytest.approx(0.1)
+    assert final_stats.profit_usd == pytest.approx(100.0)
+    assert (
+        final_stats.internal_share_price,
+        final_stats.internal_total_supply,
+        final_stats.internal_profit_pct,
+        final_stats.internal_profit_usd,
+    ) == original_internal_stats
+    assert repair_hypercore_closed_position_profitability(state) == []

--- a/tradeexecutor/state/position.py
+++ b/tradeexecutor/state/position.py
@@ -1601,11 +1601,11 @@ class TradingPosition(GenericPosition):
 
             profit = sum(sell proceeds) + current value of holdings - sum(buy costs)
 
-        This is definitional rather than model-dependent, so Hypercore vault positions use it as
-        the anchor for both :py:meth:`get_total_profit_usd` and :py:meth:`get_unrealised_profit_usd`.
-        Every dollar in such a position enters and leaves through a trade, which makes cash flows
-        exact for them. Exchange account positions look similar but are not - they establish their
-        capital through a valuation sync rather than a trade - so they keep the share-price model.
+        Hypercore vault positions use this as the anchor for both
+        :py:meth:`get_total_profit_usd` and :py:meth:`get_unrealised_profit_usd` because their USDC
+        trade flows remained reliable in the affected historical states. Exchange account
+        positions look similar but are not - they establish their capital through a valuation
+        sync rather than a trade - so they keep the share-price model.
 
         Only successful trades count; failed and pending trades move no cash.
 
@@ -1621,11 +1621,7 @@ class TradingPosition(GenericPosition):
         :return:
             Profit in dollars.
         """
-        bought = sum(
-            abs(float(t.executed_reserve or 0))
-            for t in self.trades.values()
-            if t.is_buy() and t.is_success()
-        )
+        bought = self.get_cash_flow_bought_usd()
         sold = sum(
             abs(float(t.executed_reserve or 0))
             for t in self.trades.values()
@@ -1633,6 +1629,33 @@ class TradingPosition(GenericPosition):
         )
         held = float(self.get_value() or 0.0) if self.is_open() else 0.0
         return sold + held - bought
+
+    def get_cash_flow_bought_usd(self) -> USDollarAmount:
+        """Get capital deposited through successful buy trades."""
+        return sum(
+            abs(float(t.executed_reserve or 0))
+            for t in self.trades.values()
+            if t.is_buy() and t.is_success()
+        )
+
+    def get_cash_flow_profit_percent(self) -> Percent:
+        """Calculate return against the capital deposited through successful buys.
+
+        Hypercore vault quantities have not always been reliable during partial
+        withdrawals.  The affected records retained reliable USDC flows, so use
+        the same cash-flow basis as
+        :py:meth:`get_cash_flow_profit_usd` for its percentage return.
+
+        :return:
+            Profit divided by successful buy cash flow, or zero when the
+            position never received capital.
+        """
+        return self._calculate_cash_flow_return(self.get_cash_flow_profit_usd())
+
+    def _calculate_cash_flow_return(self, profit_usd: USDollarAmount) -> Percent:
+        """Calculate a cash-flow return with a zero-capital guard."""
+        bought = self.get_cash_flow_bought_usd()
+        return profit_usd / bought if bought else 0.0
 
     def get_realised_profit_usd(
             self,
@@ -1779,7 +1802,7 @@ class TradingPosition(GenericPosition):
             if self.pair.is_hyperliquid_vault():
                 # The share-price model measures profit on the outstanding internal supply and
                 # therefore omits profit already withdrawn through partial sells. Anchor to the
-                # position's cash flows, which is definitional.
+                # position's USDC cash flows, which remained reliable in the affected state.
                 return self.get_cash_flow_profit_usd()
             if self.share_price_state is not None:
                 return self.get_share_price_profit().profit_usd
@@ -1814,6 +1837,11 @@ class TradingPosition(GenericPosition):
 
         # Exchange account positions use placeholder trades ($1) that don't represent real capital.
         if self.is_using_internal_share_price_profit():
+            if self.pair.is_hyperliquid_vault():
+                # Hypercore vault cash flows are authoritative.  Historical
+                # partial withdrawals sometimes recorded net USDC as vault
+                # quantity, corrupting the proportional internal-share burn.
+                return self.get_cash_flow_profit_percent()
             if self.share_price_state is not None:
                 data = self.get_share_price_profit()
                 return data.profit_pct
@@ -2074,6 +2102,11 @@ class TradingPosition(GenericPosition):
             Return ``0`` if the position profitability cannot be calculated,
             e.g. due to broken trades.
         """
+        if self.pair.is_hyperliquid_vault() and self.is_closed():
+            # Historical partial withdrawals may have corrupt vault quantities,
+            # but the completed position's USDC cash flows remain reliable. For
+            # an open position, keep reporting only the part already realised.
+            return self.get_cash_flow_profit_percent()
         if self.is_spot():
             # This is the new code path that takes account in-kind redemptions
             # and redefines the meaning of realised profit
@@ -2279,6 +2312,10 @@ class TradingPosition(GenericPosition):
         """
 
         if self.is_using_internal_share_price_profit():
+            if self.pair.is_hyperliquid_vault():
+                if self.is_closed():
+                    return 0.0
+                return self._calculate_cash_flow_return(self.get_unrealised_profit_usd())
             # Share price state is initialised on the first valuation sync.
             # Until then, profit is unknown.
             if self.share_price_state is not None:

--- a/tradeexecutor/state/repair.py
+++ b/tradeexecutor/state/repair.py
@@ -81,6 +81,104 @@ class HypercoreDuplicateCloseCandidate:
     close_reason: str
 
 
+@dataclass(slots=True)
+class HypercoreProfitabilityRepair:
+    """One closed Hypercore position whose reporting data was repaired."""
+
+    position_id: int
+    symbol: str
+    old_profitability: float
+    new_profitability: float
+    old_profit_usd: float
+    new_profit_usd: float
+
+
+def repair_hypercore_closed_position_profitability(
+    state: State,
+    position_ids: set[int] | None = None,
+) -> list[HypercoreProfitabilityRepair]:
+    """Repair derived profitability data for closed Hypercore vault positions.
+
+    Historical Hypercore partial withdrawals could record the net USDC
+    received as the decrease in vault quantity.  Gross vault units and net
+    proceeds are different accounting dimensions, so replaying these quantities
+    produces a corrupt internal share supply and profitability.
+
+    Successful deposit and withdrawal cash flows remain intact in the affected
+    state.  Repair the final closed-position reporting record from those cash
+    flows without modifying trades, position quantities, cash, portfolio equity,
+    or the original internal-share state.
+
+    Internal-share fields are preserved for post-incident analysis.  They use a
+    different accounting model and are not replaced with cash-flow return.
+
+    :param state:
+        State to modify in memory.
+
+    :param position_ids:
+        Optional explicit subset of closed position ids.
+
+    :return:
+        Changed positions with their old and repaired values.  Calling this
+        function again on an already repaired state returns an empty list.
+    """
+    repairs: list[HypercoreProfitabilityRepair] = []
+    closed_hypercore_ids = {
+        position.position_id
+        for position in state.portfolio.closed_positions.values()
+        if position.pair.is_hyperliquid_vault()
+    }
+    if position_ids is not None:
+        if unknown_ids := position_ids - closed_hypercore_ids:
+            raise ValueError(f"Not closed Hypercore position ids: {sorted(unknown_ids)}")
+
+    for position in state.portfolio.closed_positions.values():
+        if position_ids is not None and position.position_id not in position_ids:
+            continue
+        if not position.pair.is_hyperliquid_vault():
+            continue
+
+        position_stats = state.stats.positions.get(position.position_id, [])
+        if not position_stats:
+            if position_ids is not None:
+                raise ValueError(f"Position {position.position_id} has no position statistics")
+            continue
+
+        new_profit_usd = position.get_cash_flow_profit_usd()
+        new_profitability = position.get_cash_flow_profit_percent()
+        latest_stats = position_stats[-1]
+        if latest_stats.calculated_at < position.closed_at:
+            if position_ids is not None:
+                raise ValueError(
+                    f"Position {position.position_id} has no close-time position statistics"
+                )
+            continue
+        old_profitability = latest_stats.profitability
+        old_profit_usd = latest_stats.profit_usd
+
+        if (
+            abs(old_profitability - new_profitability) <= 1e-12
+            and abs(old_profit_usd - new_profit_usd) <= 1e-9
+        ):
+            continue
+
+        latest_stats.profitability = new_profitability
+        latest_stats.profit_usd = new_profit_usd
+
+        repairs.append(
+            HypercoreProfitabilityRepair(
+                position_id=position.position_id,
+                symbol=position.pair.get_ticker(),
+                old_profitability=old_profitability,
+                new_profitability=new_profitability,
+                old_profit_usd=old_profit_usd,
+                new_profit_usd=new_profit_usd,
+            )
+        )
+
+    return repairs
+
+
 def _get_hypercore_vault_address(position: TradingPosition) -> str:
     """Get the canonical vault address for a Hypercore position."""
 


### PR DESCRIPTION
## Why

Historical HyperCore withdrawals sometimes stored net USDC proceeds as the decrease in vault quantity. The internal-share calculation interpreted that cash value as vault units, burned the wrong share amount, and left false residual supply. Closed positions could consequently show extreme returns such as -100% even when their USD P&L was positive.

The affected positions retain reliable USDC deposit and withdrawal flows, so closed-position profitability should use the same cash-flow basis as their USD P&L.

## Lessons learnt

- Vault quantity and net redemption proceeds are separate accounting dimensions and must not be substituted for one another.
- A closed HyperCore position must report zero unrealised profit; its total and realised return can be rebuilt from executed USDC cash flows.
- Historical repair should preserve the damaged internal-share diagnostics for incident analysis instead of fabricating a replacement share price.
- Repair commands should preview by default, validate explicit targets before creating a backup, and leave authoritative trade history untouched.

## Summary

- Calculate HyperCore total and closed realised profitability from cash-flow profit over successful buy cash flow.
- Keep open unrealised percentage aligned with unrealised USD P&L and report zero unrealised percentage after close.
- Add `repair-closed-position-profitability.py`, with preview-first output, strict position selection, idempotent final-statistics repair, and backup-before-write behaviour.
- Limit historical mutations to the final public `profitability` and `profit_usd` fields; trades, quantities, cash, equity, share state, and internal diagnostics remain unchanged.
- Document the 2026-06-16 incident mechanism and add focused lifecycle, repair, and regression coverage.
