### PR TITLE
fix: never drop oversized log records on the Logstash UDP handler

### DIFF
--- a/tests/cli/test_cli_logging.py
+++ b/tests/cli/test_cli_logging.py
@@ -4,12 +4,16 @@ import json
 import logging
 import os
 import socket
+import sys
+from collections.abc import Iterator
 
+import logstash
 import pytest
 from eth_defi.coloured_logging import EthDefiRichHandler
 
 from tradeexecutor.cli.log import (
     MAX_LOGSTASH_UDP_PAYLOAD_SIZE,
+    create_logstash_handler,
     setup_logging,
     setup_logstash_logging,
 )
@@ -136,22 +140,41 @@ def test_setup_logging_uses_plain_handler_when_colour_is_disabled(
 
 
 @pytest.fixture()
-def logstash_udp_socket() -> socket.socket:
+def logstash_udp_socket() -> Iterator[socket.socket]:
     """Bind a local UDP socket standing in for a Logstash server.
 
     A real socket is used instead of a mock, because the bug under test is
     raised by the operating system - a datagram larger than the socket limit
     fails with ``OSError: [Errno 90] Message too long`` - and a mocked
     ``sendto()`` would happily accept any payload size.
+
+    1. Bind a datagram socket on an ephemeral loopback port.
+    2. Hand the socket to the test.
+    3. Close the socket afterwards.
     """
 
+    # 1. Bind a datagram socket on an ephemeral loopback port.
     server = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
     server.bind(("127.0.0.1", 0))
     server.settimeout(5)
+
     try:
+        # 2. Hand the socket to the test.
         yield server
     finally:
+        # 3. Close the socket afterwards.
         server.close()
+
+
+def receive_messages(server: socket.socket, count: int) -> dict[str, bytes]:
+    """Read datagrams and index them by their log message.
+
+    UDP does not guarantee ordering, so tests must not assume the datagrams
+    arrive in the order they were logged.
+    """
+
+    datagrams = [server.recvfrom(65535)[0] for _ in range(count)]
+    return {json.loads(datagram)["message"]: datagram for datagram in datagrams}
 
 
 def test_logstash_logging_truncates_oversized_messages(
@@ -163,6 +186,11 @@ def test_logstash_logging_truncates_oversized_messages(
     Diagnostic tables like the stale vault listing are tens of kilobytes and
     used to fail with ``OSError: [Errno 90] Message too long``, printing
     ``--- Logging error ---`` and dropping the record entirely.
+
+    The table is built from CJK and emoji vault names as seen in production,
+    because ``json.dumps()`` escapes those into ``\\uXXXX`` sequences of up to 12
+    bytes per character. A budget counted in characters instead of bytes would
+    therefore still produce an oversized datagram.
 
     1. Point Logstash logging at a local UDP socket.
     2. Log a small message and an oversized diagnostic table.
@@ -182,26 +210,84 @@ def test_logstash_logging_truncates_oversized_messages(
 
     # 2. Log a small message and an oversized diagnostic table.
     table = "\n".join(
-        f"Vault {i:<40} 0x{'a' * 40} 2026-08-29 00:00:00 2026-08-29 03:48:46.965000 2 days 12:51:14"
+        f"● MONO BLACK TOKYO「MORI 森」💩 {i:<20} 0x{'a' * 40} 2026-08-29 00:00:00 2 days 12:51:14"
         for i in range(345)
     )
     assert len(table) > MAX_LOGSTASH_UDP_PAYLOAD_SIZE
     logger.warning("Vault candle data is fresh")
     logger.warning("Vault candle data is stale for %d vault(s):\n%s", 345, table)
+    messages = receive_messages(logstash_udp_socket, 2)
 
     # 3. Verify the small message is delivered intact.
-    small_datagram, _ = logstash_udp_socket.recvfrom(65535)
-    assert json.loads(small_datagram)["message"] == "Vault candle data is fresh"
+    assert len(messages["Vault candle data is fresh"]) <= MAX_LOGSTASH_UDP_PAYLOAD_SIZE
 
     # 4. Verify the oversized message is delivered truncated, with its beginning preserved.
-    large_datagram, _ = logstash_udp_socket.recvfrom(65535)
-    assert len(large_datagram) <= MAX_LOGSTASH_UDP_PAYLOAD_SIZE
-    message = json.loads(large_datagram)["message"]
-    assert message.startswith("Vault candle data is stale for 345 vault(s):\nVault 0 ")
-    assert "truncated" in message
+    truncated_message = next(
+        message for message in messages if message.startswith("Vault candle data is stale")
+    )
+    assert len(messages[truncated_message]) <= MAX_LOGSTASH_UDP_PAYLOAD_SIZE
+    assert truncated_message.startswith(
+        "Vault candle data is stale for 345 vault(s):\n● MONO BLACK TOKYO「MORI 森」💩 0 "
+    )
+    assert "truncated" in truncated_message
 
     # 5. Verify logging did not report an error.
     assert "--- Logging error ---" not in capsys.readouterr().err
+
+
+def test_logstash_handler_leaves_fitting_records_untouched() -> None:
+    """Check the truncating handler is transparent for ordinary log records.
+
+    Truncation must not become a tax on every log line: a record that fits has
+    to serialise exactly as the stock handler serialises it, and an oversized
+    record must not corrupt the shared record that console, file and Sentry
+    handlers read afterwards.
+
+    1. Create a truncating handler and a stock handler with the same settings.
+    2. Serialise a small record with both.
+    3. Verify the two payloads are byte for byte identical.
+    4. Serialise an oversized record with the truncating handler.
+    5. Verify the oversized record itself was not modified.
+    """
+
+    # 1. Create a truncating handler and a stock handler with the same settings.
+    truncating_handler = create_logstash_handler(
+        "127.0.0.1",
+        5959,
+        tags=["python"],
+        extra_fields={"application": "test-executor"},
+    )
+    reference_handler = logstash.UDPLogstashHandler(
+        "127.0.0.1",
+        5959,
+        version=1,
+        tags=["python"],
+        extra_fields={"application": "test-executor"},
+    )
+
+    # 2. Serialise a small record with both.
+    small_record = logging.LogRecord(
+        "test", logging.WARNING, "/tmp/test.py", 10, "Vault %s is fresh", ("Storm",), None
+    )
+
+    # 3. Verify the two payloads are byte for byte identical.
+    assert truncating_handler.makePickle(small_record) == reference_handler.makePickle(small_record)
+
+    # 4. Serialise an oversized record with the truncating handler.
+    table = "森" * MAX_LOGSTASH_UDP_PAYLOAD_SIZE
+    try:
+        raise RuntimeError("Vault price feed is stale")
+    except RuntimeError:
+        large_record = logging.LogRecord(
+            "test", logging.WARNING, "/tmp/test.py", 10, "Stale:\n%s", (table,), sys.exc_info()
+        )
+    payload = truncating_handler.makePickle(large_record)
+    assert len(payload) <= MAX_LOGSTASH_UDP_PAYLOAD_SIZE
+
+    # 5. Verify the oversized record itself was not modified.
+    assert large_record.getMessage() == f"Stale:\n{table}"
+    assert large_record.args == (table,)
+    assert large_record.exc_info is not None
 
 
 def test_logstash_logging_replaces_records_that_cannot_be_shortened(
@@ -236,9 +322,10 @@ def test_logstash_logging_replaces_records_that_cannot_be_shortened(
     )
 
     # 3. Verify a placeholder datagram is delivered instead.
-    datagram, _ = logstash_udp_socket.recvfrom(65535)
+    messages = receive_messages(logstash_udp_socket, 1)
+    message, datagram = next(iter(messages.items()))
     assert len(datagram) <= MAX_LOGSTASH_UDP_PAYLOAD_SIZE
-    assert "dropped" in json.loads(datagram)["message"]
+    assert "dropped" in message
 
     # 4. Verify logging did not report an error.
     assert "--- Logging error ---" not in capsys.readouterr().err

--- a/tests/cli/test_cli_logging.py
+++ b/tests/cli/test_cli_logging.py
@@ -1,12 +1,18 @@
 """Tests for command line logging setup."""
 
+import json
 import logging
 import os
+import socket
 
 import pytest
 from eth_defi.coloured_logging import EthDefiRichHandler
 
-from tradeexecutor.cli.log import setup_logging
+from tradeexecutor.cli.log import (
+    MAX_LOGSTASH_UDP_PAYLOAD_SIZE,
+    setup_logging,
+    setup_logstash_logging,
+)
 
 
 @pytest.fixture(autouse=True)
@@ -127,3 +133,112 @@ def test_setup_logging_uses_plain_handler_when_colour_is_disabled(
         isinstance(handler, logging.StreamHandler) and not isinstance(handler, EthDefiRichHandler)
         for handler in logger.handlers
     )
+
+
+@pytest.fixture()
+def logstash_udp_socket() -> socket.socket:
+    """Bind a local UDP socket standing in for a Logstash server.
+
+    A real socket is used instead of a mock, because the bug under test is
+    raised by the operating system - a datagram larger than the socket limit
+    fails with ``OSError: [Errno 90] Message too long`` - and a mocked
+    ``sendto()`` would happily accept any payload size.
+    """
+
+    server = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+    server.bind(("127.0.0.1", 0))
+    server.settimeout(5)
+    try:
+        yield server
+    finally:
+        server.close()
+
+
+def test_logstash_logging_truncates_oversized_messages(
+    logstash_udp_socket: socket.socket,
+    capsys: pytest.CaptureFixture,
+) -> None:
+    """Check a huge diagnostic table still reaches Logstash as a truncated datagram.
+
+    Diagnostic tables like the stale vault listing are tens of kilobytes and
+    used to fail with ``OSError: [Errno 90] Message too long``, printing
+    ``--- Logging error ---`` and dropping the record entirely.
+
+    1. Point Logstash logging at a local UDP socket.
+    2. Log a small message and an oversized diagnostic table.
+    3. Verify the small message is delivered intact.
+    4. Verify the oversized message is delivered truncated, with its beginning preserved.
+    5. Verify logging did not report an error.
+    """
+
+    # 1. Point Logstash logging at a local UDP socket.
+    port = logstash_udp_socket.getsockname()[1]
+    setup_logstash_logging(
+        "127.0.0.1",
+        application_name="test-executor",
+        port=port,
+    )
+    logger = logging.getLogger(__name__)
+
+    # 2. Log a small message and an oversized diagnostic table.
+    table = "\n".join(
+        f"Vault {i:<40} 0x{'a' * 40} 2026-08-29 00:00:00 2026-08-29 03:48:46.965000 2 days 12:51:14"
+        for i in range(345)
+    )
+    assert len(table) > MAX_LOGSTASH_UDP_PAYLOAD_SIZE
+    logger.warning("Vault candle data is fresh")
+    logger.warning("Vault candle data is stale for %d vault(s):\n%s", 345, table)
+
+    # 3. Verify the small message is delivered intact.
+    small_datagram, _ = logstash_udp_socket.recvfrom(65535)
+    assert json.loads(small_datagram)["message"] == "Vault candle data is fresh"
+
+    # 4. Verify the oversized message is delivered truncated, with its beginning preserved.
+    large_datagram, _ = logstash_udp_socket.recvfrom(65535)
+    assert len(large_datagram) <= MAX_LOGSTASH_UDP_PAYLOAD_SIZE
+    message = json.loads(large_datagram)["message"]
+    assert message.startswith("Vault candle data is stale for 345 vault(s):\nVault 0 ")
+    assert "truncated" in message
+
+    # 5. Verify logging did not report an error.
+    assert "--- Logging error ---" not in capsys.readouterr().err
+
+
+def test_logstash_logging_replaces_records_that_cannot_be_shortened(
+    logstash_udp_socket: socket.socket,
+    capsys: pytest.CaptureFixture,
+) -> None:
+    """Check a record bloated outside its message is replaced by a placeholder.
+
+    The Logstash formatter turns every custom record attribute into an extra
+    field, so a short message can still produce an oversized datagram. Cutting
+    the message cannot help there, and the record must not be lost silently.
+
+    1. Point Logstash logging at a local UDP socket.
+    2. Log a short message carrying a megabyte-sized extra field.
+    3. Verify a placeholder datagram is delivered instead.
+    4. Verify logging did not report an error.
+    """
+
+    # 1. Point Logstash logging at a local UDP socket.
+    port = logstash_udp_socket.getsockname()[1]
+    setup_logstash_logging(
+        "127.0.0.1",
+        application_name="test-executor",
+        port=port,
+    )
+    logger = logging.getLogger(__name__)
+
+    # 2. Log a short message carrying a megabyte-sized extra field.
+    logger.warning(
+        "Position dump",
+        extra={"position_dump": "x" * 1_000_000},
+    )
+
+    # 3. Verify a placeholder datagram is delivered instead.
+    datagram, _ = logstash_udp_socket.recvfrom(65535)
+    assert len(datagram) <= MAX_LOGSTASH_UDP_PAYLOAD_SIZE
+    assert "dropped" in json.loads(datagram)["message"]
+
+    # 4. Verify logging did not report an error.
+    assert "--- Logging error ---" not in capsys.readouterr().err

--- a/tradeexecutor/cli/log.py
+++ b/tradeexecutor/cli/log.py
@@ -49,6 +49,25 @@ MAX_LOGSTASH_UDP_PAYLOAD_SIZE = 32_000
 #: See :py:class:`TruncatingLogstashHandlerMixin`.
 MAX_LOGSTASH_TRUNCATION_ATTEMPTS = 5
 
+#: Extra headroom taken on every shrink attempt, as a percentage.
+#:
+#: Shrinking strictly in proportion to the overshoot converges slowly when the
+#: payload is only a few bytes too large, and could burn all the attempts moving
+#: one character at a time. Overshooting the shrink guarantees progress.
+LOGSTASH_TRUNCATION_MARGIN_PERCENT = 5
+
+#: Maximum length of the record fields we copy into a placeholder record.
+#:
+#: Keeps the size of the last resort payload bounded even if a caller uses an
+#: unusually long logger name or source path.
+MAX_LOGSTASH_PLACEHOLDER_FIELD_LENGTH = 200
+
+#: Smallest datagram size the handler can work with.
+#:
+#: A placeholder record needs to fit in it, see
+#: :py:meth:`TruncatingLogstashHandlerMixin.create_placeholder_record`.
+MIN_LOGSTASH_UDP_PAYLOAD_SIZE = 2_000
+
 
 def setup_logging(
     log_level: None | str | int=logging.INFO,
@@ -443,6 +462,7 @@ class TruncatingLogstashHandlerMixin:
         :param max_payload_size:
             Maximum size of the serialised record, in bytes.
         """
+        assert max_payload_size >= MIN_LOGSTASH_UDP_PAYLOAD_SIZE, f"Datagram size {max_payload_size} is too small to fit a placeholder record"
         super().__init__(*args, **kwargs)
         self.max_payload_size = max_payload_size
 
@@ -466,8 +486,11 @@ class TruncatingLogstashHandlerMixin:
             # The JSON envelope and extra fields take room as well, and
             # non-ASCII characters expand to \uXXXX escapes when serialised,
             # so a character budget does not map one to one to datagram bytes.
-            # Shrink the budget in proportion to the overshoot and try again.
+            # Shrink the budget in proportion to the overshoot, with extra
+            # headroom so that a payload that is only slightly too large does
+            # not creep down one character per attempt, and try again.
             budget = budget * self.max_payload_size // len(payload)
+            budget = budget * (100 - LOGSTASH_TRUNCATION_MARGIN_PERCENT) // 100
             if budget <= 0:
                 break
 
@@ -523,18 +546,19 @@ class TruncatingLogstashHandlerMixin:
 
         We build a fresh record instead of copying, because the original may
         carry large custom attributes which the Logstash formatter turns into
-        extra fields.
+        extra fields. Every field we do copy over is capped, so that the size of
+        the resulting datagram stays bounded by the handler configuration.
         """
 
         placeholder = logging.LogRecord(
-            name=record.name,
+            name=record.name[:MAX_LOGSTASH_PLACEHOLDER_FIELD_LENGTH],
             level=record.levelno,
-            pathname=record.pathname,
+            pathname=record.pathname[:MAX_LOGSTASH_PLACEHOLDER_FIELD_LENGTH],
             lineno=record.lineno,
             msg="Log message of %d characters dropped: too long for a %d byte Logstash UDP datagram",
             args=(message_length, self.max_payload_size),
             exc_info=None,
-            func=record.funcName,
+            func=(record.funcName or "")[:MAX_LOGSTASH_PLACEHOLDER_FIELD_LENGTH],
         )
         # Report the moment of the original event, not the moment of the fallback
         placeholder.created = record.created

--- a/tradeexecutor/cli/log.py
+++ b/tradeexecutor/cli/log.py
@@ -3,6 +3,7 @@
 We have a custom level `logging.TRADE` that we use to log trade execution to Discord and such.
 """
 
+import copy
 import logging
 import os
 import sys
@@ -27,6 +28,26 @@ except ImportError:
 
 #: Stored here as a global so that we can later call RingBufferHandler.export()
 _ring_buffer_handler: Optional[RingBufferHandler] = None
+
+
+#: Maximum size of a single UDP datagram we send to a Logstash server.
+#:
+#: The operating system refuses to send datagrams larger than ~64 kB and raises
+#: ``OSError: [Errno 90] Message too long`` (``EMSGSIZE``). Python's logging
+#: module then prints ``--- Logging error ---`` with a traceback and drops the
+#: record, so the log line never reaches Logstash or Sentry.
+#:
+#: Trade executor emits diagnostic tables (stale vault listings, universe dumps)
+#: and long tracebacks that easily exceed this limit, so we truncate the message
+#: before handing it to the socket. The limit is set well below the theoretical
+#: 65,507 byte maximum, because intermediate network equipment and the Logstash
+#: UDP input buffer may cap the datagram size lower than the local kernel does.
+MAX_LOGSTASH_UDP_PAYLOAD_SIZE = 32_000
+
+#: How many times we shrink an oversized message before giving up on its content.
+#:
+#: See :py:class:`TruncatingLogstashHandlerMixin`.
+MAX_LOGSTASH_TRUNCATION_ATTEMPTS = 5
 
 
 def setup_logging(
@@ -392,6 +413,164 @@ def setup_telegram_logging(
     return telegram_handler
 
 
+class TruncatingLogstashHandlerMixin:
+    """Truncate oversized log records before they are sent over UDP.
+
+    A Logstash UDP handler serialises the whole log record into a single
+    datagram. When the datagram does not fit the operating system limit, the
+    send fails with ``OSError: [Errno 90] Message too long`` (``EMSGSIZE``),
+    Python's logging module prints ``--- Logging error ---`` with a traceback
+    to stderr, and the record is lost.
+
+    Trade executor logs diagnostic tables that can be tens of kilobytes, for
+    example the stale vault listing in
+    :py:func:`tradeexecutor.ethereum.vault.checks.log_stale_vault_candle_data`
+    which tabulates every vault in the trading universe. Those messages are the
+    ones an operator needs most when the executor is misbehaving, so instead of
+    dropping them we shorten the message until the datagram fits.
+
+    Only the copy sent to Logstash is shortened. Console and file handlers keep
+    receiving the full, untouched record.
+    """
+
+    def __init__(
+        self,
+        *args,
+        max_payload_size: int = MAX_LOGSTASH_UDP_PAYLOAD_SIZE,
+        **kwargs,
+    ):
+        """
+        :param max_payload_size:
+            Maximum size of the serialised record, in bytes.
+        """
+        super().__init__(*args, **kwargs)
+        self.max_payload_size = max_payload_size
+
+    def makePickle(self, record: logging.LogRecord):
+        """Serialise the record, shortening the message if the datagram is too large."""
+
+        payload = super().makePickle(record)
+        if len(payload) <= self.max_payload_size:
+            return payload
+
+        message = record.getMessage()
+        budget = min(len(message), self.max_payload_size)
+
+        for _ in range(MAX_LOGSTASH_TRUNCATION_ATTEMPTS):
+            payload = super().makePickle(
+                self.truncate_record(record, message, budget)
+            )
+            if len(payload) <= self.max_payload_size:
+                return payload
+
+            # The JSON envelope and extra fields take room as well, and
+            # non-ASCII characters expand to \uXXXX escapes when serialised,
+            # so a character budget does not map one to one to datagram bytes.
+            # Shrink the budget in proportion to the overshoot and try again.
+            budget = budget * self.max_payload_size // len(payload)
+            if budget <= 0:
+                break
+
+        # The record carries so much data outside the message - long extra
+        # fields or a huge stack trace - that no message length fits. Send a
+        # fixed size placeholder instead, so that at least the existence of the
+        # log entry reaches Logstash.
+        return super().makePickle(self.create_placeholder_record(record, len(message)))
+
+    def truncate_record(
+        self,
+        record: logging.LogRecord,
+        message: str,
+        budget: int,
+    ) -> logging.LogRecord:
+        """Create a copy of the record with the message cut to ``budget`` characters.
+
+        The original record is never mutated, because it is shared with the
+        other handlers of the logger.
+
+        :param message:
+            The already interpolated message of the original record.
+
+        :param budget:
+            How many characters of the message we can keep.
+        """
+
+        # len(message) is an upper bound for the digits of the omitted counter,
+        # so accounting for the suffix with it can never underestimate its length
+        suffix_length = len(self.format_truncation_suffix(len(message)))
+        kept = max(0, budget - suffix_length)
+
+        truncated = copy.copy(record)
+        truncated.msg = message[:kept] + self.format_truncation_suffix(len(message) - kept)
+        truncated.args = None
+        # A stack trace would be truncated away anyway, and it is available
+        # in the console and file logs
+        truncated.exc_info = None
+        truncated.exc_text = None
+        truncated.stack_info = None
+        return truncated
+
+    def format_truncation_suffix(self, omitted_characters: int) -> str:
+        """Human-readable marker appended to a shortened message."""
+        return f"... [truncated {omitted_characters} characters to fit a {self.max_payload_size} byte Logstash UDP datagram]"
+
+    def create_placeholder_record(
+        self,
+        record: logging.LogRecord,
+        message_length: int,
+    ) -> logging.LogRecord:
+        """Create a minimal stand-in record for a log entry we cannot fit in a datagram.
+
+        We build a fresh record instead of copying, because the original may
+        carry large custom attributes which the Logstash formatter turns into
+        extra fields.
+        """
+
+        placeholder = logging.LogRecord(
+            name=record.name,
+            level=record.levelno,
+            pathname=record.pathname,
+            lineno=record.lineno,
+            msg="Log message of %d characters dropped: too long for a %d byte Logstash UDP datagram",
+            args=(message_length, self.max_payload_size),
+            exc_info=None,
+            func=record.funcName,
+        )
+        # Report the moment of the original event, not the moment of the fallback
+        placeholder.created = record.created
+        placeholder.msecs = record.msecs
+        return placeholder
+
+
+def create_logstash_handler(
+    logstash_server: str,
+    port: int,
+    tags: List[str],
+    extra_fields: dict,
+    max_payload_size: int = MAX_LOGSTASH_UDP_PAYLOAD_SIZE,
+):
+    """Create an UDP Logstash handler that survives oversized log messages.
+
+    ``logstash`` is an optional dependency, not available in the Pyodide build,
+    so the handler class is only constructed when this function is called.
+
+    :param max_payload_size:
+        Maximum size of a single datagram, in bytes.
+    """
+
+    class TruncatingUDPLogstashHandler(TruncatingLogstashHandlerMixin, logstash.UDPLogstashHandler):
+        """UDP Logstash handler that shortens oversized messages."""
+
+    return TruncatingUDPLogstashHandler(
+        logstash_server,
+        port,
+        version=1,
+        tags=tags,
+        extra_fields=extra_fields,
+        max_payload_size=max_payload_size,
+    )
+
+
 def setup_logstash_logging(
         logstash_server: str,
         application_name: str,
@@ -438,7 +617,12 @@ def setup_logstash_logging(
     # Include our application name in the logs
     assert application_name, "Cannot use Logstash without application_name set"
     extra_fields = {"application": application_name}
-    handler = logstash.UDPLogstashHandler(logstash_server, port, version=1, tags=tags, extra_fields=extra_fields)
+    handler = create_logstash_handler(
+        logstash_server,
+        port,
+        tags=tags,
+        extra_fields=extra_fields,
+    )
     handler.setLevel(level)
     logger.addHandler(handler)
     return logger


### PR DESCRIPTION
## Why

The `hyper-ai` production executor logs this on every strategy cycle:

```
--- Logging error ---
Traceback (most recent call last):
  File "/usr/local/lib/python3.14/logging/handlers.py", line 751, in send
    self.sock.sendto(s, self.address)
OSError: [Errno 90] Message too long
Message: 'Vault candle data is stale (>24h after source-history check) for %d vault(s); ...'
```

`setup_logstash_logging()` attaches a plain `logstash.UDPLogstashHandler` to the
root logger. That handler serialises the whole record into JSON and sends it as a
single UDP datagram. The stale vault warning from `log_stale_vault_candle_data()`
tabulates every vault of the trading universe — 345 rows, ~38,000 characters — and
many Hyperliquid vault names contain CJK characters and emoji, which `json.dumps()`
escapes into `\uXXXX` sequences of up to 12 bytes per character. The datagram
therefore blows past the operating system limit, `sendto()` fails with `EMSGSIZE`,
and Python's logging prints `--- Logging error ---` and drops the record.

The consequence is that the diagnostic explaining why the executor is unhealthy is
the one log line that never reaches Logstash or Sentry. The problem is not specific
to that one message: any long traceback or diagnostic table hits the same limit.

This was a known, unfixed problem. `check_data_age()` in
`tradeexecutor/strategy/trading_strategy_universe.py` carries a commented-out
`logger.error()` with the note `# base-ath | OSError: [Errno 90] Message too long`
and falls back to bare `print()` to work around it.

Note this is only the noisy half of the incident. The executor crash itself was
`DataTooOld`, caused by the upstream `cleaned-vault-prices-1h.parquet` dataset not
being regenerated for 2.5 days. That is not addressed here.

## Lessons learnt

- A datagram handler puts a hard size ceiling on a single log record. Any log call
  that interpolates unbounded data — a `tabulate()` table, a full traceback, a state
  dump — can silently exceed it, and the failure surfaces as stderr noise rather
  than as a normal exception.
- Non-ASCII content makes the ceiling much closer than it looks. `json.dumps()`
  defaults to `ensure_ascii=True`, so a CJK character costs 6 bytes and an emoji 12.
  A message that looks like 38 kB of text can serialise to well over the 65,507 byte
  datagram maximum.
- Truncating on the transport is the right layer for this. Fixing individual log
  call sites would have to be repeated for every future diagnostic, and it would
  degrade the console and file logs, which have no size limit and are where an
  operator reads the full table.
- Log records are shared between handlers. Anything that shortens a record for one
  handler must work on a copy, otherwise the console output is truncated too.
- A fallback path only helps if its own size is bounded. The first version of the
  placeholder record copied the logger name and source path verbatim, so a caller
  with a pathological logger name would have hit the very error being fixed.
- Shrinking a budget strictly in proportion to the overshoot converges badly at the
  margin: a payload one byte too large moves the budget by one character per
  attempt. Taking deliberate headroom on each attempt guarantees progress.
- The failure is invisible on loopback. Its MTU is 64 kB+, so a local socket happily
  accepts a 53 kB datagram; only the real deployment path rejects it. Tests therefore
  assert the payload size contract rather than trying to reproduce the kernel error.

## Summary

- Add `TruncatingLogstashHandlerMixin` in `tradeexecutor/cli/log.py`, which wraps
  `makePickle()`:
  - a record that fits is serialised unchanged, byte for byte;
  - an oversized record is re-serialised from a copy whose message is cut to a
    character budget, with the stack trace dropped and a
    `... [truncated N characters …]` marker appended. Because a character budget
    does not map one to one to serialised bytes, the budget is shrunk in proportion
    to the overshoot plus 5% headroom, and retried;
  - a record bloated outside its message — a large `extra=` field turned into a
    Logstash extra field — cannot be helped by cutting the message, so it is
    replaced with a small placeholder record carrying the original timestamp. Every
    field copied into the placeholder is capped, so its size stays bounded, and the
    handler asserts a minimum datagram size that a placeholder always fits into.
- Add `create_logstash_handler()`, which builds the handler class on call, because
  `logstash` is an optional dependency that is absent in the Pyodide build.
- Wire `setup_logstash_logging()` to the new handler. Console and file handlers are
  untouched and keep receiving the full record.
- Add `MAX_LOGSTASH_UDP_PAYLOAD_SIZE` (32,000 bytes, deliberately well below the
  theoretical maximum), `MIN_LOGSTASH_UDP_PAYLOAD_SIZE`,
  `MAX_LOGSTASH_TRUNCATION_ATTEMPTS`, `LOGSTASH_TRUNCATION_MARGIN_PERCENT` and
  `MAX_LOGSTASH_PLACEHOLDER_FIELD_LENGTH`.
- Add tests in `tests/cli/test_cli_logging.py`:
  - a socket test that binds a real local UDP socket rather than mocking `sendto()`,
    which would accept any payload size and defeat the purpose. It logs a table built
    from CJK and emoji vault names as seen in production, and asserts on the datagrams
    actually received — looked up by content, since UDP does not guarantee ordering —
    that the small message arrives, the oversized one arrives truncated with its
    beginning preserved, and stderr contains no `--- Logging error ---`;
  - a unit test that a fitting record serialises byte for byte identically to the
    stock `UDPLogstashHandler`, and that truncating an oversized record leaves the
    original record's `msg`, `args` and `exc_info` intact for the console, file and
    Sentry handlers;
  - a test that a record carrying a megabyte-sized extra field arrives as a placeholder.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
