### PR TITLE
fix: add GMX AI CoW cleanup proposal

### DIFF
--- a/scripts/gmx-ai/propose-cowswap-cleanup.py
+++ b/scripts/gmx-ai/propose-cowswap-cleanup.py
@@ -1,0 +1,474 @@
+"""Propose the one-off GMX AI stranded-token clean-up through its Safe.
+
+This script is designed for the production Docker Compose container. It never
+executes the 4-of-6 Safe transaction. ``--propose`` signs and submits the Safe
+proposal using the existing asset-manager ``PRIVATE_KEY``. After the owners
+execute the proposal, ``--post-orders`` submits the now-pre-signed orders to
+CoW Protocol.
+
+The live executor must remain stopped from proposal creation until both orders
+have been posted and settled. From the production Compose project:
+
+.. code-block:: shell
+
+    docker compose stop gmx-ai
+    docker compose run --entrypoint /bin/bash gmx-ai --
+    test -s state/gmx-ai.json
+    test -n "$SAFE_TRANSACTION_SERVICE_API_KEY"
+
+    # Preview only: no Safe or CoW API writes.
+    poetry run python scripts/gmx-ai/propose-cowswap-cleanup.py
+
+    # Create and sign the 4-of-6 Safe proposal. Note the artefact path printed.
+    poetry run python scripts/gmx-ai/propose-cowswap-cleanup.py \
+        --propose --confirm-executor-stopped
+
+    # After the Safe transaction has been executed by the owners:
+    poetry run python scripts/gmx-ai/propose-cowswap-cleanup.py \
+        --post-orders state/gmx-ai-cowswap-cleanup-safe-nonce-12.json \
+        --confirm-executor-stopped
+
+Do not restart the executor until the CoW explorer shows both orders settled
+and the Safe's WBTC and WBNB balances are zero or economically negligible.
+"""
+
+import argparse
+import json
+import os
+import time
+from dataclasses import dataclass
+from pathlib import Path
+
+from eth_account import Account
+from hexbytes import HexBytes
+from safe_eth.safe import Safe
+from safe_eth.safe.api.transaction_service_api.transaction_service_api import (
+    TransactionServiceApi,
+)
+from safe_eth.safe.multi_send import MultiSend, MultiSendOperation, MultiSendTx
+from safe_eth.safe.safe_tx import SafeTx
+from web3 import Web3
+
+from eth_defi.cow.api import get_cowswap_api
+from eth_defi.cow.constants import COWSWAP_SETTLEMENT, COWSWAP_VAULT_RELAYER
+from eth_defi.provider.multi_provider import create_multi_provider_web3
+from eth_defi.safe.safe_compat import create_safe_ethereum_client
+from eth_defi.token import fetch_erc20_details
+
+from tradeexecutor.ethereum.cowswap.safe_proposal import (
+    PreparedCowSwapOrder,
+    calculate_order_uid,
+    fetch_cowswap_quote,
+    post_presigned_order,
+    prepare_cowswap_order,
+)
+
+
+ARBITRUM_CHAIN_ID = 42161
+SAFE_ADDRESS = Web3.to_checksum_address("0x7838A4E4ecD438c1BdD13b014675c7e877b8b490")
+ASSET_MANAGER_ADDRESS = Web3.to_checksum_address(
+    "0x350c2d78c06d4d6963eEB6cD44A5A038AAb41d3f"
+)
+USDC_ADDRESS = Web3.to_checksum_address("0xaf88d065e77c8cC2239327C5EDb3A432268e5831")
+MULTISEND_CALL_ONLY_ADDRESS = Web3.to_checksum_address(
+    "0x9641d764fc13c8B624c04430C7356C1C7C8102e2"
+)
+DEFAULT_STATE_FILE = Path("state/gmx-ai.json")
+DEFAULT_VALID_FOR_SECONDS = 24 * 60 * 60
+DEFAULT_SLIPPAGE_BPS = 100
+
+# Native ETH is deliberately excluded from this clean-up. The Safe uses ETH as
+# its GMX execution-fee reserve; excess ETH will be analysed and handled in a
+# separate, explicitly reviewed transaction.
+ASSETS_TO_CASH_OUT = (
+    ("WBTC", Web3.to_checksum_address("0x2f2a2543B76A4166549F7aaB2e75Bef0aefC5B0f")),
+    ("WBNB", Web3.to_checksum_address("0xa9004A5421372E1D83fB1f85b0fc986c912f91f3")),
+)
+
+
+SETTLEMENT_ABI = [
+    {
+        "inputs": [
+            {"name": "orderUid", "type": "bytes"},
+            {"name": "signed", "type": "bool"},
+        ],
+        "name": "setPreSignature",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function",
+    },
+    {
+        "inputs": [{"name": "orderUid", "type": "bytes"}],
+        "name": "preSignature",
+        "outputs": [{"name": "", "type": "uint256"}],
+        "stateMutability": "view",
+        "type": "function",
+    },
+]
+
+
+@dataclass(slots=True, frozen=True)
+class PreparedSafeProposal:
+    """Safe transaction and CoW orders produced from one balance snapshot."""
+
+    safe: Safe
+    safe_tx: SafeTx
+    safe_tx_gas: int
+    orders: tuple[PreparedCowSwapOrder, ...]
+    balances: dict[str, str]
+
+
+def parse_args() -> argparse.Namespace:
+    """Parse production-operation arguments."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    action = parser.add_mutually_exclusive_group()
+    action.add_argument(
+        "--propose",
+        action="store_true",
+        help="Sign and submit the Safe transaction proposal",
+    )
+    action.add_argument(
+        "--post-orders",
+        type=Path,
+        metavar="ARTEFACT",
+        help="Post orders after the Safe proposal was executed",
+    )
+    parser.add_argument(
+        "--confirm-executor-stopped",
+        action="store_true",
+        help="Acknowledge that the production gmx-ai executor is stopped",
+    )
+    parser.add_argument(
+        "--state-file",
+        type=Path,
+        default=DEFAULT_STATE_FILE,
+        help="Mounted authoritative production state file",
+    )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        help="Proposal artefact path; defaults to state/gmx-ai-cowswap-cleanup-safe-nonce-N.json",
+    )
+    parser.add_argument(
+        "--valid-for-seconds",
+        type=int,
+        default=DEFAULT_VALID_FOR_SECONDS,
+        help="CoW order validity window",
+    )
+    parser.add_argument(
+        "--slippage-bps",
+        type=int,
+        default=DEFAULT_SLIPPAGE_BPS,
+        help="Price protection applied below the verified quote",
+    )
+    return parser.parse_args()
+
+
+def assert_production_preconditions(args: argparse.Namespace) -> None:
+    """Verify the mounted production state and explicit operator acknowledgement."""
+    if not args.state_file.is_file() or args.state_file.stat().st_size == 0:
+        raise RuntimeError(
+            f"Authoritative production state file is missing or empty: {args.state_file}"
+        )
+    if (args.propose or args.post_orders) and not args.confirm_executor_stopped:
+        raise RuntimeError(
+            "Stop the gmx-ai executor and pass --confirm-executor-stopped"
+        )
+    if args.propose and not os.environ.get("PRIVATE_KEY"):
+        raise RuntimeError("PRIVATE_KEY is required to propose the Safe transaction")
+    if args.propose and not os.environ.get("SAFE_TRANSACTION_SERVICE_API_KEY"):
+        raise RuntimeError(
+            "SAFE_TRANSACTION_SERVICE_API_KEY is required for a reliable production proposal"
+        )
+    if args.valid_for_seconds <= 0:
+        raise ValueError("--valid-for-seconds must be positive")
+    if not 0 <= args.slippage_bps < 10_000:
+        raise ValueError("--slippage-bps must be between 0 and 9999")
+
+
+def create_web3() -> Web3:
+    """Create the production Arbitrum connection."""
+    json_rpc = os.environ.get("JSON_RPC_ARBITRUM")
+    if not json_rpc:
+        raise RuntimeError("JSON_RPC_ARBITRUM is required")
+    web3 = create_multi_provider_web3(json_rpc)
+    if web3.eth.chain_id != ARBITRUM_CHAIN_ID:
+        raise RuntimeError(
+            f"Expected Arbitrum chain {ARBITRUM_CHAIN_ID}, got {web3.eth.chain_id}"
+        )
+    return web3
+
+
+def prepare_safe_proposal(
+    web3: Web3, *, valid_for_seconds: int, slippage_bps: int
+) -> PreparedSafeProposal:
+    """Fetch balances and quotes, then construct the approval and pre-sign batch."""
+    ethereum_client = create_safe_ethereum_client(web3)
+    safe = Safe(SAFE_ADDRESS, ethereum_client)
+    safe_version = safe.get_version()
+    if safe_version != "1.4.1":
+        raise RuntimeError(f"Expected Safe version 1.4.1, got {safe_version}")
+    owners = safe.retrieve_owners()
+    threshold = safe.retrieve_threshold()
+    if ASSET_MANAGER_ADDRESS not in owners:
+        raise RuntimeError(f"Asset manager {ASSET_MANAGER_ADDRESS} is not a Safe owner")
+    if threshold != 4 or len(owners) != 6:
+        raise RuntimeError(f"Expected a 4-of-6 Safe, got {threshold}-of-{len(owners)}")
+
+    settlement = web3.eth.contract(
+        address=Web3.to_checksum_address(COWSWAP_SETTLEMENT), abi=SETTLEMENT_ABI
+    )
+    api_base_url = get_cowswap_api(ARBITRUM_CHAIN_ID)
+    orders = []
+    balances = {}
+    calls = []
+
+    for symbol, token_address in ASSETS_TO_CASH_OUT:
+        token = fetch_erc20_details(web3, token_address)
+        raw_balance = token.fetch_raw_balance_of(SAFE_ADDRESS)
+        balances[symbol] = str(token.convert_to_decimals(raw_balance))
+        if raw_balance == 0:
+            continue
+        quote = fetch_cowswap_quote(
+            api_base_url=api_base_url,
+            safe_address=SAFE_ADDRESS,
+            sell_token=token_address,
+            buy_token=USDC_ADDRESS,
+            sell_amount_before_fee=raw_balance,
+            valid_for_seconds=valid_for_seconds,
+        )
+        prepared_order = prepare_cowswap_order(
+            symbol=symbol,
+            balance=raw_balance,
+            sell_token=token_address,
+            buy_token=USDC_ADDRESS,
+            quote_response=quote,
+            chain_id=ARBITRUM_CHAIN_ID,
+            settlement=COWSWAP_SETTLEMENT,
+            owner=SAFE_ADDRESS,
+            slippage_bps=slippage_bps,
+        )
+        orders.append(prepared_order)
+
+        approval_data = HexBytes(
+            token.contract.functions.approve(
+                COWSWAP_VAULT_RELAYER, raw_balance
+            )._encode_transaction_data()
+        )
+        presign_data = HexBytes(
+            settlement.functions.setPreSignature(
+                prepared_order.uid, True
+            )._encode_transaction_data()
+        )
+        calls.extend(
+            (
+                MultiSendTx(MultiSendOperation.CALL, token.address, 0, approval_data),
+                MultiSendTx(
+                    MultiSendOperation.CALL,
+                    Web3.to_checksum_address(COWSWAP_SETTLEMENT),
+                    0,
+                    presign_data,
+                ),
+            )
+        )
+
+    if not orders:
+        raise RuntimeError("The Safe has no configured stranded assets to cash out")
+
+    multisend = MultiSend(
+        ethereum_client, address=MULTISEND_CALL_ONLY_ADDRESS, call_only=True
+    )
+    if not web3.eth.get_code(MULTISEND_CALL_ONLY_ADDRESS):
+        raise RuntimeError(
+            f"MultiSendCallOnly is not deployed at {MULTISEND_CALL_ONLY_ADDRESS}"
+        )
+    multisend_data = multisend.build_tx_data(calls)
+    # Safe's SimulateTxAccessor cannot simulate this production Safe because it
+    # has no fallback handler. A zero safeTxGas together with zero gasPrice is
+    # the standard Safe proposal representation: execution forwards the gas
+    # supplied by the final signer instead of imposing a signed internal cap.
+    safe_tx_gas = 0
+    safe_tx = safe.build_multisig_tx(
+        to=MULTISEND_CALL_ONLY_ADDRESS,
+        value=0,
+        data=multisend_data,
+        operation=MultiSendOperation.DELEGATE_CALL.value,
+        safe_tx_gas=safe_tx_gas,
+    )
+    return PreparedSafeProposal(
+        safe=safe,
+        safe_tx=safe_tx,
+        safe_tx_gas=safe_tx_gas,
+        orders=tuple(orders),
+        balances=balances,
+    )
+
+
+def build_artefact(proposal: PreparedSafeProposal, *, slippage_bps: int) -> dict:
+    """Build the non-secret hand-off artefact for the post-execution phase."""
+    return {
+        "version": 1,
+        "chain_id": ARBITRUM_CHAIN_ID,
+        "safe": SAFE_ADDRESS,
+        "safe_nonce": proposal.safe_tx.safe_nonce,
+        "safe_tx_hash": Web3.to_hex(proposal.safe_tx.safe_tx_hash),
+        "safe_tx_to": proposal.safe_tx.to,
+        "safe_tx_operation": proposal.safe_tx.operation,
+        "safe_tx_gas": proposal.safe_tx_gas,
+        "safe_tx_data": Web3.to_hex(proposal.safe_tx.data),
+        "slippage_bps": slippage_bps,
+        "balances": proposal.balances,
+        "orders": [order.to_json() for order in proposal.orders],
+    }
+
+
+def propose_safe_transaction(
+    proposal: PreparedSafeProposal, *, private_key: str, safe_api_key: str
+) -> str:
+    """Sign and submit the proposal to the Safe Transaction Service."""
+    proposer = Account.from_key(private_key)
+    if proposer.address != ASSET_MANAGER_ADDRESS:
+        raise RuntimeError(
+            f"PRIVATE_KEY resolves to {proposer.address}, expected asset manager {ASSET_MANAGER_ADDRESS}"
+        )
+    if proposal.safe.retrieve_nonce() != proposal.safe_tx.safe_nonce:
+        raise RuntimeError(
+            f"Safe nonce changed after preparation: expected {proposal.safe_tx.safe_nonce}, "
+            f"got {proposal.safe.retrieve_nonce()}"
+        )
+
+    proposal.safe_tx.sign(private_key)
+    transaction_service = TransactionServiceApi(
+        network=proposal.safe.ethereum_client.get_network(),
+        ethereum_client=proposal.safe.ethereum_client,
+        api_key=safe_api_key,
+    )
+    existing_transactions = transaction_service.get_transactions(
+        SAFE_ADDRESS,
+        executed=False,
+        nonce=proposal.safe_tx.safe_nonce,
+    )
+    expected_hash = Web3.to_hex(proposal.safe_tx.safe_tx_hash).lower()
+    for transaction in existing_transactions:
+        existing_hash = str(
+            transaction.get("safeTxHash")
+            or transaction.get("contractTransactionHash")
+            or ""
+        ).lower()
+        if existing_hash == expected_hash:
+            return Web3.to_hex(proposal.safe_tx.safe_tx_hash)
+    if existing_transactions:
+        raise RuntimeError(
+            f"Safe nonce {proposal.safe_tx.safe_nonce} already has a different pending "
+            "proposal; inspect or remove it in the Safe UI before retrying"
+        )
+    transaction_service.post_transaction(proposal.safe_tx)
+    return Web3.to_hex(proposal.safe_tx.safe_tx_hash)
+
+
+def prepared_order_from_json(data: dict) -> PreparedCowSwapOrder:
+    """Load one prepared order from the hand-off artefact."""
+    prepared_order = PreparedCowSwapOrder(
+        symbol=data["symbol"],
+        balance=int(data["balance"]),
+        quoted_buy_amount=int(data["quoted_buy_amount"]),
+        order=data["order"],
+        uid=HexBytes(data["uid"]),
+    )
+    expected_uid = calculate_order_uid(
+        chain_id=ARBITRUM_CHAIN_ID,
+        settlement=COWSWAP_SETTLEMENT,
+        owner=SAFE_ADDRESS,
+        order=prepared_order.order,
+    )
+    if prepared_order.uid != expected_uid:
+        raise RuntimeError(
+            f"Artefact order UID mismatch for {prepared_order.symbol}: "
+            f"{Web3.to_hex(prepared_order.uid)} != {Web3.to_hex(expected_uid)}"
+        )
+    return prepared_order
+
+
+def post_orders(web3: Web3, artefact_path: Path) -> None:
+    """Verify Safe execution and submit its pre-signed orders to CoW."""
+    artefact = json.loads(artefact_path.read_text())
+    if (
+        artefact["chain_id"] != ARBITRUM_CHAIN_ID
+        or artefact["safe"].lower() != SAFE_ADDRESS.lower()
+    ):
+        raise RuntimeError(
+            f"Artefact does not belong to the production GMX AI Safe: {artefact_path}"
+        )
+    settlement = web3.eth.contract(
+        address=Web3.to_checksum_address(COWSWAP_SETTLEMENT), abi=SETTLEMENT_ABI
+    )
+    api_base_url = get_cowswap_api(ARBITRUM_CHAIN_ID)
+    for order_data in artefact["orders"]:
+        prepared_order = prepared_order_from_json(order_data)
+        if int(prepared_order.order["validTo"]) <= int(time.time()):
+            raise RuntimeError(
+                f"CoW order for {prepared_order.symbol} expired at {prepared_order.order['validTo']}"
+            )
+        if settlement.functions.preSignature(prepared_order.uid).call() == 0:
+            raise RuntimeError(
+                f"Safe has not executed the pre-signature for {prepared_order.symbol}: {Web3.to_hex(prepared_order.uid)}"
+            )
+        posted_uid = post_presigned_order(
+            api_base_url=api_base_url,
+            owner=SAFE_ADDRESS,
+            prepared_order=prepared_order,
+        )
+        print(
+            f"Posted {prepared_order.symbol}: https://explorer.cow.fi/arb1/orders/{posted_uid}"
+        )
+
+
+def main() -> None:
+    """Run preview, proposal, or post-execution order submission."""
+    args = parse_args()
+    assert_production_preconditions(args)
+    web3 = create_web3()
+
+    if args.post_orders:
+        post_orders(web3, args.post_orders)
+        return
+
+    proposal = prepare_safe_proposal(
+        web3,
+        valid_for_seconds=args.valid_for_seconds,
+        slippage_bps=args.slippage_bps,
+    )
+    artefact = build_artefact(proposal, slippage_bps=args.slippage_bps)
+    print(json.dumps(artefact, indent=2))
+    if not args.propose:
+        print(
+            "Preview only. Re-run with --propose --confirm-executor-stopped to submit to Safe."
+        )
+        return
+
+    private_key = os.environ["PRIVATE_KEY"]
+    safe_api_key = os.environ["SAFE_TRANSACTION_SERVICE_API_KEY"]
+    output_path = args.output or Path(
+        f"state/gmx-ai-cowswap-cleanup-safe-nonce-{proposal.safe_tx.safe_nonce}.json"
+    )
+    if output_path.exists():
+        raise RuntimeError(
+            f"Refusing to overwrite existing proposal artefact: {output_path}"
+        )
+    safe_tx_hash = propose_safe_transaction(
+        proposal,
+        private_key=private_key,
+        safe_api_key=safe_api_key,
+    )
+    # Persist only after the Transaction Service accepted the proposal. A failed
+    # API call must not leave a stale artefact that blocks a fresh quote/retry.
+    output_path.write_text(json.dumps(artefact, indent=2) + "\n")
+    print(f"Safe proposal submitted: {safe_tx_hash}")
+    print(f"Order artefact: {output_path}")
+    print(
+        "After 4-of-6 execution, run --post-orders with this artefact before restarting gmx-ai."
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/cowswap/test_safe_proposal.py
+++ b/tests/cowswap/test_safe_proposal.py
@@ -1,0 +1,171 @@
+"""Test Safe-compatible CoW orders without external API calls."""
+
+import pytest
+from hexbytes import HexBytes
+from web3 import Web3
+
+from tradeexecutor.ethereum.cowswap import safe_proposal
+from tradeexecutor.ethereum.cowswap.safe_proposal import (
+    CowSwapAPIError,
+    calculate_order_digest,
+    calculate_order_uid,
+    post_presigned_order,
+    prepare_cowswap_order,
+)
+
+
+SAFE = "0x7838A4E4ecD438c1BdD13b014675c7e877b8b490"
+SETTLEMENT = "0x9008D19f58AAbD9eD0D60971565AA8510560ab41"
+WBTC = "0x2f2a2543B76A4166549F7aaB2e75Bef0aefC5B0f"
+USDC = "0xaf88d065e77c8cC2239327C5EDb3A432268e5831"
+
+
+def test_prepare_cowswap_order_uid():
+    """Test that a quote becomes a correctly packed pre-sign order UID.
+
+    1. Prepare a deterministic Safe-compatible CoW quote.
+    2. Apply one per cent price protection and the current zero signed-fee rule.
+    3. Verify the owner and expiry packed into the prepared order UID.
+    4. Check hashing against a real fulfilled Arbitrum CoW order UID.
+    """
+    # 1. Prepare a deterministic Safe-compatible CoW quote.
+    quote_response = {
+        "quote": {
+            "sellToken": WBTC,
+            "buyToken": USDC,
+            "receiver": SAFE,
+            "sellAmount": "184800",
+            "buyAmount": "146000000",
+            "validTo": 1_800_000_000,
+            "appData": "0x" + "00" * 32,
+            "feeAmount": "17",
+            "kind": "sell",
+            "partiallyFillable": False,
+            "sellTokenBalance": "erc20",
+            "buyTokenBalance": "erc20",
+            "signingScheme": "presign",
+        }
+    }
+
+    # 2. Apply one per cent price protection and the current zero signed-fee rule.
+    prepared = prepare_cowswap_order(
+        symbol="WBTC",
+        balance=184817,
+        sell_token=WBTC,
+        buy_token=USDC,
+        quote_response=quote_response,
+        chain_id=42161,
+        settlement=SETTLEMENT,
+        owner=SAFE,
+        slippage_bps=100,
+    )
+    assert prepared.order["buyAmount"] == "144540000"
+    assert prepared.order["feeAmount"] == "0"
+    assert prepared.order["sellAmount"] == "184817"
+
+    # 3. Verify the owner and expiry packed into the prepared order UID.
+    digest = calculate_order_digest(
+        chain_id=42161, settlement=SETTLEMENT, order=prepared.order
+    )
+    assert len(digest) == 32
+    assert len(prepared.uid) == 56
+    assert prepared.uid[:32] == digest
+    assert prepared.uid[32:52] == HexBytes(SAFE)
+    assert int.from_bytes(prepared.uid[52:], byteorder="big") == 1_800_000_000
+
+    # 4. Check hashing against a real fulfilled Arbitrum CoW order UID.
+    # Source: CoW Order Book API, auction 8657295, fetched 2026-08-28.
+    settled_order = {
+        "sellToken": "0xe50fa9b3c56ffb159cb0fca61f5c9d750e8128c8",
+        "buyToken": "0x724dc807b04555b71ed48a6896b6f41593b8c637",
+        "receiver": "0xcb46281bee2dfa0af6753576bb6b11923243582c",
+        "sellAmount": "36653551915617423412",
+        "buyAmount": "91019171318",
+        "validTo": 1_787_922_985,
+        "appData": "0xa3465c7c262898375e108c2bee18f39e29e9894807d5f724aba044a14a33ff3d",
+        "feeAmount": "0",
+        "kind": "sell",
+        "partiallyFillable": False,
+        "sellTokenBalance": "erc20",
+        "buyTokenBalance": "erc20",
+    }
+    settled_uid = calculate_order_uid(
+        chain_id=42161,
+        settlement=SETTLEMENT,
+        owner=settled_order["receiver"],
+        order=settled_order,
+    )
+    assert Web3.to_hex(settled_uid) == (
+        "0xa2b42c3bd124e5ba6e8b56399e5b98d807b940ab60e1e6c840dfa380ea9ed125"
+        "cb46281bee2dfa0af6753576bb6b11923243582c6a918a29"
+    )
+
+
+def test_cowswap_order_rejects_unsafe_api_data(monkeypatch: pytest.MonkeyPatch):
+    """Test that unsafe quote and order-book responses are rejected.
+
+    1. Prepare a quote whose receiver is not the expected Safe.
+    2. Attempt to prepare a pre-signable order.
+    3. Verify preparation rejects the unsafe receiver before transaction creation.
+    4. Stub the CoW API because this unit test must not make network requests.
+    5. Verify a mismatched UID returned during order creation is rejected.
+    """
+    # 1. Prepare a quote whose receiver is not the expected Safe.
+    quote_response = {
+        "quote": {
+            "sellToken": WBTC,
+            "buyToken": USDC,
+            "receiver": "0x0000000000000000000000000000000000000001",
+            "sellAmount": "184800",
+            "buyAmount": "146000000",
+            "validTo": 1_800_000_000,
+            "appData": "0x" + "00" * 32,
+            "feeAmount": "17",
+            "kind": "sell",
+            "partiallyFillable": False,
+            "sellTokenBalance": "erc20",
+            "buyTokenBalance": "erc20",
+            "signingScheme": "presign",
+        }
+    }
+
+    # 2. Attempt to prepare a pre-signable order.
+    # 3. Verify preparation rejects the unsafe receiver before transaction creation.
+    with pytest.raises(AssertionError, match="Unexpected quote receiver"):
+        prepare_cowswap_order(
+            symbol="WBTC",
+            balance=184817,
+            sell_token=WBTC,
+            buy_token=USDC,
+            quote_response=quote_response,
+            chain_id=42161,
+            settlement=SETTLEMENT,
+            owner=SAFE,
+            slippage_bps=100,
+        )
+
+    # 4. Stub the CoW API because this unit test must not make network requests.
+    quote_response["quote"]["receiver"] = SAFE
+    prepared = prepare_cowswap_order(
+        symbol="WBTC",
+        balance=184817,
+        sell_token=WBTC,
+        buy_token=USDC,
+        quote_response=quote_response,
+        chain_id=42161,
+        settlement=SETTLEMENT,
+        owner=SAFE,
+        slippage_bps=100,
+    )
+    responses = iter(((404, {}), (201, "0x" + "00" * 56)))
+    monkeypatch.setattr(
+        safe_proposal, "_request_json", lambda *args, **kwargs: next(responses)
+    )
+
+    # 5. Verify a mismatched UID returned during order creation is rejected.
+    with pytest.raises(CowSwapAPIError, match="unexpected order UID"):
+        post_presigned_order(
+            api_base_url="https://api.cow.fi/arbitrum_one",
+            owner=SAFE,
+            prepared_order=prepared,
+        )

--- a/tradeexecutor/ethereum/cowswap/safe_proposal.py
+++ b/tradeexecutor/ethereum/cowswap/safe_proposal.py
@@ -1,0 +1,295 @@
+"""Build CoW Protocol pre-signed orders for Gnosis Safe proposals."""
+
+import json
+import urllib.error
+import urllib.request
+from dataclasses import dataclass
+
+from eth_account.messages import encode_typed_data
+from hexbytes import HexBytes
+from web3 import Web3
+
+
+COWSWAP_ORDER_TYPES = {
+    "EIP712Domain": [
+        {"name": "name", "type": "string"},
+        {"name": "version", "type": "string"},
+        {"name": "chainId", "type": "uint256"},
+        {"name": "verifyingContract", "type": "address"},
+    ],
+    "Order": [
+        {"name": "sellToken", "type": "address"},
+        {"name": "buyToken", "type": "address"},
+        {"name": "receiver", "type": "address"},
+        {"name": "sellAmount", "type": "uint256"},
+        {"name": "buyAmount", "type": "uint256"},
+        {"name": "validTo", "type": "uint32"},
+        {"name": "appData", "type": "bytes32"},
+        {"name": "feeAmount", "type": "uint256"},
+        {"name": "kind", "type": "string"},
+        {"name": "partiallyFillable", "type": "bool"},
+        {"name": "sellTokenBalance", "type": "string"},
+        {"name": "buyTokenBalance", "type": "string"},
+    ],
+}
+
+
+@dataclass(slots=True, frozen=True)
+class PreparedCowSwapOrder:
+    """A CoW order and the metadata needed to submit it after Safe execution."""
+
+    symbol: str
+    balance: int
+    quoted_buy_amount: int
+    order: dict
+    uid: HexBytes
+
+    def to_json(self) -> dict:
+        """Serialise the prepared order without any private material."""
+        return {
+            "symbol": self.symbol,
+            "balance": str(self.balance),
+            "quoted_buy_amount": str(self.quoted_buy_amount),
+            "uid": Web3.to_hex(self.uid),
+            "order": self.order,
+        }
+
+
+class CowSwapAPIError(RuntimeError):
+    """A CoW Order Book API request failed."""
+
+
+def _request_json(
+    url: str, method: str = "GET", payload: dict | None = None, timeout: float = 30
+) -> tuple[int, dict | str]:
+    """Make a JSON request using the standard library.
+
+    ``requests`` is currently blocked by CoW's CloudFront configuration while
+    urllib and curl are accepted, so production scripts use urllib here.
+    """
+    data = json.dumps(payload).encode("utf-8") if payload is not None else None
+    request = urllib.request.Request(
+        url,
+        data=data,
+        headers={
+            "Content-Type": "application/json",
+            "User-Agent": "trade-executor-cowswap-cleanup/1",
+        },
+        method=method,
+    )
+    try:
+        with urllib.request.urlopen(request, timeout=timeout) as response:
+            body = response.read().decode("utf-8")
+            return response.status, json.loads(body) if body else {}
+    except urllib.error.HTTPError as exc:
+        body = exc.read().decode("utf-8")
+        try:
+            decoded_body = json.loads(body)
+        except json.JSONDecodeError:
+            decoded_body = body
+        return exc.code, decoded_body
+
+
+def fetch_cowswap_quote(
+    *,
+    api_base_url: str,
+    safe_address: str,
+    sell_token: str,
+    buy_token: str,
+    sell_amount_before_fee: int,
+    valid_for_seconds: int,
+) -> dict:
+    """Fetch a long-lived, Safe-compatible exact-sell quote."""
+    payload = {
+        "sellToken": sell_token,
+        "buyToken": buy_token,
+        "receiver": safe_address,
+        "from": safe_address,
+        "kind": "sell",
+        "sellAmountBeforeFee": str(sell_amount_before_fee),
+        "priceQuality": "optimal",
+        "signingScheme": "presign",
+        "onchainOrder": True,
+        "validFor": valid_for_seconds,
+    }
+    status, response = _request_json(
+        f"{api_base_url}/api/v1/quote", method="POST", payload=payload
+    )
+    if status != 200 or not isinstance(response, dict):
+        raise CowSwapAPIError(f"CoW quote failed with HTTP {status}: {response}")
+    return response
+
+
+def calculate_order_digest(*, chain_id: int, settlement: str, order: dict) -> HexBytes:
+    """Calculate the CoW EIP-712 order digest."""
+    typed_message = {
+        "types": COWSWAP_ORDER_TYPES,
+        "primaryType": "Order",
+        "domain": {
+            "name": "Gnosis Protocol",
+            "version": "v2",
+            "chainId": chain_id,
+            "verifyingContract": settlement,
+        },
+        "message": {
+            "sellToken": order["sellToken"],
+            "buyToken": order["buyToken"],
+            "receiver": order["receiver"],
+            "sellAmount": int(order["sellAmount"]),
+            "buyAmount": int(order["buyAmount"]),
+            "validTo": int(order["validTo"]),
+            "appData": HexBytes(order["appData"]),
+            "feeAmount": int(order["feeAmount"]),
+            "kind": order["kind"],
+            "partiallyFillable": order["partiallyFillable"],
+            "sellTokenBalance": order["sellTokenBalance"],
+            "buyTokenBalance": order["buyTokenBalance"],
+        },
+    }
+    signable_message = encode_typed_data(full_message=typed_message)
+    return HexBytes(
+        Web3.keccak(
+            b"\x19"
+            + signable_message.version
+            + signable_message.header
+            + signable_message.body
+        )
+    )
+
+
+def calculate_order_uid(
+    *, chain_id: int, settlement: str, owner: str, order: dict
+) -> HexBytes:
+    """Calculate the 56-byte CoW order UID."""
+    digest = calculate_order_digest(
+        chain_id=chain_id, settlement=settlement, order=order
+    )
+    owner_bytes = HexBytes(Web3.to_checksum_address(owner))
+    valid_to = int(order["validTo"]).to_bytes(4, byteorder="big")
+    return HexBytes(digest + owner_bytes + valid_to)
+
+
+def prepare_cowswap_order(
+    *,
+    symbol: str,
+    balance: int,
+    sell_token: str,
+    buy_token: str,
+    quote_response: dict,
+    chain_id: int,
+    settlement: str,
+    owner: str,
+    slippage_bps: int,
+) -> PreparedCowSwapOrder:
+    """Turn a CoW quote into a pre-signable order with explicit price protection."""
+    assert 0 <= slippage_bps < 10_000, f"Invalid slippage: {slippage_bps} bps"
+    quote = quote_response["quote"]
+    assert quote["signingScheme"] == "presign", (
+        f"Unexpected signing scheme: {quote['signingScheme']}"
+    )
+    assert quote["kind"] == "sell", f"Unexpected order kind: {quote['kind']}"
+    assert quote["sellToken"].lower() == sell_token.lower(), (
+        f"Unexpected quote sell token: {quote['sellToken']}"
+    )
+    assert quote["buyToken"].lower() == buy_token.lower(), (
+        f"Unexpected quote buy token: {quote['buyToken']}"
+    )
+    assert quote["receiver"].lower() == owner.lower(), (
+        f"Unexpected quote receiver: {quote['receiver']}"
+    )
+    assert quote["appData"] == "0x" + "00" * 32, (
+        f"Unexpected quote appData: {quote['appData']}"
+    )
+    assert quote["partiallyFillable"] is False, "Partial fills are not allowed"
+    assert quote["sellTokenBalance"] == "erc20", (
+        f"Unexpected sell token balance: {quote['sellTokenBalance']}"
+    )
+    assert quote["buyTokenBalance"] == "erc20", (
+        f"Unexpected buy token balance: {quote['buyTokenBalance']}"
+    )
+    quote_sell_amount = int(quote["sellAmount"])
+    quote_fee_amount = int(quote["feeAmount"])
+    assert quote_sell_amount + quote_fee_amount == balance, (
+        f"CoW quote does not consume the full {symbol} balance: "
+        f"sell {quote_sell_amount} + fee {quote_fee_amount} != balance {balance}"
+    )
+    quoted_buy_amount = int(quote["buyAmount"])
+    minimum_buy_amount = quoted_buy_amount * (10_000 - slippage_bps) // 10_000
+    assert minimum_buy_amount > 0, f"Minimum buy amount is zero for {symbol}"
+
+    order = {
+        "sellToken": Web3.to_checksum_address(quote["sellToken"]),
+        "buyToken": Web3.to_checksum_address(quote["buyToken"]),
+        "receiver": Web3.to_checksum_address(owner),
+        # The quote splits the requested input into sellAmount + feeAmount.
+        # New orders sign a zero legacy fee, so the signed sell amount must be
+        # the original before-fee input for the full Safe balance to be sold.
+        "sellAmount": str(balance),
+        "buyAmount": str(minimum_buy_amount),
+        "validTo": int(quote["validTo"]),
+        "appData": quote["appData"],
+        # CoW's current API requires newly created orders to sign a zero legacy fee.
+        # Solvers compute the actual fee dynamically within the order's limit price.
+        "feeAmount": "0",
+        "kind": "sell",
+        "partiallyFillable": False,
+        "sellTokenBalance": "erc20",
+        "buyTokenBalance": "erc20",
+    }
+    uid = calculate_order_uid(
+        chain_id=chain_id, settlement=settlement, owner=owner, order=order
+    )
+    return PreparedCowSwapOrder(
+        symbol=symbol,
+        balance=balance,
+        quoted_buy_amount=quoted_buy_amount,
+        order=order,
+        uid=uid,
+    )
+
+
+def post_presigned_order(
+    *, api_base_url: str, owner: str, prepared_order: PreparedCowSwapOrder
+) -> str:
+    """Post a Safe-pre-signed order, returning its UID.
+
+    The operation is idempotent: an order already visible through the API is
+    accepted as success after its UID is checked.
+    """
+    uid = Web3.to_hex(prepared_order.uid)
+    status, existing = _request_json(f"{api_base_url}/api/v1/orders/{uid}")
+    if status == 200:
+        assert (
+            isinstance(existing, dict)
+            and existing.get("uid", "").lower() == uid.lower()
+        ), f"Unexpected existing order: {existing}"
+        return uid
+    if status != 404:
+        raise CowSwapAPIError(
+            f"Could not check CoW order {uid}: HTTP {status}: {existing}"
+        )
+
+    payload = prepared_order.order.copy()
+    payload.update(
+        {
+            "signature": "0x",
+            "signingScheme": "presign",
+            "from": Web3.to_checksum_address(owner),
+            # CoW's OrderCreation API uses this to validate the full fill-or-kill
+            # balance and allowance rather than accepting a partial balance.
+            "fullBalanceCheck": True,
+        }
+    )
+    status, response = _request_json(
+        f"{api_base_url}/api/v1/orders", method="POST", payload=payload
+    )
+    if status not in {200, 201}:
+        raise CowSwapAPIError(
+            f"Posting CoW order {uid} failed with HTTP {status}: {response}"
+        )
+    posted_uid = response if isinstance(response, str) else response.get("uid")
+    if not isinstance(posted_uid, str) or posted_uid.lower() != uid.lower():
+        raise CowSwapAPIError(
+            f"CoW returned unexpected order UID {posted_uid}, expected {uid}"
+        )
+    return uid


### PR DESCRIPTION
## Why

The GMX AI Safe retained WBTC and WBNB after profit-taking instead of converting the full proceeds to USDC. The stranded assets need a guarded production workflow that proposes owner-reviewed transactions without executing the 4-of-6 Safe or touching its ETH execution-fee reserve.

## Lessons learnt

CoW quotes split an exact sell input into the quoted sell amount and legacy fee amount, while newly created zero-fee orders must sign the complete before-fee input. Safe pre-sign orders also require two distinct phases: owners first execute the on-chain approval and pre-sign batch, then the verified order is submitted to the CoW order book.

## Summary

- Add a production Docker script that previews and proposes a Safe MultiSend batch for the GMX AI WBTC and WBNB balances.
- Convert both token balances to native USDC through price-protected, fill-or-kill CoW orders while explicitly excluding native ETH.
- Require the asset-manager owner key, authenticated Safe Transaction Service access, the expected Arbitrum Safe configuration, and an operator acknowledgement that the executor is stopped.
- Persist a non-secret hand-off artefact only after the Safe proposal is accepted, then verify its UID and on-chain pre-signature before posting orders to CoW.
- Add focused tests for full-balance order construction, a fulfilled Arbitrum order hash vector, receiver pinning, and CoW response UID validation.

## How to run in production

Run this only after the deployment uses an image built from this PR or a release containing it. Do not download or copy the script into an older container, and do not use a standalone `docker run`: it would not receive the production Compose service's environment and mounted state.

From the production Docker Compose project, stop the live executor before opening the maintenance container:

```shell
docker compose stop gmx-ai
docker compose run --entrypoint /bin/bash gmx-ai --
```

Inside the maintenance container, confirm the image contains the script, the authoritative state file is mounted, and the required proposal credentials are present. These checks do not print either secret.

```shell
test -f scripts/gmx-ai/propose-cowswap-cleanup.py
test -s state/gmx-ai.json
test -n "$PRIVATE_KEY"
test -n "$SAFE_TRANSACTION_SERVICE_API_KEY"
poetry run python scripts/gmx-ai/propose-cowswap-cleanup.py --help
```

### 1. Preview

Run the default preview first. It reads the production Safe and obtains CoW quotes, but does not submit a Safe proposal or a CoW order.

```shell
poetry run python scripts/gmx-ai/propose-cowswap-cleanup.py
```

Review the printed artefact before continuing. Confirm at least:

- `chain_id` is `42161`.
- `safe` is `0x7838A4E4ecD438c1BdD13b014675c7e877b8b490`.
- Only WBTC and WBNB are sold, and both orders buy native USDC at `0xaf88d065e77c8cC2239327C5EDb3A432268e5831`.
- The receiver is the same GMX AI Safe.
- The balances and one-per-cent price-protection amounts are reasonable.
- Native ETH is absent from the transaction.
- Each order's `validTo` leaves enough time for the 4-of-6 Safe approval and order posting. The default validity is 24 hours.

### 2. Propose the Safe transaction

After reviewing the preview, create the Safe Transaction Service proposal using the existing asset-manager `PRIVATE_KEY`:

```shell
poetry run python scripts/gmx-ai/propose-cowswap-cleanup.py \
    --propose \
    --confirm-executor-stopped
```

The command proposes but does not execute the 4-of-6 Safe transaction. Record the printed Safe transaction hash and artefact path, for example:

```text
state/gmx-ai-cowswap-cleanup-safe-nonce-12.json
```

The nonce in the real filename may differ. Do not edit the artefact. Keep the `gmx-ai` executor stopped while the Safe owners inspect and execute the proposal.

In the Safe UI, owners must confirm that the batch contains only exact WBTC/WBNB approvals to the CoW vault relayer and the corresponding CoW `setPreSignature` calls. It must not contain ETH or unrelated calls.

### 3. Post the executed orders to CoW

Only after the Safe transaction is executed on Arbitrum, submit the pre-signed orders using the exact artefact path printed by the proposal command:

```shell
poetry run python scripts/gmx-ai/propose-cowswap-cleanup.py \
    --post-orders state/gmx-ai-cowswap-cleanup-safe-nonce-12.json \
    --confirm-executor-stopped
```

The script recalculates each order UID and checks its on-chain Safe pre-signature before posting. It prints a CoW explorer link for each order.

Keep the executor stopped until both explorer links show the orders as settled and the Safe shows the expected USDC proceeds. Confirm that the WBTC and WBNB balances are zero or economically negligible. The script deliberately does not handle native ETH.

If the Safe nonce changes, a conflicting proposal exists, an order expires, or either command fails, stop and inspect the reported condition. Do not edit and reuse an expired artefact; run a new preview and obtain a newly reviewed Safe proposal.

### 4. Restart and verify

After both CoW orders have settled, leave the maintenance container and restart the existing Compose service:

```shell
exit
docker compose start gmx-ai
docker compose ps gmx-ai
```

Finally, confirm that the executor starts cleanly and its production state endpoint loads before considering the maintenance complete.
