### PR TITLE
docs: document production maintenance shell

### DIFF
--- a/.claude/docs/cli-command.md
+++ b/.claude/docs/cli-command.md
@@ -276,6 +276,36 @@ Examples:
 - `repair_hypercore_dust` logs the resolved state path, duplicate diagnostics, save step, and final `All ok`
 - `show_positions` is intentionally print-heavy because it is a pure inspection command
 
+## Running production repair and migration scripts
+
+Production state scripts must run through the deployment's Docker Compose
+service, not a standalone `docker run` container. A standalone container does
+not mount the authoritative state directory or inherit the full service
+environment.
+
+The canonical Hyper AI production shell command is:
+
+```shell
+docker compose run --entrypoint /bin/bash hyper-ai --
+```
+
+Stop the running `hyper-ai` service before starting a state-mutating repair or
+migration because `docker compose run` starts a separate container and does not
+stop concurrent writers. Inside the shell:
+
+1. Confirm the expected state file is present and non-empty.
+2. Use the script shipped in the deployed image and run it with `poetry run
+   python`. Do not download a script into production; a missing script means the
+   deployment image is stale or incorrect.
+3. Preview first when supported, then use only the script's documented mutation
+   option.
+4. Require a recoverable state backup before mutation.
+5. Run the script's validation, or repeat an idempotent preview, before
+   restarting the executor.
+
+The complete operator runbook and the Hyper AI profitability-repair example are
+in `docs/docker.md`.
+
 ## How `All ok` happens
 
 There is no automatic success footer in the CLI framework. `All ok` is always emitted explicitly by the command itself.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -54,6 +54,43 @@ When running a Python script use `poetry run python` command instead of plain `p
 source .local-test.env && poetry run python scripts/logos/post-process-logo.py
 ```
 
+### Running production repair and migration scripts
+
+Run production maintenance from the deployment's Docker Compose project. Never
+use a standalone `docker run` container for a production repair or migration:
+it does not inherit the service's production state and cache mounts or its full
+environment.
+
+The canonical way to open the Hyper AI production shell is:
+
+```shell
+docker compose run --entrypoint /bin/bash hyper-ai --
+```
+
+For any script that can change production state:
+
+1. Confirm that the Compose deployment uses an image containing the script. All
+   repository `scripts/` are copied into current release images. If a script is
+   missing, update the image; do not download or copy a different revision into
+   the container.
+2. Stop the running executor before opening the maintenance shell. `docker
+   compose run` creates a separate one-off container and does not stop the live
+   service, so otherwise both processes could write the same state file.
+3. In the shell, confirm the authoritative state file exists, for example with
+   `test -s state/hyper-ai.json`.
+4. Run scripts with `poetry run python scripts/<path>.py ...`. Do not source
+   `.local-test.env` in production; Docker Compose supplies the service
+   environment.
+5. For repairs that support preview mode, run the preview first, inspect the
+   proposed changes, then rerun with the script's explicit write option. Do not
+   assume that migration scripts use the same options: check `--help` and their
+   runbook before executing them.
+6. Confirm that a backup was created before a state mutation. Run the script's
+   post-migration validation or repeat an idempotent preview, then restart the
+   executor and verify its state endpoint.
+
+See `docs/docker.md` for the production maintenance runbook.
+
 ## Running trade-executor
 
 E.g. to test CLI commands

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -33,11 +33,71 @@ export TRADE_EXECUTOR_VERSION=v50
 docker run ghcr.io/tradingstrategy-ai/trade-executor:$TRADE_EXECUTOR_VERSION --help
 ```
 
-You can start a shell within the container as:
+For an image-level debugging shell that does not need production files, you can
+use:
 
 ```shell
 docker run -ti --entrypoint /bin/bash ghcr.io/tradingstrategy-ai/trade-executor:$TRADE_EXECUTOR_VERSION 
 ```
+
+This standalone container does **not** have the production Compose service's
+state or cache volumes. Do not use it for production repairs or migrations.
+
+## Production maintenance shell
+
+Run production repairs and migrations through the deployment's Docker Compose
+project so that the container receives the same image, environment, state
+volume, and cache volume as the `hyper-ai` service.
+
+Stop the live service before any command that may write state. The maintenance
+shell is a separate one-off container; opening it does not stop the running
+executor or prevent concurrent state writes.
+
+```shell
+docker compose stop hyper-ai
+docker compose run --entrypoint /bin/bash hyper-ai --
+```
+
+Inside the shell, first confirm that the authoritative production state is
+mounted:
+
+```shell
+test -s state/hyper-ai.json
+```
+
+Run repository scripts directly from the image with Poetry. For example, the
+Hyper AI closed-position profitability repair is previewed and applied with:
+
+```shell
+poetry run python scripts/hyper-ai/repair-closed-position-profitability.py state/hyper-ai.json
+poetry run python scripts/hyper-ai/repair-closed-position-profitability.py state/hyper-ai.json --write
+```
+
+Run the preview again after writing; an idempotent repair should report no
+remaining changes. The repair creates a numbered backup before replacing the
+state and also refreshes the compressed state copy.
+
+For other repair and migration scripts:
+
+1. Ensure the deployed image contains the intended script revision. A missing
+   script means the deployment image must be updated; do not download a script
+   from another revision into a production container.
+2. Read the script's `--help` and its specific runbook. Preview first when the
+   script supports it. Do not add `--write` unless that script documents the
+   option.
+3. Confirm the authoritative input path and the backup behaviour before any
+   mutation.
+4. Run the documented post-migration validation before restarting the service.
+
+Leave the maintenance shell and restart the service:
+
+```shell
+exit
+docker compose start hyper-ai
+```
+
+Finally, check that the executor starts cleanly and that its production state
+endpoint loads. Keep the numbered backup until the result has been verified.
 
 # Building locally
 


### PR DESCRIPTION
## Why

The previous Docker documentation suggested opening a standalone container for production maintenance. That container does not inherit the Docker Compose service's state mounts or full environment, which made production repair scripts appear broken and could lead operators to work against the wrong state.

## Lessons learnt

Production repair and migration instructions must start from the deployment's Compose service. Scripts should be shipped in the release image and run against the mounted authoritative state; downloading scripts or manually reconstructing production mounts is error-prone.

## Summary

- Document `docker compose run --entrypoint /bin/bash hyper-ai --` as the canonical Hyper AI production shell.
- Explain how to stop concurrent state writers and verify the mounted state.
- Document preview, backup, write, validation, and restart practices for repair and migration scripts.
- Keep raw `docker run` instructions explicitly scoped to image-level debugging.
