### PR TITLE
fix: include all scripts in Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -68,7 +68,7 @@ RUN (cd deps/web3-ethereum-defi/contracts/lagoon-v0 && forge soldeer install --c
 # Copy the application only after dependency-heavy layers.
 COPY tradeexecutor tradeexecutor
 COPY spec spec
-COPY scripts/docker-entrypoint.sh scripts/docker-smoke-test.py scripts/
+COPY scripts scripts
 
 RUN poetry install --only-root --no-interaction --no-ansi
 RUN poetry run --quiet --directory /usr/src/trade-executor python scripts/docker-smoke-test.py


### PR DESCRIPTION
## Why

The production Docker image copied only the entrypoint and smoke-test scripts. Operational commands present in the tagged source tree, including the Hyper AI profitability repair command, were therefore missing from the corresponding image.

## Lessons learnt

Operational scripts intended to run against a release image must be packaged at their repository-relative paths. The complete scripts directory is small enough that maintaining a selective allow-list adds fragility without a meaningful image-size benefit.

## Summary

Copy the complete `scripts/` directory into the trade-executor Docker image.
